### PR TITLE
fix(search): batch-index fulltext worker writes once, not once per record

### DIFF
--- a/packages/search/src/__tests__/search-indexer-batch.test.ts
+++ b/packages/search/src/__tests__/search-indexer-batch.test.ts
@@ -11,15 +11,20 @@ describe('SearchIndexer.indexRecordsById', () => {
           enabled: true,
           formatResult: async (ctx) => ({ title: String(ctx.record.name ?? ctx.record.id) }),
         },
+        {
+          entityId: 'test:other',
+          enabled: true,
+          formatResult: async (ctx) => ({ title: String(ctx.record.name ?? ctx.record.id) }),
+        },
       ],
     },
   ]
 
-  function makeQueryEngine(records: Record<string, unknown>[]): QueryEngine {
+  function makeQueryEngine(recordsByEntity: Record<string, Record<string, unknown>[]>): QueryEngine {
     return {
-      query: jest.fn(async (_entity, opts) => {
+      query: jest.fn(async (entity, opts) => {
         const wantedId = (opts?.filters as { id?: string } | undefined)?.id
-        const items = records.filter((r) => r.id === wantedId)
+        const items = (recordsByEntity[entity as string] ?? []).filter((r) => r.id === wantedId)
         return { items, total: items.length } as QueryResult
       }),
     }
@@ -33,18 +38,18 @@ describe('SearchIndexer.indexRecordsById', () => {
     ]
     const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
     const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
-      queryEngine: makeQueryEngine(records),
+      queryEngine: makeQueryEngine({ 'test:entity': records }),
     })
 
-    const result = await indexer.indexRecordsById(
-      [
+    const result = await indexer.indexRecordsById({
+      items: [
         { entityId: 'test:entity', recordId: 'rec-1' },
         { entityId: 'test:entity', recordId: 'rec-2' },
         { entityId: 'test:entity', recordId: 'rec-3' },
       ],
-      'tenant-123',
-      'org-456',
-    )
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+    })
 
     expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
     expect(searchService.bulkIndex).toHaveBeenCalledWith([
@@ -55,39 +60,155 @@ describe('SearchIndexer.indexRecordsById', () => {
     expect(result).toEqual({ indexed: 3, skipped: 0 })
   })
 
+  it('collapses records spanning multiple entities into one bulkIndex call', async () => {
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
+      queryEngine: makeQueryEngine({
+        'test:entity': [{ id: 'rec-1', name: 'Alpha' }],
+        'test:other': [{ id: 'other-1', name: 'Delta' }],
+      }),
+    })
+
+    const result = await indexer.indexRecordsById({
+      items: [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:other', recordId: 'other-1' },
+      ],
+      tenantId: 'tenant-123',
+      organizationId: null,
+    })
+
+    expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
+    expect(searchService.bulkIndex).toHaveBeenCalledWith([
+      expect.objectContaining({ entityId: 'test:entity', recordId: 'rec-1' }),
+      expect.objectContaining({ entityId: 'test:other', recordId: 'other-1' }),
+    ])
+    expect(result).toEqual({ indexed: 2, skipped: 0 })
+  })
+
+  it('loads each record with custom fields and without triggering auto-reindex', async () => {
+    const queryEngine = makeQueryEngine({ 'test:entity': [{ id: 'rec-1', name: 'Alpha' }] })
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, { queryEngine })
+
+    await indexer.indexRecordsById({
+      items: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+    })
+
+    expect(queryEngine.query).toHaveBeenCalledWith(
+      'test:entity',
+      expect.objectContaining({
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        filters: { id: 'rec-1' },
+        includeCustomFields: true,
+        skipAutoReindex: true,
+      }),
+    )
+  })
+
   it('skips records that no longer exist without failing the batch write', async () => {
     const records = [{ id: 'rec-1', name: 'Alpha' }]
     const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
     const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
-      queryEngine: makeQueryEngine(records),
+      queryEngine: makeQueryEngine({ 'test:entity': records }),
     })
 
-    const result = await indexer.indexRecordsById(
-      [
+    const result = await indexer.indexRecordsById({
+      items: [
         { entityId: 'test:entity', recordId: 'rec-1' },
         { entityId: 'test:entity', recordId: 'missing' },
       ],
-      'tenant-123',
-      null,
-    )
+      tenantId: 'tenant-123',
+      organizationId: null,
+    })
 
     expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
     expect(result).toEqual({ indexed: 1, skipped: 1 })
   })
 
+  it('keeps indexing the batch when loading one record throws', async () => {
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const queryEngine: QueryEngine = {
+      query: jest.fn(async (_entity, opts) => {
+        const wantedId = (opts?.filters as { id?: string } | undefined)?.id
+        if (wantedId === 'boom') throw new Error('connection lost')
+        return { items: [{ id: wantedId, name: 'Alpha' }], total: 1 } as QueryResult
+      }),
+    }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, { queryEngine })
+
+    const result = await indexer.indexRecordsById({
+      items: [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'boom' },
+        { entityId: 'test:entity', recordId: 'rec-2' },
+      ],
+      tenantId: 'tenant-123',
+      organizationId: null,
+    })
+
+    expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
+    expect(searchService.bulkIndex).toHaveBeenCalledWith([
+      expect.objectContaining({ recordId: 'rec-1' }),
+      expect.objectContaining({ recordId: 'rec-2' }),
+    ])
+    expect(result).toEqual({ indexed: 2, skipped: 1 })
+  })
+
+  it('propagates a bulkIndex failure so the queue can retry the job', async () => {
+    const searchService = { bulkIndex: jest.fn().mockRejectedValue(new Error('meilisearch unavailable')) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
+      queryEngine: makeQueryEngine({ 'test:entity': [{ id: 'rec-1', name: 'Alpha' }] }),
+    })
+
+    await expect(
+      indexer.indexRecordsById({
+        items: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+        tenantId: 'tenant-123',
+        organizationId: null,
+      }),
+    ).rejects.toThrow('meilisearch unavailable')
+  })
+
   it('skips entities that are not configured and never calls bulkIndex when nothing is indexable', async () => {
     const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
     const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
-      queryEngine: makeQueryEngine([]),
+      queryEngine: makeQueryEngine({}),
     })
 
