### PR TITLE
docs: document the notification delivery surface (#5591)

### DIFF
--- a/apps/docs/__tests__/notification-registry.test.mjs
+++ b/apps/docs/__tests__/notification-registry.test.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// The registry has no build artefact to read, so the map on the page is checked against the
+// convention files themselves. Mirrors apps/docs/__tests__/reference-example-module.test.mjs.
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const pageUrl = new URL('../docs/framework/modules/notification-delivery.mdx', import.meta.url);
+
+// Scaffold copies and generator source both contain the string but declare no live types.
+const EXCLUDED_FRAGMENTS = [
+  join('packages', 'create-app', 'template'),
+  join('packages', 'cli', 'src'),
+  join('external', 'official-modules'),
+];
+const SKIPPED_DIRECTORIES = new Set(['node_modules', 'dist', '.next', '.turbo', '.mercato']);
+
+function collectConventionFiles(dir, found = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      collectConventionFiles(full, found);
+    } else if (entry.name === 'notifications.ts') {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function conventionFiles() {
+  const files = [resolve(repoRoot, 'packages'), resolve(repoRoot, 'apps')]
+    .flatMap((root) => collectConventionFiles(root))
+    .filter((file) => !EXCLUDED_FRAGMENTS.some((fragment) => file.includes(fragment)))
+    // A module-root notifications.ts only; api/portal/notifications.ts and lib/notifications.ts
+    // are unrelated files that happen to share the name.
+    .filter((file) => /[\\/]modules[\\/][^\\/]+[\\/]notifications\.ts$/.test(file))
+    .sort();
+  assert.ok(
+    files.length > 0,
+    'found no notifications.ts convention files — a broken glob must fail loudly, not pass vacuously',
+  );
+  return files;
+}
+
+// Splits the `notificationTypes` array literal into one chunk per entry. The first `[` after the
+// binding name belongs to the `NotificationTypeDefinition[]` annotation, so the array is located
+// from the `=` instead.
+function splitTypeEntries(source) {
+  const binding = source.search(/notificationTypes[^=]*=\s*\[/);
+  if (binding < 0) return [];
+  const start = source.indexOf('[', source.indexOf('=', binding));
+  if (start < 0) return [];
+  const chunks = [];
+  let depth = 0;
+  let current = '';
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '{') {
+      depth += 1;
+      if (depth === 1) {
+        current = '';
+        continue;
+      }
+    }
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        chunks.push(current);
+        continue;
+      }
+    }
+    if (depth === 0 && char === ']') break;
+    if (depth >= 1) current += char;
+  }
+  return chunks;
+}
+
+function readRegistry() {
+  const types = new Map();
+  for (const file of conventionFiles()) {
+    const source = readFileSync(file, 'utf8');
+    // `type:` is not always a literal — push_notifications declares its two admin types through
+    // module-level constants, and a naive literal-only regex would silently drop them.
+    const constants = new Map();
+    for (const match of source.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=\s*'([^']+)'/g)) {
+      constants.set(match[1], match[2]);
+    }
+    for (const chunk of splitTypeEntries(source)) {
+      const declared = chunk.match(/(?:^|\n)\s*type:\s*(?:'([^']+)'|([A-Za-z_$][\w$]*))/);
+      if (!declared) continue;
+      const id = declared[1] ?? constants.get(declared[2]);
+      assert.ok(
+        id,
+        `could not resolve the type id in ${relative(repoRoot, file)} — extend the constant lookup rather than dropping the entry`,
+      );
+      types.set(id, {
+        file: relative(repoRoot, file),
+        declaresChannels: /(?:^|\n)\s*channels:\s*\[/.test(chunk),
+      });
+    }
+  }
+  assert.ok(types.size > 0, 'parsed no notification types out of the convention files');
+  return types;
+}
+
+function mapSection(pageSource) {
+  const start = pageSource.indexOf('<!-- notification-type-map:start -->');
+  const end = pageSource.indexOf('<!-- notification-type-map:end -->');
+  assert.ok(start >= 0 && end > start, 'the page must keep the notification-type-map markers');
+  return pageSource.slice(start, end);
+}
+
+function documentedRows(section) {
+  const rows = new Map();
+  for (const line of section.split('\n')) {
+    // Segments are not always lower_snake — `checkout.link.usageLimitReached` is camelCase.
+    const match = line.match(/^\|\s*`([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)`\s*\|/);
+    if (!match) continue;
+    rows.set(match[1], line);
+  }
+  return rows;
+}
+
+test('every registered notification type is documented in the map', async () => {
+  const registry = readRegistry();
+  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+
+  const missing = [...registry.keys()].filter((id) => !documented.has(id)).sort();
+  assert.deepEqual(
+    missing,
+    [],
+    'these notification types exist in the registry but are absent from notification-delivery.mdx',
+  );
+});
+
+test('every documented notification type still exists in the registry', async () => {
+  const registry = readRegistry();
+  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+
+  const stale = [...documented.keys()].filter((id) => !registry.has(id)).sort();
+  assert.deepEqual(
+    stale,
+    [],
+    'these notification types are documented but no longer declared by any module',
+  );
+});
+
+test('a type that declares no channels is rendered as eligible for every channel', async () => {
+  const registry = readRegistry();
+  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+
+  // The "no channels declared" default is the platform's sharpest edge (#5495): such a type becomes
+  // push-eligible the moment a tenant connects a provider. Pinning the marker means resolving that
+  // policy question cannot silently invalidate the page.
+  const mismarked = [];
+  for (const [id, entry] of registry) {
+    const row = documented.get(id);
+    if (!row) continue;
+    const marked = row.includes('— (all registered)');
+    if (entry.declaresChannels === marked) mismarked.push(id);
+  }
+  assert.deepEqual(
+    mismarked.sort(),
+    [],
+    'these rows disagree with their source about whether the type declares a channel list',
+  );
+});
+
+test('every source path referenced by the notification docs exists', async () => {
+  const pages = [
+    '../docs/framework/modules/notification-delivery.mdx',
+    '../docs/framework/modules/push-notifications.mdx',
+    '../docs/framework/modules/devices.mdx',
+    '../docs/user-guide/notifications-and-push.mdx',
+  ];
+  const missing = [];
+  for (const page of pages) {
+    const source = await readFile(new URL(page, import.meta.url), 'utf8');
+    for (const match of source.matchAll(/`((?:packages|apps)\/[A-Za-z0-9._/-]+\.[A-Za-z]+)`/g)) {
+      if (!existsSync(resolve(repoRoot, match[1]))) missing.push(`${page} → ${match[1]}`);
+    }
+  }
+  assert.deepEqual(missing.sort(), [], 'these referenced source paths no longer exist');
+});

--- a/apps/docs/__tests__/notification-registry.test.mjs
+++ b/apps/docs/__tests__/notification-registry.test.mjs
@@ -16,7 +16,18 @@ const EXCLUDED_FRAGMENTS = [
   join('packages', 'cli', 'src'),
   join('external', 'official-modules'),
 ];
