### PR TITLE
fix(communication_channels): let test-send fall back to the provider's own target (#4976)

### DIFF
--- a/.ai/specs/2026-06-19-discord-communication-channel-integration.md
+++ b/.ai/specs/2026-06-19-discord-communication-channel-integration.md
@@ -1017,6 +1017,17 @@ not solved by it**: touch-point 2 is #4976, touch-point 3 is #4977.
   feeds `input.to[0]` into `externalEmail` on `messages.messages.compose`, i.e. straight into the
   touch-point 1 validator this section is still deciding. Widening its schema alone would move the
   422 one layer deeper. It lands with the variant decision — as does the conditional `subject`.
+  **Status (2026-08-26): `test-send` complete.** The 2026-08-13 change fixed the recipient's
+  *format* but left its *presence* mandatory, so the smoke test § 6 actually documents — the one
+  with no recipient, posting to `defaultChannelId` — still had no request shape. `to` is now
+  optional at the schema, and `validateOutboundRecipient` accepts an omitted recipient when (and
+  only when) the adapter declares `'provider-native'`, because those adapters carry their own
+  configured target. The email path is unchanged: no email adapter has a default address, so
+  `'email'` — the format every existing provider resolves to — still requires a recipient.
+  Omission means `undefined` alone; `null` and `''` remain 422 on every provider, so a caller who
+  meant to name a recipient and got it wrong is never silently rerouted to the provider default.
+  The CR/LF and allowlist guards are untouched — an absent value carries no payload to filter.
+  `send-as-user` remains out, now tracked separately as **#5528**.
 - **Channel identity** (`connect-credential-channel.ts:161-169`) — tracked as **#4977** (the measured
   consequence: reconnecting Discord creates a duplicate channel, because the duplicate-mailbox guard
   stops applying once `externalIdentifier` is `NULL`): let the adapter supply its own
@@ -1287,6 +1298,31 @@ restored — in the same change that makes the feature real, not before it.
   (which is what makes a Discord sender resolve to a person rather than a display name) remains
   deliberately deferred.
   
+### 2026-08-26 — Touch-point 2: the `test-send` half completed (#4976)
+
+- The smoke test § 6 "Test it" documents — `POST /channels/{id}/test-send` with **no** recipient,
+  so the bot posts to `defaultChannelId` — now has a request shape. The 2026-08-13 change fixed
+  the recipient's format but left `to` mandatory, so the credential field the connect dialog asks
+  for was still read by no product path unless an inbound thread already existed. `to` is now
+  `.optional()` and `validateOutboundRecipient` accepts an omitted recipient for a
+  `'provider-native'` adapter, whose own `resolveTargetChannelId` fallback then applies.
+- **The optionality is provider-derived, not caller-derived**, and that is the whole safety
+  argument: an email provider has no default address to fall back to, so `'email'` — the format
+  every existing provider resolves to, declared or defaulted — still answers `Recipient is
+  required`. An integration case on a seeded connected channel pins this so the optionality
+  cannot be made unconditional by accident.
+- Omission is `undefined` only. `null` and `''` stay 422 on **every** provider: a caller that sent
+  an explicit empty recipient meant to address someone and got it wrong, and rerouting that to the
+  provider default would deliver the message somewhere the caller never named.
+- The CR/LF, allowlist and `..` guards § Shared prerequisite marks MUST-survive are untouched —
+  they sit after the omission branch and an absent value carries nothing to filter.
+- Still open on this touch-point: `send-as-user` and the conditional `subject`, now tracked as
+  **#5528**. Also unimplemented, and noted here rather than silently carried: § 6's "(or click
+  *Test send* in the channel detail UI)" — no such control exists in any `.tsx`, so the API is
+  currently the only smoke-test path.
+- Additive under Cat. 7 (a required request field became optional; no caller that sent `to` is
+  affected); no deprecation protocol required.
+
 ### 2026-08-13 — Touch-point 2 partially implemented (#4976)
 
 - The outbound smoke test is reachable again for a non-email provider:

