### PR TITLE
fix(backend): resolve backend page route ids from the params prop (#5600)

### DIFF
--- a/.ai/runs/2026-08-26-pr-5643-review-handback-guard-floors.md
+++ b/.ai/runs/2026-08-26-pr-5643-review-handback-guard-floors.md
@@ -1,0 +1,73 @@
+# PR #5643 — review handback: pin real floors on the backend-page route-param guard
+
+**PR:** https://github.com/open-mercato/open-mercato/pull/5643
+**Issue:** #5600
+**Branch:** `fix/issue-5600-useparams-detail-pages`
+**Base:** `develop`
+**Status:** complete
+
+## Context
+
+This plan was reconstructed by `om-auto-continue-pr` (adoption): PR #5643 was opened by
+`om-auto-fix-issue`, whose run folder never carried a `Tracking plan:` line, so the resume
+had no plan to pick up. The goal below is not invented — it is taken verbatim from the
+review handback @pkarw posted on `4d74a89fb`
+([comment](https://github.com/open-mercato/open-mercato/pull/5643#issuecomment-5423304178)),
+which states what flips the review to approve.
+
+## Goal
+
+Land review **minor 1** and dispose of **minor 2**, so `changes-requested` can return to
+`review`.
+
+**Minor 1 — the guard's collection floor is hollow.**
+`packages/core/src/__tests__/backend-page-route-params.test.ts` asserted
+`expect(pages.length).toBeGreaterThan(0)`. The scan has two swallowed filesystem `catch`
+blocks (the `readdirSync` guard in `collectBackendPages`, and the `statSync` guard in
+`collectModuleRootsUnder`). If either starts swallowing real errors, the scan silently
+shrinks — and with a floor of `0`, a scan that found **one** page still reports green while
+the `useParams()` guard passes vacuously. The two workspace guards this file says it is
+modelled on both pin real floors: `optimistic-lock-ui-coverage-workspace.test.ts:241-242`
+pins `> 3` roots and `> 200` candidates; `optimistic-lock-command-coverage.test.ts:133`
+pins `> 100` files.
+
+**Minor 2 — three surviving `resolvePathnameId` fallbacks.** Explicitly **out of scope
+here** per the reviewer ("this one does not have to land here — filing it as a follow-up
+issue and saying so is a fine disposition"). Filed as a follow-up issue and linked on the PR.
+
+## Non-goals
+
+- Re-doing or extending the #5600 page fix itself — the reviewer verified it from source and
+  did not dispute it.
+- Fixing the three `resolvePathnameId` fallbacks (minor 2) on this branch.
+- Nits 3 and 4 from the review body — optional, left for a convenient moment.
+- Touching the `needs-qa` gate. `qa-approved` is a maintainer's label; this run does not apply it.
+
+## Assumptions
+
+- The reviewer's suggested `> 200` page floor is the intended number (today's scan finds 277).
+- The module-roots floor is left to judgement ("cheap"); `> 10` is used against today's 22 roots.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands.
+> Do not rename step titles.
+
+### Phase 1: Pin the guard's collection floors
+
+- [x] 1.1 Hoist `moduleRoots` into a named binding so it can be asserted on
+- [x] 1.2 Replace `expect(pages.length).toBeGreaterThan(0)` with `> 200`, and assert `moduleRoots.length > 10` alongside it
+- [x] 1.3 Verify the floors actually bite (simulate each swallowed `catch` collapsing; confirm red)
+- [x] 1.4 Run the validation gate
+
+### Phase 2: Dispose of minor 2 and hand back
+
+- [x] 2.1 File the follow-up issue for the three surviving `resolvePathnameId` fallbacks
+- [x] 2.2 Link it on the PR and say so in the handback comment
+- [x] 2.3 Normalize labels (`changes-requested` → `review`), release the lock
+
+## External references
+
+- Review handback: PR #5643 comment by @pkarw, 2026-08-26T08:58:49Z
+- Guards this file is modelled on: `packages/core/src/__tests__/optimistic-lock-ui-coverage-workspace.test.ts`,
+  `packages/core/src/__tests__/optimistic-lock-command-coverage.test.ts`

--- a/.ai/runs/2026-08-26-pr-5643-review-handback-guard-floors.md
+++ b/.ai/runs/2026-08-26-pr-5643-review-handback-guard-floors.md
@@ -55,14 +55,14 @@ issue and saying so is a fine disposition"). Filed as a follow-up issue and link
 
 ### Phase 1: Pin the guard's collection floors
 
-- [x] 1.1 Hoist `moduleRoots` into a named binding so it can be asserted on
-- [x] 1.2 Replace `expect(pages.length).toBeGreaterThan(0)` with `> 200`, and assert `moduleRoots.length > 10` alongside it
-- [x] 1.3 Verify the floors actually bite (simulate each swallowed `catch` collapsing; confirm red)
-- [x] 1.4 Run the validation gate
+- [x] 1.1 Hoist `moduleRoots` into a named binding so it can be asserted on — e82ae3dac
+- [x] 1.2 Replace `expect(pages.length).toBeGreaterThan(0)` with `> 200`, and assert `moduleRoots.length > 10` alongside it — e82ae3dac
+- [x] 1.3 Verify the floors actually bite (simulate each swallowed `catch` collapsing; confirm red) — e82ae3dac
+- [x] 1.4 Run the validation gate — e82ae3dac
 
 ### Phase 2: Dispose of minor 2 and hand back
 
-- [x] 2.1 File the follow-up issue for the three surviving `resolvePathnameId` fallbacks
+- [x] 2.1 File the follow-up issue for the three surviving `resolvePathnameId` fallbacks — issue #5656
 - [x] 2.2 Link it on the PR and say so in the handback comment
 - [x] 2.3 Normalize labels (`changes-requested` → `review`), release the lock
 

--- a/packages/channel-discord/src/modules/channel_discord/backend/channel_discord/channels/[id]/ai-auto-reply/page.tsx
+++ b/packages/channel-discord/src/modules/channel_discord/backend/channel_discord/channels/[id]/ai-auto-reply/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { useParams } from 'next/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudField } from '@open-mercato/ui/backend/CrudForm'
@@ -53,10 +52,9 @@ const CHANNELS_LIST_HREF = '/backend/communication_channels/channels'
  * from a tab opened before someone else touched the channel surfaces the shared
  * conflict bar instead of overwriting them.
  */
-export default function DiscordAiAutoReplyPage() {
+export default function DiscordAiAutoReplyPage({ params }: { params?: { id?: string } }) {
   const t = useT()
-  const params = useParams<{ id: string }>()
-  const channelId = (params?.id as string) ?? ''
+  const channelId = params?.id ?? ''
 
   const [settings, setSettings] = React.useState<AiAutoReplySettings | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
@@ -64,7 +62,11 @@ export default function DiscordAiAutoReplyPage() {
   const [notFound, setNotFound] = React.useState(false)
 
   const load = React.useCallback(async () => {
-    if (!channelId) return
+    if (!channelId) {
+      setIsLoading(false)
+      setErrorMessage(t('channel_discord.aiAutoReply.errors.missingChannelId', 'No channel selected.'))
+      return
+    }
     setIsLoading(true)
     setErrorMessage(null)
     setNotFound(false)

--- a/packages/channel-discord/src/modules/channel_discord/i18n/de.json
+++ b/packages/channel-discord/src/modules/channel_discord/i18n/de.json
@@ -5,6 +5,7 @@
   "channel_discord.aiAutoReply.errors.aiUnavailable": "Die Autoantwort benötigt das KI-Assistent-Modul, das in dieser Installation fehlt",
   "channel_discord.aiAutoReply.errors.load": "KI-Autoantwort-Einstellungen konnten nicht geladen werden",
   "channel_discord.aiAutoReply.errors.loadChannels": "Discord-Kanäle konnten nicht geladen werden",
+  "channel_discord.aiAutoReply.errors.missingChannelId": "Kein Kanal ausgewählt.",
   "channel_discord.aiAutoReply.errors.save": "KI-Autoantwort-Einstellungen konnten nicht gespeichert werden",
   "channel_discord.aiAutoReply.fields.agent": "Agent",
   "channel_discord.aiAutoReply.fields.agentHelp": "Nur Agenten mit strukturierter Ausgabe können auf einem Kanal antworten. Geben Sie dem Kanal-Bot-Benutzer des Mandanten die vom Agenten geforderten Berechtigungen, bevor Sie einen Agenten aus einem anderen Modul wählen.",

--- a/packages/channel-discord/src/modules/channel_discord/i18n/en.json
+++ b/packages/channel-discord/src/modules/channel_discord/i18n/en.json
@@ -5,6 +5,7 @@
   "channel_discord.aiAutoReply.errors.aiUnavailable": "Auto-reply needs the AI assistant module, which is not installed in this deployment",
   "channel_discord.aiAutoReply.errors.load": "Failed to load AI auto-reply settings",
   "channel_discord.aiAutoReply.errors.loadChannels": "Failed to load Discord channels",
+  "channel_discord.aiAutoReply.errors.missingChannelId": "No channel selected.",
   "channel_discord.aiAutoReply.errors.save": "Failed to save AI auto-reply settings",
   "channel_discord.aiAutoReply.fields.agent": "Agent",
   "channel_discord.aiAutoReply.fields.agentHelp": "Only agents that produce structured output can answer a channel. Grant the tenant channel-bot user the agent's required features before choosing an agent from another module.",

--- a/packages/channel-discord/src/modules/channel_discord/i18n/es.json
+++ b/packages/channel-discord/src/modules/channel_discord/i18n/es.json
@@ -5,6 +5,7 @@
   "channel_discord.aiAutoReply.errors.aiUnavailable": "La respuesta automática necesita el módulo de asistente de IA, que no está instalado en este despliegue",
   "channel_discord.aiAutoReply.errors.load": "No se pudo cargar la configuración de respuesta automática de IA",
   "channel_discord.aiAutoReply.errors.loadChannels": "No se pudieron cargar los canales de Discord",
+  "channel_discord.aiAutoReply.errors.missingChannelId": "Ningún canal seleccionado.",
   "channel_discord.aiAutoReply.errors.save": "No se pudo guardar la configuración de respuesta automática de IA",
   "channel_discord.aiAutoReply.fields.agent": "Agente",
   "channel_discord.aiAutoReply.fields.agentHelp": "Solo los agentes que producen salida estructurada pueden responder en un canal. Concede al usuario bot del inquilino los permisos que exige el agente antes de elegir uno de otro módulo.",

--- a/packages/channel-discord/src/modules/channel_discord/i18n/ko.json
+++ b/packages/channel-discord/src/modules/channel_discord/i18n/ko.json
@@ -5,6 +5,7 @@
   "channel_discord.aiAutoReply.errors.aiUnavailable": "자동 응답에는 AI 어시스턴트 모듈이 필요하지만 이 배포에는 설치되어 있지 않습니다",
   "channel_discord.aiAutoReply.errors.load": "AI 자동 응답 설정을 불러오지 못했습니다",
   "channel_discord.aiAutoReply.errors.loadChannels": "Discord 채널을 불러오지 못했습니다",
+  "channel_discord.aiAutoReply.errors.missingChannelId": "선택된 채널이 없습니다.",
   "channel_discord.aiAutoReply.errors.save": "AI 자동 응답 설정을 저장하지 못했습니다",
   "channel_discord.aiAutoReply.fields.agent": "에이전트",
   "channel_discord.aiAutoReply.fields.agentHelp": "구조화된 출력을 생성하는 에이전트만 채널에서 답장할 수 있습니다. 다른 모듈의 에이전트를 선택하기 전에 테넌트의 채널 봇 사용자에게 해당 에이전트가 요구하는 권한을 부여하세요.",

--- a/packages/channel-discord/src/modules/channel_discord/i18n/pl.json
+++ b/packages/channel-discord/src/modules/channel_discord/i18n/pl.json
@@ -5,6 +5,7 @@
   "channel_discord.aiAutoReply.errors.aiUnavailable": "Automatyczne odpowiedzi wymagają modułu asystenta AI, którego nie ma w tym wdrożeniu",
   "channel_discord.aiAutoReply.errors.load": "Nie udało się wczytać ustawień automatycznych odpowiedzi AI",
   "channel_discord.aiAutoReply.errors.loadChannels": "Nie udało się wczytać kanałów Discord",
+  "channel_discord.aiAutoReply.errors.missingChannelId": "Nie wybrano kanału.",
   "channel_discord.aiAutoReply.errors.save": "Nie udało się zapisać ustawień automatycznych odpowiedzi AI",
   "channel_discord.aiAutoReply.fields.agent": "Agent",
   "channel_discord.aiAutoReply.fields.agentHelp": "Na kanale mogą odpowiadać tylko agenci zwracający ustrukturyzowany wynik. Zanim wybierzesz agenta z innego modułu, nadaj użytkownikowi-botowi tenanta uprawnienia wymagane przez tego agenta.",

--- a/packages/core/src/__tests__/backend-page-route-params.test.ts
+++ b/packages/core/src/__tests__/backend-page-route-params.test.ts
@@ -33,6 +33,13 @@ import { join, relative, sep } from 'node:path'
 
 const USE_PARAMS = /\buseParams\b/
 
+/**
+ * The generator treats `page.ts`, `page.tsx`, `page.js`, and `page.jsx` alike
+ * (`MODULE_CODE_EXTENSIONS` in packages/cli/src/lib/generators/scanner.ts), so
+ * scanning only `.tsx` would let a `page.ts` backend page regress unseen.
+ */
+const PAGE_FILE = /^page\.(tsx|ts|jsx|js)$/
+
 const packagesRoot = join(__dirname, '..', '..', '..')
 const repoRoot = join(packagesRoot, '..')
 const appsRoot = join(repoRoot, 'apps')
@@ -55,7 +62,7 @@ function collectBackendPages(dir: string, insideBackend: boolean, acc: string[])
     if (stat.isDirectory()) {
       if (name === 'node_modules' || name === '__tests__' || name === 'dist' || name === 'generated') continue
       collectBackendPages(full, insideBackend || name === 'backend', acc)
-    } else if (insideBackend && (name === 'page.tsx' || name === 'page.jsx')) {
+    } else if (insideBackend && PAGE_FILE.test(name)) {
       acc.push(full)
     }
   }

--- a/packages/core/src/__tests__/backend-page-route-params.test.ts
+++ b/packages/core/src/__tests__/backend-page-route-params.test.ts
@@ -92,13 +92,23 @@ function toRepoRelative(full: string): string {
 }
 
 describe('backend module pages resolve route params from the params prop', () => {
+  const moduleRoots = [...collectModuleRootsUnder(packagesRoot), ...collectModuleRootsUnder(appsRoot)]
   const pages: string[] = []
-  for (const root of [...collectModuleRootsUnder(packagesRoot), ...collectModuleRootsUnder(appsRoot)]) {
-    collectBackendPages(root, false, pages)
-  }
+  for (const root of moduleRoots) collectBackendPages(root, false, pages)
 
-  it('finds backend pages to scan', () => {
-    expect(pages.length).toBeGreaterThan(0)
+  /**
+   * Both floors exist because the two filesystem `catch` blocks above swallow
+   * their errors and return an empty result: without a floor, a scan that
+   * collapsed to a handful of workspaces or files would still report green and
+   * the guard below would pass vacuously. The numbers are the same style of
+   * floor the sibling workspace guards pin (optimistic-lock-ui-coverage-workspace
+   * pins > 3 roots and > 200 candidates; optimistic-lock-command-coverage pins
+   * > 100 files) — set well under today's 22 module roots and 277 pages so
+   * ordinary churn never trips them.
+   */
+  it('scans every workspace module tree, not a truncated slice of it', () => {
+    expect(moduleRoots.length).toBeGreaterThan(10)
+    expect(pages.length).toBeGreaterThan(200)
   })
 
   it('has no backend page that reads route params via useParams()', () => {

--- a/packages/core/src/__tests__/backend-page-route-params.test.ts
+++ b/packages/core/src/__tests__/backend-page-route-params.test.ts
@@ -1,0 +1,104 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+/**
+ * Workspace-wide guard for #5600: a module backend page MUST take its route
+ * params from the `params` prop, never from `useParams()`.
+ *
+ * Module backend pages are not Next.js route files. They are mounted by the
+ * catch-all at `apps/mercato/src/app/(backend)/backend/[...slug]/page.tsx`,
+ * which matches the pathname against the generated backend route manifest and
+ * renders `<Component params={match.params} />`. The matched pattern params
+ * (`/backend/<mod>/channels/[id]` -> `{ id: '<uuid>' }`) therefore arrive as a
+ * PROP. `useParams()` from `next/navigation` returns the params of the real
+ * Next.js route instead — always `{ slug: [...] }` for the catch-all — so a
+ * page reading `params.id` off it gets `undefined`, never issues its fetch, and
+ * hangs on its initial loading state with zero API calls (#5600).
+ *
+ * Positional workarounds (`params.slug[1]`, `params.slug[params.slug.length - 1]`)
+ * are equally forbidden: they hard-code how deep the page sits under `/backend`,
+ * so they silently return the wrong segment the moment the page is nested under
+ * a module-specific folder — which is exactly what the generator's duplicate
+ * route guard (packages/cli/src/lib/generators/module-registry.ts) instructs
+ * module authors to do.
+ *
+ * Fix a failure by giving the page the signature every working detail page uses:
+ *
+ *   export default function MyDetailPage({ params }: { params?: { id?: string } }) {
+ *     const id = params?.id ?? ''
+ *
+ * Do NOT weaken this scan by adding pages to an allowlist — there is no
+ * sanctioned reason for a backend page to call `useParams()`.
+ */
+
+const USE_PARAMS = /\buseParams\b/
+
+const packagesRoot = join(__dirname, '..', '..', '..')
+const repoRoot = join(packagesRoot, '..')
+const appsRoot = join(repoRoot, 'apps')
+
+function collectBackendPages(dir: string, insideBackend: boolean, acc: string[]): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const name of entries) {
+    const full = join(dir, name)
+    let stat
+    try {
+      stat = statSync(full)
+    } catch {
+      continue
+    }
+    if (stat.isDirectory()) {
+      if (name === 'node_modules' || name === '__tests__' || name === 'dist' || name === 'generated') continue
+      collectBackendPages(full, insideBackend || name === 'backend', acc)
+    } else if (insideBackend && (name === 'page.tsx' || name === 'page.jsx')) {
+      acc.push(full)
+    }
+  }
+}
+
+function collectModuleRootsUnder(workspaceRoot: string): string[] {
+  const roots: string[] = []
+  let entries: string[]
+  try {
+    entries = readdirSync(workspaceRoot)
+  } catch {
+    return roots
+  }
+  for (const workspace of entries) {
+    const modulesDir = join(workspaceRoot, workspace, 'src', 'modules')
+    try {
+      if (statSync(modulesDir).isDirectory()) roots.push(modulesDir)
+    } catch {
+      // workspace has no src/modules — skip
+    }
+  }
+  return roots
+}
+
+function toRepoRelative(full: string): string {
+  return relative(repoRoot, full).split(sep).join('/')
+}
+
+describe('backend module pages resolve route params from the params prop', () => {
+  const pages: string[] = []
+  for (const root of [...collectModuleRootsUnder(packagesRoot), ...collectModuleRootsUnder(appsRoot)]) {
+    collectBackendPages(root, false, pages)
+  }
+
+  it('finds backend pages to scan', () => {
+    expect(pages.length).toBeGreaterThan(0)
+  })
+
+  it('has no backend page that reads route params via useParams()', () => {
+    const offenders = pages
+      .filter((file) => USE_PARAMS.test(readFileSync(file, 'utf8')))
+      .map(toRepoRelative)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/core/src/modules/business_rules/backend/logs/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/logs/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { useParams, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@open-mercato/ui/backend/utils/api'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -36,17 +36,9 @@ type RuleExecutionLog = {
   organizationId: string | null
 }
 
-export default function ExecutionLogDetailPage() {
+export default function ExecutionLogDetailPage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
-  const params = useParams()
-
-  // Handle catch-all route: params.slug = ['logs', 'id']
-  let logId: string | undefined
-  if (params?.slug && Array.isArray(params.slug)) {
-    logId = params.slug[1] // Second element is the ID
-  } else if (params?.id) {
-    logId = Array.isArray(params.id) ? params.id[0] : params.id
-  }
+  const logId = params?.id
 
   const t = useT()
 

--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { useRouter, useParams, usePathname } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
@@ -25,18 +25,10 @@ import { ConditionBuilder } from '../../../components/ConditionBuilder'
 import { ActionBuilder } from '../../../components/ActionBuilder'
 import { buildRulePayload, parseRuleToFormValues } from '../../../components/utils/formHelpers'
 
-export default function EditBusinessRulePage() {
+export default function EditBusinessRulePage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
-  const params = useParams()
   const pathname = usePathname()
-
-  // Handle catch-all route: params.slug = ['rules', 'uuid']
-  let ruleId: string | undefined
-  if (params?.slug && Array.isArray(params.slug)) {
-    ruleId = params.slug[1] // Second element is the ID
-  } else if (params?.id) {
-    ruleId = Array.isArray(params.id) ? params.id[0] : params.id
-  }
+  const ruleId = params?.id
 
   const t = useT()
   const { organizationId, tenantId } = useOrganizationScopeDetail()

--- a/packages/core/src/modules/business_rules/backend/sets/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/sets/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { useRouter, useParams, usePathname } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
@@ -53,18 +53,10 @@ type RuleSetDetail = {
   }>
 }
 
-export default function EditRuleSetPage() {
+export default function EditRuleSetPage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
-  const params = useParams()
   const pathname = usePathname()
-
-  // Handle catch-all route: params.slug = ['sets', 'uuid']
-  let setId: string | undefined
-  if (params?.slug && Array.isArray(params.slug)) {
-    setId = params.slug[1] // Second element is the ID
-  } else if (params?.id) {
-    setId = Array.isArray(params.id) ? params.id[0] : params.id
-  }
+  const setId = params?.id
 
   const t = useT()
   const { organizationId, tenantId } = useOrganizationScopeDetail()

--- a/packages/core/src/modules/communication_channels/backend/communication_channels/channels/[id]/page.tsx
+++ b/packages/core/src/modules/communication_channels/backend/communication_channels/channels/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { useParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
 import { Tag } from '@open-mercato/ui/primitives/tag'
@@ -35,10 +34,9 @@ type ChannelHealth = {
   }>
 }
 
-export default function ChannelDetailPage() {
+export default function ChannelDetailPage({ params }: { params?: { id?: string } }) {
   const t = useT()
-  const params = useParams<{ id: string }>()
-  const id = (params?.id as string) ?? ''
+  const id = params?.id ?? ''
 
   const [detail, setDetail] = React.useState<ChannelDetail | null>(null)
   const [health, setHealth] = React.useState<ChannelHealth | null>(null)
@@ -47,7 +45,11 @@ export default function ChannelDetailPage() {
   const [notFound, setNotFound] = React.useState(false)
 
   React.useEffect(() => {
-    if (!id) return
+    if (!id) {
+      setIsLoading(false)
+      setErrorMessage(t('communication_channels.errors.missingChannelId', 'No channel selected.'))
+      return
+    }
     let cancelled = false
     async function load() {
       setIsLoading(true)

--- a/packages/core/src/modules/communication_channels/backend/communication_channels/channels/__tests__/ChannelDetailPage.test.tsx
+++ b/packages/core/src/modules/communication_channels/backend/communication_channels/channels/__tests__/ChannelDetailPage.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import ChannelDetailPage from '../[id]/page'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  LoadingMessage: ({ label }: any) => <div data-testid="loading">{label}</div>,
+  ErrorMessage: ({ label }: any) => <div data-testid="error">{label}</div>,
+  RecordNotFoundState: ({ label }: any) => <div data-testid="not-found">{label}</div>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/tag', () => ({
+  Tag: ({ children }: any) => <span>{children}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+const channel = {
+  id: 'chan-1',
+  providerKey: 'slack',
+  channelType: 'chat',
+  displayName: 'Support Slack',
+  externalIdentifier: 'C123',
+  capabilities: null,
+  isActive: true,
+}
+
+const health = {
+  channelId: 'chan-1',
+  providerKey: 'slack',
+  channelType: 'chat',
+  windowHours: 24,
+  totalsLast24h: 0,
+  counts: {},
+  recentFailures: [],
+}
+
+describe('ChannelDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(apiCall as jest.Mock).mockImplementation((url: string) =>
+      Promise.resolve({ ok: true, result: url.endsWith('/health') ? health : channel }),
+    )
+  })
+
+  // Regression guard for #5600: backend module pages render inside the
+  // `/backend/[...slug]` catch-all, which passes the matched route params as a
+  // prop. A page that read the id from `useParams()` got `undefined` and never
+  // issued this request.
+  it('loads the channel using the id from the params prop', async () => {
+    render(<ChannelDetailPage params={{ id: 'chan-1' }} />)
+
+    await waitFor(() => expect(apiCall).toHaveBeenCalled())
+    const requestedUrls = (apiCall as jest.Mock).mock.calls.map((call) => call[0])
+    expect(requestedUrls).toContain('/api/communication_channels/channels/chan-1')
+    expect(requestedUrls).toContain('/api/communication_channels/channels/chan-1/health')
+    expect(await screen.findByText('Support Slack')).toBeTruthy()
+  })
+
+  it('leaves the loading state with an error when no id is supplied', async () => {
+    render(<ChannelDetailPage />)
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy())
+    expect(screen.queryByTestId('loading')).toBeNull()
+    expect(apiCall).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/communication_channels/i18n/de.json
+++ b/packages/core/src/modules/communication_channels/i18n/de.json
@@ -23,6 +23,7 @@
   "communication_channels.emptyState": "Noch keine gemeinsamen Kanäle. Diese Seite listet gemeinsame, mandantenweite Kanäle auf. Ihr persönliches E-Mail-Postfach ist privat – verbinden und verwalten Sie es unter Profil → Kommunikationskanäle.",
   "communication_channels.errors.loadDetail": "Kanal konnte nicht geladen werden",
   "communication_channels.errors.loadList": "Kanäle konnten nicht geladen werden",
+  "communication_channels.errors.missingChannelId": "Kein Kanal ausgewählt.",
   "communication_channels.errors.pollNowPushDriven": "Der Kanal ist Push-gesteuert — Abrufen ist nicht anwendbar. Eingehende Nachrichten kommen über die Push-Verbindung des Anbieters.",
   "communication_channels.errors.reactionFailed": "Reaktion fehlgeschlagen",
   "communication_channels.errors.undoBlockedPrimaryConflict": "Ein anderer Kanal ist jetzt für diesen Benutzer als primär festgelegt. Setze ihn auf nicht-primär, bevor du den getrennten Kanal wieder als primär festlegst.",

--- a/packages/core/src/modules/communication_channels/i18n/en.json
+++ b/packages/core/src/modules/communication_channels/i18n/en.json
@@ -23,6 +23,7 @@
   "communication_channels.emptyState": "No shared channels yet. This page lists shared, tenant-wide channels. Your personal email mailbox is private — connect and manage it under Profile → Communication Channels.",
   "communication_channels.errors.loadDetail": "Failed to load channel",
   "communication_channels.errors.loadList": "Failed to load channels",
+  "communication_channels.errors.missingChannelId": "No channel selected.",
   "communication_channels.errors.pollNowPushDriven": "Channel is push-driven — polling does not apply. Inbound messages arrive through the provider push connection.",
   "communication_channels.errors.reactionFailed": "Reaction failed",
   "communication_channels.errors.undoBlockedPrimaryConflict": "Another channel is now primary for this user. Set it as non-primary before restoring the disconnected channel as primary.",

--- a/packages/core/src/modules/communication_channels/i18n/es.json
+++ b/packages/core/src/modules/communication_channels/i18n/es.json
@@ -23,6 +23,7 @@
   "communication_channels.emptyState": "Aún no hay canales compartidos. Esta página muestra los canales compartidos de toda la organización. Tu buzón de correo personal es privado: conéctalo y gestiónalo en Perfil → Canales de comunicación.",
   "communication_channels.errors.loadDetail": "No se pudo cargar el canal",
   "communication_channels.errors.loadList": "No se pudieron cargar los canales",
+  "communication_channels.errors.missingChannelId": "Ningún canal seleccionado.",
   "communication_channels.errors.pollNowPushDriven": "El canal funciona con push — el sondeo no aplica. Los mensajes entrantes llegan por la conexión push del proveedor.",
   "communication_channels.errors.reactionFailed": "La reacción falló",
   "communication_channels.errors.undoBlockedPrimaryConflict": "Otro canal es ahora el principal para este usuario. Configúralo como no principal antes de restaurar el canal desconectado como principal.",

--- a/packages/core/src/modules/communication_channels/i18n/ko.json
+++ b/packages/core/src/modules/communication_channels/i18n/ko.json
@@ -23,6 +23,7 @@
   "communication_channels.emptyState": "아직 공유 채널이 없습니다. 이 페이지에는 공유되는 테넌트 전체 채널이 나열됩니다. 개인 이메일 메일함은 비공개이며, 프로필 → 통신 채널에서 연결하고 관리하세요.",
   "communication_channels.errors.loadDetail": "채널을 불러오지 못했습니다",
   "communication_channels.errors.loadList": "채널을 불러오지 못했습니다",
+  "communication_channels.errors.missingChannelId": "선택된 채널이 없습니다.",
   "communication_channels.errors.pollNowPushDriven": "이 채널은 푸시 기반입니다 — 폴링은 적용되지 않습니다. 수신 메시지는 공급자의 푸시 연결로 전달됩니다.",
   "communication_channels.errors.reactionFailed": "반응 처리에 실패했습니다",
   "communication_channels.errors.undoBlockedPrimaryConflict": "다른 채널이 현재 이 사용자의 기본 채널로 설정되어 있습니다. 연결이 끊어진 채널을 기본으로 복원하기 전에 해당 채널을 기본이 아닌 채널로 설정하세요.",

--- a/packages/core/src/modules/communication_channels/i18n/pl.json
+++ b/packages/core/src/modules/communication_channels/i18n/pl.json
@@ -23,6 +23,7 @@
   "communication_channels.emptyState": "Brak kanałów współdzielonych. Ta strona pokazuje współdzielone kanały obejmujące całą organizację. Twoja osobista skrzynka e-mail jest prywatna — połącz ją i zarządzaj nią w Profil → Kanały komunikacji.",
   "communication_channels.errors.loadDetail": "Nie udało się załadować kanału",
   "communication_channels.errors.loadList": "Nie udało się załadować kanałów",
+  "communication_channels.errors.missingChannelId": "Nie wybrano kanału.",
   "communication_channels.errors.pollNowPushDriven": "Kanał działa w trybie push — odpytywanie go nie dotyczy. Wiadomości przychodzące docierają połączeniem push dostawcy.",
   "communication_channels.errors.reactionFailed": "Reakcja nie powiodła się",
   "communication_channels.errors.undoBlockedPrimaryConflict": "Inny kanał jest teraz głównym dla tego użytkownika. Ustaw go jako niegłówny, zanim przywrócisz rozłączony kanał jako główny.",

--- a/packages/core/src/modules/currencies/backend/currencies/[id]/page.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { useRouter, useParams, usePathname } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
 import { updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'

--- a/packages/core/src/modules/workflows/backend/definitions/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from 'react'
-import { useRouter, useParams, usePathname } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
@@ -33,20 +33,12 @@ import { MobileDefinitionDetail } from '../../../components/mobile/MobileDefinit
 import { useIsMobile } from '@open-mercato/ui/hooks/useIsMobile'
 import type { WorkflowDefinitionTrigger } from '../../../data/entities'
 
-export default function EditWorkflowDefinitionPage() {
+export default function EditWorkflowDefinitionPage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
-  const params = useParams()
   const pathname = usePathname()
   const t = useT()
   const isMobile = useIsMobile()
-
-  // Handle catch-all route: params.slug = ['definitions', 'uuid']
-  let definitionId: string | undefined
-  if (params?.slug && Array.isArray(params.slug)) {
-    definitionId = params.slug[1] // Second element is the ID
-  } else if (params?.id) {
-    definitionId = Array.isArray(params.id) ? params.id[0] : params.id
-  }
+  const definitionId = params?.id
 
   const { data: definition, isLoading, error } = useQuery({
     queryKey: ['workflow-definition', definitionId],

--- a/packages/core/src/modules/workflows/backend/events/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/events/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { useParams, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@open-mercato/ui/backend/utils/api'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -36,19 +36,10 @@ type WorkflowEvent = {
   } | null
 }
 
-export default function WorkflowEventDetailPage() {
+export default function WorkflowEventDetailPage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
-  const params = useParams()
   const t = useT()
-
-  // Handle both {id: '17'} and {slug: ['events', '17']} formats
-  let eventId: string | undefined
-  if (params?.id) {
-    eventId = Array.isArray(params.id) ? params.id[0] : params.id
-  } else if (params?.slug && Array.isArray(params.slug)) {
-    // If slug is ['events', '17'], extract '17'
-    eventId = params.slug[params.slug.length - 1]
-  }
+  const eventId = params?.id
 
   const { data: event, isLoading, error } = useQuery({
     queryKey: ['workflows', 'events', eventId],

--- a/packages/enterprise/src/modules/sso/backend/sso/config/[id]/page.tsx
+++ b/packages/enterprise/src/modules/sso/backend/sso/config/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
@@ -45,11 +45,8 @@ interface SsoIdentityRow {
   createdAt: string
 }
 
-export default function SsoConfigDetailPage() {
-  const params = useParams()
-  const configId = (params?.slug && Array.isArray(params.slug))
-    ? params.slug[2]
-    : (Array.isArray(params?.id) ? params.id[0] : params?.id as string)
+export default function SsoConfigDetailPage({ params }: { params?: { id?: string } }) {
+  const configId = params?.id ?? ''
   const router = useRouter()
   const searchParams = useSearchParams()
   const t = useT()

--- a/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/page.tsx
+++ b/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { Page, PageBody, PageHeader } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Badge } from '@open-mercato/ui/primitives/badge'
@@ -52,16 +52,11 @@ type ExecutionRun = {
   durationMs?: number
 }
 
-export default function ScheduleDetailPage() {
-  const params = useParams()
+export default function ScheduleDetailPage({ params }: { params?: { id?: string } }) {
   const router = useRouter()
   const t = useT()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
-  // Extract schedule ID from either params.id or params.slug
-  // When using catch-all routes, the ID is in params.slug[2]
-  const scheduleId = params.id 
-    ? (Array.isArray(params.id) ? params.id[0] : params.id)
-    : (Array.isArray(params.slug) && params.slug.length >= 3 ? params.slug[2] : undefined)
+  const scheduleId = params?.id
 
   const [schedule, setSchedule] = React.useState<ScheduleDetail | null>(null)
   const [runs, setRuns] = React.useState<ExecutionRun[]>([])

--- a/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/page.tsx
+++ b/packages/scheduler/src/modules/scheduler/backend/config/scheduled-jobs/[id]/page.tsx
@@ -106,10 +106,13 @@ export default function ScheduleDetailPage({ params }: { params?: { id?: string 
   }, [scheduleId, isAsyncStrategy])
 
   React.useEffect(() => {
-    if (scheduleId) {
-      fetchScheduleAndRuns()
+    if (!scheduleId) {
+      setLoading(false)
+      setError(t('scheduler.error.missing_schedule_id', 'No schedule selected.'))
+      return
     }
-  }, [scheduleId, fetchScheduleAndRuns])
+    fetchScheduleAndRuns()
+  }, [scheduleId, fetchScheduleAndRuns, t])
 
   const handleTriggerNow = async () => {
     if (!scheduleId || !schedule) return

--- a/packages/scheduler/src/modules/scheduler/i18n/de.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/de.json
@@ -40,6 +40,7 @@
   "scheduler.error.invalid_schedule_value": "Ungültiger Zeitplanwert.",
   "scheduler.error.job_not_found": "Job in BullMQ nicht gefunden (möglicherweise entfernt)",
   "scheduler.error.load_failed": "Fehler beim Laden des Zeitplans",
+  "scheduler.error.missing_schedule_id": "Kein Zeitplan ausgewählt.",
   "scheduler.error.not_found": "Zeitplan nicht gefunden",
   "scheduler.error.queue_param_required": "Queue-Parameter erforderlich",
   "scheduler.error.trigger_async_hint": "Ausführungsverlauf und manuelle Auslösung sind nur mit BullMQ (Async-Strategie) verfügbar",

--- a/packages/scheduler/src/modules/scheduler/i18n/en.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/en.json
@@ -40,6 +40,7 @@
   "scheduler.error.invalid_schedule_value": "Invalid schedule value.",
   "scheduler.error.job_not_found": "Job not found in BullMQ (may have been removed)",
   "scheduler.error.load_failed": "Failed to load schedule",
+  "scheduler.error.missing_schedule_id": "No schedule selected.",
   "scheduler.error.not_found": "Schedule not found",
   "scheduler.error.queue_param_required": "queue parameter required",
   "scheduler.error.trigger_async_hint": "Execution history and manual triggers are only available with BullMQ (async strategy)",

--- a/packages/scheduler/src/modules/scheduler/i18n/es.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/es.json
@@ -40,6 +40,7 @@
   "scheduler.error.invalid_schedule_value": "Valor de programación no válido.",
   "scheduler.error.job_not_found": "Trabajo no encontrado en BullMQ (puede haber sido eliminado)",
   "scheduler.error.load_failed": "Error al cargar la programación",
+  "scheduler.error.missing_schedule_id": "Ningún programa seleccionado.",
   "scheduler.error.not_found": "Programación no encontrada",
   "scheduler.error.queue_param_required": "Se requiere el parámetro queue",
   "scheduler.error.trigger_async_hint": "El historial de ejecución y los disparadores manuales solo están disponibles con BullMQ (estrategia async)",

--- a/packages/scheduler/src/modules/scheduler/i18n/ko.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/ko.json
@@ -40,6 +40,7 @@
   "scheduler.error.invalid_schedule_value": "일정 값이 잘못되었습니다.",
   "scheduler.error.job_not_found": "BullMQ에서 작업을 찾을 수 없습니다 (제거되었을 수 있음)",
   "scheduler.error.load_failed": "일정을 불러오지 못했습니다",
+  "scheduler.error.missing_schedule_id": "선택된 일정이 없습니다.",
   "scheduler.error.not_found": "일정을 찾을 수 없습니다",
   "scheduler.error.queue_param_required": "queue 매개변수가 필요합니다",
   "scheduler.error.trigger_async_hint": "실행 기록 및 수동 실행은 BullMQ(비동기 전략)에서만 사용할 수 있습니다",

--- a/packages/scheduler/src/modules/scheduler/i18n/pl.json
+++ b/packages/scheduler/src/modules/scheduler/i18n/pl.json
@@ -40,6 +40,7 @@
   "scheduler.error.invalid_schedule_value": "Nieprawidłowa wartość harmonogramu.",
   "scheduler.error.job_not_found": "Zadanie nie zostało znalezione w BullMQ (mogło zostać usunięte)",
   "scheduler.error.load_failed": "Nie udało się załadować harmonogramu",
+  "scheduler.error.missing_schedule_id": "Nie wybrano harmonogramu.",
   "scheduler.error.not_found": "Harmonogram nie znaleziony",
   "scheduler.error.queue_param_required": "Parametr queue jest wymagany",
   "scheduler.error.trigger_async_hint": "Historia wykonań i ręczne wyzwalanie są dostępne tylko z BullMQ (strategia async)",

--- a/packages/webhooks/src/modules/webhooks/backend/webhooks/[id]/page.tsx
+++ b/packages/webhooks/src/modules/webhooks/backend/webhooks/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as React from 'react'
 import { extensionPoints } from '@open-mercato/webhooks/modules/webhooks/extension-points'
-import { useParams, usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { RotateCw } from 'lucide-react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
@@ -97,8 +97,7 @@ const statusVariantMap: Record<string, 'default' | 'secondary' | 'destructive' |
 }
 const DELIVERY_AUTO_REFRESH_INTERVAL_MS = 30000
 
-export default function WebhookDetailPage() {
-  const params = useParams()
+export default function WebhookDetailPage({ params }: { params?: { id?: string } }) {
   const pathname = usePathname()
   const router = useRouter()
   const t = useT()

--- a/packages/webhooks/src/modules/webhooks/backend/webhooks/[id]/page.tsx
+++ b/packages/webhooks/src/modules/webhooks/backend/webhooks/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as React from 'react'
 import { extensionPoints } from '@open-mercato/webhooks/modules/webhooks/extension-points'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { RotateCw } from 'lucide-react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
@@ -98,10 +98,9 @@ const statusVariantMap: Record<string, 'default' | 'secondary' | 'destructive' |
 const DELIVERY_AUTO_REFRESH_INTERVAL_MS = 30000
 
 export default function WebhookDetailPage({ params }: { params?: { id?: string } }) {
-  const pathname = usePathname()
   const router = useRouter()
   const t = useT()
-  const webhookId = React.useMemo(() => resolveWebhookId(params?.id, pathname), [params?.id, pathname])
+  const webhookId = params?.id ?? null
 
   const [webhook, setWebhook] = React.useState<Webhook | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
@@ -732,22 +731,3 @@ export default function WebhookDetailPage({ params }: { params?: { id?: string }
   )
 }
 
-function resolveWebhookId(paramValue: string | string[] | undefined, pathname: string | null): string | null {
-  if (typeof paramValue === 'string' && paramValue.trim().length > 0) {
-    return paramValue
-  }
-
-  if (Array.isArray(paramValue)) {
-    const first = paramValue.find((value) => typeof value === 'string' && value.trim().length > 0)
-    if (first) return first
-  }
-
-  if (typeof pathname === 'string') {
-    const match = pathname.match(/\/backend\/webhooks\/([^/?#]+)/)
-    if (match?.[1]) {
-      return decodeURIComponent(match[1])
-    }
-  }
-
-  return null
-}

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -85,6 +85,10 @@ export const REPO_WIDE_GUARDS = [
         scans: 'every packages/*/src/modules tree — optimistic-lock command coverage',
       },
       {
+        path: 'src/__tests__/backend-page-route-params.test.ts',
+        scans: 'every packages/*/src/modules and apps/*/src/modules backend page — route ids read from the `params` prop rather than `useParams()`, which the /backend/[...slug] catch-all never populates with an id (#5600)',
+      },
+      {
         path: 'src/modules/__tests__/crud-indexer-config.test.ts',
         scans: 'packages/ and apps/ — CRUD indexer configuration',
       },


### PR DESCRIPTION
Closes #5600

Tracking plan: `.ai/runs/2026-08-26-pr-5643-review-handback-guard-floors.md`
Status: complete
Follow-up: #5656 (review minor 2 — surviving `resolvePathnameId` fallbacks)

## 🎯 Goal

Backend module detail pages that read their record id from `useParams()` open, hang on their loading state, and never issue a single API call. This PR makes every module backend page take its route id from the `params` prop the backend catch-all already hands it, so those pages load their record — and adds a workspace-wide guard so the pattern cannot come back.

## 🔍 Problem

Reported on a production build (`yarn build:app` + `mercato server start`): `/backend/communication_channels/channels/<uuid>` sat on "Loading channel…" for over two minutes with **zero** network requests and no console error, while sibling detail pages such as `/backend/currencies/<uuid>` and the `warranty_claims` pages worked normally. The difference between the two groups was exactly how each page obtained its record id.

## 🔍 Root Cause

Module backend pages are not Next.js route files. They are mounted by the catch-all at `apps/mercato/src/app/(backend)/backend/[...slug]/page.tsx`, which matches the pathname against the generated backend route manifest and renders the module page as `<Component params={match.params} />`. The params parsed from the module's own manifest pattern (`/backend/communication_channels/channels/[id]` → `{ id: '<uuid>' }`) therefore arrive **as a prop**.

`useParams()` from `next/navigation` reports the params of the *real* Next.js route instead — for the catch-all that is always `{ slug: [...] }`, with no `id` key. So in `communication_channels/.../channels/[id]/page.tsx`:

```tsx
const params = useParams<{ id: string }>()
const id = (params?.id as string) ?? ''     // → ''
React.useEffect(() => {
  if (!id) return                            // early return
  setIsLoading(true) …                       // never reached
}, [id])
```

`isLoading` is initialised to `true` and the only `setIsLoading(false)` sits past that early return, so the spinner never resolves.

The other affected pages hid the same defect behind positional slug heuristics — `params.slug[1]`, `params.slug[2]`, `params.slug[params.slug.length - 1]`, and in the webhooks page an explicit `pathname.match(/\/backend\/webhooks\/([^/?#]+)/)` workaround. Each is correct only for the depth that page happens to sit at today, and silently returns the wrong segment as soon as the page is nested under a module-specific folder — which is exactly what the generator's duplicate-route guard (`packages/cli/src/lib/generators/module-registry.ts`) instructs module authors to do.

## What Changed

- **`packages/core/src/modules/communication_channels/.../channels/[id]/page.tsx`** — the reported page. Now `({ params }: { params?: { id?: string } })`; a missing id resolves the loading state into a translated error instead of spinning forever.
- **`packages/core/src/modules/business_rules/backend/{rules,sets,logs}/[id]/page.tsx`** — dropped the `params.slug[1]` heuristic in favour of the prop. These pages route through `useQuery({ enabled: !!id })`, so a missing id falls through to their existing "failed to load" state.
- **`packages/core/src/modules/workflows/backend/{definitions,events}/[id]/page.tsx`** — same, replacing `slug[1]` and `slug[slug.length - 1]`.
- **`packages/core/src/modules/currencies/backend/currencies/[id]/page.tsx`** — already prop-based and working; removed the leftover unused `useParams` import so it satisfies the new guard.
- **`packages/channel-discord/.../channels/[id]/ai-auto-reply/page.tsx`** — the instance the issue traced back to PR #4391, broken the same way as the channels page; now prop-based, and its missing-id path resolves to a translated error rather than an endless spinner.
- **`packages/enterprise/src/modules/sso/backend/sso/config/[id]/page.tsx`**, **`packages/scheduler/.../scheduled-jobs/[id]/page.tsx`**, **`packages/webhooks/.../webhooks/[id]/page.tsx`** — three further live instances found by re-running the issue's grep across every workspace rather than just `packages/core`. All three worked today via `slug[2]` / a pathname regex; all three are now prop-based, and the webhooks page's pathname-parsing workaround is gone.
- **i18n** — one new key each for `communication_channels` and `channel_discord` (`errors.missingChannelId`), added to all five locales (en, pl, es, de, ko).

**A note on the issue's reproduction table:** `/backend/business_rules/rules/<uuid>` rendered blank because that URL does not exist — `business_rules` mounts its pages at `/backend/rules/<id>`, so that was a 404, not the hang. The id-derivation fragility on those pages was real and is fixed regardless.

## 🧪 Tests

- `packages/core/src/modules/communication_channels/backend/communication_channels/channels/__tests__/ChannelDetailPage.test.tsx` **(new)** — asserts the page requests `/api/communication_channels/channels/chan-1` and `.../health` from the prop id and renders the record, and that with no id it *leaves* the loading state with an error and issues no API call. Both cases fail against the pre-fix component.
- `packages/core/src/__tests__/backend-page-route-params.test.ts` **(new)** — workspace-wide guard, in the same style as the existing `optimistic-lock-ui-coverage-workspace` scan. It walks every module backend `page.tsx` under `packages/*/src/modules` and `apps/*/src/modules` (277 files today) and fails on any `useParams()` reference, with a message naming the correct prop signature. Deliberately allowlist-free: there is no sanctioned reason for a backend page to call `useParams()`.
- **Floors verified to bite, not just to pass.** Each swallowed `catch` was simulated in turn: forcing `collectModuleRootsUnder` to fail drops `moduleRoots` to 0, forcing `collectBackendPages` to fail drops `pages` to 0, and narrowing the scan to a single workspace yields **1** page — a case that passed green under the old `> 0` floor and is now red under `> 200`. That last one is exactly the failure mode the review described.
- Full validation gate re-run in full on `e82ae3dac`, all 8 commands green, uncached: `yarn build:packages`, `yarn generate` (no generated-file drift), `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test` (34/34 tasks; `@open-mercato/core` 11555 passed / 1437 suites / 0 failures), `yarn build:app`.
- Full validation gate from `.ai/agentic.config.json`, in order, all green: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck` (27/27 tasks), `yarn test` (34/34 tasks, 0 failures), `yarn build:app`.
- The first gate run caught a real regression introduced by this change: removing the SSO page's `as string` cast left `configId` typed `string | undefined`, which its `RoleMappingsTab` / `ScimProvisioningTab` / `SsoActivityTab` children reject. Resolved with `?? ''` (matching the other pages) and re-run green.

### Review round 2 — @pkarw's handback on `4d74a89fb`

- **Minor 1 (landed, `e82ae3dac`)** — `packages/core/src/__tests__/backend-page-route-params.test.ts` asserted `expect(pages.length).toBeGreaterThan(0)`, which is a hollow floor: `collectBackendPages` and `collectModuleRootsUnder` both swallow their filesystem errors and return empty, so a scan that silently collapsed still reported green while the `useParams()` assertion passed vacuously. `moduleRoots` is now a named binding and both dimensions of the scan are pinned — `moduleRoots.length > 10` (22 today) and `pages.length > 200` (277 today) — matching the floors the two sibling guards this file is modelled on already pin.
- **Minor 2 (not landed here, by the reviewer's own disposition)** — the three surviving `resolvePathnameId` fallbacks in `integrations/[id]`, `integrations/bundle/[id]` and `data_sync/data-sync/runs/[id]` are filed as **#5656**.
- **Nits 3 and 4** — left as noted in the review body.

## 💥 Breaking Changes

None. No route, API, event, DB, DI, ACL, or exported-type surface changes. The edited page components gain an optional `params` prop that the backend catch-all already supplies to every module page, so they behave identically when mounted normally. The ten new i18n keys are additive and present in all five locales.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790317281&installation_model_id=432243&pr_number=5643&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5643&signature=92e17c1371800a8d6ad95d57b9ad97dc0d956effb9b90f2feba45e4447c578c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
