### PR TITLE
fix(shared/query): promote BasicQueryEngine columnExists cache to process scope (#5605)

### DIFF
--- a/packages/shared/src/lib/query/__tests__/engine.count-distinct.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.count-distinct.test.ts
@@ -1,5 +1,12 @@
-import { BasicQueryEngine } from '../engine'
+import { BasicQueryEngine, clearColumnExistsCache } from '../engine'
 import { registerModules } from '../../i18n/server'
+
+// The column-existence answer is memoized on the module, not the instance (#5605), so
+// the per-test fake schemas below would otherwise inherit whatever the first test
+// probed for the same table names.
+beforeEach(() => {
+  clearColumnExistsCache()
+})
 
 // One entity extension on auth:user so includeExtensions exercises the joined-aggregate path.
 registerModules([

--- a/packages/shared/src/lib/query/__tests__/engine.scope-and-or.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.scope-and-or.test.ts
@@ -1,5 +1,15 @@
-import { BasicQueryEngine } from '../engine'
+import { BasicQueryEngine, clearColumnExistsCache } from '../engine'
 import { normalizeFilters } from '../join-utils'
+
+// The column-existence answer is memoized on the module, not the instance (#5605), and
+// the fixtures below declare mutually contradictory `information_schema.columns` shapes
+// for the same `scheduled_jobs` table. Without this clear, whichever test ran first
+// decides the scoping every later test sees — the automatic tenant/organization guard
+// would silently drop out of a query and the assertion for it would still be reading a
+// stale `false`.
+beforeEach(() => {
+  clearColumnExistsCache()
+})
 
 type FakeData = Record<string, any[]>
 

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -2,13 +2,14 @@ import { BasicQueryEngine } from '../engine'
 import { SortDir } from '../types'
 import { registerModules } from '../../i18n/server'
 import { clearSearchTokenPresenceCache } from '../../search/availability'
-import { clearEncryptedLikeFieldsCache } from '../engine'
+import { clearEncryptedLikeFieldsCache, clearColumnExistsCache } from '../engine'
 
 // The token-presence answer is cached process-wide (TTL); without clearing it,
 // probe-count assertions would observe hits from earlier tests in this file.
 beforeEach(() => {
   clearSearchTokenPresenceCache()
   clearEncryptedLikeFieldsCache()
+  clearColumnExistsCache()
 })
 
 // Mock modules with one entity extension
@@ -1413,5 +1414,58 @@ describe('BasicQueryEngine like/ilike routing by column encryption', () => {
       .then(() => {
         expect(applySearchTokensSpy).toHaveBeenCalled()
       })
+  })
+})
+
+describe('process-scoped column-existence cache (#5605)', () => {
+  const columnProbes = (fakeDb: any) =>
+    fakeDb._calls.filter((b: any) => b._ops.table === 'information_schema.columns')
+
+  const columnProbesFor = (fakeDb: any, column: string) =>
+    columnProbes(fakeDb).filter((b: any) =>
+      b._ops.wheres.some((w: any) => Array.isArray(w) && w[0] === 'column_name' && w[1] === '=' && w[2] === column)
+    )
+
+  test('the column-existence cache is shared across separate engine instances', async () => {
+    // `createRequestContainer()` builds a fresh `BasicQueryEngine` per HTTP request.
+    // The cache must live on the module, not the instance, so a later "request" (a
+    // second engine here) reuses the first request's answer instead of re-probing
+    // `information_schema.columns`.
+    const fakeDb = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+      ],
+    })
+    const queryOpts = { tenantId: 't1', fields: ['id'], page: { page: 1, pageSize: 10 } }
+
+    const engine1 = new BasicQueryEngine({} as any, () => fakeDb as any)
+    await engine1.query('customers:customer_entity', queryOpts)
+    const probesAfterFirstEngine = columnProbes(fakeDb).length
+    expect(probesAfterFirstEngine).toBeGreaterThan(0)
+
+    const engine2 = new BasicQueryEngine({} as any, () => fakeDb as any)
+    await engine2.query('customers:customer_entity', queryOpts)
+    expect(columnProbes(fakeDb).length).toBe(probesAfterFirstEngine)
+  })
+
+  test('a missing column is remembered as false instead of being re-queried on every call', async () => {
+    // Before the fix, `columnExists` deleted a `false` result instead of caching it,
+    // so `organization_id` (absent here) was re-queried once per query projection
+    // ('full' and 'count') within a single `.query()` call.
+    const fakeDb = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [],
+    })
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+
+    await engine.query('customers:customer_entity', {
+      tenantId: 't1',
+      organizationId: 'org1',
+      fields: ['id'],
+      page: { page: 1, pageSize: 10 },
+    })
+
+    expect(columnProbesFor(fakeDb, 'organization_id').length).toBe(1)
   })
 })

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -2,7 +2,7 @@ import { BasicQueryEngine } from '../engine'
 import { SortDir } from '../types'
 import { registerModules } from '../../i18n/server'
 import { clearSearchTokenPresenceCache } from '../../search/availability'
