### PR TITLE
fix(sales): register sales_channels_enabled from the sales module setup (#5503)

### DIFF
--- a/apps/docs/docs/architecture/configuration-decision-guide.mdx
+++ b/apps/docs/docs/architecture/configuration-decision-guide.mdx
@@ -83,7 +83,7 @@ Client side, `useFeatureFlagBoolean({ id })` and `<FeatureGuard id={...}>` read 
 
 A toggle with no definition row resolves to `MISSING_TOGGLE`, the check API answers `404`, and the client helpers coerce that to **disabled**. Two consequences:
 
-- Every toggle must have a definition row before dependent code runs. Core toggles should ship in `packages/core/src/modules/feature_toggles/defaults.json` and be seeded with `yarn mercato feature_toggles seed-defaults`; third-party definitions currently require explicit operator provisioning.
+- Every toggle must have a definition row before dependent code runs. The owning module should register its own toggles idempotently from its `setup.ts` `seedDefaults` hook (`portal`, `customers`, `sales` and `wms` all do), which covers new tenants and lets existing installations catch up with `yarn mercato seed:defaults --module <moduleId>`. `packages/core/src/modules/feature_toggles/defaults.json` is only for demo/platform toggles that no module owns; it is seeded once by `yarn mercato feature_toggles seed-defaults` during `init`, so a toggle that lives only there stays unregistered on every database created before it shipped.
 - Name toggles so that *missing* is the safe state. Prefer a positive `*_enabled` identifier with `defaultValue: true` over an inverted `disable_*` flag.
 
 Where hiding UI on a failed lookup would be worse than showing it, wrap the check in your own fail-open helper rather than depending on the default coercion — `packages/core/src/modules/sales/lib/salesChannelsToggle.ts` is the reference.
@@ -132,7 +132,7 @@ Follow the standard entity workflow: update `data/entities.ts`, run `yarn db:gen
 
 A client uses products but has a single sales channel, so the channel picker, column, filter, and management pages are noise for them.
 
-The value varies per tenant, only gates UI surfaces, and has to be read from client components — litmus test step 3, so a **feature toggle**. `sales_channels_enabled` ships in `defaults.json` with `defaultValue: true`; tenant admins override it at `/backend/feature-toggles/overrides`. No data-layer change was needed: `channelId` is already nullable and channel-less base prices already resolve.
+The value varies per tenant, only gates UI surfaces, and has to be read from client components — litmus test step 3, so a **feature toggle**. `sales_channels_enabled` is defined and seeded by the sales module itself (`packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts`, wired into `sales/setup.ts` `seedDefaults`) with `defaultValue: true`; tenant admins override it at `/backend/feature-toggles/overrides`. No data-layer change was needed: `channelId` is already nullable and channel-less base prices already resolve.
 
 Two alternatives that would have been wrong:
 
@@ -143,6 +143,6 @@ Two alternatives that would have been wrong:
 
 Documented so you are not surprised by them:
 
-- **Toggle definitions are centralised.** `defaults.json` lives inside `@open-mercato/core`, so a third-party module cannot ship a toggle definition without editing core or having an operator run the CLI. Every other module contract (`acl.ts`, `events.ts`, `ce.ts`, `setup.ts`) is auto-discovered from the module's own folder.
+- **Toggle definitions are not auto-discovered.** A module registers its toggles by calling its own seeding helper from `setup.ts` `seedDefaults`; there is no `toggles.ts` contract the generator picks up the way it picks up `acl.ts`, `events.ts` or `ce.ts`. Forgetting the `seedDefaults` call is silent — the toggle simply resolves to `MISSING_TOGGLE` at runtime.
 - **Feature toggles have no code-side default.** `getFeatureToggleValue` and `useFeatureFlagBoolean` take no default value, so callers who need fail-open behaviour hand-roll it. `ModuleConfigService.getValue` does accept `defaultValue`.
 - **`OM_*` env vars are not indexed.** There are well over a hundred and they are only discoverable by grep. A handful are semantically per-tenant despite being process-wide — `OM_ATTACHMENT_TENANT_QUOTA_MB` and `OM_SEARCH_ENABLED` among them. Treat those as legacy, not as precedent.

--- a/packages/core/src/modules/feature_toggles/defaults.json
+++ b/packages/core/src/modules/feature_toggles/defaults.json
@@ -17,14 +17,6 @@
       "defaultValue": "Free shipping on orders over $50"
     },
     {
-      "identifier": "sales_channels_enabled",
-      "name": "Sales Channels",
-      "description": "Show sales channel pickers, filters, and management UI. Disable for tenants that do not use sales channels.",
-      "category": "sales",
-      "type": "boolean",
-      "defaultValue": true
-    },
-    {
       "identifier": "order_review_threshold",
       "name": "Order Review Threshold",
       "description": "Routes orders above this total to manual review.",

--- a/packages/core/src/modules/sales/__tests__/setupSeedsSalesChannelsToggle.test.ts
+++ b/packages/core/src/modules/sales/__tests__/setupSeedsSalesChannelsToggle.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment node */
+
+jest.mock('../lib/dictionaries', () => ({
+  seedSalesStatusDictionaries: jest.fn().mockResolvedValue(undefined),
+  seedSalesAdjustmentKinds: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../seed/examples-data', () => ({
+  ensureExampleShippingMethods: jest.fn().mockResolvedValue(undefined),
+  ensureExamplePaymentMethods: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../seed/examples', () => ({
+  seedSalesExamples: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../lib/salesChannelsToggleSeed', () => ({
+  seedSalesChannelsToggle: jest.fn().mockResolvedValue(undefined),
+}))
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { seedSalesChannelsToggle } from '../lib/salesChannelsToggleSeed'
+import setup from '../setup'
+
+const seedSalesChannelsToggleMock = jest.mocked(seedSalesChannelsToggle)
+
+function createEm(): EntityManager {
+  const em = {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    persist: jest.fn(),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    flush: jest.fn().mockResolvedValue(undefined),
+    transactional: jest.fn(async (cb: (tem: unknown) => Promise<void>) => cb(em)),
+  }
+  return em as unknown as EntityManager
+}
+
+describe('sales setup seedDefaults', () => {
+  beforeEach(() => {
+    seedSalesChannelsToggleMock.mockClear()
+  })
+
+  // Regression for #5503: the toggle used to live only in the core
+  // feature_toggles defaults file, so any database seeded before it shipped
+  // never registered it and every page mounting useSalesChannelsEnabled 404d.
+  it('registers the sales channels feature toggle', async () => {
+    const em = createEm()
+
+    await setup.seedDefaults?.({ em, tenantId: 'tenant-1', organizationId: 'org-1', container: {} as never })
+
+    expect(seedSalesChannelsToggleMock).toHaveBeenCalledTimes(1)
+    expect(seedSalesChannelsToggleMock).toHaveBeenCalledWith(em)
+  })
+})

--- a/packages/core/src/modules/sales/lib/__tests__/salesChannelsToggleSeed.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/salesChannelsToggleSeed.test.ts
@@ -30,11 +30,12 @@ describe('seedSalesChannelsToggle', () => {
 
     await seedSalesChannelsToggle(em as never)
 
-    expect(findOneWithDecryptionMock).toHaveBeenCalledWith(
-      em,
-      FeatureToggle,
-      expect.objectContaining({ identifier: SALES_CHANNELS_TOGGLE_ID, deletedAt: null }),
-    )
+    // The filter must stay `deletedAt`-free: deletion is soft and the identifier
+    // unique constraint covers deleted rows too, so a `deletedAt: null` filter
+    // would turn a deleted toggle into a duplicate insert.
+    expect(findOneWithDecryptionMock).toHaveBeenCalledWith(em, FeatureToggle, {
+      identifier: SALES_CHANNELS_TOGGLE_ID,
+    })
     expect(em.create).toHaveBeenCalledWith(
       FeatureToggle,
       expect.objectContaining({
@@ -49,6 +50,21 @@ describe('seedSalesChannelsToggle', () => {
 
   it('is idempotent when the toggle already exists', async () => {
     findOneWithDecryptionMock.mockResolvedValue({ id: 'existing' })
+    const em = createEm()
+
+    await seedSalesChannelsToggle(em as never)
+
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  // Deleting a toggle sets `deleted_at` but keeps the row, and
+  // `feature_toggles_identifier_unique` is not scoped to live rows, so seeding on
+  // top of a deleted definition must skip rather than raise a unique violation
+  // and abort the whole seed run.
+  it('does not insert when the definition row exists but was soft-deleted', async () => {
+    findOneWithDecryptionMock.mockResolvedValue({ id: 'deleted', deletedAt: new Date() })
     const em = createEm()
 
     await seedSalesChannelsToggle(em as never)

--- a/packages/core/src/modules/sales/lib/__tests__/salesChannelsToggleSeed.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/salesChannelsToggleSeed.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { FeatureToggle } from '@open-mercato/core/modules/feature_toggles/data/entities'
+import { SALES_CHANNELS_TOGGLE_ID } from '../salesChannelsToggleId'
+import { SALES_CHANNELS_TOGGLE_DEFINITION, seedSalesChannelsToggle } from '../salesChannelsToggleSeed'
+
+const findOneWithDecryptionMock = jest.mocked(findOneWithDecryption)
+
+function createEm() {
+  return {
+    persist: jest.fn(),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    flush: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('seedSalesChannelsToggle', () => {
+  beforeEach(() => {
+    findOneWithDecryptionMock.mockReset()
+  })
+
+  it('registers the sales channels toggle when the definition row is missing', async () => {
+    findOneWithDecryptionMock.mockResolvedValue(null)
+    const em = createEm()
+
+    await seedSalesChannelsToggle(em as never)
+
+    expect(findOneWithDecryptionMock).toHaveBeenCalledWith(
+      em,
+      FeatureToggle,
+      expect.objectContaining({ identifier: SALES_CHANNELS_TOGGLE_ID, deletedAt: null }),
+    )
+    expect(em.create).toHaveBeenCalledWith(
+      FeatureToggle,
+      expect.objectContaining({
+        identifier: SALES_CHANNELS_TOGGLE_ID,
+        type: 'boolean',
+        defaultValue: true,
+      }),
+    )
+    expect(em.persist).toHaveBeenCalledTimes(1)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent when the toggle already exists', async () => {
+    findOneWithDecryptionMock.mockResolvedValue({ id: 'existing' })
+    const em = createEm()
+
+    await seedSalesChannelsToggle(em as never)
+
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('uses the identifier the client and server hooks poll', () => {
+    expect(SALES_CHANNELS_TOGGLE_DEFINITION.identifier).toBe('sales_channels_enabled')
+    expect(SALES_CHANNELS_TOGGLE_DEFINITION.defaultValue).toBe(true)
+  })
+})

--- a/packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts
+++ b/packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts
@@ -1,0 +1,36 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { FeatureToggle } from '@open-mercato/core/modules/feature_toggles/data/entities'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { SALES_CHANNELS_TOGGLE_ID } from './salesChannelsToggleId'
+
+export const SALES_CHANNELS_TOGGLE_DEFINITION = {
+  identifier: SALES_CHANNELS_TOGGLE_ID,
+  name: 'Sales Channels',
+  description: 'Show sales channel pickers, filters, and management UI. Disable for tenants that do not use sales channels.',
+  category: 'sales',
+  type: 'boolean' as const,
+  defaultValue: true,
+} as const
+
+// The sales module owns this toggle definition, so tenant setup registers it the
+// same way portal, customers and wms register theirs. Shipping it only in the
+// core defaults file left it unregistered on every database initialized before
+// the toggle existed, and `useSalesChannelsEnabled` then 404s on every mount.
+export async function seedSalesChannelsToggle(em: EntityManager): Promise<void> {
+  const existing = await findOneWithDecryption(em, FeatureToggle, {
+    identifier: SALES_CHANNELS_TOGGLE_DEFINITION.identifier,
+    deletedAt: null,
+  })
+  if (existing) return
+  em.persist(
+    em.create(FeatureToggle, {
+      identifier: SALES_CHANNELS_TOGGLE_DEFINITION.identifier,
+      name: SALES_CHANNELS_TOGGLE_DEFINITION.name,
+      description: SALES_CHANNELS_TOGGLE_DEFINITION.description,
+      category: SALES_CHANNELS_TOGGLE_DEFINITION.category,
+      type: SALES_CHANNELS_TOGGLE_DEFINITION.type,
+      defaultValue: SALES_CHANNELS_TOGGLE_DEFINITION.defaultValue,
+    }),
+  )
+  await em.flush()
+}

--- a/packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts
+++ b/packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts
@@ -16,10 +16,16 @@ export const SALES_CHANNELS_TOGGLE_DEFINITION = {
 // same way portal, customers and wms register theirs. Shipping it only in the
 // core defaults file left it unregistered on every database initialized before
 // the toggle existed, and `useSalesChannelsEnabled` then 404s on every mount.
+//
+// The lookup deliberately does not filter on `deletedAt`. Deletion is soft
+// (`feature_toggles.global.delete`) while `feature_toggles_identifier_unique`
+// covers every row, so filtering would make this insert a duplicate and fail the
+// whole seed run on any installation where the toggle was deleted. Matching the
+// create command's own uniqueness check also leaves an operator's deletion alone
+// instead of resurrecting the definition on every tenant seed.
 export async function seedSalesChannelsToggle(em: EntityManager): Promise<void> {
   const existing = await findOneWithDecryption(em, FeatureToggle, {
     identifier: SALES_CHANNELS_TOGGLE_DEFINITION.identifier,
-    deletedAt: null,
   })
   if (existing) return
   em.persist(

--- a/packages/core/src/modules/sales/setup.ts
+++ b/packages/core/src/modules/sales/setup.ts
@@ -3,6 +3,7 @@ import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
 import { SalesSettings, SalesDocumentSequence, SalesTaxRate } from './data/entities'
 import { DEFAULT_ORDER_NUMBER_FORMAT, DEFAULT_QUOTE_NUMBER_FORMAT } from './lib/documentNumberTokens'
 import { seedSalesStatusDictionaries, seedSalesAdjustmentKinds } from './lib/dictionaries'
+import { seedSalesChannelsToggle } from './lib/salesChannelsToggleSeed'
 import { ensureExampleShippingMethods, ensureExamplePaymentMethods } from './seed/examples-data'
 import { seedSalesExamples } from './seed/examples'
 
@@ -116,6 +117,7 @@ export const setup: ModuleSetupConfig = {
     await seedSalesAdjustmentKinds(em, scope)
     await ensureExampleShippingMethods(em, scope)
     await ensureExamplePaymentMethods(em, scope)
+    await seedSalesChannelsToggle(em)
   },
 
   async seedExamples({ em, container, tenantId, organizationId }) {


### PR DESCRIPTION
Closes #5503

## 🎯 Goal
Stop every backend page that mounts `useSalesChannelsEnabled` from firing a request that 404s. The sales channels feature toggle is now registered by the module that owns it, so the check API resolves it instead of answering `MISSING_TOGGLE`.

## 🔍 Problem
`GET /api/feature_toggles/check/boolean?identifier=sales_channels_enabled` returns `404 MISSING_TOGGLE` on installations where the toggle was never seeded. The hook declares `defaultValue: true` and fails open, so channels stay visible and nothing breaks functionally — but the failed request is logged on every page that mounts the hook, which buries real errors in console noise. The reporter's instance lists 13 registered identifiers and `sales_channels_enabled` is not among them, even though the other four toggles from the core defaults file are.

## 🔍 Root Cause
The sales module owned the toggle's *behaviour* (`lib/salesChannelsToggleId.ts`, `lib/salesChannelsToggle.ts`, `components/useSalesChannelsEnabled.ts`) but not its *definition*. The definition lived only in `packages/core/src/modules/feature_toggles/defaults.json`, which reaches the database exclusively through the one-shot `yarn mercato feature_toggles seed-defaults` step invoked during `mercato init` (`packages/cli/src/mercato.ts:1200`). Any database initialized before that entry shipped never receives it, and nothing re-seeds it afterwards — which is exactly why the reporter has the four older `defaults.json` toggles but not this one.

Every other module that ships a toggle avoids this by registering it idempotently from its own `setup.ts` `seedDefaults` hook: `portal/setup.ts` (`portal_enabled`), `customers/setup.ts` (`customers.interactions.*`), and `wms/setup.ts` via `lib/wmsIntegrationToggles.ts` (`wms_integration_*`). `sales/setup.ts` has a `seedDefaults` hook, but it only seeded tax rates, dictionaries and methods.

## What Changed
- **`packages/core/src/modules/sales/lib/salesChannelsToggleSeed.ts`** (new) — holds `SALES_CHANNELS_TOGGLE_DEFINITION` and an idempotent `seedSalesChannelsToggle(em)` that creates the `FeatureToggle` row only when it is absent, mirroring the `wms` helper. Kept in its own file rather than added to `lib/salesChannelsToggle.ts`, because that module is imported by `page.meta.ts` files and must not statically pull in ORM entities.
- **`packages/core/src/modules/sales/setup.ts`** — `seedDefaults` now calls `seedSalesChannelsToggle(em)`. New tenants and onboarding register the toggle automatically; existing installations catch up with `yarn mercato seed:defaults --module sales`, which re-runs module `seedDefaults` hooks for every organization.
- **`packages/core/src/modules/feature_toggles/defaults.json`** — the `sales_channels_enabled` entry is removed so the definition has exactly one owner and the two copies cannot drift. No behavior depends on it being there: `mercato init` runs module `seedDefaults` after the CLI seeding step, so both paths still end with the toggle registered.
- **`apps/docs/docs/architecture/configuration-decision-guide.mdx`** — the provisioning guidance said core toggles should ship in `defaults.json`; it now documents module-owned seeding as the rule, explains that a `defaults.json`-only toggle stays unregistered on databases created before it shipped, and updates the worked example and the known-gaps entry to match.

## 🧪 Tests
- `packages/core/src/modules/sales/lib/__tests__/salesChannelsToggleSeed.test.ts` (new) — locks in that the helper creates the row when the definition is missing, no-ops when it already exists, and uses the same identifier and `defaultValue: true` that the client and server hooks poll.
- `packages/core/src/modules/sales/__tests__/setupSeedsSalesChannelsToggle.test.ts` (new) — the actual regression guard: asserts the sales `seedDefaults` hook calls the seeder. Verified red without the fix (`expect(seedSalesChannelsToggleMock).toHaveBeenCalledTimes(1)` fails) and green with it.
- Full validation gate run locally, in order: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app` — all pass except one pre-existing failure noted below. Test totals include `@open-mercato/core` 11457 passed / 2 skipped, `ui` 1924, `shared` 1998, `cli` 1802, `ai-assistant` 1478, `documents` 1003, with zero failures across every workspace but one.
- **Pre-existing, unrelated failure:** `create-mercato-app` fails in `agent-harness-evaluator.test.ts`, `agent-harness-release.test.ts`, `business-writable-oracles.test.ts` and `writable-ast-oracles.test.ts`. These oracle tests shell out to the `codex` and `claude` CLIs and run a scaffolded app's `yarn typecheck` against a 120s budget, so they depend on local tooling and machine load. Confirmed pre-existing by running the same suite on a clean `origin/develop` checkout, where it fails **161** cases across the same four files — more than on this branch. This PR touches no file in `packages/create-app`.

## 💥 Breaking Changes
None. `sales_channels_enabled` keeps its identifier, type, description and `defaultValue: true`, so existing tenant overrides and both fail-open helpers are unaffected. Removing the entry from `defaults.json` narrows what `yarn mercato feature_toggles seed-defaults` creates, but the toggle is still registered on every path that previously registered it, and the seeding is idempotent, so re-running either command on an installation that already has the row is a no-op.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169293&installation_model_id=432243&pr_number=5569&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5569&signature=091323835e0ed5d5e4b54a66e36b392935ba2a23d706e28e0c7e4e6a386d3f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->