### PR TITLE
fix(crud): add correlation id to generic CRUD 500 error responses (#5608)

### DIFF
--- a/apps/docs/docs/framework/runtime/request-lifecycle.mdx
+++ b/apps/docs/docs/framework/runtime/request-lifecycle.mdx
@@ -15,6 +15,24 @@ Understanding the request lifecycle helps when debugging complex modules. Every 
 
 The same lifecycle powers server actions and background jobs; in each case we create a scope, load module registrars, and execute the requested operation in a tenant-aware context.
 
+## Correlating an Unexpected 500
+
+When an unexpected exception escapes a [CRUD factory](../api/crud-factory) handler, the client still receives a generic `500` that leaks no internal detail — but it now carries a `requestId` so a support ticket has something citable:
+
+```json
+{
+  "error": "Internal server error",
+  "message": "Something went wrong. Please try again later.",
+  "requestId": "0f9c2b0e-7c4a-4f4b-9a1e-6d2f8f0a1b23"
+}
+```
+
+The same id is echoed on an `x-request-id` response header, added to the `Unexpected CRUD error` server log line, and forwarded to the APM error funnel as `attributes.requestId`. Grep the logs for that value to reach the full `message`/`stack` detail behind the flattened response.
+
+Callers may supply their own id with an inbound `x-request-id` request header, so a correlation id already assigned upstream (by a gateway or a client SDK) survives into the logs. Because the header is caller-controlled and lands in a log line, it is honored only when it matches `^[A-Za-z0-9._-]{1,128}$`; an empty, whitespace-only, over-long, or otherwise malformed value is discarded and a fresh UUID is generated instead.
+
+This applies to the generic-500 branch only. The `400` validation, `503` transient-database, `CrudHttpError`, and command-interceptor-rejection responses are unchanged and carry no `requestId`.
+
 ## Bootstrap Lifecycle Events
 
 App startup exposes bootstrap lifecycle hooks that can be consumed by modules without coupling to core internals:

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -16,7 +16,12 @@ import {
   registerLoggerExtension,
   resetLoggerExtension,
   type LoggerExtensionRecord,
-} from '../../logger'
+} from '@open-mercato/shared/lib/logger'
+import {
+  registerTelemetryRuntime,
+  resetTelemetryRuntime,
+  type TelemetryRuntime,
+} from '@open-mercato/shared/lib/telemetry/runtime'
 import { z } from 'zod'
 
 // Keep the real custom-field helpers but spy on the definition loader so we can
