### PR TITLE
fix(sales): serve persisted order totals on single-row GET (#5438)

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
@@ -15,6 +15,12 @@ jest.mock('@open-mercato/core/generated/entities.ids.generated', () => ({
   },
 }))
 
+const mockRecalculateOrderTotalsForDisplay = jest.fn()
+
+jest.mock('../../commands/returns', () => ({
+  recalculateOrderTotalsForDisplay: (...args: unknown[]) => mockRecalculateOrderTotalsForDisplay(...args),
+}))
+
 import { MAX_IDS_PER_REQUEST } from '@open-mercato/shared/lib/crud/ids'
 import { buildDocumentCrudOptions } from '../documents/factory'
 import { SalesOrder, SalesQuote } from '../../data/entities'
@@ -336,6 +342,10 @@ describe('buildDocumentCrudOptions', () => {
     })
   })
   describe('afterList composition', () => {
+    beforeEach(() => {
+      mockRecalculateOrderTotalsForDisplay.mockReset()
+    })
+
     const orderBinding = {
       kind: 'order' as const,
       entity: SalesOrder,
@@ -348,9 +358,9 @@ describe('buildDocumentCrudOptions', () => {
       viewFeature: 'sales.orders.view',
     }
 
-    // The channel-name resolution is appended to an afterList hook that already attaches tags and
-    // recalculates single-order display totals. Assigning the hook instead of extending it would
-    // silently drop both, so this pins that all three still run off one list payload.
+    // The channel-name resolution is appended to an afterList hook that already attaches tags.
+    // Assigning the hook instead of extending it would silently drop that work, so this pins
+    // that both still run off one list payload.
     it('should still attach tags alongside the channel names', async () => {
       const options = buildDocumentCrudOptions(orderBinding)
       const channelId = '11111111-1111-4111-8111-111111111111'
@@ -386,6 +396,64 @@ describe('buildDocumentCrudOptions', () => {
       expect(payload.items[0].tags).toEqual([{ id: 'tag-1', label: 'Priority', color: '#fff' }])
       expect(payload.items[0].channelName).toBe('Web shop')
       expect(entitiesSeen).toHaveLength(2)
+    })
+
+    it('keeps persisted totals when the response contains exactly one order (#5438)', async () => {
+      mockRecalculateOrderTotalsForDisplay.mockResolvedValue({
+        subtotalNetAmount: 549.9,
+        subtotalGrossAmount: 549.9,
+        discountTotalAmount: 45,
+        taxTotalAmount: 0,
+        shippingNetAmount: 24.9,
+        shippingGrossAmount: 24.9,
+        surchargeTotalAmount: 0,
+        grandTotalNetAmount: 549.9,
+        grandTotalGrossAmount: 549.9,
+        paidTotalAmount: 0,
+        refundedTotalAmount: 0,
+        outstandingAmount: 549.9,
+      })
+
+      const options = buildDocumentCrudOptions(orderBinding)
+      const em = {
+        find: jest.fn(async () => []),
+        fork: jest.fn(function fork(this: { find: unknown }) {
+          return this
+        }),
+      }
+      const ctx = {
+        container: { resolve: (token: string) => (token === 'em' ? em : null) },
+        auth: { tenantId: 'ten-1', orgId: 'org-1' },
+        selectedOrganizationId: 'org-1',
+      }
+      const payload = {
+        items: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            tenantId: 'ten-1',
+            organizationId: 'org-1',
+            grandTotalGrossAmount: 525,
+            outstandingAmount: 525,
+            subtotalGrossAmount: 570,
+            shippingGrossAmount: 0,
+            updatedAt: '2026-08-01T00:00:00.000Z',
+          },
+        ] as Array<Record<string, unknown>>,
+      }
+
+      await options.hooks.afterList(payload, ctx as never)
+
+      expect(mockRecalculateOrderTotalsForDisplay).not.toHaveBeenCalled()
+      expect(em.fork).not.toHaveBeenCalled()
+      expect(payload.items[0]).toEqual(
+        expect.objectContaining({
+          grandTotalGrossAmount: 525,
+          outstandingAmount: 525,
+          subtotalGrossAmount: 570,
+          shippingGrossAmount: 0,
+          updatedAt: '2026-08-01T00:00:00.000Z',
+        }),
+      )
     })
   })
 })

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -26,7 +26,6 @@ import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { parseIdsParam } from '@open-mercato/shared/lib/crud/ids'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
-import { recalculateOrderTotalsForDisplay } from '../../commands/returns'
 import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 
 type DocumentKind = 'order' | 'quote'