-    const result = await indexer.indexRecordsById(
-      [{ entityId: 'unknown:entity', recordId: 'rec-1' }],
-      'tenant-123',
-      null,
-    )
+    const result = await indexer.indexRecordsById({
+      items: [{ entityId: 'unknown:entity', recordId: 'rec-1' }],
+      tenantId: 'tenant-123',
+      organizationId: null,
+    })
 
     expect(searchService.bulkIndex).not.toHaveBeenCalled()
     expect(result).toEqual({ indexed: 0, skipped: 1 })
+  })
+
+  it('counts records dropped for a missing id as skipped so the totals add up', async () => {
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const queryEngine: QueryEngine = {
+      query: jest.fn(async (_entity, opts) => {
+        const wantedId = (opts?.filters as { id?: string } | undefined)?.id
+        const item = wantedId === 'no-id' ? { name: 'Ghost' } : { id: wantedId, name: 'Alpha' }
+        return { items: [item], total: 1 } as QueryResult
+      }),
+    }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, { queryEngine })
+
+    const result = await indexer.indexRecordsById({
+      items: [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'no-id' },
+      ],
+      tenantId: 'tenant-123',
+      organizationId: null,
+    })
+
+    expect(result).toEqual({ indexed: 1, skipped: 1 })
   })
 })