-import { clearEncryptedLikeFieldsCache, clearColumnExistsCache } from '../engine'
+import { clearEncryptedLikeFieldsCache, clearColumnExistsCache, columnExistsCacheSize } from '../engine'
 
 // The token-presence answer is cached process-wide (TTL); without clearing it,
 // probe-count assertions would observe hits from earlier tests in this file.
@@ -1417,7 +1417,7 @@ describe('BasicQueryEngine like/ilike routing by column encryption', () => {
   })
 })
 
-describe('process-scoped column-existence cache (#5605)', () => {
+describe('module-scoped column-existence cache (#5605)', () => {
   const columnProbes = (fakeDb: any) =>
     fakeDb._calls.filter((b: any) => b._ops.table === 'information_schema.columns')
 
@@ -1425,6 +1425,24 @@ describe('process-scoped column-existence cache (#5605)', () => {
     columnProbes(fakeDb).filter((b: any) =>
       b._ops.wheres.some((w: any) => Array.isArray(w) && w[0] === 'column_name' && w[1] === '=' && w[2] === column)
     )
+
+  const hasTenantGuard = (fakeDb: any) => {
+    const baseCall = fakeDb._calls.find((b: any) => b._ops.table === 'customer_entities')
+    return !!baseCall?._ops.wheres.some(
+      (w: any) => Array.isArray(w) && w[0] === 'customer_entities.tenant_id' && w[1] === '=' && w[2] === 't1',
+    )
+  }
+
+  const originalTtl = process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MS
+  const originalMaxEntries = process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES
+
+  afterEach(() => {
+    if (originalTtl === undefined) delete process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MS
+    else process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MS = originalTtl
+    if (originalMaxEntries === undefined) delete process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES
+    else process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES = originalMaxEntries
+    jest.restoreAllMocks()
+  })
 
   test('the column-existence cache is shared across separate engine instances', async () => {
     // `createRequestContainer()` builds a fresh `BasicQueryEngine` per HTTP request.
@@ -1467,5 +1485,90 @@ describe('process-scoped column-existence cache (#5605)', () => {
     })
 
     expect(columnProbesFor(fakeDb, 'organization_id').length).toBe(1)
+  })
+
+  test('a cached negative expires, so a migrated-in scope column is picked up without a process restart', async () => {
+    // A cached `false` is consumed where the tenant/organization/soft-delete predicates
+    // are applied, so a stale one does not merely slow a query down — it silently drops
+    // a scope guard. The TTL bounds that window: a migration applied against a running
+    // process (`yarn dev`, or pods not recycled by a separate migration release step)
+    // converges once the entry expires instead of never.
+    const now = 1_700_000_000_000
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now)
+
+    const beforeMigration = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [],
+    })
+    const queryOpts = { tenantId: 't1', fields: ['id'], page: { page: 1, pageSize: 10 } }
+    await new BasicQueryEngine({} as any, () => beforeMigration as any).query('customers:customer_entity', queryOpts)
+    expect(columnProbesFor(beforeMigration, 'tenant_id').length).toBe(1)
+    expect(hasTenantGuard(beforeMigration)).toBe(false)
+
+    // Same process, same cache — a second request while the entry is still fresh reuses
+    // the negative and does not re-probe, even though the column now exists.
+    const afterMigration = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+      ],
+    })
+    await new BasicQueryEngine({} as any, () => afterMigration as any).query('customers:customer_entity', queryOpts)
+    expect(columnProbesFor(afterMigration, 'tenant_id').length).toBe(0)
+    expect(hasTenantGuard(afterMigration)).toBe(false)
+
+    nowSpy.mockReturnValue(now + 300_001)
+
+    const afterTtl = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+      ],
+    })
+    await new BasicQueryEngine({} as any, () => afterTtl as any).query('customers:customer_entity', queryOpts)
+    expect(columnProbesFor(afterTtl, 'tenant_id').length).toBe(1)
+    expect(hasTenantGuard(afterTtl)).toBe(true)
+  })
+
+  test('the cache is bounded, so caller-supplied sort fields cannot grow it without limit', async () => {
+    // `columnExists` is reached with raw request input through `resolveBaseColumn` —
+    // `sortField` arrives from the query string and many list schemas type it as a plain
+    // string. Without a cap, one distinct name per request would be retained for the
+    // lifetime of the process.
+    process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES = '4'
+    const fakeDb = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [],
+    })
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+
+    for (let index = 0; index < 20; index += 1) {
+      await engine.query('customers:customer_entity', {
+        tenantId: 't1',
+        fields: ['id'],
+        sort: [{ field: `attacker_supplied_${index}`, dir: SortDir.Asc }],
+        page: { page: 1, pageSize: 10 },
+      })
+      expect(columnExistsCacheSize()).toBeLessThanOrEqual(4)
+    }
+  })
+
+  test('OM_QUERY_COLUMN_EXISTS_CACHE_MS=0 disables the memo and probes per request again', async () => {
+    process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MS = '0'
+    const fakeDb = createFakeKysely({
+      customer_entities: [],
+      'information_schema.columns': [
+        { table_name: 'customer_entities', column_name: 'tenant_id' },
+      ],
+    })
+    const queryOpts = { tenantId: 't1', fields: ['id'], page: { page: 1, pageSize: 10 } }
+
+    await new BasicQueryEngine({} as any, () => fakeDb as any).query('customers:customer_entity', queryOpts)
+    const probesAfterFirstEngine = columnProbesFor(fakeDb, 'tenant_id').length
+    expect(probesAfterFirstEngine).toBeGreaterThan(0)
+    expect(columnExistsCacheSize()).toBe(0)
+
+    await new BasicQueryEngine({} as any, () => fakeDb as any).query('customers:customer_entity', queryOpts)
+    expect(columnProbesFor(fakeDb, 'tenant_id').length).toBeGreaterThan(probesAfterFirstEngine)
   })
 })

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -33,6 +33,7 @@ import { warnOnCiphertextLikeFallback } from './ciphertext-search-warning'
 import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from './encrypted-sort'
 import { resolveListCountCap } from './count-cap'
 import { mapWithConcurrency } from './bounded-decrypt'