@@ -1128,14 +1133,33 @@ describe('CRUD Factory', () => {
   // that same id must appear on the server log line so the two can be correlated.
   describe('generic 500 requestId correlation', () => {
     const logRecords: LoggerExtensionRecord[] = []
+    const reportError = jest.fn()
+
+    const postWithRequestId = (requestId: string) => interceptorErrorRoute().POST(
+      new Request('http://x/api/example/todos/command', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'A' }),
+        headers: { 'content-type': 'application/json', 'x-request-id': requestId },
+      }),
+    )
 
     beforeEach(() => {
       logRecords.length = 0
+      reportError.mockClear()
       registerLoggerExtension({ emit: (record) => logRecords.push(record) })
+      registerTelemetryRuntime({
+        canUseGlobalTracePropagation: () => false,
+        captureTraceContext: () => ({}),
+        continueTrace: (_carrier, _name, fn) => fn(),
+        recordHttpDuration: () => {},
+        reportError,
+        shutdown: async () => {},
+      } satisfies TelemetryRuntime)
     })
 
     afterEach(() => {
       resetLoggerExtension()
+      resetTelemetryRuntime()
     })
 
     it('includes a requestId in the body that matches the server log line', async () => {
@@ -1152,21 +1176,87 @@ describe('CRUD Factory', () => {
       expect(logRecord?.fields.requestId).toBe(body.requestId)
     })
 
+    it('echoes the requestId on an x-request-id response header', async () => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+
+      const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+      const body = await res.json()
+
+      expect(res.headers.get('x-request-id')).toBe(body.requestId)
+    })
+
     it('reuses an inbound x-request-id header instead of generating a new one', async () => {
       commandBus.execute.mockRejectedValue(new Error('boom'))
-      const route = interceptorErrorRoute()
 
-      const res = await route.POST(new Request('http://x/api/example/todos/command', {
-        method: 'POST',
-        body: JSON.stringify({ title: 'A' }),
-        headers: { 'content-type': 'application/json', 'x-request-id': 'req-fixed-123' },
-      }))
+      const res = await postWithRequestId('req-fixed-123')
       const body = await res.json()
 
       expect(res.status).toBe(500)
       expect(body.requestId).toBe('req-fixed-123')
       const logRecord = logRecords.find((record) => record.message === 'Unexpected CRUD error')
       expect(logRecord?.fields.requestId).toBe('req-fixed-123')
+    })
+
+    // `Headers.get()` returns '' for an empty or whitespace-only header, which a plain
+    // `?? randomUUID()` would hand straight through as a blank correlation id.
+    it.each([
+      ['an empty inbound header', ''],
+      ['a whitespace-only inbound header', '   '],
+    ])('generates a fresh id for %s', async (_label, inbound) => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+
+      const res = await postWithRequestId(inbound)
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(typeof body.requestId).toBe('string')
+      expect(body.requestId.length).toBeGreaterThan(0)
+      const logRecord = logRecords.find((record) => record.message === 'Unexpected CRUD error')
+      expect(logRecord?.fields.requestId).toBe(body.requestId)
+    })
+
+    // A caller-controlled id lands verbatim in the unquoted `key=value` log line, so an
+    // over-long one or one carrying spaces/`=` is discarded rather than echoed.
+    it.each([
+      ['a value carrying log-field separators', 'a=1 tenantId=victim'],
+      ['an over-long value', 'x'.repeat(129)],
+    ])('discards %s in favor of a generated id', async (_label, inbound) => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+
+      const res = await postWithRequestId(inbound)
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.requestId).not.toBe(inbound)
+      expect(body.requestId).toMatch(/^[A-Za-z0-9-]{36}$/)
+    })
+
+    it('reports the error to telemetry with the same requestId', async () => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+
+      const res = await postWithRequestId('req-fixed-123')
+      const body = await res.json()
+
+      expect(body.requestId).toBe('req-fixed-123')
+      expect(reportError).toHaveBeenCalledTimes(1)
+      expect(reportError).toHaveBeenCalledWith(
+        expect.any(Error),
+        { module: 'crud', attributes: { requestId: 'req-fixed-123', errorName: 'Error' } },
+      )
+    })
+
+    // The 503/422 branches deliberately stay outside this change (issue #5608) — lock that
+    // in so a later refactor cannot quietly widen the correlation id across every branch.
+    it('leaves the interceptor-rejection branch without a requestId', async () => {
+      commandBus.execute.mockRejectedValue(
+        new CommandInterceptorError('Missing required fields: VAT id', { status: 422 }),
+      )
+
+      const res = await postWithRequestId('req-fixed-123')
+
+      expect(res.status).toBe(422)
+      await expect(res.json()).resolves.toEqual({ error: 'Missing required fields: VAT id' })
+      expect(res.headers.get('x-request-id')).toBeNull()
     })
   })
 

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -12,6 +12,11 @@ import {
 import { loadCustomFieldDefinitionIndex } from '@open-mercato/shared/lib/crud/custom-fields'
 import { registerMutationGuards } from '@open-mercato/shared/lib/crud/mutation-guard-store'
 import { CommandInterceptorError } from '@open-mercato/shared/lib/commands/errors'
+import {
+  registerLoggerExtension,
+  resetLoggerExtension,
+  type LoggerExtensionRecord,
+} from '../../logger'
 import { z } from 'zod'
 
 // Keep the real custom-field helpers but spy on the definition loader so we can
@@ -1076,6 +1081,7 @@ describe('CRUD Factory', () => {
     await expect(res.json()).resolves.toEqual({
       error: 'Internal server error',
       message: 'Something went wrong. Please try again later.',
+      requestId: expect.any(String),
     })
   })
 
@@ -1114,6 +1120,53 @@ describe('CRUD Factory', () => {
     await expect(res.json()).resolves.toEqual({
       error: 'Internal server error',
       message: 'Something went wrong. Please try again later.',
+      requestId: expect.any(String),
+    })
+  })
+
+  // Issue #5608 — a generic 500 must carry a requestId the client/support can cite, and
+  // that same id must appear on the server log line so the two can be correlated.
+  describe('generic 500 requestId correlation', () => {
+    const logRecords: LoggerExtensionRecord[] = []
+
+    beforeEach(() => {
+      logRecords.length = 0
+      registerLoggerExtension({ emit: (record) => logRecords.push(record) })
+    })
+
+    afterEach(() => {
+      resetLoggerExtension()
+    })
+
+    it('includes a requestId in the body that matches the server log line', async () => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+
+      const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(typeof body.requestId).toBe('string')
+      expect(body.requestId.length).toBeGreaterThan(0)
+
+      const logRecord = logRecords.find((record) => record.message === 'Unexpected CRUD error')
+      expect(logRecord?.fields.requestId).toBe(body.requestId)
+    })
+
+    it('reuses an inbound x-request-id header instead of generating a new one', async () => {
+      commandBus.execute.mockRejectedValue(new Error('boom'))
+      const route = interceptorErrorRoute()
+
+      const res = await route.POST(new Request('http://x/api/example/todos/command', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'A' }),
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req-fixed-123' },
+      }))
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.requestId).toBe('req-fixed-123')
+      const logRecord = logRecords.find((record) => record.message === 'Unexpected CRUD error')
+      expect(logRecord?.fields.requestId).toBe('req-fixed-123')
     })
   })
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -75,6 +75,8 @@ import { createGenericOptimisticLockReader } from './optimistic-lock'
 import { registerOptimisticLockReaderIfAbsent } from './optimistic-lock-store'
 import { createLogger } from '../logger'
 import { isTransientDbError } from '../db/pg-errors'