--- a/packages/search/src/__tests__/search-indexer-batch.test.ts
+++ b/packages/search/src/__tests__/search-indexer-batch.test.ts
@@ -1,0 +1,93 @@
+import { SearchIndexer } from '../indexer/search-indexer'
+import type { SearchModuleConfig } from '../types'
+import type { QueryEngine, QueryResult } from '@open-mercato/shared/lib/query/types'
+
+describe('SearchIndexer.indexRecordsById', () => {
+  const moduleConfigs: SearchModuleConfig[] = [
+    {
+      entities: [
+        {
+          entityId: 'test:entity',
+          enabled: true,
+          formatResult: async (ctx) => ({ title: String(ctx.record.name ?? ctx.record.id) }),
+        },
+      ],
+    },
+  ]
+
+  function makeQueryEngine(records: Record<string, unknown>[]): QueryEngine {
+    return {
+      query: jest.fn(async (_entity, opts) => {
+        const wantedId = (opts?.filters as { id?: string } | undefined)?.id
+        const items = records.filter((r) => r.id === wantedId)
+        return { items, total: items.length } as QueryResult
+      }),
+    }
+  }
+
+  it('writes N queued records through exactly one bulkIndex call, not N', async () => {
+    const records = [
+      { id: 'rec-1', name: 'Alpha' },
+      { id: 'rec-2', name: 'Beta' },
+      { id: 'rec-3', name: 'Gamma' },
+    ]
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
+      queryEngine: makeQueryEngine(records),
+    })
+
+    const result = await indexer.indexRecordsById(
+      [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'rec-2' },
+        { entityId: 'test:entity', recordId: 'rec-3' },
+      ],
+      'tenant-123',
+      'org-456',
+    )
+
+    expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
+    expect(searchService.bulkIndex).toHaveBeenCalledWith([
+      expect.objectContaining({ entityId: 'test:entity', recordId: 'rec-1', tenantId: 'tenant-123', organizationId: 'org-456' }),
+      expect.objectContaining({ entityId: 'test:entity', recordId: 'rec-2', tenantId: 'tenant-123', organizationId: 'org-456' }),
+      expect.objectContaining({ entityId: 'test:entity', recordId: 'rec-3', tenantId: 'tenant-123', organizationId: 'org-456' }),
+    ])
+    expect(result).toEqual({ indexed: 3, skipped: 0 })
+  })
+
+  it('skips records that no longer exist without failing the batch write', async () => {
+    const records = [{ id: 'rec-1', name: 'Alpha' }]
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
+      queryEngine: makeQueryEngine(records),
+    })
+
+    const result = await indexer.indexRecordsById(
+      [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'missing' },
+      ],
+      'tenant-123',
+      null,
+    )
+
+    expect(searchService.bulkIndex).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ indexed: 1, skipped: 1 })
+  })
+
+  it('skips entities that are not configured and never calls bulkIndex when nothing is indexable', async () => {
+    const searchService = { bulkIndex: jest.fn().mockResolvedValue(undefined) }
+    const indexer = new SearchIndexer(searchService as any, moduleConfigs, {
+      queryEngine: makeQueryEngine([]),
+    })
+
+    const result = await indexer.indexRecordsById(
+      [{ entityId: 'unknown:entity', recordId: 'rec-1' }],
+      'tenant-123',
+      null,
+    )
+
+    expect(searchService.bulkIndex).not.toHaveBeenCalled()
+    expect(result).toEqual({ indexed: 0, skipped: 1 })
+  })
+})

--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -431,6 +431,30 @@ describe('SearchService', () => {
       expect(strategy.index).toHaveBeenCalledTimes(2)
     })
 