+import { parseNumberWithDefault } from '../number'
 import { createLogger } from '../logger'
 
 const logger = createLogger('shared').child({ component: 'query' })
@@ -89,17 +90,56 @@ export function clearEncryptedLikeFieldsCache(): void {
   encryptedLikeFieldsCache.clear()
 }
 
-// Process-scoped: schema shape (does a table have this column?) only changes on
-// migration, and a process restart already clears this Map, so it is always safe to
-// reuse across requests — unlike per-request state such as `tenantEncryptionService`.
-// Module-level on purpose: `createRequestContainer` builds a fresh `BasicQueryEngine`
+// Module-scoped on purpose: `createRequestContainer` builds a fresh `BasicQueryEngine`
 // per request, so an instance field alone re-pays the `information_schema` probe on
-// every request (#5605).
-const columnExistsCache = new Map<string, boolean>()
+// every request (#5605). Schema shape (does a table have this column?) is not
+// per-request state — unlike `tenantEncryptionService` — so sharing the answer across
+// requests is safe. One map per module instance rather than a true process singleton:
+// standalone builds can duplicate this package, which for a memo is harmless (two
+// caches, both correct), so nothing may be built on top of singleton semantics here.
+//
+// Bounded and TTL'd for two reasons. `columnExists` is reached with caller-supplied
+// field names via `resolveBaseColumn` (sort fields and base filter keys arrive raw from
+// the HTTP layer), so an unbounded map would grow monotonically on request input. And a
+// cached `false` is consumed where the tenant/organization/soft-delete predicates are
+// applied, so a schema change that adds one of those columns must not stay invisible
+// until the process restarts — a migration applied against a running `yarn dev` or
+// not-yet-recycled pods converges within the TTL instead. The TTL still removes
+// essentially all of the traffic: a hot column is probed twelve times an hour rather
+// than tens of thousands. Set OM_QUERY_COLUMN_EXISTS_CACHE_MS=0 to disable and probe
+// per request again; OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES tunes the bound.
+const COLUMN_EXISTS_CACHE_DEFAULT_TTL_MS = 300_000
+const COLUMN_EXISTS_CACHE_DEFAULT_MAX_ENTRIES = 10_000
+const columnExistsCache = new Map<string, { value: boolean; expiresAt: number }>()
 