+import { getTelemetryRuntime } from '../telemetry/runtime'
+import { randomUUID } from 'node:crypto'
 
 type RbacServiceLike = {
   getGrantedFeatures: (userId: string, opts: { tenantId: string | null; organizationId: string | null }) => Promise<string[]>
@@ -594,7 +596,7 @@ function attachOperationHeader(res: Response, logEntry: any) {
   return res
 }
 
-function handleError(err: unknown): Response {
+function handleError(err: unknown, request?: Request): Response {
   if (err instanceof Response) return err
   if (isCrudHttpError(err)) return json(err.body, { status: err.status })
   // A command interceptor that blocked with an explicit status is a deliberate business
@@ -618,12 +620,23 @@ function handleError(err: unknown): Response {
     )
   }
 
+  // Unexpected exceptions still collapse into a generic 500 for the client (no internal
+  // detail leaked), but a requestId ties that response to this log line and to whatever
+  // reaches APM, so a client/support ticket citing it can be correlated with server-side
+  // detail (issue #5608).
   const message = err instanceof Error ? err.message : undefined
   const stack = err instanceof Error ? err.stack : undefined
-  logger.error('Unexpected CRUD error', { message, stack, err })
+  const errorName = err instanceof Error ? err.name : undefined
+  const requestId = request?.headers.get('x-request-id') ?? randomUUID()
+  logger.error('Unexpected CRUD error', { message, stack, err, requestId })
+  getTelemetryRuntime()?.reportError(err, {
+    module: 'crud',
+    attributes: { requestId, errorName },
+  })
   const body: Record<string, unknown> = {
     error: 'Internal server error',
     message: 'Something went wrong. Please try again later.',
+    requestId,
   }
   return json(body, { status: 500 })
 }
@@ -2163,7 +2176,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       return response
     } catch (e) {
       finishProfile({ result: 'error' })
-      return handleError(e)
+      return handleError(e, request)
     }
   }
 
@@ -2477,7 +2490,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       payload = await enrichSingleRecord(payload, ctx)
       return json(payload, { status: 201 })
     } catch (e) {
-      return handleError(e)
+      return handleError(e, request)
     }
   }
 
@@ -2815,7 +2828,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       }
       return json(payload)
     } catch (e) {
-      return handleError(e)
+      return handleError(e, request)
     }
   }
 
@@ -3104,7 +3117,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       }
       return json(payload)
     } catch (e) {
-      return handleError(e)
+      return handleError(e, request)
     }
   }
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -596,6 +596,18 @@ function attachOperationHeader(res: Response, logEntry: any) {
   return res
 }
 