+    it('should bound in-flight writes when falling back to individual indexing', async () => {
+      let inFlight = 0
+      let peakInFlight = 0
+      const strategy = createMockStrategy({
+        id: 'test',
+        bulkIndex: undefined,
+        index: jest.fn(async () => {
+          inFlight++
+          peakInFlight = Math.max(peakInFlight, inFlight)
+          await new Promise<void>((resolve) => setTimeout(resolve, 0))
+          inFlight--
+        }),
+      })
+      const service = new SearchService({ strategies: [strategy] })
+      const records = Array.from({ length: 50 }, (_, index) =>
+        createMockRecord({ recordId: `rec-${index}` }),
+      )
+
+      await service.bulkIndex(records)
+
+      expect(strategy.index).toHaveBeenCalledTimes(50)
+      expect(peakInFlight).toBeLessThanOrEqual(4)
+    })
+
     it('should do nothing when records array is empty', async () => {
       const strategy = createMockStrategy({ id: 'test' })
       const service = new SearchService({ strategies: [strategy] })

--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -507,14 +507,14 @@ describe('Fulltext Index Worker', () => {
     // Verify the whole batch is written through exactly one indexRecordsById
     // call, not one indexRecordById call per record.
     expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledTimes(1)
-    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledWith(
-      [
+    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledWith({
+      items: [
         { entityId: 'test:entity', recordId: 'rec-1' },
         { entityId: 'test:entity', recordId: 'rec-2' },
       ],
-      'tenant-123',
-      undefined,
-    )
+      tenantId: 'tenant-123',
+      organizationId: undefined,
+    })
     expect(mockSearchIndexer.indexRecordById).not.toHaveBeenCalled()
   })
 
@@ -548,6 +548,36 @@ describe('Fulltext Index Worker', () => {
       expect.objectContaining({ type: 'fulltext', tenantId: 'tenant-123', delta: 2 }),
     )
     expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+  })
+
+  it('re-throws a failed fulltext batch write without advancing reindex progress so the queue retries it', async () => {
+    mockSearchIndexer.indexRecordsById.mockRejectedValueOnce(new Error('meilisearch unavailable'))
+    const records = [
+      { entityId: 'test:entity', recordId: 'rec-1' },
+      { entityId: 'test:entity', recordId: 'rec-2' },
+    ]
+    const containerWithProgress: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return [mockFulltextStrategy]
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        if (name === 'progressService') return { id: 'progress' }
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records,
+    })
+
+    await expect(
+      handleFulltextIndexJob(job, createMockJobContext(), containerWithProgress),
+    ).rejects.toThrow('meilisearch unavailable')
+
+    expect(updateReindexProgress).not.toHaveBeenCalled()
+    expect(incrementReindexProgress).not.toHaveBeenCalled()
   })
 
   it('clears an orphaned fulltext reindex lock instead of recreating it when no progress job is active', async () => {

--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -451,6 +451,7 @@ describe('Fulltext Index Worker', () => {
   const mockSearchIndexer = {
     getEntityConfig: jest.fn().mockReturnValue(null),
     indexRecordById: jest.fn().mockResolvedValue({ action: 'indexed', created: true }),
+    indexRecordsById: jest.fn().mockResolvedValue({ indexed: 0, skipped: 0 }),
   }
 
   const mockEm = {
@@ -471,6 +472,7 @@ describe('Fulltext Index Worker', () => {
     ;(hasActiveReindexProgress as jest.Mock).mockResolvedValue(true)
     mockFulltextStrategy.isAvailable.mockResolvedValue(true)
     mockSearchIndexer.indexRecordById.mockResolvedValue({ action: 'indexed', created: true })
+    mockSearchIndexer.indexRecordsById.mockResolvedValue({ indexed: 0, skipped: 0 })
   })
 
   it('should skip job with missing tenantId', async () => {
@@ -486,12 +488,13 @@ describe('Fulltext Index Worker', () => {
     expect(mockFulltextStrategy.bulkIndex).not.toHaveBeenCalled()
   })
 
-  it('should index records via searchIndexer when jobType is batch-index', async () => {
+  it('should index the whole batch in a single indexRecordsById call when jobType is batch-index', async () => {
     // Use minimal record format (just entityId + recordId)
     const records = [
       { entityId: 'test:entity', recordId: 'rec-1' },
       { entityId: 'test:entity', recordId: 'rec-2' },
     ]
+    mockSearchIndexer.indexRecordsById.mockResolvedValueOnce({ indexed: 2, skipped: 0 })
     const job = createMockJob<FulltextIndexJobPayload>({
       jobType: 'batch-index',
       tenantId: 'tenant-123',
@@ -501,26 +504,22 @@ describe('Fulltext Index Worker', () => {
 
     await handleFulltextIndexJob(job, ctx, mockContainer)
 
-    // Verify indexRecordById was called for each record
-    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(2)
-    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledWith({
-      entityId: 'test:entity',
-      recordId: 'rec-1',
-      tenantId: 'tenant-123',
-      organizationId: undefined,
-    })
-    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledWith({
-      entityId: 'test:entity',
-      recordId: 'rec-2',
-      tenantId: 'tenant-123',
-      organizationId: undefined,
-    })
+    // Verify the whole batch is written through exactly one indexRecordsById
+    // call, not one indexRecordById call per record.
+    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledTimes(1)
+    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledWith(
+      [
+        { entityId: 'test:entity', recordId: 'rec-1' },
+        { entityId: 'test:entity', recordId: 'rec-2' },
+      ],
+      'tenant-123',
+      undefined,
+    )
+    expect(mockSearchIndexer.indexRecordById).not.toHaveBeenCalled()
   })
 
   it('counts handled fulltext batch records as processed so progress can complete', async () => {
-    mockSearchIndexer.indexRecordById
-      .mockResolvedValueOnce({ action: 'skipped' })
-      .mockResolvedValueOnce({ action: 'skipped' })
+    mockSearchIndexer.indexRecordsById.mockResolvedValueOnce({ indexed: 0, skipped: 2 })
     const records = [
       { entityId: 'test:entity', recordId: 'rec-1' },
       { entityId: 'test:entity', recordId: 'rec-2' },
@@ -543,7 +542,7 @@ describe('Fulltext Index Worker', () => {
 
     await handleFulltextIndexJob(job, createMockJobContext(), containerWithProgress)
 
-    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(2)
+    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledTimes(1)
     expect(updateReindexProgress).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 2, 'org-456')
     expect(incrementReindexProgress).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'fulltext', tenantId: 'tenant-123', delta: 2 }),
@@ -572,7 +571,7 @@ describe('Fulltext Index Worker', () => {
 
     await handleFulltextIndexJob(job, createMockJobContext(), containerWithProgress)
 
-    expect(mockSearchIndexer.indexRecordById).toHaveBeenCalledTimes(1)
+    expect(mockSearchIndexer.indexRecordsById).toHaveBeenCalledTimes(1)
     expect(updateReindexProgress).not.toHaveBeenCalled()
     expect(incrementReindexProgress).not.toHaveBeenCalled()
     expect(clearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')

--- a/packages/search/src/indexer/search-indexer.ts
+++ b/packages/search/src/indexer/search-indexer.ts
@@ -34,6 +34,15 @@ export type IndexRecordParams = {
 }
 
 /**
+ * Parameters for indexing a batch of records by id in a single bulk write.
+ */
+export type IndexRecordsByIdParams = {
+  items: Array<{ entityId: EntityId; recordId: string }>
+  tenantId: string
+  organizationId?: string | null
+}
+
+/**
  * Parameters for deleting a record from the search index.
  */
 export type DeleteRecordParams = {
@@ -346,14 +355,12 @@ export class SearchIndexer {
    * Index a batch of records by id in a single bulk write.
    * Unlike calling indexRecordById() in a loop, this loads each record fresh
    * (same as indexRecordById) but flushes the whole batch through a single
-   * searchService.bulkIndex() call, so N queued records become exactly one
-   * write per available strategy instead of N.
+   * searchService.bulkIndex() call. Strategies that implement bulkIndex then
+   * collapse the batch into one write; strategies without it still write per
+   * record, at the bounded concurrency SearchService applies.
    */
-  async indexRecordsById(
-    items: Array<{ entityId: EntityId; recordId: string }>,
-    tenantId: string,
-    organizationId?: string | null,
-  ): Promise<{ indexed: number; skipped: number }> {
+  async indexRecordsById(params: IndexRecordsByIdParams): Promise<{ indexed: number; skipped: number }> {
+    const { items, tenantId, organizationId } = params
     if (!this.queryEngine || items.length === 0) {
       return { indexed: 0, skipped: items.length }
     }
@@ -392,13 +399,14 @@ export class SearchIndexer {
             continue
           }
 
-          const { records: built } = await this.buildIndexableRecords(
+          const { records: built, dropped } = await this.buildIndexableRecords(
             entityId,
             tenantId,
             organizationId ?? null,
             [record],
             config,
           )
+          skipped += dropped
           allRecords.push(...built)
         } catch (error) {
           skipped++

--- a/packages/search/src/indexer/search-indexer.ts
+++ b/packages/search/src/indexer/search-indexer.ts
@@ -343,6 +343,82 @@ export class SearchIndexer {
   }
 
   /**
+   * Index a batch of records by id in a single bulk write.
+   * Unlike calling indexRecordById() in a loop, this loads each record fresh
+   * (same as indexRecordById) but flushes the whole batch through a single
+   * searchService.bulkIndex() call, so N queued records become exactly one
+   * write per available strategy instead of N.
+   */
+  async indexRecordsById(
+    items: Array<{ entityId: EntityId; recordId: string }>,
+    tenantId: string,
+    organizationId?: string | null,
+  ): Promise<{ indexed: number; skipped: number }> {
+    if (!this.queryEngine || items.length === 0) {
+      return { indexed: 0, skipped: items.length }
+    }
+
+    const recordIdsByEntity = new Map<EntityId, string[]>()
+    for (const item of items) {
+      const list = recordIdsByEntity.get(item.entityId) ?? []
+      list.push(item.recordId)
+      recordIdsByEntity.set(item.entityId, list)
+    }
+
+    const allRecords: IndexableRecord[] = []
+    let skipped = 0
+
+    for (const [entityId, recordIds] of recordIdsByEntity) {
+      const config = this.entityConfigMap.get(entityId)
+      if (!config || config.enabled === false) {
+        skipped += recordIds.length
+        continue
+      }
+
+      for (const recordId of recordIds) {
+        try {
+          const result = await this.queryEngine.query(entityId, {
+            tenantId,
+            organizationId: organizationId ?? undefined,
+            filters: { id: recordId },
+            includeCustomFields: true,
+            page: { page: 1, pageSize: 1 },
+            skipAutoReindex: true,
+          })
+
+          const record = result.items[0] as Record<string, unknown> | undefined
+          if (!record) {
+            skipped++
+            continue
+          }
+
+          const { records: built } = await this.buildIndexableRecords(
+            entityId,
+            tenantId,
+            organizationId ?? null,
+            [record],
+            config,
+          )
+          allRecords.push(...built)
+        } catch (error) {
+          skipped++
+          searchError('SearchIndexer', 'Failed to load record for batch indexing', {
+            entityId,
+            recordId,
+            error: error instanceof Error ? error.message : error,
+          })
+        }
+      }
+    }
+
+    if (allRecords.length > 0) {
+      await this.searchService.bulkIndex(allRecords)
+    }
+
+    return { indexed: allRecords.length, skipped }
+  }
+
+  /**
    * Delete a record from the search index.
    */
   async deleteRecord(params: DeleteRecordParams): Promise<void> {

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -78,8 +78,9 @@ async function advanceFulltextReindexProgress(params: {
  * This handler processes single record indexing, batch indexing, deletion, and purge
  * operations for the fulltext search strategy.
  *
- * All indexing operations (single and batch) use searchIndexer.indexRecordById() to load
- * fresh data, ensuring consistency with the vector worker pattern.
+ * Single-record jobs load fresh data via searchIndexer.indexRecordById(). Batch jobs load
+ * fresh data per record via searchIndexer.indexRecordsById(), which flushes the whole batch
+ * through a single bulk write instead of one write per record.
  *
  * @param job - The queued job containing payload
  * @param jobCtx - Queue job context with job ID and attempt info
@@ -202,7 +203,7 @@ export async function handleFulltextIndexJob(
       return
     }
 
-    // ========== BATCH-INDEX: Use searchIndexer.indexRecordById() for fresh data ==========
+    // ========== BATCH-INDEX: Load fresh data, write the whole batch in one call ==========
     if (jobType === 'batch-index') {
       const { records, organizationId } = job.payload
       if (!records || records.length === 0) {
@@ -216,30 +217,13 @@ export async function handleFulltextIndexJob(
         throw new Error('searchIndexer not available for batch indexing')
       }
 
-      // Process each record using indexRecordById (same pattern as vector worker)
-      let successCount = 0
-      let failCount = 0
-
-      for (const { entityId, recordId } of records) {
-        try {
-          const result = await searchIndexer.indexRecordById({
-            entityId: entityId as EntityId,
-            recordId,
-            tenantId,
-            organizationId,
-          })
-          if (result.action === 'indexed') {
-            successCount++
-          }
-        } catch (error) {
-          failCount++
-          searchDebugWarn('fulltext-index.worker', 'Failed to index record in batch', {
-            entityId,
-            recordId,
-            error: error instanceof Error ? error.message : error,
-          })
-        }
-      }
+      // Load and index the whole batch through a single bulk write instead of
+      // one indexRecordById() call per record.
+      const { indexed: successCount, skipped: failCount } = await searchIndexer.indexRecordsById(
+        records.map(({ entityId, recordId }) => ({ entityId: entityId as EntityId, recordId })),
+        tenantId,
+        organizationId,
+      )
 
       await advanceFulltextReindexProgress({
         db,

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -219,11 +219,11 @@ export async function handleFulltextIndexJob(
 
       // Load and index the whole batch through a single bulk write instead of
       // one indexRecordById() call per record.
-      const { indexed: successCount, skipped: failCount } = await searchIndexer.indexRecordsById(
-        records.map(({ entityId, recordId }) => ({ entityId: entityId as EntityId, recordId })),
+      const { indexed: successCount, skipped: skippedCount } = await searchIndexer.indexRecordsById({
+        items: records.map(({ entityId, recordId }) => ({ entityId: entityId as EntityId, recordId })),
         tenantId,
         organizationId,
-      )
+      })
 
       await advanceFulltextReindexProgress({
         db,
@@ -239,7 +239,7 @@ export async function handleFulltextIndexJob(
         tenantId,
         requestedCount: records.length,
         successCount,
-        failCount,
+        skippedCount,
       })
 
       await recordIndexerLog(
@@ -249,7 +249,7 @@ export async function handleFulltextIndexJob(
           handler: 'worker:fulltext:batch-index',
           message: `Indexed ${successCount}/${records.length} records to fulltext`,
           tenantId,
-          details: { jobId: jobCtx.jobId, requestedCount: records.length, successCount, failCount },
+          details: { jobId: jobCtx.jobId, requestedCount: records.length, successCount, skippedCount },
         },
       )
       return

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -25,6 +25,38 @@ const DEFAULT_MERGE_CONFIG: ResultMergeConfig = {
  */
 const STRATEGY_AVAILABILITY_CACHE_TTL_MS = 2_000
 
+/**
+ * Maximum records indexed at once when bulkIndex falls back to per-record writes
+ * for a strategy that has no bulkIndex implementation (currently the vector
+ * strategy, whose index() performs an embedding-provider round trip per record).
+ * A whole reindex page arrives in one bulkIndex call, so an unbounded fan-out
+ * would burst hundreds of concurrent provider requests from a single job.
+ */
+const BULK_INDEX_FALLBACK_CONCURRENCY = 4
+
+/**
+ * Map items through an async worker with a fixed number of in-flight calls.
+ * Rejects with the first error, matching Promise.all semantics.
+ */
+async function mapWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return
+
+  let nextIndex = 0
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const currentIndex = nextIndex++
+      if (currentIndex >= items.length) return
+      await worker(items[currentIndex])
+    }
+  })
+
+  await Promise.all(runners)
+}
+
 function normalizeOrganizationFilter(options: SearchOptions): string[] | null {
   const single = typeof options.organizationId === 'string' ? options.organizationId.trim() : ''
   if (single) return [single]
@@ -235,8 +267,11 @@ export class SearchService {
         if (strategy.bulkIndex) {
           return strategy.bulkIndex(records)
         }
-        // Fallback to individual indexing
-        return Promise.all(records.map((record) => this.executeStrategyIndex(strategy, record)))
+        // Fallback to individual indexing, bounded so a strategy without a batch
+        // implementation cannot turn one batch job into hundreds of concurrent writes.
+        return mapWithConcurrency(records, BULK_INDEX_FALLBACK_CONCURRENCY, (record) =>
+          this.executeStrategyIndex(strategy, record),
+        )
       }),
     )
 


### PR DESCRIPTION
## Summary
- The Meilisearch fulltext worker's `batch-index` job type already receives multiple record ids in one job, but looped `searchIndexer.indexRecordById()` per record — one `addDocuments([doc])` HTTP write per record — even though the driver already has a working `bulkIndex()` path (`addDocuments(documents)`, grouped per tenant) that nothing used.
- Adds `SearchIndexer.indexRecordsById()`, which loads each queued record fresh (same load as `indexRecordById`) but flushes the whole batch through exactly one `searchService.bulkIndex()` call, and wires the worker's `batch-index` branch to call it once instead of looping.
- The real-time single-record path (`fulltext_upsert.ts` subscriber → `jobType: 'index'` → `indexRecord`/`indexRecordById`) is intentionally untouched — the issue's broader ask to debounce/batch that path changes queue/timing behavior on the hot write path, which `packages/search/AGENTS.md` flags as "Ask First" ("changing search strategy defaults, entity IDs, queue behavior"). Flagging this as a separate follow-up rather than guessing at debounce-window semantics in this PR.

## Test plan
- [x] `yarn workspace @open-mercato/search test` — 34 suites / 333 tests pass, including a new regression test (`search-indexer-batch.test.ts`) asserting N queued records across one or more entities collapse into exactly one `searchService.bulkIndex()` call, and updated `workers.test.ts` batch-index tests asserting `indexRecordsById` is called once (never `indexRecordById` in a loop).
- [x] `yarn workspace @open-mercato/search build`
- [x] `yarn typecheck` (all 30 packages)
- [x] `yarn i18n:check-sync`, `yarn i18n:check-usage`
- [x] `yarn test` (full monorepo) — only failure is the pre-existing, unrelated `packages/cli` `dev-env-reload.test.ts` inotify flake (known, tracked separately; does not touch search)
- [x] `yarn build:app`

## Security impact
None — internal indexing-pipeline change only; no auth, secrets, encryption, logging/audit, backups, or access-control surface touched.

Refs #5606 — this PR implements step 2 of that issue (the `batch-index` worker branch). Step 1 (batching/debouncing the real-time per-record write path, which the issue's latency evidence attributes the regression to) is intentionally out of scope, so the issue stays open rather than being auto-closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790244272&installation_model_id=432243&pr_number=5612&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5612&signature=229a6cce4bc86bf7bd46aeffdafb84183af088afeba1edc37ed4521fb4cbba99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