-/** Test-only: the process-scoped memo would otherwise leak state across specs. */
+function resolveColumnExistsCacheTtlMs(): number {
+  return parseNumberWithDefault(process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MS, COLUMN_EXISTS_CACHE_DEFAULT_TTL_MS, { integer: true, min: 0 })
+}
+
+function resolveColumnExistsCacheMaxEntries(): number {
+  return parseNumberWithDefault(process.env.OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES, COLUMN_EXISTS_CACHE_DEFAULT_MAX_ENTRIES, { integer: true, min: 1 })
+}
+
+function storeColumnExists(key: string, value: boolean, ttlMs: number): void {
+  const maxEntries = resolveColumnExistsCacheMaxEntries()
+  if (columnExistsCache.size >= maxEntries) {
+    const now = Date.now()
+    for (const [entryKey, entry] of columnExistsCache) {
+      if (entry.expiresAt <= now) columnExistsCache.delete(entryKey)
+    }
+    if (columnExistsCache.size >= maxEntries) columnExistsCache.clear()
+  }
+  columnExistsCache.set(key, { value, expiresAt: Date.now() + ttlMs })
+}
+
+/** Test-only: the module-scoped memo would otherwise leak state across specs. */
 export function clearColumnExistsCache(): void {
   columnExistsCache.clear()
+}
+
+/** Test-only: entry count of the column-existence memo, for the cap regression test. */
+export function columnExistsCacheSize(): number {
+  return columnExistsCache.size
 }
 
 type ResolvedCustomFieldSource = {
@@ -673,7 +713,7 @@ export class BasicQueryEngine implements QueryEngine {
     // and cf filters are expressed as correlated EXISTS semi-joins, so nothing can
     // multiply base rows and a LIMIT above the query is an enforceable bound.
     // Re-running the WHERE/JOIN logic per projection is cheap: every `columnExists`
-    // check is memoized on the process-scoped `columnExistsCache`, so later passes
+    // check is memoized on the module-scoped `columnExistsCache`, so later passes
     // hit no extra DB calls.
     const buildQuery = async (projection: 'full' | 'sortKeys' | 'count'): Promise<BuiltQuery> => {
       const isSortKeysProjection = projection === 'sortKeys'
@@ -1558,8 +1598,9 @@ export class BasicQueryEngine implements QueryEngine {
 
   private async columnExists(table: string, column: string): Promise<boolean> {
     const key = `${table}.${column}`
+    const ttlMs = resolveColumnExistsCacheTtlMs()
     const cached = columnExistsCache.get(key)
-    if (cached !== undefined) return cached
+    if (cached && cached.expiresAt > Date.now()) return cached.value
     const db = this.getDb()
     const exists = await db
       .selectFrom('information_schema.columns' as any)
@@ -1569,7 +1610,7 @@ export class BasicQueryEngine implements QueryEngine {
       .limit(1)
       .executeTakeFirst()
     const present = !!exists
-    columnExistsCache.set(key, present)
+    if (ttlMs > 0) storeColumnExists(key, present, ttlMs)
     return present
   }
 

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -89,6 +89,19 @@ export function clearEncryptedLikeFieldsCache(): void {
   encryptedLikeFieldsCache.clear()
 }
 
+// Process-scoped: schema shape (does a table have this column?) only changes on
+// migration, and a process restart already clears this Map, so it is always safe to
+// reuse across requests — unlike per-request state such as `tenantEncryptionService`.
+// Module-level on purpose: `createRequestContainer` builds a fresh `BasicQueryEngine`
+// per request, so an instance field alone re-pays the `information_schema` probe on
+// every request (#5605).
+const columnExistsCache = new Map<string, boolean>()
+
+/** Test-only: the process-scoped memo would otherwise leak state across specs. */
+export function clearColumnExistsCache(): void {
+  columnExistsCache.clear()
+}
+
 type ResolvedCustomFieldSource = {
   entityId: EntityId
   alias: string
@@ -271,7 +284,6 @@ function computeCustomFieldScore(cfg: Record<string, unknown>, kind: string, ent
  * {@link HybridQueryEngine} when the query index is unavailable or incomplete.
  */
 export class BasicQueryEngine implements QueryEngine {
-  private columnCache = new Map<string, boolean>()
   private searchAliasSeq = 0
   private searchAvailabilityInstance: SearchTokenAvailability | null = null
 
@@ -661,7 +673,8 @@ export class BasicQueryEngine implements QueryEngine {
     // and cf filters are expressed as correlated EXISTS semi-joins, so nothing can
     // multiply base rows and a LIMIT above the query is an enforceable bound.
     // Re-running the WHERE/JOIN logic per projection is cheap: every `columnExists`
-    // check is memoized on `this.columnCache`, so later passes hit no extra DB calls.
+    // check is memoized on the process-scoped `columnExistsCache`, so later passes
+    // hit no extra DB calls.
     const buildQuery = async (projection: 'full' | 'sortKeys' | 'count'): Promise<BuiltQuery> => {
       const isSortKeysProjection = projection === 'sortKeys'
       const isCountProjection = projection === 'count'
@@ -1545,11 +1558,8 @@ export class BasicQueryEngine implements QueryEngine {
 
   private async columnExists(table: string, column: string): Promise<boolean> {
     const key = `${table}.${column}`
-    if (this.columnCache.has(key)) {
-      const cached = this.columnCache.get(key)
-      if (cached === true) return true
-      this.columnCache.delete(key)
-    }
+    const cached = columnExistsCache.get(key)
+    if (cached !== undefined) return cached
     const db = this.getDb()
     const exists = await db
       .selectFrom('information_schema.columns' as any)
@@ -1559,8 +1569,7 @@ export class BasicQueryEngine implements QueryEngine {
       .limit(1)
       .executeTakeFirst()
     const present = !!exists
-    if (present) this.columnCache.set(key, true)
-    else this.columnCache.delete(key)
+    columnExistsCache.set(key, present)
     return present
   }
 


### PR DESCRIPTION
Fixes #5605

## 🎯 Goal
- Make `BasicQueryEngine`'s column-existence check actually cache across requests, eliminating tens of thousands of avoidable `information_schema.columns` round-trips under load — without turning a per-request structure into an unbounded, never-expiring one.

## 🔍 Problem
Confirmed on two different modules (catalog and customers): the generic `queryEngine` DI service pays a full `information_schema.columns` probe per column check on effectively every request, even though `BasicQueryEngine` already had caching logic for exactly this.

## 🔍 Root Cause
`createRequestContainer()` (`packages/shared/src/lib/di/container.ts`) constructs a fresh `BasicQueryEngine` on every HTTP request. Its `columnCache` was a `private` **instance** field, so the cache was always empty at the start of a request and discarded at the end of it — the memoization never had a chance to pay off across requests. Separately, `columnExists()` only cached `true` results; a `false` (column absent) was deleted from the cache instead of remembered, so a persistently-absent column was re-probed on every projection pass (`full`/`sortKeys`/`count`) within a single `.query()` call.

## What Changed
- `packages/shared/src/lib/query/engine.ts` — replaced the `private columnCache` instance field with a module-level `columnExistsCache`, and made `columnExists()` cache both `true` and `false` answers instead of deleting `false` misses.
- The shared cache is **bounded and TTL'd**, following the pattern this package already uses for the equivalent structure in `packages/shared/src/lib/search/availability.ts` (a `{ value, expiresAt }` entry, a max-entry cap that sweeps expired entries before clearing wholesale, and a TTL from an env knob):
  - `OM_QUERY_COLUMN_EXISTS_CACHE_MS` — default `300000` (5 min); `0` disables the memo and probes per request again.
  - `OM_QUERY_COLUMN_EXISTS_CACHE_MAX_ENTRIES` — default `10000`.
  - **Why the bound:** `columnExists` is not only called with the fixed scope columns. It is reached with caller-supplied field names through `resolveBaseColumn`, and those names arrive raw from the HTTP layer (`sortField`, unmapped filter-param keys), so an unbounded map would retain one entry per distinct name for the life of the process.
  - **Why the TTL:** a cached `false` is consumed exactly where the `organization_id`, `tenant_id` and `deleted_at IS NULL` predicates are applied, so a stale negative does not degrade into slow queries — it silently drops a scope guard. The TTL bounds that window, so a migration applied against a long-lived process (a running `yarn dev`, or pods not recycled by a separate migration release step) converges instead of staying invisible until restart. It keeps essentially all of the win: a hot column is probed twelve times an hour rather than tens of thousands.
  - Added `clearColumnExistsCache()` and `columnExistsCacheSize()` (test-only) so specs don't leak cache state into each other and the cap is assertable.
- `packages/shared/src/lib/query/__tests__/engine.test.ts` — regression tests for the module-scoped cache: (1) two separate `BasicQueryEngine` instances (simulating two requests) share the cache; (2) a missing column (`organization_id`) is probed exactly once per `.query()` call instead of once per projection; (3) a cached negative expires at the TTL, so a migrated-in `tenant_id` is picked up and the tenant guard reappears without a restart; (4) the entry count stays under the cap under distinct-sort-field pressure; (5) `OM_QUERY_COLUMN_EXISTS_CACHE_MS=0` disables the memo.
- `packages/shared/src/lib/query/__tests__/engine.scope-and-or.test.ts` and `engine.count-distinct.test.ts` — clear the module-scoped memo in `beforeEach`. Their fixtures declare mutually contradictory `information_schema.columns` shapes for the same `scheduled_jobs` table, so promoting the cache to module scope had silently made the first test's answers decide later tests' scoping. It passed only by ordering coincidence.

## ↪️ Out of scope (tracked separately)
- `packages/core/src/modules/query_index/lib/engine.ts` has its own, separate `columnCache` on a different `BasicQueryEngine`-family class (the one covered by #2967) — untouched here, per #5605's own note that it's "related but distinct."
- **The `information_schema.tables` half of #5605** is not in this PR. `BasicQueryEngine` has no `tableCache`/`tableExists` member — the issue's citation points at `HybridQueryEngine` — but the table-probe traffic it measured is real and comes from `DefaultDataEngine.ensureStorageTableExists()` (`packages/shared/src/lib/data/engine.ts`), which is constructed fresh per request right beside the query engine. That is a different class in a different subsystem, so it is tracked in **#5619** rather than widening this diff. #5605 has been explicitly re-scoped to the columns half in [a comment](https://github.com/open-mercato/open-mercato/issues/5605#issuecomment-5410491092).

## 🧪 Tests
- `yarn workspace @open-mercato/shared test src/lib/query/__tests__/engine.test.ts` — 44 passed / 44 total
- `yarn workspace @open-mercato/shared test src/lib/query src/lib/search` — 275 passed / 5 skipped, 280 total (no regressions from the module-level cache leaking across specs)
- `yarn build:packages` — green
- `yarn workspace @open-mercato/shared typecheck` — green
- `yarn lint` — green (0 errors)

## 💥 Breaking Changes
- None. Purely internal caching/wiring change — no DI key, public type, exported signature, or API route changed. `clearColumnExistsCache()` and `columnExistsCacheSize()` are new internal exports used only by the test suite, mirroring the existing `clearEncryptedLikeFieldsCache()` convention in the same file. The two new env knobs are additive with safe defaults; unset behaviour is the intended production behaviour.

## 🔐 Security impact
- None. The cache only ever stores a boolean (does column X exist on table Y), never row data, and is keyed by `table:column` — no tenant- or request-scoped values are cached across requests. The cap prevents request-driven key names from growing it without limit, and the TTL bounds how long a stale negative can suppress a tenant/organization scope predicate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790246714&installation_model_id=432243&pr_number=5614&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5614&signature=b2ed9147148fca35e3539f55780e17e890bdfebf28e9aff331be5fffc37a6cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