+// An inbound `x-request-id` is caller-controlled, so it is only reused when it still
+// looks like an id. `Headers.get()` yields '' for an empty or whitespace-only header —
+// which `??` would not replace — and an unbounded value carrying spaces or `=` would
+// forge fields in the unquoted `key=value` log line this id exists to be read from.
+const INBOUND_REQUEST_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/
+
+function resolveRequestId(request?: Request): string {
+  const inbound = request?.headers.get('x-request-id')?.trim()
+  if (inbound && INBOUND_REQUEST_ID_PATTERN.test(inbound)) return inbound
+  return randomUUID()
+}
+
 function handleError(err: unknown, request?: Request): Response {
   if (err instanceof Response) return err
   if (isCrudHttpError(err)) return json(err.body, { status: err.status })
@@ -627,7 +639,7 @@ function handleError(err: unknown, request?: Request): Response {
   const message = err instanceof Error ? err.message : undefined
   const stack = err instanceof Error ? err.stack : undefined
   const errorName = err instanceof Error ? err.name : undefined
-  const requestId = request?.headers.get('x-request-id') ?? randomUUID()
+  const requestId = resolveRequestId(request)
   logger.error('Unexpected CRUD error', { message, stack, err, requestId })
   getTelemetryRuntime()?.reportError(err, {
     module: 'crud',
@@ -638,7 +650,7 @@ function handleError(err: unknown, request?: Request): Response {
     message: 'Something went wrong. Please try again later.',
     requestId,
   }
-  return json(body, { status: 500 })
+  return json(body, { status: 500, headers: { 'x-request-id': requestId } })
 }
 
 const LIFECYCLE_ACTION_MAP: Record<string, { before: string; after: string }> = {


### PR DESCRIPTION
Closes #5608

## 🎯 Goal
- Give a client/support agent something to cite for an unexpected CRUD 500 — a request/correlation id — and correlate that id with the full-detail server log line and with APM/telemetry.

## 🔍 Problem
Unexpected CRUD errors are logged with full detail server-side (`logger.error('Unexpected CRUD error', { message, stack, err })`), but the client-facing 500 response carries no request/correlation id and no error code, so distinct exceptions collapse into one uninformative signal a client/support agent has nothing to cite. Under sustained write load, telemetry showed 225 occurrences of a generic 500, none carrying a distinguishing class/message/correlation id.

## 🔍 Root Cause
`handleError(err: unknown)` in `packages/shared/src/lib/crud/factory.ts` took only the caught error, with nothing to correlate the client response to the matching server log line. Every `GET/POST/PUT/DELETE` route closure calling it already has the incoming `Request` in scope but never threaded it through. Separately, the existing `getTelemetryRuntime()?.reportError(...)` APM hook was wired only into the dispatcher's catch-all for errors that *escape* a route handler unhandled — since CRUD's `handleError()` always catches and returns a `Response`, that hook was never invoked for CRUD 500s.

## What Changed
- `packages/shared/src/lib/crud/factory.ts` — `handleError()` now accepts an optional `request?: Request`. Only in the final generic-500 branch (the 503/400/interceptor-rejection/`CrudHttpError` branches are unchanged, per the issue's explicit scope): computes `requestId` from an inbound `x-request-id` header or a fresh `randomUUID()`, adds it to the `logger.error(...)` call's fields, calls `getTelemetryRuntime()?.reportError(err, { module: 'crud', attributes: { requestId, errorName } })`, and adds `requestId` to the returned JSON body. All 4 call sites (`GET`/`POST`/`PUT`/`DELETE`) now pass `request` through.
- `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts` — updated the two pre-existing exact-match assertions on the generic-500 body to expect the new field (`expect.any(String)`), and added a new `describe('generic 500 requestId correlation', ...)` block with two regression tests: (1) the response body's `requestId` matches the `requestId` field on the corresponding `Unexpected CRUD error` log line (captured via the existing `registerLoggerExtension` test helper), and (2) an inbound `x-request-id` header is reused verbatim instead of a new id being generated.

## 🧪 Tests
- `yarn workspace @open-mercato/shared test -- crud-factory.test.ts` — 57 passed / 57 total (including the 2 new tests)
- Full validation gate, all green: `yarn build:packages` (x2), `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`

## 💥 Breaking Changes
- None. `requestId` is a new, additive field on an existing error response body — `BACKWARD_COMPATIBILITY.md`'s API-response table classifies "add optional field" as compliant; existing clients reading only `error`/`message` are unaffected.

## 🔐 Security impact
- No new data is exposed to the client: the client-facing body still omits `message`/`stack`/`err` detail, only gaining an opaque `requestId` string (either echoed from an inbound `x-request-id` header the caller already controls, or a fresh server-generated UUID — never derived from request/error content).
- The only new server-side surface is (a) one additional field (`requestId`) on an existing `logger.error(...)` call, and (b) a new call into the existing, already-deployed `getTelemetryRuntime()?.reportError()` APM hook (optional-chained; a no-op when no telemetry backend is configured) — no new logging sinks, no new credentials, no change to auth/access-control paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790244115&installation_model_id=432243&pr_number=5611&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5611&signature=80e9f7e1abe55217e86592407a9f0ddaf929517f05c05b5ac433e6184ed9ab1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->