@@ -616,46 +615,6 @@ export function buildDocumentCrudOptions(binding: DocumentBinding) {
       afterList: async (payload: any, ctx: CrudCtx) => {
         await attachTags(payload, { ...ctx, bindingKind: binding.kind })
         await attachChannelNames(payload, ctx)
-        if (binding.kind === 'order' && Array.isArray(payload?.items) && payload.items.length === 1) {
-          const item = payload.items[0] as Record<string, unknown>
-          const orderId = typeof item?.id === 'string' ? item.id : null
-          const tenantId = typeof item?.tenantId === 'string' ? item.tenantId : ctx?.auth?.tenantId ?? null
-          const organizationId =
-            typeof item?.organizationId === 'string' ? item.organizationId : ctx?.selectedOrganizationId ?? ctx?.auth?.orgId ?? null
-          if (orderId && tenantId && organizationId) {
-            const requestEm = ctx?.container?.resolve?.('em') as import('@mikro-orm/postgresql').EntityManager | undefined
-            // Display-only totals recalculation: run on a forked EntityManager so
-            // the order/line/adjustment entities loaded here never enter the
-            // request's Unit of Work. This guarantees a GET can never flush an
-            // UPDATE (and thus never advance `updated_at`), which would otherwise
-            // surface as a spurious optimistic-lock 409 in another tab.
-            const em = requestEm?.fork()
-            if (em) {
-              const totals = await recalculateOrderTotalsForDisplay(
-                em,
-                ctx.container,
-                orderId,
-                { tenantId, organizationId },
-              )
-              if (totals) {
-                Object.assign(item, {
-                  subtotalNetAmount: totals.subtotalNetAmount,
-                  subtotalGrossAmount: totals.subtotalGrossAmount,
-                  discountTotalAmount: totals.discountTotalAmount,
-                  taxTotalAmount: totals.taxTotalAmount,
-                  shippingNetAmount: totals.shippingNetAmount,
-                  shippingGrossAmount: totals.shippingGrossAmount,
-                  surchargeTotalAmount: totals.surchargeTotalAmount,
-                  grandTotalNetAmount: totals.grandTotalNetAmount,
-                  grandTotalGrossAmount: totals.grandTotalGrossAmount,
-                  paidTotalAmount: totals.paidTotalAmount,
-                  refundedTotalAmount: totals.refundedTotalAmount,
-                  outstandingAmount: totals.outstandingAmount,
-                })
-              }
-            }
-          }
-        }
       },
     },
   }

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -198,8 +198,10 @@ function buildCalculationContext(order: SalesOrder) {
 }
 
 /**
- * Recalculates order totals (including line-scoped return adjustments) for display.
- * Returns the totals object to merge into an order API response, or null if order not found.
+ * Recalculates order totals (including line-scoped return adjustments) from lines and
+ * adjustments. Do not merge this into GET /api/sales/orders responses: provider
+ * calculators re-emit shipping/payment fees on top of already-persisted adjustments
+ * and make list vs detail totals diverge (#5438). Persist via commands instead.
  */
 export async function recalculateOrderTotalsForDisplay(
   em: EntityManager,


### PR DESCRIPTION
## Summary

Ports the fix for #5438 to `main`. The change already landed on `develop` in #5470 (squash commit `136748c`), but `main` never received it, so the defect is still live on the `main` line.

This is a clean cherry-pick of `136748c` — no conflicts, no adaptation needed.

- `GET /api/sales/orders` returned **different grand totals for the same order** depending on whether the response contained exactly one row.
- The list path served the persisted columns (arithmetically correct: lines ± adjustments). The detail path (`items.length === 1`) ran `recalculateOrderTotalsForDisplay`, which re-emits shipping rates and the Stripe `applicationFee` on top of already-stored adjustments. Outstanding balance could flip from `0` (paid) to a non-zero remainder.
- GET now returns the persisted totals for every result size, matching quotes and matching the amount filters. Write paths still persist totals through `salesCalculationService` on create/update/return.

## Test plan

- [x] `packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts` — 29 passed, including the `#5438` regression test (single-row `afterList` no longer calls the recalculator or `em.fork()`)
- [x] Full `packages/core/src/modules/sales` suite — 611 tests passed
- [ ] CI covers the remaining gate (`build:packages`, `generate`, `i18n:check-*`, `typecheck`, full `test`, `build:app`)

> Two `src/modules/sales` suites (`channels.route`, `shipments.afterList`) could not run in the local worktree because `packages/core/generated/` had not been built there. They resolve `#generated/entities/sales_channel` and are unrelated to this diff; CI runs `yarn generate` before the test job.

## Breaking Changes

| Surface | Status |
|---------|--------|
| `GET /api/sales/orders` path and query schema | Unchanged |
| Response envelope | Unchanged; single-row responses now match the multi-row (persisted) values |
| OpenAPI | Unchanged |
| Database schema | Untouched |
| `recalculateOrderTotalsForDisplay` | Still exported; documented as not for GET overwrite |

The only behavioral change is the intended one: a one-row GET no longer inflates shipping/fees relative to the list.

Related: #5470 (the `develop` PR this ports), #2234 (the same recompute, filed as a performance issue).

Closes #5438

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790265781&installation_model_id=432243&pr_number=5622&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5622&signature=9564dd712f359c6df12dc95ad37f2d78b00caf6b895bca4623f84c99e6128091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->