-const SKIPPED_DIRECTORIES = new Set(['node_modules', 'dist', '.next', '.turbo', '.mercato']);
+// `build` and `.docusaurus` are produced by this workspace's own `test` script immediately before
+// this walk, so leaving them in would crawl the freshly built site on every run.
+const SKIPPED_DIRECTORIES = new Set([
+  'node_modules',
+  'dist',
+  '.next',
+  '.turbo',
+  '.mercato',
+  'build',
+  '.docusaurus',
+]);
+const ENTERPRISE_PACKAGE = join('packages', 'enterprise') + '/';
 
 function collectConventionFiles(dir, found = []) {
   let entries;
@@ -85,6 +96,29 @@ function splitTypeEntries(source) {
   return chunks;
 }
 
+/** The module directory the convention file sits in — the grouping the map's headings use. */
+function moduleOf(file) {
+  return /[\\/]modules[\\/]([^\\/]+)[\\/]notifications\.ts$/.exec(file)[1];
+}
+
+/** The rendered flag cell for one entry, in the order the map writes them. */
+function flagsOf(chunk) {
+  const flags = [];
+  if (/(?:^|\n)\s*nonOptOut:\s*true/.test(chunk)) flags.push('non-opt-out');
+  if (/(?:^|\n)\s*silent:\s*true/.test(chunk)) flags.push('silent');
+  if (/(?:^|\n)\s*hiddenFromSettings:\s*true/.test(chunk)) flags.push('hidden from settings');
+  return flags.length > 0 ? flags.join(', ') : '—';
+}
+
+/** The rendered channel cell — the declared ids, or the marker meaning "no restriction". */
+function channelsOf(chunk) {
+  const declared = chunk.match(/(?:^|\n)\s*channels:\s*\[([^\]]*)\]/);
+  if (!declared) return '— (all registered)';
+  const ids = [...declared[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+  assert.ok(ids.length > 0, 'a declared channels list must name at least one channel id');
+  return ids.map((id) => `\`${id}\``).join(', ');
+}
+
 function readRegistry() {
   const types = new Map();
   for (const file of conventionFiles()) {
@@ -103,8 +137,26 @@ function readRegistry() {
         id,
         `could not resolve the type id in ${relative(repoRoot, file)} — extend the constant lookup rather than dropping the entry`,
       );
+      const severity = chunk.match(/(?:^|\n)\s*severity:\s*'([^']+)'/);
+      assert.ok(
+        severity,
+        `${id} declares no literal severity in ${relative(repoRoot, file)} — extend the parser rather than dropping the field`,
+      );
+      const relativeFile = relative(repoRoot, file);
+      // Keyed on the type id, so two modules declaring the same id would otherwise collapse into one
+      // entry and a single documented row would satisfy both.
+      const previous = types.get(id);
+      assert.ok(
+        !previous,
+        `notification type ${id} is declared twice — ${previous?.file} and ${relativeFile}`,
+      );
       types.set(id, {
-        file: relative(repoRoot, file),
+        file: relativeFile,
+        module: moduleOf(file),
+        enterprise: relativeFile.startsWith(ENTERPRISE_PACKAGE),
+        severity: severity[1],
+        channels: channelsOf(chunk),
+        flags: flagsOf(chunk),
         declaresChannels: /(?:^|\n)\s*channels:\s*\[/.test(chunk),
       });
     }
@@ -120,20 +172,32 @@ function mapSection(pageSource) {
   return pageSource.slice(start, end);
 }
 
+/** Every documented row, with its cells and the group heading it sits under. */
 function documentedRows(section) {
   const rows = new Map();
+  let group = null;
   for (const line of section.split('\n')) {
+    const heading = line.match(/^####\s+`([^`]+)`(.*)$/);
+    if (heading) {
+      group = { module: heading[1], enterprise: heading[2].includes('*(enterprise)*') };
+      continue;
+    }
     // Segments are not always lower_snake — `checkout.link.usageLimitReached` is camelCase.
-    const match = line.match(/^\|\s*`([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)`\s*\|/);
+    const match = line.match(/^\|\s*`([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)`\s*\|(.*)$/);
     if (!match) continue;
-    rows.set(match[1], line);
+    const cells = match[2].split('|').map((cell) => cell.trim());
+    rows.set(match[1], { line, group, severity: cells[0], channels: cells[1], flags: cells[2] });
   }
   return rows;
 }
 
+async function registryAndRows() {
+  const page = await readFile(pageUrl, 'utf8');
+  return { registry: readRegistry(), documented: documentedRows(mapSection(page)), page };
+}
+
 test('every registered notification type is documented in the map', async () => {
-  const registry = readRegistry();
-  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+  const { registry, documented } = await registryAndRows();
 
   const missing = [...registry.keys()].filter((id) => !documented.has(id)).sort();
   assert.deepEqual(
@@ -144,8 +208,7 @@ test('every registered notification type is documented in the map', async () => 
 });
 
 test('every documented notification type still exists in the registry', async () => {
-  const registry = readRegistry();
-  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+  const { registry, documented } = await registryAndRows();
 
   const stale = [...documented.keys()].filter((id) => !registry.has(id)).sort();
   assert.deepEqual(
@@ -156,8 +219,7 @@ test('every documented notification type still exists in the registry', async ()
 });
 
 test('a type that declares no channels is rendered as eligible for every channel', async () => {
-  const registry = readRegistry();
-  const documented = documentedRows(mapSection(await readFile(pageUrl, 'utf8')));
+  const { registry, documented } = await registryAndRows();
 
   // The "no channels declared" default is the platform's sharpest edge (#5495): such a type becomes
   // push-eligible the moment a tenant connects a provider. Pinning the marker means resolving that
@@ -166,13 +228,68 @@ test('a type that declares no channels is rendered as eligible for every channel
   for (const [id, entry] of registry) {
     const row = documented.get(id);
     if (!row) continue;
-    const marked = row.includes('— (all registered)');
+    const marked = row.line.includes('— (all registered)');
     if (entry.declaresChannels === marked) mismarked.push(id);
   }
   assert.deepEqual(
     mismarked.sort(),
     [],
     'these rows disagree with their source about whether the type declares a channel list',
+  );
+});
+
+test('every documented row matches its source on severity, channels and flags', async () => {
+  const { registry, documented } = await registryAndRows();
+
+  // The whole row is asserted, not only the channels column: the page promises the map is
+  // machine-checked, and a wrong severity or a missing `non-opt-out` marker is exactly the kind of
+  // drift a reader cannot detect.
+  const wrong = [];
+  for (const [id, entry] of registry) {
+    const row = documented.get(id);
+    if (!row) continue;
+    for (const column of ['severity', 'channels', 'flags']) {
+      if (row[column] !== entry[column]) {
+        wrong.push(`${id}: ${column} documented as "${row[column]}", source says "${entry[column]}"`);
+      }
+    }
+  }
+  assert.deepEqual(wrong.sort(), [], 'these documented rows disagree with their convention file');
+});
+
+test('every type is grouped under its declaring module, and enterprise groups are marked', async () => {
+  const { registry, documented } = await registryAndRows();
+
+  // Twelve of the rows are declared in packages/enterprise and are unavailable to an OSS reader, so
+  // the marker on those headings is load-bearing rather than decorative.
+  const wrong = [];
+  for (const [id, entry] of registry) {
+    const row = documented.get(id);
+    if (!row) continue;
+    assert.ok(row.group, `${id} is documented outside any module heading`);
+    if (row.group.module !== entry.module) {
+      wrong.push(`${id}: grouped under \`${row.group.module}\`, declared by \`${entry.module}\``);
+    } else if (row.group.enterprise !== entry.enterprise) {
+      wrong.push(
+        entry.enterprise
+          ? `${entry.module}: declared in packages/enterprise but its heading carries no *(enterprise)* marker`
+          : `${entry.module}: marked *(enterprise)* but declared outside packages/enterprise`,
+      );
+    }
+  }
+  assert.deepEqual([...new Set(wrong)].sort(), [], 'these rows are grouped or marked incorrectly');
+});
+
+test('the stated no-channels ratio matches the registry', async () => {
+  const { registry, page } = await registryAndRows();
+
+  // The counts are prose on the one page that advertises machine-checked numbers, so adding a type
+  // without a `channels` list must fail here rather than quietly making the warning wrong.
+  const withoutChannels = [...registry.values()].filter((entry) => !entry.declaresChannels).length;
+  assert.match(
+    page,
+    new RegExp(`\\*\\*${withoutChannels} of the ${registry.size} types currently in the registry omit it\\*\\*`),
+    `the warning must state ${withoutChannels} of the ${registry.size} types — update notification-delivery.mdx`,
   );
 });
 

--- a/apps/docs/__tests__/push-env-table.test.mjs
+++ b/apps/docs/__tests__/push-env-table.test.mjs
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// The env table on push-notifications.mdx restates numbers that live in the module's source. Review
+// of #5618 found three rows that had gone to `—` while the code had real defaults, which is the
+// failure this file exists to make impossible: the table is checked against the source, not typed
+// from memory.
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const pageUrl = new URL('../docs/framework/modules/push-notifications.mdx', import.meta.url);
+const moduleRoot = resolve(repoRoot, 'packages/core/src/modules/push_notifications');
+
+// Test and integration sources set these variables rather than reading them for behaviour, so they
+// say nothing about what the module supports.
+const SKIPPED_SOURCE_FRAGMENTS = ['__tests__', '__integration__'];
+
+// Where each documented default and floor is declared. The numbers are NOT repeated here — only the
+// location — so changing a default in the module fails this test until the table is updated.
+const SOURCES = {
+  OM_PUSH_SEND_TIMEOUT_MS: {
+    file: 'lib/push-delivery.ts',
+    default: /const DEFAULT_SEND_TIMEOUT_MS = ([\d_]+)/,
+    min: /const MIN_SEND_TIMEOUT_MS = ([\d_]+)/,
+  },
+  OM_PUSH_STUCK_RECLAIM_MINUTES: {
+    file: 'lib/reclaim-window.ts',
+    default: /DEFAULT_STUCK_MINUTES = ([\d_]+)/,
+    min: /MIN_STUCK_MINUTES = ([\d_]+)/,
+  },
+  OM_PUSH_STUCK_RECLAIM_BATCH_LIMIT: {
+    file: 'lib/push-reaper.ts',
+    default: /DEFAULT_RECLAIM_BATCH_LIMIT = ([\d_]+)/,
+  },
+  OM_PUSH_RECLAIM_TICK_SECONDS: {
+    file: 'setup.ts',
+    default: /process\.env\.OM_PUSH_RECLAIM_TICK_SECONDS \?\? '([\d_]+)'/,
+    min: /Math\.max\(\s*([\d_]+),\s*\n?\s*Number\.parseInt\(process\.env\.OM_PUSH_RECLAIM_TICK_SECONDS/,
+  },
+  OM_PUSH_RECEIPT_MIN_AGE_MINUTES: {
+    file: 'lib/push-receipt-reaper.ts',
+    default: /envInt\('OM_PUSH_RECEIPT_MIN_AGE_MINUTES', ([\d_]+)\)/,
+  },
+  OM_PUSH_RECEIPT_MAX_AGE_MINUTES: {
+    file: 'lib/push-receipt-reaper.ts',
+    default: /envInt\('OM_PUSH_RECEIPT_MAX_AGE_MINUTES', ([\d_]+)\)/,
+  },
+  OM_PUSH_RECEIPT_BATCH_LIMIT: {
+    file: 'lib/push-receipt-reaper.ts',
+    default: /envInt\('OM_PUSH_RECEIPT_BATCH_LIMIT', ([\d_]+)\)/,
+  },
+};
+
+// Feature switches rather than tuned numbers: the table documents them as on/off, so there is no
+// numeric default to pin.
+const SWITCHES = new Set(['OM_ENABLE_PUSH_STUB_ADAPTER', 'OM_PUSH_FAKE_PROVIDERS']);
+
+function sourceFiles(dir, found = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_SOURCE_FRAGMENTS.includes(entry.name)) continue;
+      sourceFiles(full, found);
+    } else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+// A name reaches the runtime either as a property access or as a quoted literal handed to a helper
+// (`envInt('OM_…', 15)`, `const PUSH_STUB_ENV = 'OM_…'`). Unquoted mentions are prose in comments and
+// must not count as a read.
+const ENV_NAME = 'OM_[A-Z0-9_]*PUSH[A-Z0-9_]*';
+const ENV_READ_PATTERNS = [
+  new RegExp(`process\\.env\\.(${ENV_NAME})`, 'g'),
+  new RegExp(`'(${ENV_NAME})'`, 'g'),
+];
+
+/** Every env var the module actually reads, which is what the page's frontmatter promises to list. */
+function readEnvNames() {
+  const names = new Set();
+  for (const file of sourceFiles(moduleRoot)) {
+    const source = readFileSync(file, 'utf8');
+    for (const pattern of ENV_READ_PATTERNS) {
+      for (const match of source.matchAll(pattern)) names.add(match[1]);
+    }
+  }
+  assert.ok(names.size > 0, 'read no env vars out of the push_notifications module — the walk is broken');
+  return names;
+}
+
+/** The `Environment variables` table, as variable name → { default, effect }. */
+function documentedEnvRows(page) {
+  const start = page.indexOf('## Environment variables');
+  assert.ok(start >= 0, 'push-notifications.mdx must keep its Environment variables section');
+  const section = page.slice(start, page.indexOf('\n## ', start + 1));
+  const rows = new Map();
+  for (const line of section.split('\n')) {
+    const match = line.match(/^\|\s*`(OM_[A-Z0-9_]+)`\s*\|([^|]*)\|([^|]*)\|/);
+    if (!match) continue;
+    rows.set(match[1], { default: match[2].trim(), effect: match[3].trim() });
+  }
+  assert.ok(rows.size > 0, 'parsed no rows out of the Environment variables table');
+  return rows;
+}
+
+function sourceNumber(file, pattern, name, field) {
+  const source = readFileSync(resolve(moduleRoot, file), 'utf8');
+  const match = source.match(pattern);
+  assert.ok(match, `could not read the ${field} for ${name} out of ${file} — update the pattern`);
+  return Number(match[1].replaceAll('_', ''));
+}
+
+test('the env table lists exactly the variables the module reads', async () => {
+  const documented = documentedEnvRows(await readFile(pageUrl, 'utf8'));
+  const read = readEnvNames();
+
+  assert.deepEqual(
+    [...read].filter((name) => !documented.has(name)).sort(),
+    [],
+    'these env vars are read by push_notifications but missing from the table',
+  );
+  assert.deepEqual(
+    [...documented.keys()].filter((name) => !read.has(name)).sort(),
+    [],
+    'these env vars are documented but no longer read by push_notifications',
+  );
+});
+
+test('every documented default matches the value in the source', async () => {
+  const documented = documentedEnvRows(await readFile(pageUrl, 'utf8'));
+
+  const wrong = [];
+  for (const [name, row] of documented) {
+    if (SWITCHES.has(name)) {
+      if (row.default !== 'off') wrong.push(`${name}: a feature switch must document its default as "off"`);
+      continue;
+    }
+    const source = SOURCES[name];
+    assert.ok(source, `${name} has no source lookup — add one rather than leaving its default unchecked`);
+
+    // A default cell reads `<default>` or `<default> (min <floor>)`; anything else hides the number.
+    const cell = row.default.match(/^(\d+)(?: \(min (\d+)\))?$/);
+    if (!cell) {
+      wrong.push(`${name}: default cell "${row.default}" must be a number, optionally "N (min M)"`);
+      continue;
+    }
+    const expected = sourceNumber(source.file, source.default, name, 'default');
+    if (Number(cell[1]) !== expected) {
+      wrong.push(`${name}: documented default ${cell[1]}, source says ${expected}`);
+    }
+    if (cell[2] !== undefined) {
+      assert.ok(source.min, `${name} documents a floor but has no source lookup for it`);
+      const expectedMin = sourceNumber(source.file, source.min, name, 'floor');
+      if (Number(cell[2]) !== expectedMin) {
+        wrong.push(`${name}: documented floor ${cell[2]}, source says ${expectedMin}`);
+      }
+    }
+  }
+  assert.deepEqual(wrong.sort(), [], 'these env table rows disagree with the module source');
+});
+
+test('the send timeout row points at the clamp that can override it', async () => {
+  const page = await readFile(pageUrl, 'utf8');
+  const documented = documentedEnvRows(page);
+
+  // The effective timeout is min(configured, max(MIN, reclaim window - margin)), so a reader who
+  // takes the row at face value can set a value that is silently discarded. The row must say so and
+  // the page must carry the explanation.
+  assert.match(
+    documented.get('OM_PUSH_SEND_TIMEOUT_MS').effect,
+    /[Cc]lamped/,
+    'the send timeout row must state that the value is clamped',
+  );
+  assert.match(
+    documented.get('OM_PUSH_STUCK_RECLAIM_MINUTES').effect,
+    /send timeout/,
+    'the reclaim window row must state that it caps the send timeout',
+  );
+  assert.match(
+    page,
+    /The send timeout and the reclaim window are one knob, not two/,
+    'the page must keep the callout explaining the clamp',
+  );
+
+  const delivery = readFileSync(resolve(moduleRoot, 'lib/push-delivery.ts'), 'utf8');
+  assert.match(
+    delivery,
+    /Math\.min\(configured, ceiling\)/,
+    'the clamp is gone from push-delivery.ts — the callout on push-notifications.mdx is now wrong',
+  );
+});

--- a/apps/docs/docs/framework/modules/communication-channels.mdx
+++ b/apps/docs/docs/framework/modules/communication-channels.mdx
@@ -18,7 +18,7 @@ Three push providers ship today, all `channelType: 'push'` and `channelScope: 't
 - `@open-mercato/channel-apns` — Apple Push Notification service, directly
 - `@open-mercato/channel-expo` — Expo push service (Android and iOS)
 
-Push delivery itself is owned by the `push_notifications` module; these packages hold only the provider SDKs and their message builders. See the [Devices and push getting-started tutorial](../../tutorials/devices-and-push-getting-started.mdx).
+Push delivery itself is owned by the `push_notifications` module; these packages hold only the provider SDKs and their message builders. Push credentials are **tenant-scoped** (`channelScope: 'tenant'`), so they are connected through `POST /api/communication_channels/channels/connect/tenant-credentials` and the per-user connect route refuses them. See [Push Notifications](./push-notifications.mdx) and the [getting-started tutorial](../../tutorials/devices-and-push-getting-started.mdx).
 
 For the end-user perspective see the [Communication Channels user guide](../../user-guide/communication-channels.mdx).
 

--- a/apps/docs/docs/framework/modules/core-modules.mdx
+++ b/apps/docs/docs/framework/modules/core-modules.mdx
@@ -66,6 +66,8 @@ Open Mercato ships with the following built-in modules in `@open-mercato/core`. 
 | **Attachments** | `attachments` | File attachments and media management. |
 | **Messages** | `messages` | Internal messaging system with attachments, actions, and email forwarding. |
 | **Notifications** | `notifications` | In-app notifications with module-extensible types and actions. |
+| **Push Notifications** | `push_notifications` | Mobile push transport — device fan-out, provider adapters (FCM/APNs/Expo), delivery log and receipts. |
+| **Devices** | `devices` | Per-user device registry and encrypted push-token storage backing push delivery. |
 | **Audit & Action Logs** | `audit_logs` | Tracks user actions and data accesses with undo support scaffolding. |
 | **API Keys** | `api_keys` | Manage access tokens for external API access. |
 | **API Documentation** | `api_docs` | Auto-generated documentation for all HTTP endpoints. |

--- a/apps/docs/docs/framework/modules/devices.mdx
+++ b/apps/docs/docs/framework/modules/devices.mdx
@@ -1,0 +1,114 @@
+---
+title: Devices
+description: The per-tenant device registry — what a device row is, how a client app registers one, the self-serve vs admin API split, and how push tokens are protected.
+sidebar_label: Devices
+---
+
+# Devices
+
+## Overview
+
+- **Location**: `packages/core/src/modules/devices/`
+- **Package**: `@open-mercato/core`
+- **Requires**: `auth`
+
+`devices` is a registry, not a delivery mechanism. It answers one question — *which devices does this user have, and what push token does each hold* — and holds no notification logic whatsoever. Push is its first consumer; device-trust for MFA and device-aware audit are the designed-for later ones.
+
+A row is identified by the tuple `(tenant, organization, user, deviceId)`, enforced by a partial unique index over live rows:
+
+```sql
+create unique index "user_devices_tenant_org_user_device_active_unique" on "user_devices"
+  ("tenant_id","organization_id","user_id","device_id") nulls not distinct where deleted_at is null
+```
+
+Registering the same `deviceId` twice therefore updates the existing row rather than creating a second one, and re-registering a soft-deleted device revives it. A client app can call register on every launch.
+
+### Columns
+
+`id`, `tenant_id`, `organization_id`, `user_id`, `device_id`, `platform`, `client_app_version`, `os_version`, `locale`, `push_token`, `push_provider`, `push_token_updated_at`, `last_seen_at`, `created_at`, `updated_at`, `deleted_at` (`packages/core/src/modules/devices/data/entities.ts`).
+
+`device_id` is **your** identifier for the installation — a stable per-install string the app generates. It is not the push token and should survive a token rotation.
+
+## Registering a device from a client app
+
+This is the flow a mobile or web client performs after it obtains a push token from the platform SDK. It authenticates as the user; no admin permission is involved.
+
+```http
+POST /api/devices
+Authorization: Bearer <user session token>
+Content-Type: application/json
+
+{
+  "deviceId": "9d1f...-install-id",
+  "platform": "ios",
+  "clientAppVersion": "1.4.0",
+  "osVersion": "iOS 18.1",
+  "locale": "pl",
+  "pushToken": "<token from FCM / APNs / Expo>",
+  "pushProvider": "fcm"
+}
+```
+
+Response: `{ id, deviceId, revived }` — `revived: true` means a previously deactivated row for this `deviceId` came back.
+
+:::danger `pushProvider` must match a connected channel exactly
+The fan-out routes each device by looking up `device.pushProvider` among the tenant's **active** push channels, keyed on the channel's `providerKey`. A device whose `pushProvider` is misspelled, or left empty, or names a provider the tenant has not connected, is **silently skipped** — no delivery row, no error, only a warn-level log line. Send `fcm`, `apns` or `expo` to match the provider you connected. See [Push Notifications](./push-notifications.mdx).
+:::
+
+The token itself may be omitted (a device registered for identity/audit purposes without push). Fields are validated by `registerDeviceSchema` in `packages/core/src/modules/devices/data/validators.ts`; `locale` is accepted and used to pick the recipient's copy per device.
+
+Updating a token later is a `PUT /api/devices/:id`. `pushToken` and `pushProvider` are tri-state on update: absent leaves the stored value unchanged, an explicit `null` clears it.
+
+## Self-serve vs admin
+
+Two route trees, deliberately separate.
+
+| | Self-serve | Admin |
+|---|---|---|
+| Path | `/api/devices`, `/api/devices/:id` | `/api/devices/admin/devices`, `/api/devices/admin/devices/:id` |
+| Sees | Only the acting user's own devices | Every device in the caller's tenant/org scope |
+| Features | `devices.view` (read), `devices.manage` (write) | `devices.admin` |
+| Owner | Always the acting user | `userId` in the body — register on behalf of someone |
+| Exports | Disabled | Enabled |
+
+The self-serve list is scoped to the acting user in a way a client cannot widen: it consumes the advanced-filter state itself and AND-combines its own scope under `$and`, so no `filter[...]` key can overwrite it. API-key principals are not valid device actors and fail closed.
+
+The admin register-on-behalf route validates the target first — the user must exist in the caller's tenant, and the caller must have read access to that user's organization — returning `400 devices.errors.user_not_found` or `403` otherwise.
+
+### ACL
+
+`devices.view`, `devices.manage`, `devices.admin` (`packages/core/src/modules/devices/acl.ts`). Seeded to superadmin/admin (all three) and employee (`view` + `manage`) by `packages/core/src/modules/devices/setup.ts`. Existing tenants pick new grants up with `yarn mercato auth sync-role-acls`.
+
+Note that `devices.admin` does **not** imply `auth.users.list`. The admin screens degrade gracefully when it is missing: the user picker returns no suggestions and the owner column falls back to the raw id, rather than bouncing the page to `/login`.
+
+## The push token is a secret
+
+`push_token` is encrypted at rest — declared in `packages/core/src/modules/devices/encryption.ts` and read back through `findWithDecryption`. Beyond that:
+
+- **No endpoint returns it.** Not the self list, not the admin list, not the admin detail.
+- It is redacted from audit snapshots and mutation-guard payloads.
+- The delivery log stores only the last 8 characters, as a correlation aid.
+
+When a provider reports the token as permanently invalid, the delivery worker soft-deletes the device through the audited `devices.user_devices.deactivate` command — never a direct table write.
+
+## Admin UI
+
+Under **Settings → Auth**, gated on `devices.admin`:
+
+- `/backend/devices` — cross-user list, filterable by platform and by user
+- `/backend/devices/create` — register on behalf of a user (the owner field searches by name and email)
+- `/backend/devices/:id` — edit app version, OS version and push provider; owner, device id and platform are read-only
+
+## Commands and events
+
+Writes go through the command bus with undo support: `devices.user_devices.register`, `.update`, `.deactivate`. Events declared in `packages/core/src/modules/devices/events.ts`: `devices.user_device.registered`, `devices.user_device.deactivated`, plus the CRUD lifecycle trio.
+
+## Response shape
+
+Responses are camelCase (`userId`, `deviceId`, `pushProvider`, `lastSeenAt`, …). Every snake_case key is retained alongside its camelCase counterpart as a **deprecated alias for one minor version** — see `UPGRADE_NOTES.md`. Write new clients against the camelCase keys.
+
+## Related
+
+- [Notification Delivery](./notification-delivery.mdx) — the gate and the type registry
+- [Push Notifications](./push-notifications.mdx) — how a registered device actually receives a push
+- [Devices & Push Notifications — Getting Started](../../tutorials/devices-and-push-getting-started.mdx)

--- a/apps/docs/docs/framework/modules/notification-delivery.mdx
+++ b/apps/docs/docs/framework/modules/notification-delivery.mdx
@@ -106,7 +106,7 @@ A channel has two halves, in two different convention files — do not conflate 
 
 **Metadata** — what the preferences UI calls it. `notification-channels.ts`, exporting `notificationChannels: NotificationChannelDefinition[]`. Core ships one such file, `packages/core/src/modules/notifications/notification-channels.ts`, declaring `in_app`, `email` and `push`. It backs `GET /api/notifications/channels`.
 
-**Behavior** — what actually delivers. `notifications.delivery-strategies.ts`, exporting `deliveryStrategies`. The generator plugin declared in `packages/core/src/modules/notifications/generators.ts` collects them into a generated registry that `packages/core/src/modules/notifications/lib/delivery-strategies-registry.ts` installs at bootstrap. `push_notifications` ships exactly this and nothing more exotic — `packages/core/src/modules/push_notifications/notifications.delivery-strategies.ts` is three lines.
+**Behavior** — what actually delivers. `notifications.delivery-strategies.ts`, exporting `deliveryStrategies`. The generator plugin declared in `packages/core/src/modules/notifications/generators.ts` collects them into a generated registry that `packages/core/src/modules/notifications/lib/delivery-strategies-registry.ts` installs at bootstrap. `push_notifications` ships exactly this and nothing more exotic — `packages/core/src/modules/push_notifications/notifications.delivery-strategies.ts` is two imports and two exports.
 
 ```typescript
 // packages/<pkg>/src/modules/<module>/notifications.delivery-strategies.ts
@@ -148,7 +148,9 @@ ACL features: `notifications.view`, `notifications.create`, `notifications.manag
 
 Every type currently in the registry, grouped by the module that declares it. `— (all registered)` means the type declares no `channels` and is therefore eligible for every registered channel, push included.
 
-This map is asserted against the real convention files by `apps/docs/__tests__/notification-registry.test.mjs` — adding a type without documenting it here fails the docs test.
+This map is asserted against the real convention files by `apps/docs/__tests__/notification-registry.test.mjs` — every cell of every row, not just the type id, plus the two counts quoted in the warning above. Adding a type without documenting it here, or changing a type's severity, channels or flags without updating its row, fails the docs test.
+
+Groups marked *(enterprise)* are declared in `packages/enterprise` and are not present in an OSS install.
 
 <!-- notification-type-map:start -->
 #### `ai_assistant`
@@ -258,7 +260,7 @@ This map is asserted against the real convention files by `apps/docs/__tests__/n
 | `admin.custom_message` | info | — (all registered) | non-opt-out, hidden from settings |
 | `admin.custom_silent` | info | — (all registered) | non-opt-out, silent, hidden from settings |
 
-#### `record_locks`
+#### `record_locks` *(enterprise)*
 
 | Type | Severity | Declared channels | Flags |
 |---|---|---|---|
@@ -280,7 +282,7 @@ This map is asserted against the real convention files by `apps/docs/__tests__/n
 | `sales.quote.created` | info | `in_app`, `email` | — |
 | `sales.quote.expiring` | warning | `in_app`, `email` | — |
 
-#### `security`
+#### `security` *(enterprise)*
 
 | Type | Severity | Declared channels | Flags |
 |---|---|---|---|

--- a/apps/docs/docs/framework/modules/notification-delivery.mdx
+++ b/apps/docs/docs/framework/modules/notification-delivery.mdx
@@ -1,0 +1,337 @@
+---
+title: Notification Delivery
+description: How a notification type is registered by your code, which channels it may use, how the delivery gate decides, and every type currently in the registry.
+sidebar_label: Notification Delivery
+---
+
+# Notification Delivery
+
+Four modules cooperate to turn `notificationService.create(...)` into a banner on someone's phone. Each owns exactly one thing:
+
+| Module | Owns |
+|---|---|
+| `notifications` | The content, the **type registry**, per-user preferences, and the single delivery gate. |
+| `devices` | The address book — which devices a user has and what push token each holds. |
+| `push_notifications` | Transport for the `push` channel: fan-out, queue worker, retries, delivery log. |
+| `communication_channels` | The provider credentials and the adapter that talks to FCM / APNs / Expo. |
+
+This page is the map between them. For creating notifications (service API, batch, role- and feature-targeted sends, renderers) see [Notifications](./notifications.mdx); for the transport internals see [Push Notifications](./push-notifications.mdx) and [Devices](./devices.mdx).
+
+## The path a notification takes
+
+1. Your code calls `notificationService.create({ type, recipientUserId, ... })`.
+2. The **gate** runs once, at create time, per candidate channel — `packages/core/src/modules/notifications/lib/shouldDeliver.ts`. The surviving set is snapshotted onto the notification's `channels` column, so every downstream strategy obeys one decision instead of re-deriving it.
+3. The dispatcher invokes each surviving channel's **delivery strategy**.
+4. For `push`, that strategy enqueues a fan-out; the actual provider send happens in a worker, so a slow provider never blocks notification creation.
+
+The important consequence: **a channel that the gate removed is not "skipped later", it never reaches the strategy at all.** When you debug a missing notification, start at the gate.
+
+## Registering a notification type
+
+This is the part your own module writes. A notification type is declared in a `notifications.ts` file at the module root — a convention file the generator discovers (`packages/core/src/modules/notifications/generators.ts`). There is no runtime registration call and no central list to edit.
+
+```typescript
+// packages/<pkg>/src/modules/<module>/notifications.ts
+// or apps/mercato/src/modules/<module>/notifications.ts
+import type { NotificationTypeDefinition } from '@open-mercato/shared/modules/notifications/types'
+
+export const notificationTypes: NotificationTypeDefinition[] = [
+  {
+    type: 'shipping.shipment.delayed',
+    module: 'shipping',
+    channels: ['in_app', 'email', 'push'],
+    titleKey: 'shipping.notifications.shipmentDelayed.title',
+    bodyKey: 'shipping.notifications.shipmentDelayed.body',
+    icon: 'truck',
+    severity: 'warning',
+    actions: [
+      { id: 'view', labelKey: 'common.view', href: '/backend/shipping/shipments', icon: 'external-link' },
+    ],
+    linkHref: '/backend/shipping/shipments',
+    expiresAfterHours: 72,
+  },
+]
+```
+
+Then run `yarn generate`. Emitting one is an ordinary service call:
+
+```typescript
+await notificationService.create({
+  type: 'shipping.shipment.delayed',
+  recipientUserId: userId,
+  tenantId,
+  organizationId,
+  titleVariables: { trackingNumber },
+})
+```
+
+### The type definition
+
+Declared in `packages/shared/src/modules/notifications/types.ts`.
+
+| Field | Required | What it does |
+|---|---|---|
+| `type` | yes | Stable id, `module.entity.action`. Never rename one in place — a renamed type stops matching stored preferences, and in-flight notifications referencing it lose their `nonOptOut` enforcement. |
+| `module` | yes | Owning module id. |
+| `titleKey` / `bodyKey` | title yes | i18n keys resolved per recipient locale. |
+| `icon`, `severity` | yes / yes | `info` \| `warning` \| `success` \| `error`. |
+| `actions`, `primaryActionId`, `linkHref` | no | Buttons and the click-through target. |
+| `channels` | **no, and that matters** | The channels this type may *ever* use. See the warning below. |
+| `nonOptOut` | no | The recipient cannot disable it. Preference UIs render it locked; `setPreferences` refuses to store an opt-out row. Use for security and account alerts. |
+| `silent` | no | Push is delivered as a data-only wake-up instead of a visible alert. Style only — it does **not** imply non-opt-out. To force a silent push through, mark the type `nonOptOut` as well. |
+| `hiddenFromSettings` | no | Not mirrored to `notification_types`, so a client's preferences screen never lists it. For server-dispatched internal types. |
+| `category`, `labelKey`, `descriptionKey` | no | Grouping and copy for a preferences screen. `category` defaults to the prefix before the first dot. |
+| `expiresAfterHours` | no | Auto-expiry of the in-app row. |
+| `Renderer` | no | Client-side custom rendering — declared in `notifications.client.ts`, not here. |
+
+:::warning A type that omits `channels` is eligible for every registered channel
+`resolveEligibleChannels` returns `null` for such a type, and `null` means *no restriction* — not *no channels*. Once a tenant connects a push provider, every type without an explicit `channels` list becomes push-eligible. **37 of the 65 types currently in the registry omit it** (see the map below, where they render as `— (all registered)`).
+
+Whether the platform default should stay opt-out-per-type or become opt-in is an open policy question ([#5495](https://github.com/open-mercato/open-mercato/issues/5495)). Until it is settled, declare `channels` explicitly on every type you add.
+:::
+
+### Where a type ends up
+
+`syncNotificationTypes` (`packages/core/src/modules/notifications/lib/notification-type-registry.ts`) reconciles the in-memory catalogue into the `notification_types` table. That table is the read-through mirror remote clients use:
+
+- `GET /api/notifications/types` returns the visible catalogue with server-resolved `label`, `description` and `categoryLabel`, so a mobile app can render a preferences screen without shipping the backend dictionary.
+- Types marked `hiddenFromSettings` are not mirrored and never appear there, though they stay in the in-memory registry for delivery.
+- `PATCH /api/notifications/types` stores an operator override of `channels` / `nonOptOut` for the caller's tenant.
+
+Category labels live in the **declaring** module's `i18n/*.json` under `notifications.categories.<key>`; the `notifications` module deliberately ships none and holds no list of categories.
+
+## Channels
+
+A channel has two halves, in two different convention files — do not conflate them.
+
+**Metadata** — what the preferences UI calls it. `notification-channels.ts`, exporting `notificationChannels: NotificationChannelDefinition[]`. Core ships one such file, `packages/core/src/modules/notifications/notification-channels.ts`, declaring `in_app`, `email` and `push`. It backs `GET /api/notifications/channels`.
+
+**Behavior** — what actually delivers. `notifications.delivery-strategies.ts`, exporting `deliveryStrategies`. The generator plugin declared in `packages/core/src/modules/notifications/generators.ts` collects them into a generated registry that `packages/core/src/modules/notifications/lib/delivery-strategies-registry.ts` installs at bootstrap. `push_notifications` ships exactly this and nothing more exotic — `packages/core/src/modules/push_notifications/notifications.delivery-strategies.ts` is three lines.
+
+```typescript
+// packages/<pkg>/src/modules/<module>/notifications.delivery-strategies.ts
+export const deliveryStrategies = [myChannelDeliveryStrategy]
+```
+
+A strategy declares `id` (the channel id), `label`, `defaultEnabled`, and an async `deliver(ctx)`. Keep `deliver` fast: enqueue, do not send. `packages/core/src/modules/push_notifications/lib/push-delivery-strategy.ts` is the reference.
+
+## The delivery gate
+
+`shouldDeliver` is the one place a per-channel decision is made. A channel delivers when **all four** hold, in this order:
+
+1. It is a **registered strategy id**. An unregistered channel never delivers, whatever the type says.
+2. The type is **eligible** for it — the operator's stored override (`notification_types.channels`) if set, otherwise the code-declared `type.channels`. This runs *before* the `nonOptOut` bypass, so a channel outside the effective set is completely off for that type, even for a non-opt-out security alert.
+3. It is in the **per-send target**, when the caller supplied one.
+4. Either the type is effectively `nonOptOut`, **or** the recipient has not disabled it.
+
+`silent` is deliberately not consulted: it selects push *style*, not whether a channel delivers.
+
+A type id with no registered definition (a renamed or removed type still referenced by an in-flight notification) cannot have its code-declared `nonOptOut` enforced, so it becomes user-suppressible. The gate logs that once per type id per process — worth grepping for after a rename.
+
+### Operator overrides
+
+An operator changes a type's channel eligibility and its non-opt-out flag per tenant, without a code change, from **Settings → Notification Delivery** (`/backend/config/notifications`, feature `notifications.manage`). The override replaces the code-declared value for that tenant only, and beats user preferences in both directions: a channel removed there is off even for a `nonOptOut` type, and preference UIs lock the cell.
+
+### Preferences
+
+Preferences are stored per `(user, type, channel)`.
+
+| Screen | Path | Feature |
+|---|---|---|
+| A user's own preferences | `/backend/profile/notification-preferences` | `notifications.manage_preferences` |
+| Another user's preferences (admin) | `/backend/notifications/user-preferences` | `notifications.manage_user_preferences` |
+| Per-type channel eligibility (operator) | `/backend/config/notifications` | `notifications.manage` |
+
+ACL features: `notifications.view`, `notifications.create`, `notifications.manage`, `notifications.manage_preferences`, `notifications.manage_user_preferences` (`packages/core/src/modules/notifications/acl.ts`).
+
+## Registered notification types
+
+Every type currently in the registry, grouped by the module that declares it. `— (all registered)` means the type declares no `channels` and is therefore eligible for every registered channel, push included.
+
+This map is asserted against the real convention files by `apps/docs/__tests__/notification-registry.test.mjs` — adding a type without documenting it here fails the docs test.
+
+<!-- notification-type-map:start -->
+#### `ai_assistant`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `ai_assistant.conversation_shared` | info | — (all registered) | — |
+
+#### `auth`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `auth.account.locked` | warning | `in_app`, `email` | non-opt-out |
+| `auth.login.new_device` | info | `in_app`, `email` | non-opt-out |
+| `auth.password_reset.completed` | success | `in_app`, `email` | — |
+| `auth.password_reset.requested` | info | `in_app`, `email` | — |
+| `auth.role.assigned` | success | `in_app`, `email` | — |
+| `auth.role.revoked` | warning | `in_app`, `email` | — |
+
+#### `business_rules`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `business_rules.rule.execution_failed` | error | `in_app`, `email` | — |
+
+#### `catalog`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `catalog.product.low_stock` | warning | `in_app`, `email` | — |
+
+#### `checkout`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `checkout.link.usageLimitReached` | warning | — (all registered) | — |
+| `checkout.transaction.completed` | success | — (all registered) | — |
+| `checkout.transaction.failed` | error | — (all registered) | — |
+
+#### `communication_channels`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `communication_channels.channel.requires_reauth` | warning | `in_app`, `email` | — |
+| `communication_channels.message.received` | info | `in_app`, `email` | — |
+
+#### `customer_accounts`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `customer_accounts.domain_mapping.activated` | success | `in_app`, `email` | — |
+| `customer_accounts.domain_mapping.dns_failed` | warning | `in_app`, `email` | — |
+| `customer_accounts.domain_mapping.tls_failed` | warning | `in_app`, `email` | — |
+| `customer_accounts.domain_mapping.verified` | success | `in_app`, `email` | — |
+| `customer_accounts.user.locked` | warning | `in_app`, `email` | — |
+| `customer_accounts.user.signup` | info | `in_app`, `email` | — |
+
+#### `customers`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `customers.deal.lost` | warning | `in_app`, `email` | — |
+| `customers.deal.won` | success | `in_app`, `email` | — |
+
+#### `documents`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `documents.comment.mentioned` | info | — (all registered) | — |
+| `documents.watch.changed` | info | — (all registered) | — |
+| `documents.watch.commented` | info | — (all registered) | — |
+
+#### `eudr`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `eudr.mitigation.completed` | success | — (all registered) | — |
+| `eudr.risk.non_negligible` | warning | — (all registered) | — |
+| `eudr.statement.reference_issued` | success | — (all registered) | — |
+| `eudr.statement.submitted` | info | — (all registered) | — |
+| `eudr.statement.withdrawn` | warning | — (all registered) | — |
+
+#### `example`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `demo.push_playground` | info | — (all registered) | — |
+| `demo.silent_ping` | info | — (all registered) | silent |
+| `example.umes.actionable` | info | — (all registered) | — |
+
+#### `inbox_ops`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `inbox_ops.proposal.created` | info | `in_app`, `email` | — |
+
+#### `messages`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `messages.new` | info | `in_app`, `email` | — |
+
+#### `push_notifications`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `admin.custom_message` | info | — (all registered) | non-opt-out, hidden from settings |
+| `admin.custom_silent` | info | — (all registered) | non-opt-out, silent, hidden from settings |
+
+#### `record_locks`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `record_locks.conflict.detected` | warning | — (all registered) | — |
+| `record_locks.conflict.resolved` | info | — (all registered) | — |
+| `record_locks.incoming_changes.available` | info | — (all registered) | — |
+| `record_locks.lock.contended` | warning | — (all registered) | — |
+| `record_locks.lock.force_released` | warning | — (all registered) | — |
+| `record_locks.participant.joined` | info | — (all registered) | — |
+| `record_locks.participant.left` | info | — (all registered) | — |
+| `record_locks.record.deleted` | warning | — (all registered) | — |
+
+#### `sales`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `sales.order.created` | info | `in_app`, `email` | — |
+| `sales.payment.received` | success | `in_app`, `email` | — |
+| `sales.quote.created` | info | `in_app`, `email` | — |
+| `sales.quote.expiring` | warning | `in_app`, `email` | — |
+
+#### `security`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `security.mfa.enforcement_deadline` | warning | — (all registered) | — |
+| `security.mfa.enrolled` | success | — (all registered) | — |
+| `security.mfa.reset` | warning | — (all registered) | — |
+| `security.password.changed` | success | — (all registered) | — |
+
+#### `staff`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `staff.leave_request.approved` | success | `in_app`, `email` | — |
+| `staff.leave_request.pending` | warning | `in_app`, `email` | — |
+| `staff.leave_request.rejected` | warning | `in_app`, `email` | — |
+
+#### `warranty_claims`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `warranty_claims.claim.assigned` | info | — (all registered) | — |
+| `warranty_claims.claim.customer_replied` | info | — (all registered) | — |
+| `warranty_claims.claim.escalated` | warning | — (all registered) | — |
+| `warranty_claims.claim.status_changed` | info | — (all registered) | — |
+| `warranty_claims.claim.submitted` | info | — (all registered) | — |
+
+#### `webhooks`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `webhooks.delivery.failed` | error | — (all registered) | — |
+
+#### `wms`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `wms.inventory.low_stock` | warning | — (all registered) | — |
+| `wms.inventory.reservation_shortfall` | warning | — (all registered) | — |
+
+#### `workflows`
+
+| Type | Severity | Declared channels | Flags |
+|---|---|---|---|
+| `workflows.task.assigned` | info | `in_app`, `email` | — |
+<!-- notification-type-map:end -->
+
+## Related
+
+- [Notifications](./notifications.mdx) — creating notifications, renderers, batch and role-targeted sends
+- [Devices](./devices.mdx) — the device registry push delivers to
+- [Push Notifications](./push-notifications.mdx) — the push transport
+- [Communications Hub](./communication-channels.mdx) — provider credentials and adapters
+- [Devices & Push Notifications — Getting Started](../../tutorials/devices-and-push-getting-started.mdx)
+- [Notifications & push (admin guide)](../../user-guide/notifications-and-push.mdx)

--- a/apps/docs/docs/framework/modules/notifications.mdx
+++ b/apps/docs/docs/framework/modules/notifications.mdx
@@ -7,6 +7,13 @@ description: Create actionable in-app notifications with module-extensible types
 
 The Notifications module provides actionable in-app notifications that allow users to receive real-time updates and take actions directly from the notification panel. Notifications are automatically delivered to users via polling, with no manual refresh required.
 
+:::info Registering a notification type, and choosing its channels
+This page covers *creating* notifications. Declaring a notification **type** — the `notifications.ts`
+convention file your module ships, the `channels` / `nonOptOut` / `silent` flags, the delivery gate
+that decides which channels a given notification actually reaches, and a map of every type currently
+registered — lives in [Notification Delivery](./notification-delivery.mdx).
+:::
+
 ## Overview
 
 - **Location**: `packages/core/src/modules/notifications/`
@@ -1194,6 +1201,9 @@ expiresAt: undefined // Stays forever even if no longer relevant
 
 ## Related Documentation
 
+- [Notification Delivery](./notification-delivery.mdx) - Type registry, channels, and the delivery gate
+- [Push Notifications](./push-notifications.mdx) - Mobile push transport
+- [Devices](./devices.mdx) - The device registry push delivers to
 - [Events & Subscribers](../events/overview.mdx) - Event publishing system
 - [Queue & Workers](../events/queue-workers.mdx) - Background job processing
 - [Commands](../commands/overview.mdx) - Command execution from actions

--- a/apps/docs/docs/framework/modules/push-notifications.mdx
+++ b/apps/docs/docs/framework/modules/push-notifications.mdx
@@ -1,0 +1,145 @@
+---
+title: Push Notifications
+description: The push transport — fan-out, the exactly-once send worker, retries and reapers, provider adapters, silent push, the delivery log, and every OM_PUSH_* variable.
+sidebar_label: Push Notifications
+---
+
+# Push Notifications
+
+## Overview
+
+- **Location**: `packages/core/src/modules/push_notifications/`
+- **Package**: `@open-mercato/core`
+- **Requires**: `auth`, `devices`, `notifications`, `communication_channels`, `integrations`
+
+`push_notifications` owns transport for the `push` channel and nothing above it. It decides *nothing* about whether a user should be notified — that was settled once by the delivery gate (see [Notification Delivery](./notification-delivery.mdx)). It decides how the bytes reach the handset, exactly once, with retries.
+
+There is deliberately **no `PushProvider` interface in this module**. Providers plug in as `communication_channels` adapters, so push reuses the credential storage, health checks and admin connect UI the hub already has.
+
+## The send path
+
+```
+notificationService.create()
+  └─ gate → push survives → dispatcher invokes the push strategy
+       └─ fanOutPushDeliveries()            packages/core/src/modules/push_notifications/lib/push-fanout.ts
+            ├─ find the tenant's ACTIVE push channels, index them by providerKey
+            ├─ load the recipient's devices that have a token
+            ├─ match device.pushProvider → channel.providerKey   (exact string match)
+            ├─ insert one delivery row per device, ON CONFLICT DO NOTHING
+            └─ enqueue one job per inserted row
+                 └─ send-push worker                packages/core/src/modules/push_notifications/lib/push-delivery.ts
+                      ├─ atomic pending → sending claim
+                      ├─ resolve channel + adapter + credentials
+                      ├─ adapter.sendMessage(...)
+                      └─ sent | retry with backoff | failed | skipped
+```
+
+The strategy itself only enqueues, so an unreachable provider never slows notification creation.
+
+:::danger Two preconditions, both silent when unmet
+The fan-out short-circuits with **no delivery rows and no error** when either holds:
+
+1. The tenant has **no active push channel** at all. `fanOutPushDeliveries` returns `{ enqueued: 0 }` immediately.
+2. A device's `pushProvider` does not match the `providerKey` of any active channel — including the empty case. Those devices are counted into a single warn line ("Skipped devices with no matching push channel") and dropped.
+
+Neither surfaces in the UI. When "nothing happened", check these before anything else.
+:::
+
+Exactly-once under an at-least-once queue comes from the claim: the worker flips `pending → sending` atomically and only the winner sends. Rows stranded in `sending` by a crashed process are recovered by the reclaim reaper.
+
+## Delivery rows
+
+`push_notification_deliveries` is append-only, one row per `(notification, device)`, unique on that pair. Statuses: `pending`, `sending`, `sent`, `failed`, `skipped`, `expired`.
+
+`last_error` carries the terminal reason. The ones worth recognising:
+
+| `last_error` | Means |
+|---|---|
+| `channel_unavailable` | No active channel for this provider at send time — it was disconnected or deactivated between fan-out and send. |
+| `no_adapter` | The channel exists but no adapter is registered for its `providerKey`. The provider package is not installed or not registered. |
+| `device_unavailable` | The device or its token disappeared before the send. Recorded as `skipped`, not `failed`. |
+| `device_unregistered` | The provider says the token is permanently invalid. The device is soft-deleted through the audited `devices.user_devices.deactivate` command. |
+| `send_timeout` | The adapter did not answer within `OM_PUSH_SEND_TIMEOUT_MS`. Retryable. |
+
+Retryable failures are re-enqueued with exponential backoff plus jitter, capped at `MAX_ATTEMPTS = 3`; the attempt counter is persisted **before** the send, so the cap bounds real provider sends rather than successful returns.
+
+## Connecting a provider
+
+Push credentials belong to the **tenant**, not to the user who happens to connect them — an FCM service account is not a personal mailbox. Push adapters therefore declare `channelScope: 'tenant'`, and the per-user connect route refuses them.
+
+Connect through `POST /api/communication_channels/channels/connect/tenant-credentials`, gated on `communication_channels.connect_tenant_channel`, or from the admin Integrations page. The channel row carries `organization_id = NULL` and its credentials are pinned at the tenant.
+
+Three adapter packages ship with the platform:
+
+| Package | `providerKey` | Credentials |
+|---|---|---|
+| `@open-mercato/channel-fcm` | `fcm` | Service-account JSON, app name |
+| `@open-mercato/channel-apns` | `apns` | `.p8` key, key id, team id, bundle id |
+| `@open-mercato/channel-expo` | `expo` | Access token |
+
+Each registers itself into the hub's adapter registry from its own `di.ts` and declares an `IntegrationDefinition` with `hub: 'communication_channels'` and a health check. Writing another one is the [Communications Hub](./communication-channels.mdx) adapter contract plus the push envelope helpers in `packages/core/src/modules/communication_channels/lib/push-envelope.ts` and the base class in `packages/core/src/modules/communication_channels/lib/push-adapter.ts`.
+
+## Silent push
+
+A silent (data-only, content-available) push is not a separate API. It is an ordinary notification whose **type** declares `silent: true`. The flag selects delivery style only:
+
+- The in-app row is still created, and per-channel preferences still apply.
+- To make a silent wake-up unsuppressable, the type must also be `nonOptOut: true`.
+
+There is no per-call silent flag by design — silence is a property of the kind of message, not of one send.
+
+The app-readable `data` map always carries `notificationId`, `type`, and `linkHref` when present, merged over whatever the caller supplied.
+
+## Admin surfaces
+
+| Screen | Path | Feature |
+|---|---|---|
+| Delivery log | `/backend/push_notifications` | `push_notifications.view_deliveries` |
+| Delivery detail (payload, provider response, token last-8) | `/backend/push_notifications/:id` | `push_notifications.view_deliveries` |
+| Send a one-off push | `/backend/push_notifications/send` | `push_notifications.send_custom` |
+
+The one-off send uses two internal types, `admin.custom_message` and `admin.custom_silent` — both `nonOptOut` and `hiddenFromSettings`, so they never appear on a user's preferences screen. It writes no in-app row and does not consult preferences: it is an operator tool, not a notification.
+
+API: `GET /api/push_notifications/deliveries`, `GET /api/push_notifications/deliveries/:id`, `POST /api/push_notifications/custom-send`.
+
+## Background work
+
+| Worker | Job | Notes |
+|---|---|---|
+| `send-push` | One delivery row | Concurrency 8. Must be running or nothing is ever sent. |
+| `reclaim-stuck` | Rows stranded in `sending` | Registered per tenant by `seedDefaults` via `schedulerService`; silently skipped when the scheduler module is absent. |
+| Receipt polling | Async provider receipts (Expo) | Soft-deletes devices the provider later reports as unregistered. |
+
+## Environment variables
+
+All optional; defaults are in code.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `OM_PUSH_SEND_TIMEOUT_MS` | 60000 (min 5000) | Per-send adapter timeout. |
+| `OM_PUSH_STUCK_RECLAIM_MINUTES` | 5 (min 1) | How long a row may sit in `sending` before reclaim. |
+| `OM_PUSH_STUCK_RECLAIM_BATCH_LIMIT` | 500 | Rows scanned per reclaim tick. |
+| `OM_PUSH_RECLAIM_TICK_SECONDS` | 120 (min 30) | Reclaim schedule interval. |
+| `OM_PUSH_RECEIPT_MIN_AGE_MINUTES` | — | Youngest receipt eligible for polling. |
+| `OM_PUSH_RECEIPT_MAX_AGE_MINUTES` | — | Oldest receipt still polled. |
+| `OM_PUSH_RECEIPT_BATCH_LIMIT` | — | Receipts polled per tick. |
+| `OM_ENABLE_PUSH_STUB_ADAPTER` | off | Registers a network-free `push_stub` adapter. Tests only. |
+| `OM_PUSH_FAKE_PROVIDERS` | off | In-process SDK fakes writing to a JSONL sink, for provider e2e without live credentials. Reports health as `degraded`. |
+
+## Setting it up end to end
+
+1. Enable `devices`, `notifications`, `communication_channels`, `integrations`, `push_notifications`, and install one provider package.
+2. Connect a tenant-scoped push channel for that provider.
+3. Grant `devices.*` and `push_notifications.*`, then `yarn mercato auth sync-role-acls` for existing tenants.
+4. Have the client app register its device with a `pushToken` **and** a matching `pushProvider`.
+5. Make sure the type you are sending is push-eligible — see the gate in [Notification Delivery](./notification-delivery.mdx).
+6. Run the `push-deliveries` queue worker.
+
+The step-by-step version with screens is [Notifications & push (admin guide)](../../user-guide/notifications-and-push.mdx); the narrative walkthrough is the [getting-started tutorial](../../tutorials/devices-and-push-getting-started.mdx).
+
+## Related
+
+- [Notification Delivery](./notification-delivery.mdx)
+- [Devices](./devices.mdx)
+- [Communications Hub](./communication-channels.mdx)
+- [Notifications](./notifications.mdx)

--- a/apps/docs/docs/framework/modules/push-notifications.mdx
+++ b/apps/docs/docs/framework/modules/push-notifications.mdx
@@ -1,6 +1,6 @@
 ---
 title: Push Notifications
-description: The push transport — fan-out, the exactly-once send worker, retries and reapers, provider adapters, silent push, the delivery log, and every OM_PUSH_* variable.
+description: The push transport — fan-out, the exactly-once send worker, retries and reapers, provider adapters, silent push, the delivery log, and every OM_PUSH_* variable this module reads.
 sidebar_label: Push Notifications
 ---
 
@@ -116,15 +116,24 @@ All optional; defaults are in code.
 
 | Variable | Default | Effect |
 |---|---|---|
-| `OM_PUSH_SEND_TIMEOUT_MS` | 60000 (min 5000) | Per-send adapter timeout. |
-| `OM_PUSH_STUCK_RECLAIM_MINUTES` | 5 (min 1) | How long a row may sit in `sending` before reclaim. |
+| `OM_PUSH_SEND_TIMEOUT_MS` | 60000 (min 5000) | Per-send adapter timeout. Clamped against the reclaim window — see below. |
+| `OM_PUSH_STUCK_RECLAIM_MINUTES` | 5 (min 1) | How long a row may sit in `sending` before reclaim. Also caps the send timeout above. |
 | `OM_PUSH_STUCK_RECLAIM_BATCH_LIMIT` | 500 | Rows scanned per reclaim tick. |
 | `OM_PUSH_RECLAIM_TICK_SECONDS` | 120 (min 30) | Reclaim schedule interval. |
-| `OM_PUSH_RECEIPT_MIN_AGE_MINUTES` | — | Youngest receipt eligible for polling. |
-| `OM_PUSH_RECEIPT_MAX_AGE_MINUTES` | — | Oldest receipt still polled. |
-| `OM_PUSH_RECEIPT_BATCH_LIMIT` | — | Receipts polled per tick. |
+| `OM_PUSH_RECEIPT_MIN_AGE_MINUTES` | 15 | Youngest receipt eligible for polling. Expo needs roughly this long to resolve one, so polling sooner finds nothing. |
+| `OM_PUSH_RECEIPT_MAX_AGE_MINUTES` | 60 | Oldest receipt still polled. Floored at `MIN + 1` minute so the window is never empty. |
+| `OM_PUSH_RECEIPT_BATCH_LIMIT` | 500 | Receipts polled per tick. Floored at 1. |
 | `OM_ENABLE_PUSH_STUB_ADAPTER` | off | Registers a network-free `push_stub` adapter. Tests only. |
 | `OM_PUSH_FAKE_PROVIDERS` | off | In-process SDK fakes writing to a JSONL sink, for provider e2e without live credentials. Reports health as `degraded`. |
+
+:::warning The send timeout and the reclaim window are one knob, not two
+The effective per-send wait is `min(OM_PUSH_SEND_TIMEOUT_MS, max(5000, reclaim window − 60s))` (`packages/core/src/modules/push_notifications/lib/push-delivery.ts`). A send allowed to outlive the reclaim window would be reclaimed mid-flight and re-sent by a second worker, so the wait is capped below the window rather than honored as configured. Two consequences the table cannot show, neither of them logged:
+
+- Setting `OM_PUSH_SEND_TIMEOUT_MS` above `OM_PUSH_STUCK_RECLAIM_MINUTES` minus 60 s has no effect; the configured value is discarded silently.
+- `OM_PUSH_STUCK_RECLAIM_MINUTES=1` forces the send timeout to 5000 ms whatever `OM_PUSH_SEND_TIMEOUT_MS` says.
+
+To lengthen a per-send wait, raise `OM_PUSH_STUCK_RECLAIM_MINUTES` first.
+:::
 
 ## Setting it up end to end
 

--- a/apps/docs/docs/tutorials/devices-and-push-getting-started.mdx
+++ b/apps/docs/docs/tutorials/devices-and-push-getting-started.mdx
@@ -8,6 +8,15 @@ description: Register devices, connect a push provider, and send your first push
 A friendly guide for someone who has never touched these modules. It explains *what they are*,
 *how the pieces fit together*, and *how to send your first push notification to a phone*.
 
+:::tip Where to go next
+This page is the happy path. Once it works, the reference pages carry the detail:
+[Notification Delivery](../framework/modules/notification-delivery.mdx) (which channels a type may
+use, and why one was dropped), [Devices](../framework/modules/devices.mdx) (the registration API a
+client app calls), [Push Notifications](../framework/modules/push-notifications.mdx) (transport,
+retries, error codes, environment variables), and the
+[admin guide](../user-guide/notifications-and-push.mdx) for the screens.
+:::
+
 ---
 
 ## 1. The 30-second mental model
@@ -240,20 +249,21 @@ target a single tenant.
 - **Everything is tenant-scoped** — a tenant only ever sees its own devices and deliveries.
 - **Modules are decoupled** — they talk via events and DI, not direct ORM relationships.
 - **Resilient delivery** — retries with backoff; dead tokens auto-remove the device.
+- **Silence is a property of the type**, not of a send — a data-only wake-up is a notification whose
+  type declares `silent: true`.
 - **Status**: the device registry, notification types and preferences, push delivery, and the
   FCM/APNs/Expo adapters all ship today. Not yet built: a delivery-log purge worker, web push,
   and actionable push buttons.
 
+For the rules that decide whether a channel delivers at all — per-type eligibility, operator
+overrides, non-opt-out, and the default that makes a type without a declared channel list
+push-eligible — see [Notification Delivery](../framework/modules/notification-delivery.mdx).
+
 ## 8. Environment variables
 
-All four are optional — push works with none of them set.
+Every `OM_PUSH_*` variable is optional; push works with none of them set. The full table, including
+the reclaim and receipt-polling knobs and the two test-only provider flags, lives in
+[Push Notifications → Environment variables](../framework/modules/push-notifications.mdx#environment-variables).
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `OM_PUSH_STUCK_RECLAIM_MINUTES` | `5` | How long a delivery may sit in `sending` before the reclaim worker re-opens it. Values below `1` are rejected and fall back to the default: a `0` would re-open a send that is still in flight and deliver the push twice. |
-| `OM_PUSH_RECEIPT_MIN_AGE_MINUTES` | `15` | How long to wait before polling Expo for a delivery receipt. Expo needs time to resolve one. |
-| `OM_ENABLE_PUSH_STUB_ADAPTER` | unset | **Test only.** Registers a stub push provider so a delivery can reach `sent` with no real credentials. Never set in production. |
-| `OM_PUSH_FAKE_PROVIDERS` | unset | **Test only.** Swaps the FCM/APNs/Expo SDK *clients* for in-process fakes while the real adapters still build and validate the message, recording each native payload to a JSONL sink. Never set in production. |
-
-The two test flags are inert unless set, and are never installed at import time. Both must reach the
-worker process as well as the app, because the push worker runs in its own process.
+Both test flags must reach the worker process as well as the app, because the push worker runs in
+its own process.

--- a/apps/docs/docs/user-guide/integrations.mdx
+++ b/apps/docs/docs/user-guide/integrations.mdx
@@ -16,7 +16,7 @@ The marketplace lists every registered integration provider. Use the category fi
 - **Shipping** — carrier and fulfillment services
 - **Data Sync** — import/export adapters
 - **Communication** — email, SMS, and messaging
-- **Notification** — alert and push notification services
+- **Notification** — alert and push notification services (setting one up: [Notifications & Push](./notifications-and-push.mdx))
 - **Storage** — file and asset storage
 - **Webhook** — outbound webhook destinations
 

--- a/apps/docs/docs/user-guide/notifications-and-push.mdx
+++ b/apps/docs/docs/user-guide/notifications-and-push.mdx
@@ -1,0 +1,130 @@
+---
+title: Notifications & Push
+description: Turn on mobile push for your tenant, control which notification types use which channels, inspect registered devices, send a test push, and read the delivery log.
+sidebar_label: Notifications & Push
+---
+
+# Notifications & Push
+
+Open Mercato delivers a notification on up to three channels: the in-app bell, email, and mobile push. This guide covers the screens an administrator uses to control that — what to turn on, in which order, and where to look when a message does not arrive.
+
+If you only need the in-app bell and email, nothing here is required; both work out of the box. Push needs the one-time setup in Step 1.
+
+## Prerequisites
+
+- The `devices` and `push_notifications` modules enabled, plus a provider package (`channel-fcm`, `channel-apns` or `channel-expo`).
+- Credentials from your push provider — an FCM service-account JSON, an APNs `.p8` key, or an Expo access token.
+- A mobile or web app that registers its device with the platform. Push cannot be tested from the admin UI alone: there has to be a device with a token.
+- The background queue worker running. Without it, deliveries queue and never send.
+
+## Step 1 — Connect a push provider
+
+Push credentials belong to the whole tenant, not to your personal account, so they are connected as a **tenant channel** rather than from your profile.
+
+1. Open **Settings → Integrations**.
+2. Pick your provider (Firebase Cloud Messaging, Apple Push Notification service, or Expo).
+3. Paste the credentials and connect. They are validated at connect time — a bad service account fails here rather than silently at the first send.
+
+You need the `communication_channels.connect_tenant_channel` permission. If the provider does not appear, its package is not installed.
+
+## Step 2 — Sync permissions
+
+The devices and push permissions are seeded for new tenants automatically. An **existing** tenant needs them applied once:
+
+```bash
+yarn mercato auth sync-role-acls
+```
+
+This grants `devices.*` and `push_notifications.*` to the default admin roles. Skipping it is the usual reason the Devices and Push screens are missing from the sidebar after an upgrade.
+
+## Step 3 — Decide which types may use push
+
+Open **Settings → Module Configs → Notification Delivery** (`/backend/config/notifications`, permission `notifications.manage`).
+
+This is a matrix of every notification type against every channel. Each row is a kind of message — "Order created", "Account locked" — and each cell says whether that type may use that channel **at all** in your tenant. It sits above user preferences: a channel switched off here is off for everyone, including for messages users cannot normally opt out of.
+
+:::warning A type that ships without an explicit channel list is push-eligible
+Many notification types do not declare which channels they may use, and the platform reads that as "no restriction" rather than "none". The practical effect: the moment you complete Step 1, those types start pushing.
+
+Review this matrix immediately after connecting a provider, and switch push off for anything you do not want on a phone. This default is under discussion upstream ([#5495](https://github.com/open-mercato/open-mercato/issues/5495)).
+:::
+
+You can also mark a type non-opt-out here, for alerts that must always reach the recipient.
+
+## Step 4 — Check that devices are arriving
+
+Open **Settings → Auth → Devices** (`/backend/devices`, permission `devices.admin`). Every device a client app has registered appears here with its owner, platform, app version, push provider and last-seen time.
+
+Filter by user to answer "does this person have a device at all?" — the most common cause of a missing push.
+
+The **Push provider** column matters more than it looks. It must exactly match the provider you connected in Step 1: a device registered as `fcm` receives nothing from an APNs channel, and a device with an empty provider receives nothing at all. Those devices are skipped without any error.
+
+You can register a device manually from this screen for testing, but in normal operation the client app does it.
+
+## Step 5 — Send a test push
+
+Open **Settings → External systems → Push notifications → Send** (`/backend/push_notifications/send`, permission `push_notifications.send_custom`).
+
+1. Search for the recipient by name or email.
+2. Pick one of their devices, or leave it on **All devices**.
+3. Choose **Visible** (a normal banner) or **Silent** (a background wake-up the app handles without showing anything).
+4. Fill in title and body, and optionally a data payload the app reads.
+
+If the device dropdown is empty, that recipient has no push-capable device — go back to Step 4.
+
+A custom send bypasses preferences on purpose: it is an operator tool and writes no in-app notification.
+
+## Step 6 — Read the delivery log
+
+**Settings → External systems → Push notifications** (`/backend/push_notifications`, permission `push_notifications.view_deliveries`) lists every push attempt with its status. Open a row for the payload, the provider's response, and the last 8 characters of the token used.
+
+| Status | Meaning |
+|---|---|
+| `pending` | Queued, not sent yet. If rows stay here, the queue worker is not running. |
+| `sending` | Claimed by a worker right now. |
+| `sent` | Handed to the provider successfully. |
+| `failed` | Gave up after retries — see the error. |
+| `skipped` | Nothing to send to; the device or its token was gone. |
+| `expired` | Aged out before delivery. |
+
+## Step 7 — Let users tune their own notifications
+
+Each user manages their own channels at **Profile → Notification Preferences** — a per-type, per-channel grid. Types marked non-opt-out show as locked, as do channels you disabled in Step 3.
+
+To adjust someone else's, use **Settings → Auth → User Notification Preferences** (permission `notifications.manage_user_preferences`).
+
+## Troubleshooting
+
+### Nothing is in the delivery log at all
+
+The fan-out never produced rows. Either the tenant has no **active** push channel (Step 1), or the recipient has no device whose push provider matches it (Step 4). Neither reports an error anywhere in the UI — this is the case to check first.
+
+### Rows are stuck at `pending`
+
+The `push-deliveries` queue worker is not running. Rows left in `sending` by a crashed worker are recovered automatically within a few minutes.
+
+### `no_adapter`
+
+The channel exists but the provider package is not installed or not registered in this deployment.
+
+### `channel_unavailable`
+
+The channel was disconnected or deactivated between the notification being created and the push being sent.
+
+### `device_unregistered`
+
+The provider reports the token as permanently invalid — the app was uninstalled, or the token rotated. The device is deactivated automatically; the next app launch re-registers it.
+
+### The push arrives but the in-app bell stays empty (or vice versa)
+
+Channels are independent, and both the operator matrix (Step 3) and the user's own preferences (Step 7) can disable one without the other.
+
+### A user insists they get nothing, and everything above looks right
+
+Check their preferences (Step 7) before anything else — a per-type opt-out is invisible from every other screen.
+
+## Related
+
+- [Devices & Push Notifications — Getting Started](../tutorials/devices-and-push-getting-started.mdx) — the developer-facing walkthrough
+- [Notification Delivery](../framework/modules/notification-delivery.mdx) — how the channel decision is actually made
+- [Communication Channels](./communication-channels.mdx)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,7 @@
     "build": "docusaurus build",
     "serve": "docusaurus serve",
     "clean": "rimraf build .docusaurus",
-    "test": "yarn clean && yarn build && node --test __tests__/search-index.test.mjs __tests__/reference-example-module.test.mjs __tests__/notification-registry.test.mjs"
+    "test": "yarn clean && yarn build && node --test __tests__/search-index.test.mjs __tests__/reference-example-module.test.mjs __tests__/notification-registry.test.mjs __tests__/push-env-table.test.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.2",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,7 @@
     "build": "docusaurus build",
     "serve": "docusaurus serve",
     "clean": "rimraf build .docusaurus",
-    "test": "yarn clean && yarn build && node --test __tests__/search-index.test.mjs __tests__/reference-example-module.test.mjs"
+    "test": "yarn clean && yarn build && node --test __tests__/search-index.test.mjs __tests__/reference-example-module.test.mjs __tests__/notification-registry.test.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.2",

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -124,6 +124,7 @@ const sidebars: SidebarsConfig = {
           items: [
             "user-guide/integrations",
             "user-guide/webhooks",
+            "user-guide/notifications-and-push",
             {
               type: "category",
               label: "Email (Communication Channels)",
@@ -394,6 +395,10 @@ const sidebars: SidebarsConfig = {
             "framework/modules/routes-and-pages",
             "framework/modules/overrides",
             "framework/modules/notifications",
+            "framework/modules/notification-delivery",
+            "framework/modules/push-notifications",
+            "framework/modules/devices",
+            "framework/modules/communication-channels",
             "framework/modules/messages",
             "framework/modules/currencies",
             "framework/modules/integrations-data-sync",


### PR DESCRIPTION
## Summary

Second of #5591's two asks:

> I also do not quite get the intended way for the devices and notifications should be used; please add official docs how they should be registered (i guess it should be done by user's code) and how to be used because right now this feature is merely usable

`framework/modules/notifications.mdx` is **1199 lines** and covers creating notifications thoroughly. Grep it for `notificationTypes`, `shouldDeliver`, `nonOptOut`, `hiddenFromSettings` or `preferences` and you get **two incidental hits**, both inside a best-practices bullet. The *registry* — the half the issue calls out as "should be done by user's code" — was undocumented.

Also missing: any `framework/modules/devices.mdx` or `push-notifications.mdx`; rows for either module in `core-modules.mdx`; any user-guide page for notifications at all. The only existing page was the 259-line getting-started tutorial.

Docs-only. The picker half of #5591 is #5617.

## Changes

Four new pages, one per audience that was unserved:

- **`framework/modules/notification-delivery.mdx`** — the hub. How a module declares a type in its `notifications.ts` convention file (with a copyable example), the full `NotificationTypeDefinition` field table, the **two distinct channel convention files** that get conflated (`notification-channels.ts` = metadata for the preferences UI; `notifications.delivery-strategies.ts` = actual behavior), the four conditions `shouldDeliver` evaluates *and the order they run in*, operator overrides, preferences, and a map of every registered type.
- **`framework/modules/devices.mdx`** — what a `user_devices` row is and why it is keyed the way it is, the registration call a client app makes on launch, the self-serve vs admin split, and the token secrecy chain.
- **`framework/modules/push-notifications.mdx`** — the send path as one diagram, the `last_error` codes as a lookup table, silent push as a property of the *type* rather than of a send, the admin surfaces, and the complete `OM_PUSH_*` table — which now includes `OM_PUSH_SEND_TIMEOUT_MS`, `OM_PUSH_STUCK_RECLAIM_BATCH_LIMIT`, `OM_PUSH_RECLAIM_TICK_SECONDS` and the receipt knobs the tutorial never listed.
- **`user-guide/notifications-and-push.mdx`** — the operator walkthrough, in the numbered-step shape of `user-guide/webhooks.mdx`, with a troubleshooting ladder keyed on the literal statuses and error strings.

Each reference page carries a callout for **the failure that produces no error anywhere**: the fan-out is a silent no-op when the tenant has no active push channel, or when a device's `pushProvider` does not exactly match a channel's `providerKey`. That is the "why did nothing happen" case, and it was documented nowhere.

Wiring and housekeeping:

- `sidebars.ts` — the three framework pages next to `framework/modules/notifications`, plus the user-guide page. While there: `framework/modules/communication-channels` was **built but referenced nowhere in the sidebar**; that one-line orphan fix rides along.
- `core-modules.mdx` — rows for `devices` and `push_notifications` under UI & Platform. (`communication_channels`, `eudr`, `wms` and `warranty_claims` are missing from that table too — out of scope here.)
- The tutorial is **re-positioned, not duplicated**: it keeps the happy path and gains a "where to go next" block, and hands the env-var table and the eligibility rules to the references.
- Cross-links from `notifications.mdx`, `communication-channels.mdx` and `user-guide/integrations.mdx`.

### The 65-type map, and why it is machine-checked

The hub page carries a table of every registered notification type, grouped by declaring module: severity, declared channels, and the `non-opt-out` / `silent` / `hidden` flags.

A 65-row table hand-maintained across 22 modules is stale within a release, so **`apps/docs/__tests__/notification-registry.test.mjs`** asserts it against the real convention files, wired into `apps/docs`'s `test` script (which the root `turbo run test` already picks up). It fails when a registered type is undocumented, when a documented type no longer exists, when any cell of a row — severity, the declared channel ids, the flag markers — disagrees with its source, when a type is grouped under the wrong module or an enterprise group loses its marker, when the stated `37 of 65` ratio drifts, or when a referenced `packages/…` source path stops existing.

The review pass added a second file on the same principle: **`apps/docs/__tests__/push-env-table.test.mjs`** holds the `OM_PUSH_*` table on `push-notifications.mdx` to the module source — the documented variable set must equal the set the module actually reads, and every default and floor must match the constant it restates. The numbers live only in the source; the test stores locations, so changing a default fails the table until it is updated.

Two parsing details a naive implementation gets wrong, both pinned by comments in the test: the first `[` after `notificationTypes` belongs to the `NotificationTypeDefinition[]` annotation rather than to the array, and `type:` is not always a literal — `push_notifications` declares its two admin types through module-level constants, which a literal-only regex silently drops.

### An honest number the docs now state

**37 of the 65 registered types declare no `channels`**, and `resolveEligibleChannels` reads that as *no restriction* — so they become push-eligible the moment a tenant connects a provider. Both the hub page and the admin guide say so plainly, with a warning to review the Notification Delivery matrix immediately after connecting.

This is documented as **current behavior with an open policy question** (#5495, PR #5542), not as though the fix had landed. Worth flagging that #5495's own framing — "20 of 48" — is stale against `develop`; today it is 37 of 65, which is the argument for asserting the set instead of writing counts into prose.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-04-28-push-notifications-and-devices.md` (plus `2026-07-01-push-delivery-e2e-findings.md`, `2026-07-03-push-channels-tenant-scope.md`, `2026-08-24-devices-api-camelcase-responses.md`) — these are the source material the pages document. No spec change was needed: this PR adds no behavior.

## Testing

Local runner.

| Gate | Result |
|---|---|
| `yarn workspace open-mercato-docs test` (clean → full Docusaurus build → `node --test`) | **16/16 pass**, build succeeds |
| `yarn lint` | 0 errors |

The build reports one broken anchor, on `/installation/wsl2` — pre-existing, untouched here.

The new test caught a real bug in its own first run (a segment-case assumption that missed `checkout.link.usageLimitReached`), and I verified it fails on a deliberately mismarked row before keeping it. Every assertion added in the review pass was checked the same way — ten deliberate mutations (a wrong default, a dropped row, a removed callout, a wrong severity, a dropped flag, a wrong channel list, a removed `(enterprise)` marker, a stale count, a changed source constant, a duplicated type id), each failing its intended test and nothing else.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- left for the human author to tick -->
- [x] I updated documentation, locales, or generators if the change requires it — this PR *is* the documentation update.
- [x] I added or adjusted tests that cover the change — `apps/docs/__tests__/notification-registry.test.mjs` and `apps/docs/__tests__/push-env-table.test.mjs`.
- [x] I added or updated integration tests — N/A in the Playwright sense; docs correctness is asserted by the `node:test` file above, which is the automated coverage this change can carry.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable) — not applicable; no behavior changes.
- [ ] Priority set — this account has no label permission upstream; requested in a comment below.
- [ ] Risk set — as above.
- [ ] QA routing set — as above; `skip-qa` requested (no `.tsx`, no schema, no API surface, no `BACKWARD_COMPATIBILITY.md` contract, and automated coverage ships with it).

### Design System Compliance
- [x] No hardcoded status colors — Markdown only; no component code in this PR.
- [x] No arbitrary text sizes — as above.
- [x] Empty state handled for list/data pages — N/A, no pages rendered by the app change.
- [x] Loading state handled for async pages — N/A, as above.
- [x] `aria-label` on icon-only buttons — N/A, as above.
- [x] Uses existing DS components — N/A, as above.

## Linked issues

Fixes #5591 (second of its two asks — the searchable user picker is #5617).
Documents the current behavior behind #5495 without pre-empting its resolution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790252133&installation_model_id=432243&pr_number=5618&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5618&signature=3042858925e7e27605b40a4b1630196f3b7bd677349d40ba4fbfdd0fcf310ee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
