### PR TITLE
fix(auth): preserve partial user ACL updates

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,32 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.6.7 → 0.7.0 (2026-08-26)
 
+### `PUT /api/auth/users/acl` merges omitted fields instead of clearing them (#5493)
+
+The route used to treat every omitted field as a cleared one: an omitted `features`
+became `[]` and an omitted `organizations` became `null`. A request carrying only
+`organizations` was therefore classified as an empty override, so the route **deleted the
+user's ACL row** and answered `200 {"ok":true}`. Because a per-user ACL is how a role gets
+*narrowed*, deleting it dropped the user back to their full role — the failure direction
+was fail-open, triggered by an ordinary administrative scope edit.
+
+Omitted `features`, `organizations`, and `isSuperAdmin` now keep their stored values, so a
+single-dimension edit no longer clears the dimensions it did not touch. Two consequences
+for callers that relied on the old shape:
+
+- **Removing an override now needs every dimension cleared explicitly.** Send
+  `{ userId, features: [], organizations: null }`. A bare `{ userId, features: [] }` against
+  a row that carries an organization restriction is now rejected (see below) rather than
+  deleting the row.
+- **An organization-scoped override with no feature grant returns `400`.** A `UserAcl` is an
+  absolute override, so persisting that state would revoke every role-granted feature
+  instead of narrowing the role. Restate the grant alongside the scope —
+  `{ userId, organizations: [orgId], features: ['module.*'] }`. Test fixtures and scripts
+  that set a scope with an organizations-only call need the same restatement; previously
+  such a call reported success while storing nothing.
+
+`PUT /api/auth/roles/acl` already behaved this way and is unchanged.
+
 ### Passkey MFA verification requires a real WebAuthn assertion (#3852)
 
 `PasskeyProvider.verify()` used to accept a second payload shape — `{ credentialId, challenge }` — beside the genuine `{ response }` assertion, and approved it by string comparison. Both compared values are public: `prepareChallenge()` returns the credential id and the challenge to the caller, and `GET /api/security/mfa/methods` discloses `providerMetadata.credentialId`. A third shape needed even less: with no prepared challenge at all, only the disclosed credential id was compared. Anyone who could reach the verify step for a session therefore passed the passkey second factor with no authenticator private key and no signature, in both login-time MFA and passkey-as-sudo step-up.

