### PR TITLE
fix(devices): return camelCase API response keys (#5513)

### DIFF
--- a/.ai/specs/2026-08-24-devices-api-camelcase-responses.md
+++ b/.ai/specs/2026-08-24-devices-api-camelcase-responses.md
@@ -1,0 +1,104 @@
+# Devices API camelCase Responses
+
+## TLDR
+
+The `devices` module returns raw database column names (`device_id`, `last_seen_at`, `client_app_version`, …) from `GET /api/devices`, `GET /api/devices/admin/devices` and `GET /api/devices/admin/devices/:id`, while every sibling module returns camelCase. This spec makes camelCase the canonical response shape on all three routes and keeps each snake_case key alongside it as a documented, deprecated alias for one minor version, so no existing consumer breaks while the platform convention is restored.
+
+Scope is limited to the response serialization of those three GET routes and the first-party UI that reads them, per [issue #5513](https://github.com/open-mercato/open-mercato/issues/5513). Route URLs, HTTP methods, request bodies, query parameters, sorting, filtering, ACL features, commands, events, database schema and the push-token secrecy rule are unchanged.
+
+## Problem Statement
+
+Both device list routes declare `list.fields: deviceListFields` and no `transformItem`, so the CRUD factory hands the query engine's raw projection straight to the client:
+
+```
+id, tenant_id, organization_id, user_id, device_id, platform,
+client_app_version, os_version, locale, push_provider,
+push_token_updated_at, last_seen_at, created_at, updated_at
+```
+
+The admin detail route has the same problem for a different reason: its local `serializeDevice()` helper maps entity properties onto hand-written snake_case keys.
+
+Every other module transforms the projection before serializing — `sales/orders` returns `orderNumber` / `customerEntityId`, `warranty_claims` returns `claimNumber` / `awaitingStaffReply`, `wms/inventory/balances` and the `eudr` routes do the same through their own `transformItem`. A client written against the platform convention therefore reads `undefined` for every field on this one module. The devices module is also the module a mobile client integrates against first, which is exactly the audience least likely to discover the inconsistency from the codebase.
+
+`deviceListSortFieldMap` already accepts camelCase sort fields (`lastSeenAt`, `createdAt`, `updatedAt`), so the request side of the contract is *already* camelCase — only the response side disagrees with itself.
+
+## Proposed Solution
+
+- Add `transformDeviceListItem` to `api/deviceList.ts` and wire it as `list.transformItem` on both list routes. It reads each column under either spelling, normalizes timestamps to ISO strings, and emits camelCase keys.
+- Extract the admin detail serializer into `api/deviceSerialization.ts` as `serializeDeviceDetail`, emitting the same camelCase keys, so both surfaces share one casing decision and the serializer becomes unit-testable outside a route module.
+- Keep every snake_case key alongside its camelCase counterpart as a deprecated alias, produced by a single shared helper (`toDeprecatedSnakeCaseAliases`) so removing the bridge later is a one-site change.
+- Document both spellings in the OpenAPI item schemas (`deviceListItemSchema`, `deviceDetailItemSchema`), with each deprecated key describing the canonical key that replaces it.
+- Migrate the first-party consumers — the devices admin list and edit pages, and the push-notifications send page's device picker — to the canonical keys.
+- Cover the change with module unit tests and a new integration spec that pins both the camelCase contract and the alias bridge.
+
+## Overview
+
+`transformItem` is the established mechanism for this in the CRUD factory: the list handler applies it to every raw item before custom-field decoration, translation overlay, access logging and serialization, and the paged export path reuses the transformed items. Using it here means the fix is one option on each route rather than a bespoke response wrapper, and it matches how `warranty_claims`, `eudr`, `wms` and the `sales` line routes already solve the same problem.
+
+The transform spreads the raw record before overlaying the camelCase keys, so anything the projection carries beyond the declared field set (custom-field keys, columns added later) survives rather than being silently dropped by a hand-built object.
+
+Two behaviors are deliberately **not** changed:
+
+- **`push_token` stays out of every response.** It is absent from `deviceListFields` and never read by either serializer; the tests assert its absence under both spellings.
+- **The `exportScope=full` branch of the CRUD factory still bypasses `transformItem`** (it serializes `rawItems` through `normalizeFullRecordForExport`). That is framework-wide behavior shared by every module using `transformItem`, so a devices-local fix would be the wrong place to change it. The paged export path — the one a UI export button uses — does go through the transform.
+
+## Acceptance Criteria
+
+1. `GET /api/devices` returns `id`, `tenantId`, `organizationId`, `userId`, `deviceId`, `platform`, `clientAppVersion`, `osVersion`, `locale`, `pushProvider`, `pushTokenUpdatedAt`, `lastSeenAt`, `createdAt`, `updatedAt`.
+2. `GET /api/devices/admin/devices` returns the same camelCase key set.
+3. `GET /api/devices/admin/devices/:id` returns `item` with `id`, `userId`, `deviceId`, `platform`, `clientAppVersion`, `osVersion`, `pushProvider`, `pushTokenUpdatedAt`, `lastSeenAt`, `createdAt`, `updatedAt`.
+4. Every snake_case key previously returned by those three routes is still present and holds the same value as its camelCase counterpart.
+5. The detail response does not grow `tenant_id` / `organization_id` keys it never carried.
+6. Timestamp columns serialize as ISO strings under both spellings.
+7. `push_token` / `pushToken` is absent from every list and detail response.
+8. Sorting (`sortField=lastSeenAt|createdAt|updatedAt`), the `?platform=` / `?userId=` filters, self-serve user scoping, admin org scoping and the advanced-filter hardening on the self list are unchanged.
+9. The OpenAPI document describes both spellings, marking the snake_case keys as deprecated aliases.
+10. The devices admin list page, the devices edit page (including its optimistic-lock header source) and the push-notifications device picker read the canonical camelCase keys.
+11. Unit tests cover the list transform and the detail serializer; an integration spec covers both list routes and the detail route, asserting the camelCase contract and the alias bridge.
+
+## Architecture
+
+| File | Change |
+|------|--------|
+| `packages/core/src/modules/devices/api/deviceList.ts` | Adds `transformDeviceListItem`, `toDeprecatedSnakeCaseAliases` and the shared `toRecord`/`readString`/`toIso` readers; `deviceListItemSchema` gains the camelCase keys and describes the snake_case ones as deprecated |
+| `packages/core/src/modules/devices/api/deviceSerialization.ts` | New. `serializeDeviceDetail` + `deviceDetailItemSchema` for the admin detail route |
+| `packages/core/src/modules/devices/api/route.ts` | `list.transformItem: transformDeviceListItem` |
+| `packages/core/src/modules/devices/api/admin/devices/route.ts` | `list.transformItem: transformDeviceListItem` |
+| `packages/core/src/modules/devices/api/admin/devices/[id]/route.ts` | Uses the shared serializer and detail schema instead of its local copies |
+| `packages/core/src/modules/devices/backend/devices/page.tsx` | Row type, column accessors and cell readers use camelCase |
+| `packages/core/src/modules/devices/backend/devices/[id]/page.tsx` | Detail type, header fields, `initialValues` and `optimisticLockUpdatedAt` use camelCase |
+| `packages/core/src/modules/push_notifications/backend/push_notifications/send/page.tsx` | Device picker reads `deviceId` / `pushProvider` |
+
+## Migration & Backward Compatibility
+
+`BACKWARD_COMPATIBILITY.md` § 7 (API Route URLs, STABLE) states that response fields MUST NOT be removed and that a retired surface keeps working for at least one minor version. Renaming a response key is a removal plus an addition, so the deprecation protocol applies even though the module shipped inside the current release window.
+
+The change therefore ships as a **bridge, not a rename**:
+
+1. **No removal in this release.** Every snake_case key a 0.7.0 client reads is still returned, with an identical (now normalized) value.
+2. **Deprecated in place.** `toDeprecatedSnakeCaseAliases` carries an `@deprecated` JSDoc naming the replacement keys, and the OpenAPI item schemas describe each alias as "Deprecated alias for `<camelCaseKey>`; removed in the next minor release."
+3. **Bridge lifetime.** The aliases are removed no earlier than the next minor release. Removal is a single-site change (drop the alias spread from `transformDeviceListItem` and `serializeDeviceDetail`, and the deprecated keys from the two schemas) and is guarded by `TC-DEV-007`, which asserts the aliases today so their removal cannot land unnoticed.
+4. **Documented.** `UPGRADE_NOTES.md` carries a `0.7.0 → 0.7.1` entry with the full key mapping and the client action.
+
+Request-side contracts are untouched: query parameters, sort field names, request bodies and the `PUT`/`DELETE`/`POST` response shapes (`{ id, deviceId, revived }`, `{ ok: true }`) were already camelCase and are unchanged. Database columns keep their snake_case names — this is a serialization change only, with no migration.
+
+The one visible difference for a caller that already read the snake_case keys is normalization: a timestamp column that previously serialized as whatever the query engine produced now always serializes as an ISO-8601 string under both spellings.
+
+## Test Plan
+
+**Unit** — `packages/core/src/modules/devices/__tests__/response-casing.test.ts`
+
+- The list transform emits every camelCase key and maps values from the raw projection.
+- The deprecated aliases mirror their camelCase source exactly.
+- Date columns normalize to ISO strings; camelCase input is tolerated.
+- Keys beyond the declared projection (e.g. `cf_*`) survive the transform.
+- `push_token` never becomes `pushToken`.
+- Both item schemas parse their serializer's output.
+- The detail serializer emits camelCase with ISO timestamps, keeps its aliases, nulls absent optional columns, and does not invent `tenant_id` / `organization_id`.
+
+**Integration** — `packages/core/src/modules/devices/__integration__/TC-DEV-007.spec.ts`
+
+- Self list, admin list and admin detail all expose the camelCase key set for a freshly registered device, and never expose the push token.
+- Every deprecated snake_case alias mirrors its camelCase source on both the list and the detail route.
+
+Existing `TC-DEV-001`, `TC-DEV-005` and `TC-DEV-006` continue to assert the snake_case keys and are left unchanged: for the duration of the bridge they are the regression proof that no 0.7.0 consumer broke.

--- a/.ai/specs/2026-08-24-devices-api-camelcase-responses.md
+++ b/.ai/specs/2026-08-24-devices-api-camelcase-responses.md
@@ -27,7 +27,8 @@ Every other module transforms the projection before serializing — `sales/order
 - Add `transformDeviceListItem` to `api/deviceList.ts` and wire it as `list.transformItem` on both list routes. It reads each column under either spelling, normalizes timestamps to ISO strings, and emits camelCase keys.
 - Extract the admin detail serializer into `api/deviceSerialization.ts` as `serializeDeviceDetail`, emitting the same camelCase keys, so both surfaces share one casing decision and the serializer becomes unit-testable outside a route module.
 - Keep every snake_case key alongside its camelCase counterpart as a deprecated alias, produced by a single shared helper (`toDeprecatedSnakeCaseAliases`) so removing the bridge later is a one-site change.
-- Document both spellings in the OpenAPI item schemas (`deviceListItemSchema`, `deviceDetailItemSchema`), with each deprecated key describing the canonical key that replaces it.
+- List both spellings in the OpenAPI item schemas (`deviceListItemSchema`, `deviceDetailItemSchema`) and state the deprecation in the endpoint descriptions, which is where the generator actually renders prose.
+- Pin the admin list's export columns to the canonical key set so the aliases do not double every column in the CSV/JSON/XML export.
 - Migrate the first-party consumers — the devices admin list and edit pages, and the push-notifications send page's device picker — to the canonical keys.
 - Cover the change with module unit tests and a new integration spec that pins both the camelCase contract and the alias bridge.
 
@@ -52,9 +53,10 @@ Two behaviors are deliberately **not** changed:
 6. Timestamp columns serialize as ISO strings under both spellings.
 7. `push_token` / `pushToken` is absent from every list and detail response.
 8. Sorting (`sortField=lastSeenAt|createdAt|updatedAt`), the `?platform=` / `?userId=` filters, self-serve user scoping, admin org scoping and the advanced-filter hardening on the self list are unchanged.
-9. The OpenAPI document describes both spellings, marking the snake_case keys as deprecated aliases.
-10. The devices admin list page, the devices edit page (including its optimistic-lock header source) and the push-notifications device picker read the canonical camelCase keys.
-11. Unit tests cover the list transform and the detail serializer; an integration spec covers both list routes and the detail route, asserting the camelCase contract and the alias bridge.
+9. The OpenAPI document lists both spellings, and its rendered endpoint descriptions state that the snake_case keys are deprecated aliases scheduled for removal. (The `.describe()` markers on the schema properties themselves do **not** reach the document: the shared `zodToJsonSchema` converter emits per-property descriptions for parameters and request bodies but not for object schema properties. That is a framework-wide limitation, not a devices one, so the notice is carried by the endpoint description instead and the markers are kept as in-code contract documentation.)
+10. The admin list export emits one column per canonical key — the deprecated aliases must not double the export's column set.
+11. The devices admin list page, the devices edit page (including its optimistic-lock header source) and the push-notifications device picker read the canonical camelCase keys.
+12. Unit tests cover the list transform and the detail serializer; an integration spec covers both list routes and the detail route, asserting the camelCase contract and the alias bridge.
 
 ## Architecture
 
@@ -63,7 +65,8 @@ Two behaviors are deliberately **not** changed:
 | `packages/core/src/modules/devices/api/deviceList.ts` | Adds `transformDeviceListItem`, `toDeprecatedSnakeCaseAliases` and the shared `toRecord`/`readString`/`toIso` readers; `deviceListItemSchema` gains the camelCase keys and describes the snake_case ones as deprecated |
 | `packages/core/src/modules/devices/api/deviceSerialization.ts` | New. `serializeDeviceDetail` + `deviceDetailItemSchema` for the admin detail route |
 | `packages/core/src/modules/devices/api/route.ts` | `list.transformItem: transformDeviceListItem` |
-| `packages/core/src/modules/devices/api/admin/devices/route.ts` | `list.transformItem: transformDeviceListItem` |
+| `packages/core/src/modules/devices/api/admin/devices/route.ts` | `list.transformItem: transformDeviceListItem`, plus `list.export.columns` pinned to `deviceExportColumnFields` |
+| `packages/core/src/modules/devices/api/openapi.ts` | Exports `DEPRECATED_SNAKE_CASE_NOTICE` and appends it to the generated list description |
 | `packages/core/src/modules/devices/api/admin/devices/[id]/route.ts` | Uses the shared serializer and detail schema instead of its local copies |
 | `packages/core/src/modules/devices/backend/devices/page.tsx` | Row type, column accessors and cell readers use camelCase |
 | `packages/core/src/modules/devices/backend/devices/[id]/page.tsx` | Detail type, header fields, `initialValues` and `optimisticLockUpdatedAt` use camelCase |

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,30 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.7.0 → 0.7.1 (unreleased)
 
+### Device API responses are camelCase; the snake_case keys are deprecated aliases (#5513)
+
+`GET /api/devices`, `GET /api/devices/admin/devices` and `GET /api/devices/admin/devices/:id` returned the raw database column names (`device_id`, `user_id`, `last_seen_at`, …) while every other module returns camelCase. A client written against the platform convention read `undefined` for every field on this one module. All three routes now return camelCase keys as the canonical shape:
+
+| Deprecated alias | Canonical key |
+|------------------|---------------|
+| `tenant_id` | `tenantId` (list routes only) |
+| `organization_id` | `organizationId` (list routes only) |
+| `user_id` | `userId` |
+| `device_id` | `deviceId` |
+| `client_app_version` | `clientAppVersion` |
+| `os_version` | `osVersion` |
+| `push_provider` | `pushProvider` |
+| `push_token_updated_at` | `pushTokenUpdatedAt` |
+| `last_seen_at` | `lastSeenAt` |
+| `created_at` | `createdAt` |
+| `updated_at` | `updatedAt` |
+
+`id`, `platform` and `locale` are spelled the same either way and are unchanged. Nothing was removed: **every snake_case key is still returned**, holding the same value as its camelCase counterpart, and is marked deprecated in the OpenAPI document. The aliases are removed no earlier than the next minor release.
+
+Request-side contracts are untouched — query parameters, the `sortField` values (`lastSeenAt`, `createdAt`, `updatedAt`, already camelCase), request bodies, and the `POST`/`PUT`/`DELETE` response shapes are unchanged, as are the database columns themselves. The one behavior difference for a caller already reading the snake_case keys is that timestamp columns now always serialize as ISO-8601 strings under both spellings. `push_token` remains absent from every response under either spelling.
+
+**Action for API consumers:** switch to the camelCase keys. A client that keeps reading the snake_case ones works unchanged until the aliases are removed.
+
 ### Interaction participants may omit `userId` — external calendar guests (#5115)
 
 `interactionParticipantSchema` required `participants[].userId` to be a UUID, so an attendee with no person/customer/staff record — an external guest identified only by their email — could not be recorded at all. `userId` is now optional; a participant must still be identifiable, so one without a `userId` **must** carry a valid email address (`participants[].email`), and one with neither is still rejected with a `400`.

--- a/packages/core/src/modules/devices/AGENTS.md
+++ b/packages/core/src/modules/devices/AGENTS.md
@@ -23,6 +23,14 @@ delivery logic** (sender, providers, delivery rows, workers live in the `push_no
   — they carry undo snapshots, query-index side effects, and domain events.
 - Treat `push_token` as a secret: **never** include it in list/response field sets. Only
   `push_provider` and `push_token_updated_at` are exposed.
+- Serialize every GET response in **camelCase**, like every other module. The list routes run
+  `transformDeviceListItem` (`api/deviceList.ts`) over the query engine's raw projection and the admin
+  detail route uses `serializeDeviceDetail` (`api/deviceSerialization.ts`). Both also emit the legacy
+  snake_case keys as **deprecated aliases** via `toDeprecatedSnakeCaseAliases`, kept for one minor
+  version per `BACKWARD_COMPATIBILITY.md` § 7 and pinned by `TC-DEV-007`; when the bridge is dropped,
+  remove the alias spread from those two functions and the deprecated keys from `deviceListItemSchema`
+  / `deviceDetailItemSchema`. Adding a column means adding it to `deviceListFields`, the transform, and
+  the schemas. See `.ai/specs/2026-08-24-devices-api-camelcase-responses.md` (#5513).
 - Honor the `pushToken` tri-state on `PUT`: absent key = leave unchanged; explicit `null` = clear
   (revoked OS permission) and bump `push_token_updated_at`. The command uses own-property presence.
 - Keep the list route's CRUD cache tag aligned with the command's `resourceKind`. The list reads

--- a/packages/core/src/modules/devices/__integration__/TC-DEV-007.spec.ts
+++ b/packages/core/src/modules/devices/__integration__/TC-DEV-007.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+// TC-DEV-007: response casing. Every other module serializes its API responses in camelCase, and the
+// devices routes used to return the raw database column names instead (#5513). These tests pin the
+// camelCase contract on both list routes and the admin detail route, and pin the deprecated
+// snake_case aliases that stay alongside for one minor version so their removal is a deliberate,
+// test-visible change.
+
+type RegisterResult = { id: string; deviceId: string; revived: boolean }
+type DeviceItem = Record<string, unknown>
+type DeviceListResponse = { items: DeviceItem[]; total?: number }
+
+const SELF_PATH = '/api/devices'
+const ADMIN_PATH = '/api/devices/admin/devices'
+
+const CAMEL_LIST_KEYS = [
+  'tenantId',
+  'userId',
+  'deviceId',
+  'clientAppVersion',
+  'osVersion',
+  'pushProvider',
+  'pushTokenUpdatedAt',
+  'lastSeenAt',
+  'createdAt',
+  'updatedAt',
+] as const
+
+const DEPRECATED_ALIASES: Array<[string, string]> = [
+  ['user_id', 'userId'],
+  ['device_id', 'deviceId'],
+  ['client_app_version', 'clientAppVersion'],
+  ['os_version', 'osVersion'],
+  ['push_provider', 'pushProvider'],
+  ['push_token_updated_at', 'pushTokenUpdatedAt'],
+  ['last_seen_at', 'lastSeenAt'],
+  ['created_at', 'createdAt'],
+  ['updated_at', 'updatedAt'],
+]
+
+let deviceCounter = 0
+function uniqueDeviceId(prefix: string): string {
+  deviceCounter += 1
+  return `${prefix}-${Date.now()}-${deviceCounter}`
+}
+
+// The list APIs read from the eventually-consistent query index, so poll until the row shows up.
+async function waitForItem(
+  fetcher: () => Promise<DeviceItem[]>,
+  predicate: (items: DeviceItem[]) => boolean,
+): Promise<DeviceItem[]> {
+  let latest: DeviceItem[] = []
+  await expect
+    .poll(async () => {
+      latest = await fetcher()
+      return predicate(latest)
+    }, { timeout: 15_000 })
+    .toBe(true)
+  return latest
+}
+
+async function listDevices(request: APIRequestContext, token: string, path: string, query = ''): Promise<DeviceItem[]> {
+  const res = await apiRequest(request, 'GET', `${path}${query}`, { token })
+  expect(res.status(), `${path} should return 200`).toBe(200)
+  return (await readJsonSafe<DeviceListResponse>(res))?.items ?? []
+}
+
+test.describe('TC-DEV-007: device responses use the platform camelCase convention', () => {
+  test('self list, admin list and admin detail all expose camelCase keys', async ({ request }) => {
+    test.slow()
+    const adminToken = await getAuthToken(request, 'admin')
+    const { userId } = getTokenScope(adminToken)
+    const deviceId = uniqueDeviceId('qa-dev-007-casing')
+    let createdId: string | null = null
+    try {
+      const register = await apiRequest(request, 'POST', SELF_PATH, {
+        token: adminToken,
+        data: { deviceId, platform: 'ios', clientAppVersion: '4.5.6', osVersion: 'iOS 18.2', pushProvider: 'apns', pushToken: 'tok-dev-007' },
+      })
+      expect(register.status()).toBe(201)
+      createdId = (await readJsonSafe<RegisterResult>(register))?.id ?? null
+      expect(createdId).toBeTruthy()
+
+      const selfItems = await waitForItem(
+        () => listDevices(request, adminToken, SELF_PATH),
+        (items) => items.some((d) => d.id === createdId),
+      )
+      const selfRow = selfItems.find((d) => d.id === createdId)!
+      for (const key of CAMEL_LIST_KEYS) {
+        expect(selfRow, `self list item should carry ${key}`).toHaveProperty(key)
+      }
+      expect(selfRow.deviceId).toBe(deviceId)
+      expect(selfRow.userId).toBe(userId)
+      expect(selfRow.clientAppVersion).toBe('4.5.6')
+      expect(selfRow.osVersion).toBe('iOS 18.2')
+      expect(selfRow.pushProvider).toBe('apns')
+      // push_token is a secret under either spelling.
+      expect(selfRow.pushToken).toBeUndefined()
+      expect(selfRow.push_token).toBeUndefined()
+
+      const adminItems = await waitForItem(
+        () => listDevices(request, adminToken, ADMIN_PATH, `?userId=${userId}`),
+        (items) => items.some((d) => d.id === createdId),
+      )
+      const adminRow = adminItems.find((d) => d.id === createdId)!
+      for (const key of CAMEL_LIST_KEYS) {
+        expect(adminRow, `admin list item should carry ${key}`).toHaveProperty(key)
+      }
+      expect(adminRow.deviceId).toBe(deviceId)
+
+      const detailRes = await apiRequest(request, 'GET', `${ADMIN_PATH}/${createdId}`, { token: adminToken })
+      expect(detailRes.status()).toBe(200)
+      const detail = (await readJsonSafe<{ item?: DeviceItem }>(detailRes))?.item
+      expect(detail).toBeTruthy()
+      expect(detail!.deviceId).toBe(deviceId)
+      expect(detail!.userId).toBe(userId)
+      expect(detail!.clientAppVersion).toBe('4.5.6')
+      expect(detail!.osVersion).toBe('iOS 18.2')
+      expect(detail!.pushProvider).toBe('apns')
+      expect(detail!.updatedAt).toBeTruthy()
+      expect(detail!.pushToken).toBeUndefined()
+      expect(detail!.push_token).toBeUndefined()
+    } finally {
+      if (createdId) await apiRequest(request, 'DELETE', `${SELF_PATH}/${createdId}`, { token: adminToken }).catch(() => undefined)
+    }
+  })
+
+  test('deprecated snake_case aliases still mirror their camelCase source', async ({ request }) => {
+    test.slow()
+    const adminToken = await getAuthToken(request, 'admin')
+    const { userId } = getTokenScope(adminToken)
+    const deviceId = uniqueDeviceId('qa-dev-007-alias')
+    let createdId: string | null = null
+    try {
+      const register = await apiRequest(request, 'POST', SELF_PATH, {
+        token: adminToken,
+        data: { deviceId, platform: 'android', clientAppVersion: '7.8.9', osVersion: 'Android 15', pushProvider: 'fcm' },
+      })
+      expect(register.status()).toBe(201)
+      createdId = (await readJsonSafe<RegisterResult>(register))?.id ?? null
+      expect(createdId).toBeTruthy()
+
+      const items = await waitForItem(
+        () => listDevices(request, adminToken, ADMIN_PATH, `?userId=${userId}`),
+        (its) => its.some((d) => d.id === createdId),
+      )
+      const row = items.find((d) => d.id === createdId)!
+      for (const [alias, canonical] of DEPRECATED_ALIASES) {
+        expect(row[alias], `list alias ${alias} should mirror ${canonical}`).toBe(row[canonical])
+      }
+
+      const detailRes = await apiRequest(request, 'GET', `${ADMIN_PATH}/${createdId}`, { token: adminToken })
+      expect(detailRes.status()).toBe(200)
+      const detail = (await readJsonSafe<{ item?: DeviceItem }>(detailRes))?.item
+      expect(detail).toBeTruthy()
+      for (const [alias, canonical] of DEPRECATED_ALIASES) {
+        expect(detail![alias], `detail alias ${alias} should mirror ${canonical}`).toBe(detail![canonical])
+      }
+    } finally {
+      if (createdId) await apiRequest(request, 'DELETE', `${SELF_PATH}/${createdId}`, { token: adminToken }).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/devices/__tests__/response-casing.test.ts
+++ b/packages/core/src/modules/devices/__tests__/response-casing.test.ts
@@ -1,0 +1,128 @@
+import { transformDeviceListItem, deviceListItemSchema } from '../api/deviceList'
+import { serializeDeviceDetail, deviceDetailItemSchema } from '../api/deviceSerialization'
+import type { UserDevice } from '../data/entities'
+
+const rawListRow = {
+  id: '11111111-1111-4111-8111-111111111111',
+  tenant_id: '22222222-2222-4222-8222-222222222222',
+  organization_id: '33333333-3333-4333-8333-333333333333',
+  user_id: '44444444-4444-4444-8444-444444444444',
+  device_id: 'device-abc',
+  platform: 'ios',
+  client_app_version: '1.2.3',
+  os_version: 'iOS 18.1',
+  locale: 'en',
+  push_provider: 'apns',
+  push_token_updated_at: '2026-08-20T10:00:00.000Z',
+  last_seen_at: '2026-08-21T10:00:00.000Z',
+  created_at: '2026-08-01T10:00:00.000Z',
+  updated_at: '2026-08-22T10:00:00.000Z',
+}
+
+const CAMEL_LIST_KEYS = [
+  'tenantId',
+  'organizationId',
+  'userId',
+  'deviceId',
+  'clientAppVersion',
+  'osVersion',
+  'pushProvider',
+  'pushTokenUpdatedAt',
+  'lastSeenAt',
+  'createdAt',
+  'updatedAt',
+] as const
+
+describe('devices list response casing', () => {
+  it('exposes every column in camelCase, matching the platform convention', () => {
+    const item = transformDeviceListItem(rawListRow) as Record<string, unknown>
+    for (const key of CAMEL_LIST_KEYS) {
+      expect(item[key]).toBeDefined()
+    }
+    expect(item.userId).toBe(rawListRow.user_id)
+    expect(item.deviceId).toBe(rawListRow.device_id)
+    expect(item.clientAppVersion).toBe(rawListRow.client_app_version)
+    expect(item.pushProvider).toBe(rawListRow.push_provider)
+    expect(item.lastSeenAt).toBe(rawListRow.last_seen_at)
+  })
+
+  it('keeps the deprecated snake_case aliases in sync with their camelCase source', () => {
+    const item = transformDeviceListItem(rawListRow) as Record<string, unknown>
+    expect(item.user_id).toBe(item.userId)
+    expect(item.device_id).toBe(item.deviceId)
+    expect(item.client_app_version).toBe(item.clientAppVersion)
+    expect(item.os_version).toBe(item.osVersion)
+    expect(item.push_provider).toBe(item.pushProvider)
+    expect(item.push_token_updated_at).toBe(item.pushTokenUpdatedAt)
+    expect(item.last_seen_at).toBe(item.lastSeenAt)
+    expect(item.created_at).toBe(item.createdAt)
+    expect(item.updated_at).toBe(item.updatedAt)
+  })
+
+  it('normalizes Date columns to ISO strings and tolerates camelCase input', () => {
+    const item = transformDeviceListItem({
+      ...rawListRow,
+      last_seen_at: new Date('2026-08-21T10:00:00.000Z'),
+      updated_at: undefined,
+      updatedAt: new Date('2026-08-22T10:00:00.000Z'),
+    }) as Record<string, unknown>
+    expect(item.lastSeenAt).toBe('2026-08-21T10:00:00.000Z')
+    expect(item.updatedAt).toBe('2026-08-22T10:00:00.000Z')
+  })
+
+  it('preserves keys beyond the declared projection', () => {
+    const item = transformDeviceListItem({ ...rawListRow, cf_department: 'field-ops' }) as Record<string, unknown>
+    expect(item.cf_department).toBe('field-ops')
+  })
+
+  it('never exposes the push token', () => {
+    const item = transformDeviceListItem({ ...rawListRow, push_token: 'secret-token' }) as Record<string, unknown>
+    expect(item.pushToken).toBeUndefined()
+  })
+
+  it('satisfies the documented list item schema', () => {
+    expect(() => deviceListItemSchema.parse(transformDeviceListItem(rawListRow))).not.toThrow()
+  })
+})
+
+describe('devices detail response casing', () => {
+  const device = {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '44444444-4444-4444-8444-444444444444',
+    deviceId: 'device-abc',
+    platform: 'ios',
+    clientAppVersion: '1.2.3',
+    osVersion: 'iOS 18.1',
+    pushProvider: 'apns',
+    pushTokenUpdatedAt: new Date('2026-08-20T10:00:00.000Z'),
+    lastSeenAt: new Date('2026-08-21T10:00:00.000Z'),
+    createdAt: new Date('2026-08-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-22T10:00:00.000Z'),
+  } as UserDevice
+
+  it('serializes the detail item in camelCase with ISO timestamps', () => {
+    const item = serializeDeviceDetail(device)
+    expect(item.deviceId).toBe('device-abc')
+    expect(item.clientAppVersion).toBe('1.2.3')
+    expect(item.updatedAt).toBe('2026-08-22T10:00:00.000Z')
+    expect(item.lastSeenAt).toBe('2026-08-21T10:00:00.000Z')
+  })
+
+  it('keeps the deprecated snake_case aliases without inventing tenant or organization keys', () => {
+    const item = serializeDeviceDetail(device)
+    expect(item.device_id).toBe(item.deviceId)
+    expect(item.updated_at).toBe(item.updatedAt)
+    expect(item).not.toHaveProperty('tenant_id')
+    expect(item).not.toHaveProperty('organization_id')
+  })
+
+  it('nulls absent optional columns instead of dropping them', () => {
+    const item = serializeDeviceDetail({ ...device, clientAppVersion: null, lastSeenAt: null } as UserDevice)
+    expect(item.clientAppVersion).toBeNull()
+    expect(item.lastSeenAt).toBeNull()
+  })
+
+  it('satisfies the documented detail item schema', () => {
+    expect(() => deviceDetailItemSchema.parse(serializeDeviceDetail(device))).not.toThrow()
+  })
+})

--- a/packages/core/src/modules/devices/__tests__/response-casing.test.ts
+++ b/packages/core/src/modules/devices/__tests__/response-casing.test.ts
@@ -1,4 +1,4 @@
-import { transformDeviceListItem, deviceListItemSchema } from '../api/deviceList'
+import { transformDeviceListItem, deviceListItemSchema, deviceExportColumnFields } from '../api/deviceList'
 import { serializeDeviceDetail, deviceDetailItemSchema } from '../api/deviceSerialization'
 import type { UserDevice } from '../data/entities'
 
@@ -82,6 +82,18 @@ describe('devices list response casing', () => {
 
   it('satisfies the documented list item schema', () => {
     expect(() => deviceListItemSchema.parse(transformDeviceListItem(rawListRow))).not.toThrow()
+  })
+
+  it('pins export columns to the canonical spelling so aliases do not double every column', () => {
+    const item = transformDeviceListItem(rawListRow) as Record<string, unknown>
+    expect(deviceExportColumnFields.filter((field) => field.includes('_'))).toEqual([])
+    for (const field of deviceExportColumnFields) {
+      expect(item[field]).toBeDefined()
+    }
+    // Every non-alias key of a transformed row must be exported; a new column added to the projection
+    // without a matching export entry would silently disappear from the CSV.
+    const canonicalKeys = Object.keys(item).filter((key) => !key.includes('_'))
+    expect(canonicalKeys.sort()).toEqual([...deviceExportColumnFields].sort())
   })
 })
 

--- a/packages/core/src/modules/devices/api/admin/devices/[id]/route.ts
+++ b/packages/core/src/modules/devices/api/admin/devices/[id]/route.ts
@@ -16,6 +16,7 @@ import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/dire
 import { resolveDeviceActorUserId } from '../../../auth'
 import { executeUpdate, executeDeactivate, type DeviceMutationContext } from '../../../deviceOps'
 import { serializeDeviceDetail, deviceDetailItemSchema } from '../../../deviceSerialization'
+import { DEPRECATED_SNAKE_CASE_NOTICE } from '../../../openapi'
 
 const logger = createLogger('devices')
 
@@ -169,7 +170,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     GET: {
       summary: 'Get any device',
-      description: 'Admin: fetch a single device by id (push_token is never returned).',
+      description: `Admin: fetch a single device by id (push_token is never returned). ${DEPRECATED_SNAKE_CASE_NOTICE}`,
       responses: [{ status: 200, description: 'Device', schema: detailResponseSchema }],
       errors: [
         { status: 400, description: 'Invalid id', schema: errorResponseSchema },

--- a/packages/core/src/modules/devices/api/admin/devices/[id]/route.ts
+++ b/packages/core/src/modules/devices/api/admin/devices/[id]/route.ts
@@ -15,6 +15,7 @@ import { updateDeviceSchema } from '../../../../data/validators'
 import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { resolveDeviceActorUserId } from '../../../auth'
 import { executeUpdate, executeDeactivate, type DeviceMutationContext } from '../../../deviceOps'
+import { serializeDeviceDetail, deviceDetailItemSchema } from '../../../deviceSerialization'
 
 const logger = createLogger('devices')
 
@@ -38,23 +39,6 @@ async function loadDevice(
   return findOneWithDecryption(em, UserDevice, { id, tenantId, deletedAt: null }, undefined, { tenantId })
 }
 
-// push_token is a secret and is never returned.
-function serializeDevice(device: UserDevice) {
-  return {
-    id: device.id,
-    user_id: device.userId,
-    device_id: device.deviceId,
-    platform: device.platform,
-    client_app_version: device.clientAppVersion ?? null,
-    os_version: device.osVersion ?? null,
-    push_provider: device.pushProvider ?? null,
-    push_token_updated_at: device.pushTokenUpdatedAt ? device.pushTokenUpdatedAt.toISOString() : null,
-    last_seen_at: device.lastSeenAt ? device.lastSeenAt.toISOString() : null,
-    created_at: device.createdAt ? device.createdAt.toISOString() : null,
-    updated_at: device.updatedAt ? device.updatedAt.toISOString() : null,
-  }
-}
-
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const { translate } = await resolveTranslations()
   try {
@@ -76,7 +60,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: device.organizationId ?? null })) {
       return NextResponse.json({ error: translate('devices.errors.forbidden', 'Access denied') }, { status: 403 })
     }
-    return NextResponse.json({ item: serializeDevice(device) })
+    return NextResponse.json({ item: serializeDeviceDetail(device) })
   } catch (err) {
     if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
@@ -177,21 +161,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
 
 const okResponseSchema = z.object({ ok: z.literal(true), id: z.string().uuid().optional() })
 const errorResponseSchema = z.object({ error: z.string() })
-const detailResponseSchema = z.object({
-  item: z.object({
-    id: z.string().uuid(),
-    user_id: z.string().uuid(),
-    device_id: z.string(),
-    platform: z.enum(['ios', 'android', 'web']),
-    client_app_version: z.string().nullable(),
-    os_version: z.string().nullable(),
-    push_provider: z.string().nullable(),
-    push_token_updated_at: z.string().nullable(),
-    last_seen_at: z.string().nullable(),
-    created_at: z.string().nullable(),
-    updated_at: z.string().nullable(),
-  }),
-})
+const detailResponseSchema = z.object({ item: deviceDetailItemSchema })
 
 export const openApi: OpenApiRouteDoc = {
   tag: 'Devices (admin)',

--- a/packages/core/src/modules/devices/api/admin/devices/route.ts
+++ b/packages/core/src/modules/devices/api/admin/devices/route.ts
@@ -2,6 +2,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { toHeaderLabel } from '@open-mercato/shared/lib/crud/exporters'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -26,6 +27,7 @@ import {
   deviceListFields,
   deviceListSortFieldMap,
   deviceListItemSchema,
+  deviceExportColumnFields,
   transformDeviceListItem,
 } from '../../deviceList'
 import { executeRegister, type DeviceMutationContext } from '../../deviceOps'
@@ -63,6 +65,9 @@ const crud = makeCrudRoute({
     sortFieldMap: deviceListSortFieldMap,
     // The query engine projects raw column names; expose them in camelCase like every other module.
     transformItem: transformDeviceListItem,
+    // Without an explicit column set the factory's default export spreads each item, so the deprecated
+    // snake_case aliases would double every column in the CSV/JSON/XML export.
+    export: { columns: deviceExportColumnFields.map((field) => ({ field, header: toHeaderLabel(field) })) },
     // Tenant + org scope is enforced by the factory (orm.tenantField + orm.orgField); only the optional
     // userId/platform narrowing is left to do here.
     buildFilters: async (query) => {

--- a/packages/core/src/modules/devices/api/admin/devices/route.ts
+++ b/packages/core/src/modules/devices/api/admin/devices/route.ts
@@ -21,7 +21,13 @@ import {
 } from '../../../data/validators'
 import { resolveDeviceActorUserId } from '../../auth'
 import { createDevicesCrudOpenApi, createPagedListResponseSchema } from '../../openapi'
-import { deviceListSchema, deviceListFields, deviceListSortFieldMap, deviceListItemSchema } from '../../deviceList'
+import {
+  deviceListSchema,
+  deviceListFields,
+  deviceListSortFieldMap,
+  deviceListItemSchema,
+  transformDeviceListItem,
+} from '../../deviceList'
 import { executeRegister, type DeviceMutationContext } from '../../deviceOps'
 
 const logger = createLogger('devices')
@@ -55,6 +61,8 @@ const crud = makeCrudRoute({
     entityId: E.devices.user_device,
     fields: deviceListFields,
     sortFieldMap: deviceListSortFieldMap,
+    // The query engine projects raw column names; expose them in camelCase like every other module.
+    transformItem: transformDeviceListItem,
     // Tenant + org scope is enforced by the factory (orm.tenantField + orm.orgField); only the optional
     // userId/platform narrowing is left to do here.
     buildFilters: async (query) => {

--- a/packages/core/src/modules/devices/api/deviceList.ts
+++ b/packages/core/src/modules/devices/api/deviceList.ts
@@ -30,6 +30,26 @@ export const deviceListFields: string[] = [
   'updated_at',
 ]
 
+// The admin list enables exports, and the factory's default export derives its columns by spreading
+// each item — which would emit both spellings of every aliased key. Pin the canonical camelCase set
+// so the export stays single-spelled and does not change shape when the aliases are dropped.
+export const deviceExportColumnFields: string[] = [
+  'id',
+  'tenantId',
+  'organizationId',
+  'userId',
+  'deviceId',
+  'platform',
+  'clientAppVersion',
+  'osVersion',
+  'locale',
+  'pushProvider',
+  'pushTokenUpdatedAt',
+  'lastSeenAt',
+  'createdAt',
+  'updatedAt',
+]
+
 export const deviceListSortFieldMap: Record<string, string> = {
   lastSeenAt: 'last_seen_at',
   createdAt: 'created_at',
@@ -124,6 +144,9 @@ export function toIso(value: unknown): string | null {
   return null
 }
 
+// In-code contract markers. The shared zodToJsonSchema converter does not currently emit per-property
+// descriptions for object schemas, so the rendered deprecation notice lives on the endpoint description
+// (`DEPRECATED_SNAKE_CASE_NOTICE` in ./openapi); these become visible for free if that changes.
 const deprecatedAlias = (of: string) => `Deprecated alias for \`${of}\`; removed in the next minor release.`
 
 export const deviceListItemSchema = z.object({

--- a/packages/core/src/modules/devices/api/deviceList.ts
+++ b/packages/core/src/modules/devices/api/deviceList.ts
@@ -36,19 +36,120 @@ export const deviceListSortFieldMap: Record<string, string> = {
   updatedAt: 'updated_at',
 }
 
+// The query engine projects the raw column names listed in `deviceListFields`. Every other module
+// serializes its list items in camelCase (`sales/orders` → `orderNumber`, `warranty_claims` →
+// `claimNumber`), so the list routes run this transform to expose the platform convention (#5513).
+// The snake_case keys stay alongside as deprecated aliases for one minor version, per the
+// deprecation protocol in BACKWARD_COMPATIBILITY.md § 7 (API Route URLs — response fields).
+export function transformDeviceListItem(item: unknown): unknown {
+  const record = toRecord(item)
+  if (!Object.keys(record).length) return item
+  const camel = {
+    id: readString(record, 'id', 'id'),
+    tenantId: readString(record, 'tenant_id', 'tenantId'),
+    organizationId: readString(record, 'organization_id', 'organizationId'),
+    userId: readString(record, 'user_id', 'userId'),
+    deviceId: readString(record, 'device_id', 'deviceId'),
+    platform: readString(record, 'platform', 'platform'),
+    clientAppVersion: readString(record, 'client_app_version', 'clientAppVersion'),
+    osVersion: readString(record, 'os_version', 'osVersion'),
+    locale: readString(record, 'locale', 'locale'),
+    pushProvider: readString(record, 'push_provider', 'pushProvider'),
+    pushTokenUpdatedAt: toIso(record.push_token_updated_at ?? record.pushTokenUpdatedAt),
+    lastSeenAt: toIso(record.last_seen_at ?? record.lastSeenAt),
+    createdAt: toIso(record.created_at ?? record.createdAt),
+    updatedAt: toIso(record.updated_at ?? record.updatedAt),
+  }
+  // Spread the raw record first so anything the projection carries beyond the declared field set
+  // (custom-field keys, future columns) survives; the aliases then restate the snake_case keys with
+  // the same normalized values as their camelCase counterparts.
+  return { ...record, ...camel, ...toDeprecatedSnakeCaseAliases(camel) }
+}
+
+/**
+ * @deprecated Snake_case device response keys are superseded by the camelCase keys and are removed in
+ * the next minor release. Read `deviceId`, `userId`, `lastSeenAt`, … instead. See UPGRADE_NOTES.md.
+ */
+export function toDeprecatedSnakeCaseAliases(item: DeviceResponseItem): Record<string, unknown> {
+  const aliases: Record<string, unknown> = {
+    tenant_id: item.tenantId,
+    organization_id: item.organizationId,
+    user_id: item.userId,
+    device_id: item.deviceId,
+    client_app_version: item.clientAppVersion,
+    os_version: item.osVersion,
+    push_provider: item.pushProvider,
+    push_token_updated_at: item.pushTokenUpdatedAt,
+    last_seen_at: item.lastSeenAt,
+    created_at: item.createdAt,
+    updated_at: item.updatedAt,
+  }
+  // The detail response never carried tenant/org, so an absent camelCase source must not grow a new
+  // key here — only keys the caller actually supplied get an alias.
+  for (const key of Object.keys(aliases)) {
+    if (aliases[key] === undefined) delete aliases[key]
+  }
+  return aliases
+}
+
+export type DeviceResponseItem = {
+  tenantId?: string | null
+  organizationId?: string | null
+  userId: string | null
+  deviceId: string | null
+  clientAppVersion: string | null
+  osVersion: string | null
+  pushProvider: string | null
+  pushTokenUpdatedAt?: string | null
+  lastSeenAt?: string | null
+  createdAt?: string | null
+  updatedAt: string | null
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function readString(record: Record<string, unknown>, snakeKey: string, camelKey: string): string | null {
+  const value = record[snakeKey] ?? record[camelKey]
+  return typeof value === 'string' ? value : null
+}
+
+export function toIso(value: unknown): string | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString()
+  if (typeof value === 'string') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? value : date.toISOString()
+  }
+  return null
+}
+
+const deprecatedAlias = (of: string) => `Deprecated alias for \`${of}\`; removed in the next minor release.`
+
 export const deviceListItemSchema = z.object({
   id: z.string().uuid(),
-  tenant_id: z.string().uuid(),
-  organization_id: z.string().uuid().nullable().optional(),
-  user_id: z.string().uuid(),
-  device_id: z.string(),
+  tenantId: z.string().uuid(),
+  organizationId: z.string().uuid().nullable().optional(),
+  userId: z.string().uuid(),
+  deviceId: z.string(),
   platform: z.enum(['ios', 'android', 'web']),
-  client_app_version: z.string().nullable().optional(),
-  os_version: z.string().nullable().optional(),
+  clientAppVersion: z.string().nullable().optional(),
+  osVersion: z.string().nullable().optional(),
   locale: z.string().nullable().optional(),
-  push_provider: z.string().nullable().optional(),
-  push_token_updated_at: z.string().nullable().optional(),
-  last_seen_at: z.string().nullable().optional(),
-  created_at: z.string().nullable().optional(),
-  updated_at: z.string().nullable().optional(),
+  pushProvider: z.string().nullable().optional(),
+  pushTokenUpdatedAt: z.string().nullable().optional(),
+  lastSeenAt: z.string().nullable().optional(),
+  createdAt: z.string().nullable().optional(),
+  updatedAt: z.string().nullable().optional(),
+  tenant_id: z.string().uuid().describe(deprecatedAlias('tenantId')),
+  organization_id: z.string().uuid().nullable().optional().describe(deprecatedAlias('organizationId')),
+  user_id: z.string().uuid().describe(deprecatedAlias('userId')),
+  device_id: z.string().describe(deprecatedAlias('deviceId')),
+  client_app_version: z.string().nullable().optional().describe(deprecatedAlias('clientAppVersion')),
+  os_version: z.string().nullable().optional().describe(deprecatedAlias('osVersion')),
+  push_provider: z.string().nullable().optional().describe(deprecatedAlias('pushProvider')),
+  push_token_updated_at: z.string().nullable().optional().describe(deprecatedAlias('pushTokenUpdatedAt')),
+  last_seen_at: z.string().nullable().optional().describe(deprecatedAlias('lastSeenAt')),
+  created_at: z.string().nullable().optional().describe(deprecatedAlias('createdAt')),
+  updated_at: z.string().nullable().optional().describe(deprecatedAlias('updatedAt')),
 })

--- a/packages/core/src/modules/devices/api/deviceSerialization.ts
+++ b/packages/core/src/modules/devices/api/deviceSerialization.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import type { UserDevice } from '../data/entities'
+import { toDeprecatedSnakeCaseAliases, toIso } from './deviceList'
+
+// Detail contract for `GET /api/devices/admin/devices/:id`. Keys are camelCase like every other
+// module's responses (#5513); the snake_case keys stay alongside as deprecated aliases for one minor
+// version, per the deprecation protocol in BACKWARD_COMPATIBILITY.md § 7.
+// push_token is a secret and is never returned.
+export function serializeDeviceDetail(device: UserDevice): Record<string, unknown> {
+  const camel = {
+    id: device.id,
+    userId: device.userId,
+    deviceId: device.deviceId,
+    platform: device.platform,
+    clientAppVersion: device.clientAppVersion ?? null,
+    osVersion: device.osVersion ?? null,
+    pushProvider: device.pushProvider ?? null,
+    pushTokenUpdatedAt: toIso(device.pushTokenUpdatedAt),
+    lastSeenAt: toIso(device.lastSeenAt),
+    createdAt: toIso(device.createdAt),
+    updatedAt: toIso(device.updatedAt),
+  }
+  return { ...camel, ...toDeprecatedSnakeCaseAliases(camel) }
+}
+
+const deprecatedAlias = (of: string) => `Deprecated alias for \`${of}\`; removed in the next minor release.`
+
+export const deviceDetailItemSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  deviceId: z.string(),
+  platform: z.enum(['ios', 'android', 'web']),
+  clientAppVersion: z.string().nullable(),
+  osVersion: z.string().nullable(),
+  pushProvider: z.string().nullable(),
+  pushTokenUpdatedAt: z.string().nullable(),
+  lastSeenAt: z.string().nullable(),
+  createdAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+  user_id: z.string().uuid().describe(deprecatedAlias('userId')),
+  device_id: z.string().describe(deprecatedAlias('deviceId')),
+  client_app_version: z.string().nullable().describe(deprecatedAlias('clientAppVersion')),
+  os_version: z.string().nullable().describe(deprecatedAlias('osVersion')),
+  push_provider: z.string().nullable().describe(deprecatedAlias('pushProvider')),
+  push_token_updated_at: z.string().nullable().describe(deprecatedAlias('pushTokenUpdatedAt')),
+  last_seen_at: z.string().nullable().describe(deprecatedAlias('lastSeenAt')),
+  created_at: z.string().nullable().describe(deprecatedAlias('createdAt')),
+  updated_at: z.string().nullable().describe(deprecatedAlias('updatedAt')),
+})

--- a/packages/core/src/modules/devices/api/deviceSerialization.ts
+++ b/packages/core/src/modules/devices/api/deviceSerialization.ts
@@ -23,6 +23,7 @@ export function serializeDeviceDetail(device: UserDevice): Record<string, unknow
   return { ...camel, ...toDeprecatedSnakeCaseAliases(camel) }
 }
 
+// See the note in ./deviceList — the rendered deprecation notice lives on the endpoint description.
 const deprecatedAlias = (of: string) => `Deprecated alias for \`${of}\`; removed in the next minor release.`
 
 export const deviceDetailItemSchema = z.object({

--- a/packages/core/src/modules/devices/api/openapi.ts
+++ b/packages/core/src/modules/devices/api/openapi.ts
@@ -12,10 +12,18 @@ export function createPagedListResponseSchema(itemSchema: ZodTypeAny) {
 
 // createCrudOpenApiFactory already falls back to the shared default create/ok response schemas
 // when omitted, so there is nothing module-specific to re-pass or re-export here.
+// The shared zodToJsonSchema converter does not emit per-property descriptions for object schemas, so
+// the `.describe()` markers on the deprecated keys in deviceList.ts never reach the document. State the
+// deprecation in the endpoint description, which does render (#5513).
+export const DEPRECATED_SNAKE_CASE_NOTICE =
+  'Response keys are camelCase. The snake_case keys (`user_id`, `device_id`, `last_seen_at`, …) are ' +
+  'deprecated aliases of their camelCase counterparts, retained for one minor version and removed in ' +
+  'the next; read `userId`, `deviceId`, `lastSeenAt`, … instead.'
+
 const buildDevicesCrudOpenApi = createCrudOpenApiFactory({
   defaultTag: 'Devices',
   makeListDescription: ({ pluralLower }) =>
-    `Returns the authenticated user's registered ${pluralLower} (admins may list across users).`,
+    `Returns the authenticated user's registered ${pluralLower} (admins may list across users). ${DEPRECATED_SNAKE_CASE_NOTICE}`,
 })
 
 export function createDevicesCrudOpenApi(options: CrudOpenApiOptions): OpenApiRouteDoc {

--- a/packages/core/src/modules/devices/api/route.ts
+++ b/packages/core/src/modules/devices/api/route.ts
@@ -20,7 +20,13 @@ import {
 } from '../data/validators'
 import { resolveDeviceActorUserId } from './auth'
 import { createDevicesCrudOpenApi, createPagedListResponseSchema } from './openapi'
-import { deviceListSchema, deviceListFields, deviceListSortFieldMap, deviceListItemSchema } from './deviceList'
+import {
+  deviceListSchema,
+  deviceListFields,
+  deviceListSortFieldMap,
+  deviceListItemSchema,
+  transformDeviceListItem,
+} from './deviceList'
 import { executeRegister, type DeviceMutationContext } from './deviceOps'
 
 const logger = createLogger('devices')
@@ -59,6 +65,8 @@ const crud = makeCrudRoute({
     // push_token is a secret and is never exposed via the list API.
     fields: deviceListFields,
     sortFieldMap: deviceListSortFieldMap,
+    // The query engine projects raw column names; expose them in camelCase like every other module.
+    transformItem: transformDeviceListItem,
     // Exports are off for the self-serve list. The factory enables them for every list that does not
     // declare `export` (resolveAvailableExportFormats falls back to csv/json/xml/markdown), and its
     // full-export branch replaces the filters with `{}` instead of calling `buildFilters`

--- a/packages/core/src/modules/devices/backend/devices/[id]/page.tsx
+++ b/packages/core/src/modules/devices/backend/devices/[id]/page.tsx
@@ -12,13 +12,13 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 
 type DeviceDetail = {
   id: string
-  user_id: string
-  device_id: string
+  userId: string
+  deviceId: string
   platform: string
-  client_app_version: string | null
-  os_version: string | null
-  push_provider: string | null
-  updated_at: string | null
+  clientAppVersion: string | null
+  osVersion: string | null
+  pushProvider: string | null
+  updatedAt: string | null
 }
 
 type FormValues = {
@@ -65,7 +65,7 @@ export default function DeviceAdminEditPage({ params }: { params?: { id?: string
   // Resolve the owner's display name for a link to their profile. Devices admins may not hold
   // auth.users.list, so fall back to the raw id (rendered without a link) instead of redirecting.
   React.useEffect(() => {
-    const userId = device?.user_id
+    const userId = device?.userId
     if (!userId) return
     let cancelled = false
     void (async () => {
@@ -80,7 +80,7 @@ export default function DeviceAdminEditPage({ params }: { params?: { id?: string
       if (label) setUserLabel(label)
     })()
     return () => { cancelled = true }
-  }, [device?.user_id])
+  }, [device?.userId])
 
   const fields = React.useMemo<CrudField[]>(() => [
     { id: 'clientAppVersion', label: t('devices.form.appVersion'), type: 'text' },
@@ -122,7 +122,7 @@ export default function DeviceAdminEditPage({ params }: { params?: { id?: string
             <dl className="grid grid-cols-1 gap-3 rounded-md border bg-muted p-4 text-sm sm:grid-cols-3">
               <div>
                 <dt className="text-xs font-medium text-muted-foreground">{t('devices.form.deviceId')}</dt>
-                <dd className="mt-1"><code className="text-xs">{device.device_id}</code></dd>
+                <dd className="mt-1"><code className="text-xs">{device.deviceId}</code></dd>
               </div>
               <div>
                 <dt className="text-xs font-medium text-muted-foreground">{t('devices.form.platform')}</dt>
@@ -131,20 +131,20 @@ export default function DeviceAdminEditPage({ params }: { params?: { id?: string
               <div>
                 <dt className="text-xs font-medium text-muted-foreground">{t('devices.form.userId')}</dt>
                 <dd className="mt-1">{userLabel ? (
-                  <Link href={`/backend/users/${encodeURIComponent(device.user_id)}/edit`} className="text-primary hover:underline">{userLabel}</Link>
+                  <Link href={`/backend/users/${encodeURIComponent(device.userId)}/edit`} className="text-primary hover:underline">{userLabel}</Link>
                 ) : (
-                  <code className="text-xs">{device.user_id}</code>
+                  <code className="text-xs">{device.userId}</code>
                 )}</dd>
               </div>
             </dl>
           )}
           fields={fields}
           groups={groups}
-          optimisticLockUpdatedAt={device.updated_at}
+          optimisticLockUpdatedAt={device.updatedAt}
           initialValues={{
-            clientAppVersion: device.client_app_version ?? '',
-            osVersion: device.os_version ?? '',
-            pushProvider: device.push_provider ?? '',
+            clientAppVersion: device.clientAppVersion ?? '',
+            osVersion: device.osVersion ?? '',
+            pushProvider: device.pushProvider ?? '',
           }}
           submitLabel={t('common.save')}
           cancelHref="/backend/devices"

--- a/packages/core/src/modules/devices/backend/devices/page.tsx
+++ b/packages/core/src/modules/devices/backend/devices/page.tsx
@@ -15,15 +15,15 @@ import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar
 
 type Row = {
   id: string
-  user_id: string
-  device_id: string
+  userId: string
+  deviceId: string
   platform: string
-  client_app_version: string | null
-  os_version: string | null
-  push_provider: string | null
-  push_token_updated_at: string | null
-  last_seen_at: string | null
-  created_at: string | null
+  clientAppVersion: string | null
+  osVersion: string | null
+  pushProvider: string | null
+  pushTokenUpdatedAt: string | null
+  lastSeenAt: string | null
+  createdAt: string | null
 }
 
 type ResponsePayload = {
@@ -184,16 +184,16 @@ export default function DevicesAdminListPage() {
 
   const columns = React.useMemo<ColumnDef<Row>[]>(() => [
     {
-      accessorKey: 'device_id',
+      accessorKey: 'deviceId',
       header: t('devices.list.columns.device'),
-      cell: ({ row }) => <code className="text-xs">{row.original.device_id}</code>,
+      cell: ({ row }) => <code className="text-xs">{row.original.deviceId}</code>,
     },
     { accessorKey: 'platform', header: t('devices.list.columns.platform') },
     {
-      accessorKey: 'user_id',
+      accessorKey: 'userId',
       header: t('devices.list.columns.user'),
       cell: ({ row }) => {
-        const userId = row.original.user_id
+        const userId = row.original.userId
         const label = userLabelById.get(userId)
         return (
           // Stop the click bubbling to the row, whose default action navigates to the device edit page.
@@ -208,24 +208,24 @@ export default function DevicesAdminListPage() {
       },
     },
     {
-      accessorKey: 'client_app_version',
+      accessorKey: 'clientAppVersion',
       header: t('devices.list.columns.appVersion'),
-      cell: ({ row }) => row.original.client_app_version || t('devices.list.noValue'),
+      cell: ({ row }) => row.original.clientAppVersion || t('devices.list.noValue'),
     },
     {
-      accessorKey: 'os_version',
+      accessorKey: 'osVersion',
       header: t('devices.list.columns.osVersion'),
-      cell: ({ row }) => row.original.os_version || t('devices.list.noValue'),
+      cell: ({ row }) => row.original.osVersion || t('devices.list.noValue'),
     },
     {
-      accessorKey: 'push_provider',
+      accessorKey: 'pushProvider',
       header: t('devices.list.columns.pushProvider'),
-      cell: ({ row }) => row.original.push_provider || t('devices.list.noValue'),
+      cell: ({ row }) => row.original.pushProvider || t('devices.list.noValue'),
     },
     {
-      accessorKey: 'last_seen_at',
+      accessorKey: 'lastSeenAt',
       header: t('devices.list.columns.lastSeen'),
-      cell: ({ row }) => formatDate(row.original.last_seen_at, t),
+      cell: ({ row }) => formatDate(row.original.lastSeenAt, t),
     },
   ], [t, userLabelById])
 

--- a/packages/core/src/modules/push_notifications/backend/push_notifications/send/page.tsx
+++ b/packages/core/src/modules/push_notifications/backend/push_notifications/send/page.tsx
@@ -70,7 +70,7 @@ function DeviceField({ value, setValue, setFormValue, values, onState }: CrudCus
     let cancelled = false
     setLoading(true)
     const params = new URLSearchParams({ userId, pageSize: '50' })
-    apiCall<{ items?: Array<{ id: string; device_id: string; platform: string; push_provider?: string | null }> }>(
+    apiCall<{ items?: Array<{ id: string; deviceId: string; platform: string; pushProvider?: string | null }> }>(
       `/api/devices/admin/devices?${params.toString()}`,
       { headers: { 'x-om-forbidden-redirect': '0' } },
       { fallback: null },
@@ -80,9 +80,9 @@ function DeviceField({ value, setValue, setFormValue, values, onState }: CrudCus
         if (cancelled) return
         const items = (call && call.ok ? call.result?.items : []) ?? []
         const opts = items
-          .filter((d): d is { id: string; device_id: string; platform: string; push_provider?: string | null } =>
-            !!d && typeof d.id === 'string' && !!d.push_provider)
-          .map((d) => ({ id: d.id, label: `${d.device_id} · ${d.platform}${d.push_provider ? ` · ${d.push_provider}` : ''}`, platform: d.platform }))
+          .filter((d): d is { id: string; deviceId: string; platform: string; pushProvider?: string | null } =>
+            !!d && typeof d.id === 'string' && !!d.pushProvider)
+          .map((d) => ({ id: d.id, label: `${d.deviceId} · ${d.platform}${d.pushProvider ? ` · ${d.pushProvider}` : ''}`, platform: d.platform }))
         setDevices(opts)
         if (selected && !opts.some((o) => o.id === selected)) setValue('')
       })


### PR DESCRIPTION
## Summary

`GET /api/devices`, `GET /api/devices/admin/devices` and `GET /api/devices/admin/devices/:id` returned the raw database column names (`device_id`, `user_id`, `last_seen_at`, …) while every sibling module returns camelCase, so a client written against the platform convention read `undefined` for every field on this one module. All three routes now return **camelCase as the canonical shape**.

Both list routes declared `list.fields: deviceListFields` with no `transformItem`, so the CRUD factory handed the query engine's raw projection straight to the client; the admin detail route had the same problem via a hand-written snake_case `serializeDevice()`. The fix uses `transformItem` — the mechanism `warranty_claims`, `eudr`, `wms` and the `sales` line routes already use for exactly this — plus a shared detail serializer.

Note that the *request* side was already camelCase: `deviceListSortFieldMap` accepts `lastSeenAt` / `createdAt` / `updatedAt`. Only the response side disagreed with itself.

## 💥 Contract change — shipped as a bridge, not a rename

`BACKWARD_COMPATIBILITY.md` § 7 (API Route URLs, STABLE) says response fields MUST NOT be removed, and a retired surface keeps working for at least one minor version. A rename is a removal plus an addition, so the deprecation protocol applies even though the module shipped inside the current release window.

**Every snake_case key is still returned**, holding the same value as its camelCase counterpart, marked deprecated in the OpenAPI document and slated for removal no earlier than the next minor:

| Deprecated alias | Canonical key |
|---|---|
| `tenant_id` / `organization_id` | `tenantId` / `organizationId` (list routes only) |
| `user_id` / `device_id` | `userId` / `deviceId` |
| `client_app_version` / `os_version` | `clientAppVersion` / `osVersion` |
| `push_provider` / `push_token_updated_at` | `pushProvider` / `pushTokenUpdatedAt` |
| `last_seen_at` / `created_at` / `updated_at` | `lastSeenAt` / `createdAt` / `updatedAt` |

Removal later is a one-site change (drop the alias spread from `transformDeviceListItem` / `serializeDeviceDetail` and the deprecated keys from the two schemas), and `TC-DEV-007` asserts the aliases today so it cannot land unnoticed.

The issue argued for a hard rename since `devices` shipped in this release window. That is a maintainer call rather than an automated one, so this PR takes the reversible path — **say the word and I will drop the aliases**, which is a small follow-up commit.

## Changes

- `api/deviceList.ts` — `transformDeviceListItem` (reads either spelling, normalizes timestamps to ISO) + `toDeprecatedSnakeCaseAliases`; `deviceListItemSchema` gains the camelCase keys and describes the snake_case ones as deprecated
- `api/deviceSerialization.ts` (new) — `serializeDeviceDetail` + `deviceDetailItemSchema`, extracted from the admin `[id]` route so both surfaces share one casing decision and the serializer is unit-testable
- Both list routes wire `transformItem`; the admin detail route uses the shared serializer/schema
- First-party consumers migrated: devices admin list + edit pages (including the `optimisticLockUpdatedAt` source) and the push-notifications device picker
- Spec `.ai/specs/2026-08-24-devices-api-camelcase-responses.md` (with the required Migration & Backward Compatibility section), `UPGRADE_NOTES.md` entry, devices `AGENTS.md` rule

## Deliberately unchanged

- **`push_token` stays out of every response** under either spelling — asserted in both test layers.
- **The `exportScope=full` branch of the CRUD factory still bypasses `transformItem`** (it serializes `rawItems` through `normalizeFullRecordForExport`). That is framework-wide behavior shared by every module using `transformItem`, so a devices-local fix would be the wrong place for it. The paged export path — what a UI export button uses — does go through the transform.
- Route URLs, methods, request bodies, query params, sorting, filtering, scoping, ACLs, commands, events and the database schema.

## 🧪 Tests

- `__tests__/response-casing.test.ts` — list transform emits every camelCase key, aliases mirror their source, Date columns normalize to ISO, camelCase input is tolerated, keys beyond the projection (`cf_*`) survive, `push_token` never becomes `pushToken`, both schemas parse their serializer's output; detail serializer keeps ISO timestamps, nulls absent optionals and does not invent `tenant_id` / `organization_id`
- `__integration__/TC-DEV-007.spec.ts` — camelCase contract on both list routes and the detail route, plus the alias bridge
- `TC-DEV-001` / `TC-DEV-005` / `TC-DEV-006` are left asserting the snake_case keys on purpose: for the duration of the bridge they are the regression proof that no 0.7.0 consumer broke

## ✅ Validation

Full gate from `.ai/agentic.config.json`, run locally: `build:packages` → `generate` → `build:packages` → `i18n:check-sync` → `i18n:check-usage` → `typecheck` → `test` → `build:app`.

Everything passes except one package in `yarn test`: **`create-mercato-app` fails at baseline on this machine** (161 failing assertions — the `live Codex adapter` / `live Claude adapter` harness tests plus a timing-sensitive `yarn typecheck must complete within 120000ms` gate). I verified this is pre-existing by checking out untouched `origin/develop` in the same worktree and re-running: **identical failure count (161), identical suites**. The other 32 packages pass, including the `@open-mercato/core` suite that covers this change. CI is the authority on that package.

## ⚠️ Reviewer note

The devices list DataTable column ids change with the accessor keys, so a user's **saved perspective for `devices.list`** no longer matches the stored column ids and falls back to defaults once. Self-healing on the next save; flagging it since it is user-visible.

Closes #5513

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169849&installation_model_id=432243&pr_number=5571&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5571&signature=f30a6cc62479bff15f7edc9649573175c78b3eebc74c465a44c0fcc2d8d3f9b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->