### PR TITLE
docs(changelog): extend the 0.7.0 entry with main merges through 2026-08-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Several major platform capabilities arrive around those themes. Inbound webhooks
 The release closes with a hard **security pass on authentication and scope**. Passkey MFA now requires a genuine WebAuthn assertion — the credential-id-and-challenge shortcut that let a caller pass the second factor with no private key and no signature is gone, and `POST /api/security/mfa/verify` answers `401` for it. A real `JWT_SECRET` is required and the legacy token grace period is time-bounded; dashboard widget tenant/organization overrides, user destination scope, user-consent reads and hybrid search results are all authorized against the caller's real scope; public pay endpoints fail closed under rate limiting; and anonymous API-docs exports no longer disclose ACL feature names. Read [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md) before upgrading — the passkey and `JWT_SECRET` changes are deliberate breaks, and the passkey entry carries operator actions for credentials enrolled through the still-open shortcut. Enjoy!
 
 ## ✨ Features
-- ✨ Hide the contact/feedback widget behind an ff_om_hide_contact flag. (#5486) *(@patzick)*
 - ✨ Warranty & RMA claims desk module — type-adaptive intake, line-level dispositions and supplier recovery. (#4092) *(@haxiorz)*
 - ✨ Devices registry and end-to-end mobile push notifications — FCM, APNs and Expo via communication_channels (supersedes #4326). (#5366) *(@Frshy, via @patzick)*
 - ✨ Add root/links span options and trace data-sync batches (supersedes #5196). (#5375) *(@jtomaszewski, via @patzick)*
@@ -64,6 +63,7 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - ✨ Enable community PR label commands. (#4726) *(@MStaniaszek1998)*
 - ✨ Make the standalone harness pass on Claude sonnet. (#4529) *(@pkarw)*
 - ✨ Cache organization switcher responses (#2907). (#4538) *(@hubert-madej-softiq)*
+- ✨ Hide the contact/feedback widget behind an ff_om_hide_contact flag. (#5486) *(@patzick)*
 
 ## 🔒 Security
 - 🔒 Require a genuine WebAuthn assertion for passkey MFA verification (#3852). (#5306) *(@pkarw)*
@@ -91,16 +91,6 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 🔒 Enforce cumulative capture ceiling (#4487). (#4508) *(@wojciechszyjka)*
 
 ## 🐛 Fixes
-- 🔐 Preserve partial user ACL updates (fixes #5493). (#5623) *(@patzick)*
-- 💰 Serve persisted order totals on single-row GET (#5438). (#5622) *(@Duang777, via @patzick)*
-- 📦 Bump apps/* with the monorepo version on release. (#5530) *(@patzick)*
-- 🔐 Surface login failures instead of an empty 500. (#5529) *(@patzick)*
-- 🐛 Fix the EUDR nav label, module breadcrumb and false unsaved-changes prompt. (#5489) *(@patzick)*
-- 🐛 Clear the 0.7.0 pre-release UX and i18n nits across UI, sales, business rules and record locks (fixes #5456). (#5481) *(@patzick)*
-- 🐛 Stop offering Delete on archived EUDR statements and surface the reason (#5461). (#5480) *(@patzick)*
-- 🐛 Resolve the portal address server-side to stop hydration flicker (fixes #5457). (#5479) *(@patzick)*
-- 🐛 Align the WMS KPI cards, role dialog footer and EUDR area field. (#5432) *(@patzick)*
-- 🐳 Sync role ACLs on redeploy so newly enabled modules stay reachable. (#5431) *(@patzick)*
 - 🐛 Emit the declared logout and password lifecycle events. (#5352) *(@Frshy)*
 - 🐛 Make I18nProvider children optional so it typechecks via React.createElement (#5155). (#5219) *(@adeptofvoltron)*
 - 🔐 Resolve query-index CRUD bridge scope through the metadata-aware resolver. (#5332) *(@MStaniaszek1998)*
@@ -286,6 +276,16 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 🐛 Make the usage scanner see multiline t() calls (#4666). (#4684) *(@wojciechszyjka)*
 - 🔐 Fail closed on unresolved tenant scope in read routes. (#4590) *(@tomaszscigalacshark)*
 - 🐛 Preapprove @open-mercato past yarn's minimum release age gate. (#4644) *(@patzick)*
+- 🐳 Sync role ACLs on redeploy so newly enabled modules stay reachable. (#5431) *(@patzick)*
+- 🐛 Align the WMS KPI cards, role dialog footer and EUDR area field. (#5432) *(@patzick)*
+- 🐛 Resolve the portal address server-side to stop hydration flicker (fixes #5457). (#5479) *(@patzick)*
+- 🐛 Stop offering Delete on archived EUDR statements and surface the reason (#5461). (#5480) *(@patzick)*
+- 🐛 Clear the 0.7.0 pre-release UX and i18n nits across UI, sales, business rules and record locks (fixes #5456). (#5481) *(@patzick)*
+- 🐛 Fix the EUDR nav label, module breadcrumb and false unsaved-changes prompt. (#5489) *(@patzick)*
+- 🔐 Surface login failures instead of an empty 500. (#5529) *(@patzick)*
+- 📦 Bump apps/* with the monorepo version on release. (#5530) *(@patzick)*
+- 💰 Serve persisted order totals on single-row GET (#5438). (#5622) *(@Duang777, via @patzick)*
+- 🔐 Preserve partial user ACL updates (fixes #5493). (#5623) *(@patzick)*
 
 ## 🛠️ Improvements
 - 🛠️ Publish dist/agentic through a staged swap (#5104). (#5328) *(@adeptofvoltron)*
@@ -325,7 +325,6 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 🧪 Mock i18n in the app-level storage_s3 route suite (#4926). (#4931) *(@wojciechszyjka)*
 
 ## 📝 Specs & Documentation
-- 📝 Document ff_om_hide_contact and mirror its tests to the template (fixes #5488). (#5565) *(@adeptofvoltron)*
 - 📝 Make the changelog skill credit the author, not the merger. (#4969) *(@patzick)*
 - 📝 Revise the document generators spec from #5170. (#5323) *(@adeptofvoltron)*
 - 📝 Specify an SMTP transport for transactional email. (#5303) *(@bartek5412)*
@@ -362,6 +361,7 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 📝 Add configuration decision guide (supersedes #4549). (#4741) *(@jtomaszewski, via @pkarw)*
 - 📝 Standalone harness canonical UI and i18n acceptance. (#4743) *(@pkarw)*
 - 📝 AST-first code generation for the remaining string emitters (#1637). (#4636) *(@wojciechszyjka)*
+- 📝 Document ff_om_hide_contact and mirror its tests to the template (fixes #5488). (#5565) *(@adeptofvoltron)*
 
 ## 👥 Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Several major platform capabilities arrive around those themes. Inbound webhooks
 The release closes with a hard **security pass on authentication and scope**. Passkey MFA now requires a genuine WebAuthn assertion — the credential-id-and-challenge shortcut that let a caller pass the second factor with no private key and no signature is gone, and `POST /api/security/mfa/verify` answers `401` for it. A real `JWT_SECRET` is required and the legacy token grace period is time-bounded; dashboard widget tenant/organization overrides, user destination scope, user-consent reads and hybrid search results are all authorized against the caller's real scope; public pay endpoints fail closed under rate limiting; and anonymous API-docs exports no longer disclose ACL feature names. Read [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md) before upgrading — the passkey and `JWT_SECRET` changes are deliberate breaks, and the passkey entry carries operator actions for credentials enrolled through the still-open shortcut. Enjoy!
 
 ## ✨ Features
+- ✨ Hide the contact/feedback widget behind an ff_om_hide_contact flag. (#5486) *(@patzick)*
 - ✨ Warranty & RMA claims desk module — type-adaptive intake, line-level dispositions and supplier recovery. (#4092) *(@haxiorz)*
 - ✨ Devices registry and end-to-end mobile push notifications — FCM, APNs and Expo via communication_channels (supersedes #4326). (#5366) *(@Frshy, via @patzick)*
 - ✨ Add root/links span options and trace data-sync batches (supersedes #5196). (#5375) *(@jtomaszewski, via @patzick)*
@@ -90,6 +91,16 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 🔒 Enforce cumulative capture ceiling (#4487). (#4508) *(@wojciechszyjka)*
 
 ## 🐛 Fixes
+- 🔐 Preserve partial user ACL updates (fixes #5493). (#5623) *(@patzick)*
+- 💰 Serve persisted order totals on single-row GET (#5438). (#5622) *(@Duang777, via @patzick)*
+- 📦 Bump apps/* with the monorepo version on release. (#5530) *(@patzick)*
+- 🔐 Surface login failures instead of an empty 500. (#5529) *(@patzick)*
+- 🐛 Fix the EUDR nav label, module breadcrumb and false unsaved-changes prompt. (#5489) *(@patzick)*
+- 🐛 Clear the 0.7.0 pre-release UX and i18n nits across UI, sales, business rules and record locks (fixes #5456). (#5481) *(@patzick)*
+- 🐛 Stop offering Delete on archived EUDR statements and surface the reason (#5461). (#5480) *(@patzick)*
+- 🐛 Resolve the portal address server-side to stop hydration flicker (fixes #5457). (#5479) *(@patzick)*
+- 🐛 Align the WMS KPI cards, role dialog footer and EUDR area field. (#5432) *(@patzick)*
+- 🐳 Sync role ACLs on redeploy so newly enabled modules stay reachable. (#5431) *(@patzick)*
 - 🐛 Emit the declared logout and password lifecycle events. (#5352) *(@Frshy)*
 - 🐛 Make I18nProvider children optional so it typechecks via React.createElement (#5155). (#5219) *(@adeptofvoltron)*
 - 🔐 Resolve query-index CRUD bridge scope through the metadata-aware resolver. (#5332) *(@MStaniaszek1998)*
@@ -314,6 +325,7 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - 🧪 Mock i18n in the app-level storage_s3 route suite (#4926). (#4931) *(@wojciechszyjka)*
 
 ## 📝 Specs & Documentation
+- 📝 Document ff_om_hide_contact and mirror its tests to the template (fixes #5488). (#5565) *(@adeptofvoltron)*
 - 📝 Make the changelog skill credit the author, not the merger. (#4969) *(@patzick)*
 - 📝 Revise the document generators spec from #5170. (#5323) *(@adeptofvoltron)*
 - 📝 Specify an SMTP transport for transactional email. (#5303) *(@bartek5412)*
@@ -394,6 +406,7 @@ The release closes with a hard **security pass on authentication and scope**. Pa
 - @PatrickMade
 - @bartek5412
 - @KamilGrocholski
+- @Duang777
 
 ---
 


### PR DESCRIPTION
## Summary

Regenerates the `0.7.0` changelog window against the newest `origin/main` and folds in every shipped PR the previous rebuild (#5416, 2026-08-19) could not have seen. Only `CHANGELOG.md` is modified.

The existing entry was audited rather than rewritten: no PR listed in it is unreachable from `main`, no PR number is duplicated inside the block, and the release-workflow changelog guards still pass. This change is therefore purely additive — 12 new bullets and 1 new contributor.

## How the window was built

Reachability mode per `om-auto-update-changelog`'s release-window contract, with `--release-ref main` (the release is cut from `main`, not from the configured `develop` base):

- `git rev-list v0.6.7..origin/main` → 1202 commits.
- **list-prs** (state merged) across nine date chunks spanning `2026-07-28 → 2026-08-26`, so no chunk approached the 250 cap and nothing was silently truncated. **501 PRs enumerated.**
- Kept the **350** whose `mergeCommit.oid` is reachable on `main`; dropped **151** that live only on `develop` or on the `feat/agent-orchestrator-mvp` branch and are therefore not part of this release.
- **21** reachable PRs were absent from the entry; **9** were excluded as plumbing and **12** are added here.

### Excluded (9)

| PR | Reason |
|----|--------|
| #4674, #4783, #5226, #5416 | Prior runs of this skill — changelog PRs are not release content |
| #5014, #5127, #5376 | Branch-sync plumbing (`chore: sync …`, `chore: develop merge before release`) |
| #5485 | `chore: release v0.7.0` — release plumbing, authored by `app/github-actions` |
| #4762 | The `develop` mirror of #4761, which is already credited in the 0.6.7 entry |

## Credit verification

All 12 credits were compared against commit authorship (**get-pr** with `commits`). Eleven matched the PR author outright. One mismatch:

- **#5622** — the merged PR author wrote **0 of 1** commits and the body carries no `Credit:` / `Supersedes` template. The body states the change "already landed on `develop` in #5470"; #5470 is authored by **@Duang777**, and the single commit on #5622 is authored by `Duang777` (co-authored by `cursoragent`, an excluded AI identity). Credited as `*(@Duang777, via @patzick)*` — a cherry-pick carry-forward, not authorship by the porter. #5470 itself is not listed separately: it is unreachable from `main` and is the `develop` twin of the same fix.

No credit is left unverified. @Duang777 is the only new handle in the Contributors block.

## Highlights

Deliberately left untouched — the existing `0.7.0` Highlights paragraphs were written by a human and none of the 12 additions changes the release narrative.

## Test plan

- [x] `node --test scripts/__tests__/release-workflow.test.mjs` — 13/13 pass, including `CHANGELOG.md never repeats a version heading` and `changelog-section.sh round-trips the section it extracts`
- [x] No duplicate PR number inside the `0.7.0` block
- [x] No PR listed in the `0.7.0` block is unreachable from `origin/main`

Docs-only; no runtime, database, API or contract surface is touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273527&installation_model_id=432243&pr_number=5626&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5626&signature=64aadefe09ac597c10577a971177a1d400251b7ec6375c8a09f69bce2f112f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->