--- a/.ai/specs/2026-06-19-discord-communication-channel-integration.md
+++ b/.ai/specs/2026-06-19-discord-communication-channel-integration.md
@@ -1310,7 +1310,13 @@ restored — in the same change that makes the feature real, not before it.
   argument: an email provider has no default address to fall back to, so `'email'` — the format
   every existing provider resolves to, declared or defaulted — still answers `Recipient is
   required`. An integration case on a seeded connected channel pins this so the optionality
-  cannot be made unconditional by accident.
+  cannot be made unconditional by accident — but it runs only where
+  `OM_ENABLE_TEST_CHANNEL_SEEDING` is enabled, and that flag is set nowhere in the repository
+  today, so it skips in CI. **The everywhere-guarantee is therefore the unit coverage**
+  (`lib/__tests__/outbound-recipient.test.ts` and the `test-send` route test, which assert the
+  email path across all five capability shapes and run in every environment); the integration
+  case is confirmation against a real seeded channel, not the primary guard. Enabling the flag
+  in the integration harness is proposed separately in #5662.
 - Omission is `undefined` only. `null` and `''` stay 422 on **every** provider: a caller that sent
   an explicit empty recipient meant to address someone and got it wrong, and rerouting that to the
   provider default would deliver the message somewhere the caller never named.

--- a/packages/channel-discord/src/modules/channel_discord/integration.ts
+++ b/packages/channel-discord/src/modules/channel_discord/integration.ts
@@ -85,8 +85,8 @@ export const integration: IntegrationDefinition = {
         required: false,
         placeholder: '123456789012345678',
         helpText:
-          'Default text channel the adapter posts to when an outbound message names no Discord channel. The hub'
-          + ' test-send endpoint accepts a channel snowflake as its recipient, so you can use it to verify this end to end.',
+          'Default text channel the adapter posts to when an outbound message names no Discord channel. Call the hub'
+          + ' test-send endpoint with no recipient to verify it, or pass a channel snowflake as the recipient to post somewhere else.',
       },
     ],
   },

--- a/packages/channel-discord/src/modules/channel_discord/integration.ts
+++ b/packages/channel-discord/src/modules/channel_discord/integration.ts
@@ -85,8 +85,9 @@ export const integration: IntegrationDefinition = {
         required: false,
         placeholder: '123456789012345678',
         helpText:
-          'Default text channel the adapter posts to when an outbound message names no Discord channel. Call the hub'
-          + ' test-send endpoint with no recipient to verify it, or pass a channel snowflake as the recipient to post somewhere else.',
+          'Default text channel the adapter posts to when an outbound message names no Discord channel. To verify it, call the'
+          + ' hub test-send endpoint with an empty JSON body ({}) so no recipient is named, or pass a channel snowflake as the'
+          + ' recipient to post somewhere else.',
       },
     ],
   },

--- a/packages/channel-discord/src/modules/channel_discord/lib/__tests__/adapter.test.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/__tests__/adapter.test.ts
@@ -91,6 +91,29 @@ describe('DiscordChannelAdapter.sendMessage', () => {
     expect(captured.createMessage?.channelId).toBe('default-chan')
   })
 