--- a/apps/docs/docs/api/auth.mdx
+++ b/apps/docs/docs/api/auth.mdx
@@ -208,6 +208,15 @@ Response:
 { "ok": true }
 ```
 
+Omitted fields keep their stored value: send only `features` and the organization
+scope is preserved, send only `organizations` and the feature grant is preserved.
+To remove an override entirely, clear every dimension explicitly
+(`{ "userId": "…", "features": [], "organizations": null }`).
+
+A per-user ACL is an absolute override rather than an addition to the role, so an
+organization-scoped override with no feature grant would revoke every role-granted
+feature. That combination is rejected with `400` instead of being persisted.
+
 ## Roles
 
 ### List Roles — `GET /auth/roles`

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-043-user-acl-override.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-043-user-acl-override.spec.ts
@@ -77,7 +77,32 @@ test.describe('TC-AUTH-043: user ACL override grants a feature (#2464)', () => {
       expect(aclBody?.hasCustomAcl, 'user should now have a custom ACL').toBe(true);
       expect(aclBody?.features ?? [], 'granted feature should be listed').toContain(GRANTED_FEATURE);
 
-      // The grant takes effect immediately (PUT invalidates the rbac cache for the user).
+      // A follow-up PUT that carries only the organization scope must keep the feature
+      // grant it did not touch, instead of clearing the override (#5493).
+      const scopePutRes = await apiRequest(request, 'PUT', '/api/auth/users/acl', {
+        token: superadminToken,
+        data: { userId, organizations: [organizationId] },
+      });
+      expect(scopePutRes.status(), 'partial organization PUT should return 200').toBe(200);
+      const scopePutBody = await readJsonSafe<{ ok?: boolean }>(scopePutRes);
+      expect(scopePutBody?.ok, 'partial organization PUT should report ok=true').toBe(true);
+
+      const scopedAclRes = await apiRequest(
+        request,
+        'GET',
+        `/api/auth/users/acl?userId=${encodeURIComponent(userId)}`,
+        { token: superadminToken },
+      );
+      expect(scopedAclRes.status(), 'GET scoped user ACL should return 200').toBe(200);
+      const scopedAclBody = await readJsonSafe<{ features?: string[]; organizations?: string[] | null }>(
+        scopedAclRes,
+      );
+      expect(scopedAclBody?.features ?? [], 'partial organization PUT should preserve features').toContain(
+        GRANTED_FEATURE,
+      );
+      expect(scopedAclBody?.organizations, 'organization restriction should be persisted').toEqual([organizationId]);
+
+      // The grant remains effective after both PUTs invalidate the rbac cache for the user.
       const checkAfter = await readJsonSafe<{ ok?: boolean; granted?: string[] }>(
         await apiRequest(request, 'POST', '/api/auth/feature-check', {
           token: userToken,

--- a/packages/core/src/modules/auth/api/users/acl/__tests__/partial-update.test.ts
+++ b/packages/core/src/modules/auth/api/users/acl/__tests__/partial-update.test.ts
@@ -1,0 +1,223 @@
+/** @jest-environment node */
+
+import { PUT } from '../route'
+
+const ACTOR_TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const ACTOR_USER_ID = '123e4567-e89b-12d3-a456-426614174002'
+const TARGET_USER_ID = '123e4567-e89b-12d3-a456-426614174003'
+const ACME_ORGANIZATION_ID = '123e4567-e89b-12d3-a456-426614174010'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockDeleteByTags = jest.fn()
+
+type StoredAcl = {
+  id: string
+  isSuperAdmin: boolean
+  featuresJson: string[]
+  organizationsJson: string[] | null
+  updatedAt: Date | null
+}
+
+let storedAcl: StoredAcl | null = null
+
+const mockEm = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  persist: jest.fn(),
+  remove: jest.fn(),
+}
+
+const mockRbacService = {
+  loadAcl: jest.fn(),
+  invalidateUserCache: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return mockRbacService
+    if (token === 'cache') return { deleteByTags: mockDeleteByTags }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: 'org-1',
+    filterIds: ['org-1'],
+    allowedIds: null,
+    tenantId: '123e4567-e89b-12d3-a456-426614174001',
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/flush', () => ({
+  withAtomicFlush: jest.fn(async (_em: unknown, phases: Array<() => unknown>) => {
+    for (const phase of phases) await phase()
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/optimistic-lock-command', () => ({
+  enforceCommandOptimisticLockWithGuards: jest.fn(async () => {}),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+function putRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/auth/users/acl', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('user ACL partial updates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    storedAcl = null
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: ACTOR_USER_ID,
+      tenantId: ACTOR_TENANT_ID,
+      orgId: 'org-1',
+    })
+    mockFindWithDecryption.mockResolvedValue([])
+    mockRbacService.loadAcl.mockResolvedValue({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage', 'dashboards.view'],
+      organizations: null,
+    })
+    // `isUserEffectivelySuperAdmin` probes with `isSuperAdmin: true`; every other
+    // lookup is the route loading the target user's stored ACL row.
+    mockEm.findOne.mockImplementation((_entity: unknown, filter: Record<string, unknown>) => (
+      filter?.isSuperAdmin === true ? null : storedAcl
+    ))
+    mockEm.create.mockImplementation((_entity: unknown, values: Record<string, unknown>) => ({ ...values }))
+  })
+
+  it('preserves the stored feature grant when only organizations are submitted', async () => {
+    storedAcl = {
+      id: 'acl-1',
+      isSuperAdmin: false,
+      featuresJson: ['dashboards.view'],
+      organizationsJson: null,
+      updatedAt: null,
+    }
+
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      organizations: [ACME_ORGANIZATION_ID],
+    }))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ ok: true, sanitized: false })
+    expect(mockEm.remove).not.toHaveBeenCalled()
+    expect(mockEm.persist).toHaveBeenCalledTimes(1)
+    expect(storedAcl).toMatchObject({
+      isSuperAdmin: false,
+      featuresJson: ['dashboards.view'],
+      organizationsJson: [ACME_ORGANIZATION_ID],
+    })
+  })
+
+  it('preserves the stored organization scope when only features are submitted', async () => {
+    storedAcl = {
+      id: 'acl-1',
+      isSuperAdmin: false,
+      featuresJson: ['dashboards.view'],
+      organizationsJson: [ACME_ORGANIZATION_ID],
+      updatedAt: null,
+    }
+
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      features: ['auth.acl.manage'],
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockEm.remove).not.toHaveBeenCalled()
+    expect(storedAcl).toMatchObject({
+      featuresJson: ['auth.acl.manage'],
+      organizationsJson: [ACME_ORGANIZATION_ID],
+    })
+  })
+
+  it('rejects an organization scope that would leave the user without any feature grant', async () => {
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      organizations: [ACME_ORGANIZATION_ID],
+    }))
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: expect.stringContaining('at least one feature override'),
+    })
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.remove).not.toHaveBeenCalled()
+    expect(mockRbacService.invalidateUserCache).not.toHaveBeenCalled()
+  })
+
+  it('still clears the override when every dimension is explicitly emptied', async () => {
+    const existing = {
+      id: 'acl-1',
+      isSuperAdmin: false,
+      featuresJson: ['dashboards.view'],
+      organizationsJson: [ACME_ORGANIZATION_ID],
+      updatedAt: null,
+    }
+    storedAcl = existing
+
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      features: [],
+      organizations: null,
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockEm.remove).toHaveBeenCalledWith(existing)
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
+
+  it('keeps an omitted super admin flag intact', async () => {
+    mockRbacService.loadAcl.mockResolvedValue({
+      isSuperAdmin: true,
+      features: ['*'],
+      organizations: null,
+    })
+    storedAcl = {
+      id: 'acl-1',
+      isSuperAdmin: true,
+      featuresJson: [],
+      organizationsJson: null,
+      updatedAt: null,
+    }
+
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      organizations: [ACME_ORGANIZATION_ID],
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockEm.remove).not.toHaveBeenCalled()
+    expect(storedAcl).toMatchObject({
+      isSuperAdmin: true,
+      organizationsJson: [ACME_ORGANIZATION_ID],
+    })
+  })
+})

--- a/packages/core/src/modules/auth/api/users/acl/__tests__/partial-update.test.ts
+++ b/packages/core/src/modules/auth/api/users/acl/__tests__/partial-update.test.ts
@@ -194,6 +194,33 @@ describe('user ACL partial updates', () => {
     expect(mockEm.persist).not.toHaveBeenCalled()
   })
 
+  // `[]` and `['__all__']` both mean "every organization" at authorization time
+  // (`rbacService`), so clearing the last organization checkbox in the ACL editor
+  // must still delete the override rather than trip the restriction guard.
+  it.each([
+    ['an empty organization list', [] as string[]],
+    ['an explicit all-organizations list', ['__all__']],
+  ])('clears the override when features are emptied alongside %s', async (_label, organizations) => {
+    const existing = {
+      id: 'acl-1',
+      isSuperAdmin: false,
+      featuresJson: ['dashboards.view'],
+      organizationsJson: [ACME_ORGANIZATION_ID],
+      updatedAt: null,
+    }
+    storedAcl = existing
+
+    const res = await PUT(putRequest({
+      userId: TARGET_USER_ID,
+      features: [],
+      organizations,
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockEm.remove).toHaveBeenCalledWith(existing)
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
+
   it('keeps an omitted super admin flag intact', async () => {
     mockRbacService.loadAcl.mockResolvedValue({
       isSuperAdmin: true,

--- a/packages/core/src/modules/auth/api/users/acl/route.ts
+++ b/packages/core/src/modules/auth/api/users/acl/route.ts
@@ -238,7 +238,7 @@ export async function PUT(req: Request) {
   // Retaining an organization-only override with no features would revoke every
   // role-granted feature instead of narrowing the role. Refuse that state rather
   // than persisting it or silently dropping the organization scope.
-  if (!effectiveIsSuperAdmin && effectiveFeatures.length === 0 && requestedOrganizations !== null) {
+  if (!effectiveIsSuperAdmin && effectiveFeatures.length === 0 && hasOrganizationRestriction(requestedOrganizations)) {
     const { translate } = await resolveTranslations()
     return NextResponse.json({
       error: translate(
@@ -248,9 +248,10 @@ export async function PUT(req: Request) {
     }, { status: 400 })
   }
 
-  const hasCustomAcl = effectiveIsSuperAdmin
-    || effectiveFeatures.length > 0
-    || requestedOrganizations !== null
+  // An unrestricted organization list carries no override on its own, and the guard
+  // above already refused the restricted-but-featureless case, so the override is
+  // custom exactly when it grants super admin or at least one feature.
+  const hasCustomAcl = effectiveIsSuperAdmin || effectiveFeatures.length > 0
 
   // Persist the ACL mutation inside a transaction so the per-user permission
   // write (or removal) commits atomically (proper ACL-edit transaction handling).
@@ -294,6 +295,14 @@ export async function PUT(req: Request) {
 function normalizeOrganizations(organizations: unknown): string[] | null {
   if (!Array.isArray(organizations)) return null
   return normalizeGrantFeatureList(organizations)
+}
+
+// Mirrors how the scope is read back at authorization time (`rbacService`): an
+// absent, empty, or `__all__` list grants every organization, so only a
+// non-empty explicit list actually narrows the user.
+function hasOrganizationRestriction(organizations: string[] | null): boolean {
+  if (!organizations || organizations.length === 0) return false
+  return !organizations.includes('__all__')
 }
 
 function sanitizeTenantFeatures(features: string[]): string[] {

--- a/packages/core/src/modules/auth/api/users/acl/route.ts
+++ b/packages/core/src/modules/auth/api/users/acl/route.ts
@@ -6,6 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { logCrudAccess } from '@open-mercato/shared/lib/crud/factory'
 import { forbidden, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { enforceCommandOptimisticLockWithGuards } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { UserAcl } from '@open-mercato/core/modules/auth/data/entities'
 import {
@@ -163,9 +164,6 @@ export async function PUT(req: Request) {
     }
   }
 
-  const requestedFeatures = normalizeGrantFeatureList(parsed.data.features)
-  const organizations = normalizeOrganizations(parsed.data.organizations)
-
   let acl = await em.findOne(UserAcl, { user: parsed.data.userId as any, tenantId: auth.tenantId as any })
   // Optimistic lock: refuse a stale per-user ACL overwrite so concurrent edits
   // cannot silently clobber each other (#2055). Strictly additive — a no-op when
@@ -185,8 +183,21 @@ export async function PUT(req: Request) {
   }
   const existingIsSuperAdmin = acl ? !!acl.isSuperAdmin : false
   const existingFeatures = acl ? normalizeGrantFeatureList(acl.featuresJson) : []
+  const existingOrganizations = acl ? normalizeOrganizations(acl.organizationsJson) : null
 
-  const requestedIsSuperAdmin = parsed.data.isSuperAdmin ?? false
+  // A per-user ACL is an absolute override, so an omitted dimension must keep
+  // its stored value. Normalizing an omitted `features` to `[]` or an omitted
+  // `organizations` to `null` turned a single-dimension edit into a silent
+  // clear, deleting the row and widening the user back to their full role.
+  const featuresWereProvided = parsed.data.features !== undefined
+  const requestedFeatures = featuresWereProvided
+    ? normalizeGrantFeatureList(parsed.data.features)
+    : existingFeatures
+  const requestedOrganizations = parsed.data.organizations === undefined
+    ? existingOrganizations
+    : normalizeOrganizations(parsed.data.organizations)
+
+  const requestedIsSuperAdmin = parsed.data.isSuperAdmin ?? existingIsSuperAdmin
 
   try {
     await assertActorCanGrantAcl({
@@ -197,14 +208,17 @@ export async function PUT(req: Request) {
       organizationId: auth.orgId ?? null,
       isSuperAdmin: requestedIsSuperAdmin,
       features: requestedFeatures,
-      organizations,
+      organizations: requestedOrganizations,
     })
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     throw err
   }
 
-  const effectiveFeatures = actorIsSuperAdmin
+  // An omitted feature list is already stored and in effect. Re-sanitizing it
+  // during an unrelated organization edit would silently revoke grants the
+  // actor did not touch, so only an explicitly submitted list is sanitized.
+  const effectiveFeatures = actorIsSuperAdmin || !featuresWereProvided
     ? requestedFeatures
     : sanitizeTenantFeatures(requestedFeatures)
 
@@ -221,7 +235,22 @@ export async function PUT(req: Request) {
     }
   }
 
-  const hasCustomAcl = effectiveIsSuperAdmin || effectiveFeatures.length > 0
+  // Retaining an organization-only override with no features would revoke every
+  // role-granted feature instead of narrowing the role. Refuse that state rather
+  // than persisting it or silently dropping the organization scope.
+  if (!effectiveIsSuperAdmin && effectiveFeatures.length === 0 && requestedOrganizations !== null) {
+    const { translate } = await resolveTranslations()
+    return NextResponse.json({
+      error: translate(
+        'auth.acl.organizationWarning',
+        'Organization restrictions are saved only when at least one feature override is selected. Add a feature or enable a module wildcard before saving.',
+      ),
+    }, { status: 400 })
+  }
+
+  const hasCustomAcl = effectiveIsSuperAdmin
+    || effectiveFeatures.length > 0
+    || requestedOrganizations !== null
 
   // Persist the ACL mutation inside a transaction so the per-user permission
   // write (or removal) commits atomically (proper ACL-edit transaction handling).
@@ -241,7 +270,7 @@ export async function PUT(req: Request) {
         () => {
           aclRecord.isSuperAdmin = effectiveIsSuperAdmin
           aclRecord.featuresJson = effectiveFeatures
-          aclRecord.organizationsJson = organizations
+          aclRecord.organizationsJson = requestedOrganizations
           em.persist(aclRecord)
         },
       ],
@@ -311,7 +340,7 @@ export const openApi: OpenApiRouteDoc = {
     },
     PUT: {
       summary: 'Update user ACL',
-      description: 'Configures per-user ACL overrides, including super admin access, feature list, and organization scope.',
+      description: 'Updates a per-user ACL override. Omitted super admin, feature, and organization fields preserve their stored values. An organization-scoped non-super-admin override requires at least one feature grant.',
       requestBody: {
         contentType: 'application/json',
         schema: putSchema,

--- a/packages/core/src/modules/auth/api/users/acl/route.ts
+++ b/packages/core/src/modules/auth/api/users/acl/route.ts
@@ -297,9 +297,11 @@ function normalizeOrganizations(organizations: unknown): string[] | null {
   return normalizeGrantFeatureList(organizations)
 }
 
-// Mirrors how the scope is read back at authorization time (`rbacService`): an
-// absent, empty, or `__all__` list grants every organization, so only a
-// non-empty explicit list actually narrows the user.
+// Whether the caller expressed an intentional narrowing. `null` and `__all__`
+// are the two documented ways to say "every organization"; an empty list is the
+// editor's "no organization picked" state ("Empty = all organizations"), which
+// is not a restriction an administrator chose. Only a concrete list narrows, so
+// only a concrete list has to justify itself against the feature grant below.
 function hasOrganizationRestriction(organizations: string[] | null): boolean {
   if (!organizations || organizations.length === 0) return false
   return !organizations.includes('__all__')

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-029.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-029.spec.ts
@@ -79,8 +79,11 @@ test.describe('TC-WF-029: workflow organization scoping (#2462)', () => {
         name: 'QA TC-WF-029 B',
       })
       // Restrict each user's visibility to their own organization (sets the scope filter).
-      await setUserAclVisibility(request, superadminToken, { userId: userAId, organizations: [orgAId] })
-      await setUserAclVisibility(request, superadminToken, { userId: userBId, organizations: [orgBId] })
+      // A per-user ACL is an absolute override, so the workflow grant has to be restated
+      // alongside the scope — an organization-only override would leave the user with no
+      // features at all rather than narrowing the role (#5493).
+      await setUserAclVisibility(request, superadminToken, { userId: userAId, organizations: [orgAId], features: ['workflows.*'] })
+      await setUserAclVisibility(request, superadminToken, { userId: userBId, organizations: [orgBId], features: ['workflows.*'] })
 
       tokenA = await getAuthToken(request, `qa-tc-wf-029-a-${stamp}@example.com`, password)
       const tokenB = await getAuthToken(request, `qa-tc-wf-029-b-${stamp}@example.com`, password)


### PR DESCRIPTION
Closes #5493

Ports the user-ACL partial-update fix to the `main` release line. The same
correction shipped to `develop` via #5537; `main` has diverged (35 commits `develop`
does not carry), so the change is applied to `main`'s own version of the route rather
than cherry-picked.

## Problem and root cause

`PUT /api/auth/users/acl` normalized an omitted `features` to `[]` and an omitted
`organizations` to `null`. An organization-only request was therefore classified as an
empty override, so the route **deleted the user's ACL row** and answered
`200 {"ok":true,"sanitized":false}`. Because a per-user ACL is the mechanism for
*narrowing* a role, deleting it drops the user back to the full role — the failure
direction is fail-open. A features-only request similarly erased the stored
organization restriction.

Simply retaining an organization-only row with no features is not a fix either: a
persisted `UserAcl` is an absolute override, so that state would silently revoke every
role-granted feature. The route must reject it rather than persist it.

## What changed

- Merge omitted `features`, `organizations`, and `isSuperAdmin` from the stored ACL
  before authorization and persistence, so a single-dimension edit no longer clears
  the dimensions it did not touch.
- Reject an organization-scoped, non-super-admin override whose merged feature list is
  empty with an actionable `400`, reusing the existing `auth.acl.organizationWarning`
  message (already present in every locale on `main`).
- Skip re-sanitizing an omitted feature list — it is already stored and in effect, and
  re-sanitizing during an unrelated organization edit would revoke untouched grants.
- Preserve an omitted `isSuperAdmin`, while an explicit `false` still revokes it, and
  explicit all-dimension clearing still removes the row.
- Document the partial-update semantics in the PUT OpenAPI description.

The role endpoint (`PUT /api/auth/roles/acl`) referenced in the issue **already**
implements these merge semantics on `main`, so it needed no change.

## Tests

- New `packages/core/src/modules/auth/api/users/acl/__tests__/partial-update.test.ts`
  covers five cases: organizations-only preserves features; features-only preserves the
  organization scope; organization scope with no feature grant returns `400` and writes
  nothing; explicit all-dimension clearing still removes the row; an omitted super-admin
  flag is preserved.
- `TC-AUTH-043-user-acl-override.spec.ts` extended so the integration scenario issues a
  follow-up organizations-only PUT and asserts the feature grant and the organization
  restriction both survive.
- Verified the new unit cases fail against the unfixed route (4 of 5 fail; the
  explicit-clear case passes both ways by design, guarding against over-correction).

## Validation

- `yarn workspace @open-mercato/core test src/modules/auth/api/users/acl src/modules/auth/lib/__tests__ --runInBand` — 18 suites, 145 tests passed.
- `yarn build:packages`, `yarn generate`, `yarn workspace @open-mercato/core typecheck` — passed.
- `eslint` on the three changed files — clean.
- Per the run's instructions, only the related tests were run locally; the full gate
  (`yarn test`, `yarn build:app`, i18n checks, integration) is delegated to CI.

## Breaking changes

None. No route, schema, response shape, database, event, or exported API contract was
removed or renamed. The one intentional behavior correction is that an unsafe
organization-scoped zero-feature override now returns `400` instead of silently
deleting the ACL.

## Labels and delivery

- `review` — ready for maintainer review.
- `bug` — corrects a destructive partial-update defect in an existing endpoint.
- `security` — the defect silently widens a user's effective permissions.
- `priority-high` — a routine admin scope edit removes an access restriction and reports success.
- `risk-medium` — confined to one auth route, but it affects authorization state.
- `skip-qa` — no UI-rendering or database surface changed; route and integration
  coverage for the corrected API behavior ships in this PR.

## Review notes — deliberate decisions

Three points came out of review that are behavior choices rather than defects, recorded
here so a reviewer can overrule them:

- **An omitted `isSuperAdmin` is preserved** (`?? existingIsSuperAdmin`). Previously a
  features-only PUT silently *demoted* a super admin; now it leaves the flag alone, and an
  explicit `false` still revokes it. This matches `PUT /api/auth/roles/acl`, which already
  behaves this way on `main`, and matches the develop-track fix. A non-super-admin actor
  still cannot grant the flag.
- **`AclEditor` can still submit the rejected state.** The editor warns about
  "organizations selected, no features" but does not block submit, and its `onSubmit`
  commits the `auth/users` write before the ACL write — so a 400 here leaves the profile
  saved and the retry hitting a 409 until the page reloads. The escape hatch is the
  "Allow all organizations" button. Closing this properly is a UI change (block submit, or
  refresh `initialUser` after the first write) and is deliberately not bundled into this
  backend fix; it affects the `develop` track identically.
- **Removing an override now requires clearing both dimensions** —
  `{features: [], organizations: null}`. Documented in `UPGRADE_NOTES.md` and the API
  reference rather than special-cased in the route.

`TC-WF-029` called `setUserAclVisibility` with organizations only, which previously
"succeeded" by storing nothing — so the scope filter it set up never existed. It now
restates the role's `workflows.*` grant. **The same latent breakage exists on `develop`**
(identical fixture and call site). CI scopes the integration suite to the modules a PR
touches, so #5537 — which changed only `auth` — ran 122 auth-scoped tests and never
selected the `workflows` spec. This PR touches both modules, so its run covered 206 tests
including `TC-WF-029` and the extended `TC-AUTH-043`; both pass.