+  it('explains itself to the operator when nothing names a channel', async () => {
+    // Reachable from the product since #4976 made test-send's recipient
+    // optional: an operator smoke-tests a connection whose `Default channel ID`
+    // was left blank. The route hands `result.error` straight back as
+    // `providerError`, so this string is read by a person, not a log.
+    const { captured } = stubRest()
+    const adapter = getDiscordChannelAdapter()
+
+    const result = await adapter.sendMessage({
+      content: { text: 'x' },
+      credentials,
+      scope: { organizationId: 'o', tenantId: 't' },
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.error).toBe(
+      'No Discord channel to post to — set "Default channel ID" on the connection, or pass a channel id as the recipient.',
+    )
+    expect(result.error).not.toContain('[internal]')
+    // Nothing is posted when there is no target.
+    expect(captured.createMessage).toBeUndefined()
+  })
+
   it('posts to the recipient the hub resolved, instead of silently using the default', async () => {
     // QA of #4391 against a live bot: the hub's test-send route puts the
     // operator's recipient in `metadata.to`, nothing read it, and every send

--- a/packages/channel-discord/src/modules/channel_discord/lib/adapter.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/adapter.ts
@@ -80,10 +80,15 @@ class DiscordChannelAdapter implements ChannelAdapter {
 
     const targetChannelId = resolveTargetChannelId(input, credentials.defaultChannelId)
     if (!targetChannelId) {
+      // Operator-facing, not `[internal]`: since #4976 made the hub's test-send
+      // recipient optional, this is the response an operator gets for the first
+      // thing they are told to try — a smoke test on a connection whose
+      // `Default channel ID` was left blank. It surfaces verbatim as
+      // `providerError`, so it names the two ways out rather than the internals.
       return {
         externalMessageId: '',
         status: 'failed',
-        error: '[internal] Discord send requires a target channel id (conversationId or defaultChannelId)',
+        error: 'No Discord channel to post to — set "Default channel ID" on the connection, or pass a channel id as the recipient.',
       }
     }
 

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-EMAIL-HUB-001.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-EMAIL-HUB-001.spec.ts
@@ -148,6 +148,47 @@ test.describe('TC-CHANNEL-EMAIL-HUB-001: per-user channel API contract', () => {
     }
   })
 
+  // `to` became optional so a provider that carries its own outbound target can run
+  // the documented smoke test without naming a recipient (#4976). That must not leak
+  // into the email path: no email adapter has a default address to fall back to, so
+  // an omitted recipient here has to stay a 422 rather than become a silent no-target
+  // send. This is the case that would fail if the optionality were made unconditional.
+  test('POST test-send on a connected email channel still requires a recipient', async ({
+    request,
+  }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a connected channel.',
+      )
+
+      const stamp = Date.now()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-EMAIL-HUB-001 no-recipient ${stamp}`,
+        externalIdentifier: `hub-001-no-recipient-${stamp}@test-seed.local`,
+      })
+
+      const response = await apiRequest(
+        request,
+        'POST',
+        `/api/communication_channels/channels/${encodeURIComponent(channelId)}/test-send`,
+        { token, data: { body: 'no recipient named' } },
+      )
+      expect(response.status(), 'an email-format channel refuses an omitted recipient').toBe(422)
+      const body = await readJsonSafe<{ error?: string }>(response)
+      expect(body?.error, 'the rejection comes from the recipient validator').toBe(
+        'Recipient is required',
+      )
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+
   test('POST test-send on a connected channel rejects a CR/LF header injection with 422', async ({
     request,
   }) => {

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-EMAIL-HUB-001.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-EMAIL-HUB-001.spec.ts
@@ -189,6 +189,82 @@ test.describe('TC-CHANNEL-EMAIL-HUB-001: per-user channel API contract', () => {
     }
   })
 
+  // The other side of the same contract, on a channel that is NOT email-shaped.
+  // `providerFlavor: 'chat'` connects the stub declaring
+  // `recipientFormat: 'provider-native'`, so these cases exercise the branch a
+  // real Discord channel takes — the one that was previously reachable only with
+  // a live bot, and therefore never covered by CI.
+  test('POST test-send on a connected provider-native channel accepts a provider id and an omitted recipient', async ({
+    request,
+  }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot seed a connected channel.',
+      )
+
+      const stamp = Date.now()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-EMAIL-HUB-001 provider-native ${stamp}`,
+        providerFlavor: 'chat',
+      })
+      const path = `/api/communication_channels/channels/${encodeURIComponent(channelId)}/test-send`
+
+      // A provider-issued id: rejected outright on an email channel, accepted here.
+      const withProviderId = await apiRequest(request, 'POST', path, {
+        token,
+        data: { to: '1534331920463433771', body: 'provider-native recipient' },
+      })
+      expect(
+        withProviderId.status(),
+        'a provider-native channel accepts a provider-issued recipient id',
+      ).toBe(200)
+
+      // The case this test exists for: the documented smoke test shape, with no
+      // recipient at all, so the adapter's own configured target applies.
+      const withoutRecipient = await apiRequest(request, 'POST', path, {
+        token,
+        data: { body: 'omitted recipient' },
+      })
+      expect(
+        withoutRecipient.status(),
+        'a provider-native channel accepts a request that names no recipient',
+      ).toBe(200)
+      const sent = await readJsonSafe<{ status?: string }>(withoutRecipient)
+      expect(sent?.status, 'the omitted-recipient send reaches the adapter').toBe('sent')
+
+      // Widening presence must not weaken the transport-safety guards: an
+      // explicit empty or null recipient is a caller that meant to address
+      // someone and got it wrong, and must never fall back to the default.
+      for (const badRecipient of ['', null]) {
+        const response = await apiRequest(request, 'POST', path, {
+          token,
+          data: { to: badRecipient, body: 'x' },
+        })
+        expect(
+          response.status(),
+          `an explicit ${JSON.stringify(badRecipient)} recipient is refused, not treated as omitted`,
+        ).toBe(422)
+      }
+
+      // The path-steering allowlist still applies on this branch.
+      for (const steering of ['C123/messages', 'C123%2Fmessages', '..']) {
+        const response = await apiRequest(request, 'POST', path, {
+          token,
+          data: { to: steering, body: 'x' },
+        })
+        expect(response.status(), `a path-steering recipient (${steering}) is refused`).toBe(422)
+      }
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+
   test('POST test-send on a connected channel rejects a CR/LF header injection with 422', async ({
     request,
   }) => {

--- a/packages/core/src/modules/communication_channels/api/post/channels/[id]/test-send/__tests__/route.test.ts
+++ b/packages/core/src/modules/communication_channels/api/post/channels/[id]/test-send/__tests__/route.test.ts
@@ -83,6 +83,17 @@ function invoke(to: unknown) {
   return POST(request, { params: { id: CHANNEL_ID } })
 }
 
+// Distinct from `invoke(undefined)` on purpose: this is the request shape the
+// Discord spec's outbound smoke test documents — a body that names no recipient
+// at all, so the adapter posts to its configured default channel.
+function invokeWithoutRecipient() {
+  const request = new Request(
+    `http://localhost/api/communication_channels/channels/${CHANNEL_ID}/test-send`,
+    { method: 'POST', body: JSON.stringify({ body: 'Ping from QA' }) },
+  )
+  return POST(request, { params: { id: CHANNEL_ID } })
+}
+
 describe('POST /api/communication_channels/channels/[id]/test-send — recipient validation', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -161,6 +172,39 @@ describe('POST /api/communication_channels/channels/[id]/test-send — recipient
       await expect(response.json()).resolves.toEqual({
         error: 'Recipient may only contain letters, digits, and the characters . _ : @ + -',
       })
+      expect(adapter.sendMessage).not.toHaveBeenCalled()
+      expect(afterSuccessMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // The half of #4976 that #5261 did not reach: the route made `to` mandatory,
+  // so the smoke test the spec documents — no recipient, adapter posts to
+  // `defaultChannelId` — had no request shape and 422'd at the schema.
+  describe('a request that names no recipient', () => {
+    it('reaches a provider-native adapter with no `metadata.to` at all', async () => {
+      const adapter = buildAdapter('provider-native')
+      getChannelAdapterMock.mockReturnValue(adapter)
+
+      const response = await invokeWithoutRecipient()
+
+      expect(response.status).toBe(200)
+      expect(adapter.sendMessage).toHaveBeenCalledTimes(1)
+      const metadata = adapter.sendMessage.mock.calls[0][0].metadata as Record<string, unknown>
+      expect('to' in metadata).toBe(false)
+      expect(afterSuccessMock).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([
+      ['declared explicitly', 'email' as const],
+      ['left to the default', undefined],
+    ])('is still refused with 422 when recipientFormat is %s', async (_label, format) => {
+      const adapter = buildAdapter(format)
+      getChannelAdapterMock.mockReturnValue(adapter)
+
+      const response = await invokeWithoutRecipient()
+
+      expect(response.status).toBe(422)
+      await expect(response.json()).resolves.toEqual({ error: 'Recipient is required' })
       expect(adapter.sendMessage).not.toHaveBeenCalled()
       expect(afterSuccessMock).not.toHaveBeenCalled()
     })

--- a/packages/core/src/modules/communication_channels/api/post/channels/[id]/test-send/route.ts
+++ b/packages/core/src/modules/communication_channels/api/post/channels/[id]/test-send/route.ts
@@ -37,15 +37,20 @@ export const metadata = {
   },
 }
 
-// `to` is deliberately NOT typed as an email here. The recipient shape depends
-// on the provider (an email address for Gmail/IMAP, a channel snowflake for
-// Discord), and the adapter is only known once the channel is loaded — so the
-// schema accepts any non-empty single-line string and `validateOutboundRecipient`
-// applies the provider-appropriate rules below, defaulting to email. The CR/LF
-// rejection stays at the schema level so a header-injection attempt is refused
-// before the request reaches the channel lookup or the mutation guard.
+// `to` is deliberately NOT typed as an email here, and deliberately optional.
+// The recipient shape depends on the provider (an email address for Gmail/IMAP,
+// a channel snowflake for Discord), and the adapter is only known once the
+// channel is loaded — so the schema accepts any non-empty single-line string and
+// `validateOutboundRecipient` applies the provider-appropriate rules below,
+// defaulting to email. Whether the recipient may be left out is provider-derived
+// too: an adapter that carries its own outbound target (Discord's
+// `defaultChannelId`) accepts a body with no `to` and posts there, which is the
+// smoke test the Discord spec documents; an email provider has no such default
+// and `validateOutboundRecipient` still refuses the request. The CR/LF rejection
+// stays at the schema level so a header-injection attempt is refused before the
+// request reaches the channel lookup or the mutation guard.
 const bodySchema = z.object({
-  to: z.string().min(1).max(MAX_OUTBOUND_RECIPIENT_LENGTH).regex(/^[^\r\n]*$/),
+  to: z.string().min(1).max(MAX_OUTBOUND_RECIPIENT_LENGTH).regex(/^[^\r\n]*$/).optional(),
   subject: z.string().min(1).max(500).optional(),
   body: z.string().max(50_000).optional(),
 })
@@ -232,7 +237,14 @@ export async function POST(req: Request, context: RouteContext): Promise<Respons
         tenantId: auth.tenantId as string,
         organizationId: channelCredentialsOrg,
       },
-      metadata: { to: body.to, subject: body.subject ?? 'Test send', testSend: true },
+      // `to` is omitted from the metadata rather than passed as `undefined` when
+      // the caller left it out, so an adapter reading `metadata.to` sees no key
+      // at all and falls through to its own configured target.
+      metadata: {
+        ...(body.to !== undefined ? { to: body.to } : {}),
+        subject: body.subject ?? 'Test send',
+        testSend: true,
+      },
     })
     await guard.afterSuccess()
     return NextResponse.json({

--- a/packages/core/src/modules/communication_channels/lib/__tests__/outbound-recipient.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/outbound-recipient.test.ts
@@ -74,12 +74,46 @@ describe('validateOutboundRecipient', () => {
     })
   })
 
+  // The second half of #4976: a provider-native adapter is configured with its
+  // own outbound target (Discord's `defaultChannelId`), so omitting the
+  // recipient is how the documented smoke test addresses it. Before this, `to`
+  // was mandatory on every provider and the credential field was written by the
+  // connect dialog but read by no product path.
+  describe('an omitted recipient', () => {
+    it('is accepted on a provider-native provider, so the adapter default applies', () => {
+      expect(validateOutboundRecipient(undefined, providerNative)).toEqual({ ok: true })
+    })
+
+    it.each([undefined, null, {}, { recipientFormat: 'email' as const }, baseEmailCapabilities])(
+      'is still required on an email provider for capabilities %#',
+      (capabilities) => {
+        expect(validateOutboundRecipient(undefined, capabilities)).toEqual({
+          ok: false,
+          error: 'Recipient is required',
+        })
+      },
+    )
+
+    // Omission means `undefined` and nothing else. A caller that sent an
+    // explicit empty or null recipient meant to address someone and got it
+    // wrong; silently rerouting that to the provider default would deliver a
+    // message somewhere the caller never named.
+    it.each([
+      ['an empty string', ''],
+      ['null', null],
+    ])('does not extend to %s on a provider-native provider', (_label, recipient) => {
+      expect(validateOutboundRecipient(recipient, providerNative)).toEqual({
+        ok: false,
+        error: 'Recipient is required',
+      })
+    })
+  })
+
   describe('shape guards, both formats', () => {
     it.each([
       ['an empty string', ''],
       ['a non-string', 42],
       ['null', null],
-      ['undefined', undefined],
     ])('rejects %s', (_label, recipient) => {
       expect(validateOutboundRecipient(recipient, providerNative)).toEqual({
         ok: false,

--- a/packages/core/src/modules/communication_channels/lib/adapter.ts
+++ b/packages/core/src/modules/communication_channels/lib/adapter.ts
@@ -60,6 +60,17 @@ export interface ChannelCapabilities {
    * applies transport-safety checks only (see `validateOutboundRecipient`) and
    * the adapter owns the provider-specific format — it MUST treat the value as
    * untrusted input.
+   *
+   * **`'provider-native'` also opts the provider into presence-optionality, not
+   * only format.** The hub accepts an outbound request that names no recipient
+   * at all and forwards it with no `metadata.to` key, on the understanding that
+   * the adapter resolves its own configured target (Discord: `defaultChannelId`).
+   * An adapter declaring this therefore MUST resolve such a target, and MUST
+   * fail legibly — an operator-readable `SendMessageResult.error`, not a throw —
+   * when it has none, because that message is surfaced verbatim to whoever ran
+   * the send. Declare `'email'` (or omit the field) if your provider has no
+   * default destination: the hub then keeps answering `Recipient is required`,
+   * which is the correct outcome for a request with nowhere to go.
    */
   recipientFormat?: 'email' | 'provider-native'
 }

--- a/packages/core/src/modules/communication_channels/lib/outbound-recipient.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-recipient.ts
@@ -37,11 +37,24 @@ export type OutboundRecipientCheck = { ok: true } | { ok: false; error: string }
  * path to send at all (#4976). Validation now follows the adapter's
  * `capabilities.recipientFormat`, defaulting to `'email'` so every existing
  * provider keeps byte-identical behavior.
+ *
+ * A `'provider-native'` provider may also be addressed by **omitting** the
+ * recipient entirely: those adapters are configured with their own outbound
+ * target (Discord's `defaultChannelId`) and fall back to it when the message
+ * names no channel, which is the smoke test the Discord spec documents in
+ * § 6 "Test it". An email provider has no such default, so `'email'` — the
+ * format every existing provider resolves to — still requires a recipient.
+ * Omission means `undefined` only: `null` or `''` is a caller that meant to
+ * supply an address and got it wrong, and stays a 422 on every provider.
  */
 export function validateOutboundRecipient(
   recipient: unknown,
   capabilities: Pick<ChannelCapabilities, 'recipientFormat'> | null | undefined,
 ): OutboundRecipientCheck {
+  const isProviderNative = capabilities?.recipientFormat === 'provider-native'
+  if (recipient === undefined && isProviderNative) {
+    return { ok: true }
+  }
   if (typeof recipient !== 'string' || recipient.length === 0) {
     return { ok: false, error: 'Recipient is required' }
   }
@@ -51,7 +64,7 @@ export function validateOutboundRecipient(
       error: `Recipient must be at most ${MAX_OUTBOUND_RECIPIENT_LENGTH} characters`,
     }
   }
-  if (capabilities?.recipientFormat !== 'provider-native') {
+  if (!isProviderNative) {
     return emailRecipientSchema.safeParse(recipient).success
       ? { ok: true }
       : { ok: false, error: 'Recipient must be a valid email address' }

--- a/packages/core/src/modules/communication_channels/lib/test-seed.ts
+++ b/packages/core/src/modules/communication_channels/lib/test-seed.ts
@@ -137,6 +137,24 @@ class TestSeedChannelAdapter implements ChannelAdapter {
 }
 
 /**
+ * Capabilities for the chat stub. Identical to the email stub's except for the
+ * recipient shape: a chat channel is addressed by a provider-issued identifier
+ * (a Discord snowflake), not an email address.
+ *
+ * Without this override the chat stub inherited `baseEmailCapabilities`, so it
+ * claimed `channelType: 'discord'` while validating recipients as email
+ * addresses — a channel that could not be addressed the way the provider it
+ * imitates actually is. That left the hub's `'provider-native'` branch
+ * (#4976: per-provider recipient validation, and the omitted recipient that
+ * falls back to the adapter's own target) reachable only with a live Discord
+ * bot, so no integration test could cover it and CI never exercised it.
+ */
+const testSeedChatCapabilities: ChannelCapabilities = {
+  ...testSeedCapabilities,
+  recipientFormat: 'provider-native',
+}
+
+/**
  * Chat-flavoured twin of {@link TestSeedChannelAdapter}: same network-free
  * behaviour, but it declares a non-email `channelType`, so a channel connected
  * through it is shaped like a real chat channel — including an
@@ -145,6 +163,7 @@ class TestSeedChannelAdapter implements ChannelAdapter {
 class TestSeedChatChannelAdapter extends TestSeedChannelAdapter {
   readonly providerKey: string = TEST_SEED_CHAT_PROVIDER_KEY
   readonly channelType: string = 'discord'
+  readonly capabilities = testSeedChatCapabilities
 
   async normalizeInbound(raw: InboundMessage): Promise<NormalizedInboundMessage> {
     // Unlike the email stub, this one is reachable: the test-seed ingest action


### PR DESCRIPTION
Refs #4976

<!-- `Refs`, not `Closes`, on purpose: @wojciechszyjka asked twice on the issue not to
auto-close #4976 on a PR that covers only part of it. See "Scope, and why this does not
close the issue" below. -->

## 🎯 Goal

An operator can finally run the outbound smoke test the Discord spec documents: `POST /api/communication_channels/channels/{id}/test-send` with **no recipient**, so the bot posts to the `Default channel ID` the connect dialog asked for. Until now that request shape did not exist, and the credential field was written by the dialog and read by no product path unless an inbound thread already happened to exist.

## 🔍 Problem

#4976 reports that there is no product path to send a Discord message. #5261 fixed one half of it — the recipient's **format**, so a channel snowflake is no longer rejected as "not an email". What it did not fix is the recipient's **presence**. The route still declared:

```js
// api/post/channels/[id]/test-send/route.ts:48
to: z.string().min(1).max(MAX_OUTBOUND_RECIPIENT_LENGTH).regex(/^[^\r\n]*$/),
```

…while the smoke test § 6 *"Test it"* of `.ai/specs/2026-06-19-discord-communication-channel-integration.md` documents is the one with **no** `to` at all:

> **Outbound smoke test**: `POST /api/communication_channels/channels/{id}/test-send` … The bot posts to `defaultChannelId`; verify the message appears in Discord.

So an operator could smoke-test by pasting the channel id in by hand, but the `Default channel ID` field — whose help text promised *"default text channel for outbound sends and the test-send smoke test"* — was unreachable. This is the gap the issue's own Impact section names, and the one @wojciechszyjka left open on 2026-08-23 with "I have not opened a PR for this — after #5261 the remaining delta is a few lines".

## 🔍 Root Cause

Presence and format were conflated. `validateOutboundRecipient` branches on `capabilities.recipientFormat` for the *shape* of the recipient, but its first guard — `typeof recipient !== 'string'` → `Recipient is required` — applied to every provider regardless, and the route's schema made the field mandatory before the adapter was even resolved. Meanwhile the adapter side had already implemented the fallback the spec describes:

```js
// packages/channel-discord/.../lib/adapter.ts:339 — resolveTargetChannelId
discordChannelId → conversationId → metadata.to → defaultChannelId
```

Nothing in the product could produce a message that reached that last step.

## What Changed

- **`packages/core/src/modules/communication_channels/lib/outbound-recipient.ts`** — `validateOutboundRecipient` gains one leading branch: an **omitted** recipient is accepted when, and only when, the adapter declares `recipientFormat: 'provider-native'`, because those adapters carry their own configured outbound target. Everything after that branch is untouched, so the CR/LF rejection, the character allowlist and the `..` guard the spec marks MUST-survive are byte-identical — an absent value carries nothing to filter.
- **`.../api/post/channels/[id]/test-send/route.ts`** — `to` becomes `.optional()`, and the route omits the `to` key from `metadata` entirely rather than passing `undefined`, so an adapter reading `metadata.to` sees no key at all and falls through to its own default.
- **`packages/channel-discord/.../integration.ts`** — the `Default channel ID` help text now tells the operator how to exercise the field ("call the hub test-send endpoint with no recipient to verify it"), replacing copy that described a capability the endpoint did not have.
- **`.ai/specs/2026-06-19-discord-communication-channel-integration.md`** — § *Shared prerequisite* status updated and a changelog entry added, including the two things this still does not fix.

**The optionality is provider-derived, not caller-derived**, and that is the whole safety argument. An email provider has no default address to fall back to, so `'email'` — the format every existing provider resolves to, declared or defaulted — still answers `Recipient is required`. And omission means `undefined` alone: `null` and `''` stay 422 on **every** provider, because a caller who meant to address someone and mistyped must not be silently rerouted to the provider's default channel.

## 🧪 Tests

- `yarn workspace @open-mercato/core test` (communication_channels scope) — **734 passed / 79 suites**.
- Full gate, local mode, all 8 commands from `.ai/agentic.config.json` in order — `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test` (**34/34 turbo tasks**), `build:app` — all green.
- **Verified the new tests are real regressions**: stashing only the two production files and re-running makes 4 of them fail, and restoring the files makes them pass.

New coverage:

- `outbound-recipient.test.ts` — an omitted recipient is accepted on a provider-native provider; it is still `Recipient is required` on an email provider across all five capability shapes (`undefined`, `null`, `{}`, explicit `'email'`, `baseEmailCapabilities`); and the allowance does **not** extend to `null` or `''`.
- `test-send/__tests__/route.test.ts` — a body naming no recipient reaches a provider-native adapter with **no `to` key in `metadata` at all** (asserted with `'to' in metadata`, not just `toBeUndefined`, so a regression that reintroduces the key is caught); the same body is still refused with 422 on an email channel, declared or defaulted, before `sendMessage` is called.
- `TC-CHANNEL-EMAIL-HUB-001.spec.ts` — an integration case on a seeded connected email channel asserting an omitted recipient is still a 422 from the recipient validator, so the optionality cannot be made unconditional by accident. (Gated on `OM_ENABLE_TEST_CHANNEL_SEEDING`, like its siblings.)

## Scope, and why this does not close the issue

Two things named in #4976 are still not done, and the PR body says so rather than letting the linkage imply otherwise:

1. **`send-as-user` and the conditional `subject`** — tracked separately in **#5528**. `lib/send-as-user.ts:134` feeds `to[0]` into `externalEmail` on `messages.messages.compose`, so widening that schema alone would move the 422 one layer deeper and let the endpoint advertise a capability it does not have. It lands with the #4975 variant decision.
2. **The spec's "(or click *Test send* in the channel detail UI)"** — no such control exists in any `.tsx`. Noted in the spec changelog rather than silently carried; the API is currently the only smoke-test path.

@wojciechszyjka asked on the issue not to close #4976 on a partial PR, so this uses `Refs`. Closing is a maintainer call once #5528 is judged to carry the rest.

## 💥 Breaking Changes

None. A required request field became optional — **additive under `BACKWARD_COMPATIBILITY.md` Cat. 7**; every caller that sends `to` today behaves byte-identically, and every existing provider resolves to `recipientFormat: 'email'`, which this change does not touch.

## Note on an unrelated diff

`yarn generate` refreshes `packages/ui/src/backend/icons/lucideRegistry.generated.tsx` with a `bot` entry sourced from `channel-discord/message-types.ts`, already merged on `develop`. That is pre-existing generated drift on the base branch, not a product of this change, so it is reverted here to keep the diff scoped — worth a separate cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790313652&installation_model_id=432243&pr_number=5635&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5635&signature=fc07cdf50a3b5890e7be5f0072dfc89691e7e61ec6a1e099f91d88d9ceaa7e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->