### PR TITLE
fix(messages): let operators reply and deliver on channel threads (#5535)

### DIFF
--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -69,5 +69,5 @@
 
 ### Phase 5: Validation, review and hand-back
 
-- [ ] 5.1 Run the full configured validation gate
+- [x] 5.1 Run the full configured validation gate — all eight commands green locally on `b82bc962` (plus `yarn lint`: 0 errors, 10 pre-existing warnings in untouched files)
 - [ ] 5.2 Run `om-auto-review-pr 5645 --autofix`, push, and re-request review from @pkarw

--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -1,0 +1,73 @@
+# Execution plan — close @pkarw's two review blockers on the channel-reply fix (adopted from PR #5645)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-26 because PR #5645 carried no execution plan (it was opened by an earlier automation run that never committed one).
+**PR:** #5645 · **Branch:** `fix/issue-5535-reply-inbound-channel-message` · **Base:** `develop`
+**Author:** @wojciechszyjka — this plan interprets the review feedback on that PR; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+`GET /api/messages/{id}` and the `communication_channels` outbound bridge must both close the authorization and delivery-intent gaps @pkarw's `CHANGES_REQUESTED` review found, with a regression test per blocker that drives the real cross-module seam rather than the mocked component in isolation, so PR #5645 can be re-reviewed and merged.
+
+## Scope
+
+- `packages/core/src/modules/communication_channels/subscribers/outbound-bridge.ts` and the lib module that answers "was this message meant to leave the platform?".
+- `packages/core/src/modules/messages/api/[id]/route.ts` — the channel-thread fallback added by this PR (the feature gate and the thread-slice visibility filter).
+- `packages/core/src/modules/messages/api/route.ts` — the new 409 refusal string (review minor).
+- `packages/core/src/modules/messages/lib/channelThreadAccess.ts` — the inert `features` plumbing (review nit).
+- Tests in both modules, plus the `messages` locale files for the translated error.
+
+## Non-goals
+
+- The inbox **list** route's participant scope (`applyMessageParticipantScope`) — already recorded in the PR body as a follow-up; it changes what a list endpoint returns to every caller and deserves its own change and review.
+- Migrating the other nine hardcoded error strings in the compose handler — only the string this PR introduced is in scope.
+- Widening `GET /api/messages/{id}`'s route-level `requireAuth: true` into a route-wide `requireFeatures` — that would deny participants who legitimately read their own messages without `messages.view`. The gate belongs on the channel fallback path this PR added.
+- Executing `TC-CHANNEL-REPLY-001`; it needs a live application environment and belongs to the QA pass.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| Blocker 1: the bridge enqueues internal/forwarded messages for external delivery | @pkarw review (2026-08-26T08:56Z) § Blockers 1, with the `forwardMessageCommand` field-by-field trace; confirmed by reading `commands/messages.ts:903-916` and `outbound-bridge.ts:133-183` | high |
+| Blocker 2: the detail-route channel fallback is ungated | Same review § Blockers 2; confirmed by `api/[id]/route.ts:33` (`GET: { requireAuth: true }`) and `access-control.ts:89` (`void userFeatures`) | high |
+| Each blocker needs a test that crosses the module seam | Same review § Tests & validation, and the user's instruction on this run | high |
+| The minor is the new 409 string; the nit is the inert `features` plumbing | Same review § Minor / § Nits | high |
+| The repository rule for a user-facing error string is `t('module.errors.<key>')`, not the `[internal]` opt-out | root `AGENTS.md` § UI & HTTP; precedent in `auth/api/login.ts`, `attachments/api/route.ts` | high |
+
+## Assumptions
+
+- The review's suggested fix for blocker 1 ("return early when `visibility === 'internal'`") is necessary but not sufficient: `forwardMessageCommand` copies `visibility` from the original, so a forward of a **public** inbound message stays public. The forward therefore needs its own signal. The `messages.message.sent` payload already declares `forwardedFrom`, which records the operator's intent; nothing observable on the `messages` row distinguishes a forward from a reply (both set `parentMessageId` and both can carry platform recipient rows once `replyAll` is used), so the payload field is the only precise discriminator. Documented at the call site.
+- `messages.view` is the right feature for the detail-route fallback gate — the minimum the review names, and the feature that already gates `DELETE` on the same route.
+- The nit is resolved by documenting the `features` plumbing rather than deleting it: it mirrors `assertCanAccessChannel`'s own retained signature and its docblock's "reserved for the v2 admin-oversight feature". Deleting it would diverge the facade from the function it delegates to.
+
+## Risks
+
+- Over-blocking outbound delivery would silently drop an operator's legitimate reply — the same class of failure this PR set out to fix. Mitigated by keeping the intent guard to two narrow, explicitly-tested signals and by leaving the existing "operator reply is delivered" test in place as the counter-case.
+- Filtering internal-visibility messages out of the channel thread slice changes what the detail route returns for a caller who *is* a participant of those internal notes; the filter must keep participants' own internal messages visible.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Channel-thread access facade, DI registration, `messages`-side `tryResolve` wrapper, reply-guard widening, outbound-bridge origin test, compose threading, detail-route fallback — c7f33fe1, 1b687da9
+
+### Phase 2: Blocker 1 — outbound delivery intent guard
+
+- [ ] 2.1 Add the delivery-intent predicate and wire it into the outbound bridge
+- [ ] 2.2 Regression test driving `messages.messages.forward` through the real bridge seam
+
+### Phase 3: Blocker 2 — gate and filter the detail-route channel fallback
+
+- [ ] 3.1 Gate the channel fallback on an explicit feature and filter internal-visibility thread messages to participants
+- [ ] 3.2 Regression test exercising the detail route as a caller holding no features
+
+### Phase 4: Review minor and nit
+
+- [ ] 4.1 Translate the new 409 refusal string across all locales
+- [ ] 4.2 Document the `features` plumbing as a pass-through, not an authorization input
+
+### Phase 5: Validation, review and hand-back
+
+- [ ] 5.1 Run the full configured validation gate
+- [ ] 5.2 Run `om-auto-review-pr 5645 --autofix`, push, and re-request review from @pkarw

--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -54,8 +54,8 @@
 
 ### Phase 2: Blocker 1 — outbound delivery intent guard
 
-- [ ] 2.1 Add the delivery-intent predicate and wire it into the outbound bridge
-- [ ] 2.2 Regression test driving `messages.messages.forward` through the real bridge seam
+- [x] 2.1 Add the delivery-intent predicate and wire it into the outbound bridge — 1a2f1004
+- [x] 2.2 Regression test driving `messages.messages.forward` through the real bridge seam — 1a2f1004
 
 ### Phase 3: Blocker 2 — gate and filter the detail-route channel fallback
 

--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -71,3 +71,13 @@
 
 - [x] 5.1 Run the full configured validation gate — all eight commands green locally on `b82bc962` (plus `yarn lint`: 0 errors, 10 pre-existing warnings in untouched files)
 - [x] 5.2 Run `om-auto-review-pr 5645 --autofix`, push, and re-request review from @pkarw — re-review of `3e62eb24` found no blocker or major in the follow-up work and recorded all four inherited findings as fixed; autofix had nothing to apply. `changes-requested` → `review`, review re-requested from @pkarw.
+
+### Phase 6: UI QA against a live app (added after the QA pass found a blocker)
+
+- [x] 6.1 Provision an ephemeral app from the PR head and execute `TC-CHANNEL-REPLY-001` for the first time — it **failed** on `b683e650` with `403` on `GET /api/messages/{id}`: the Phase 3 gate read `ctx.auth.features`, and the session JWT carries no `features` claim, so it denied every caller including a tenant admin
+- [x] 6.2 Resolve the gate through `rbacService.userHasAllFeatures` instead, drop the test stub that hid it, and pin the regression — c160232e
+- [x] 6.3 Re-run `TC-CHANNEL-REPLY-001` on the fixed head — passes (25.3s) — c160232e
+- [x] 6.4 Drive the browser through the whole #5535 journey and verify blocker 1 on the live system: the reply is delivered (channel total 2), the forward is not (total stays 2) — evidence posted on the PR
+- [x] 6.5 Re-run the full validation gate on the fixed head
+
+> QA note: `OM_ENABLE_TEST_CHANNEL_SEEDING` is set nowhere in the CLI runner or the CI workflow, so `TC-CHANNEL-REPLY-001` and every sibling channel spec `test.skip` silently in CI. That is why a defect this size survived an all-green run, and it is worth wiring in its own change.

--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -70,4 +70,4 @@
 ### Phase 5: Validation, review and hand-back
 
 - [x] 5.1 Run the full configured validation gate — all eight commands green locally on `b82bc962` (plus `yarn lint`: 0 errors, 10 pre-existing warnings in untouched files)
-- [ ] 5.2 Run `om-auto-review-pr 5645 --autofix`, push, and re-request review from @pkarw
+- [x] 5.2 Run `om-auto-review-pr 5645 --autofix`, push, and re-request review from @pkarw — re-review of `3e62eb24` found no blocker or major in the follow-up work and recorded all four inherited findings as fixed; autofix had nothing to apply. `changes-requested` → `review`, review re-requested from @pkarw.

--- a/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
+++ b/.ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
@@ -59,13 +59,13 @@
 
 ### Phase 3: Blocker 2 — gate and filter the detail-route channel fallback
 
-- [ ] 3.1 Gate the channel fallback on an explicit feature and filter internal-visibility thread messages to participants
-- [ ] 3.2 Regression test exercising the detail route as a caller holding no features
+- [x] 3.1 Gate the channel fallback on an explicit feature and filter internal-visibility thread messages to participants — 7f3f89e7
+- [x] 3.2 Regression test exercising the detail route as a caller holding no features — 7f3f89e7
 
 ### Phase 4: Review minor and nit
 
-- [ ] 4.1 Translate the new 409 refusal string across all locales
-- [ ] 4.2 Document the `features` plumbing as a pass-through, not an authorization input
+- [x] 4.1 Translate the new 409 refusal string across all locales — b82bc962
+- [x] 4.2 Document the `features` plumbing as a pass-through, not an authorization input — b82bc962
 
 ### Phase 5: Validation, review and hand-back
 

--- a/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-REPLY-001.spec.ts
+++ b/packages/core/src/modules/communication_channels/__integration__/TC-CHANNEL-REPLY-001.spec.ts
@@ -1,0 +1,156 @@
+import path from 'node:path'
+import { config as loadEnv } from 'dotenv'
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { drainIntegrationQueue } from '@open-mercato/core/helpers/integration/queue'
+import {
+  deleteChannelIfExists,
+  ingestInboundChatMessage,
+  isChannelSeedingAvailable,
+  seedConnectedChannel,
+} from '@open-mercato/core/helpers/integration/communicationChannelsFixtures'
+
+/**
+ * TC-CHANNEL-REPLY-001 — an operator can read and answer an inbound channel
+ * message, and the answer is queued for delivery back to the channel.
+ * Source: https://github.com/open-mercato/open-mercato/issues/5535
+ *
+ * The defect this pins was invisible to every existing test because it only
+ * appears on a message the platform did not author: the ingest attributes the
+ * message to the channel system user and, on an unassigned conversation, writes
+ * no `message_recipients` row, so `messages`' sender-or-recipient predicate was
+ * false for every operator by construction — a tenant admin included.
+ *
+ * Three assertions, in the order an operator hits them:
+ *   1. `GET /api/messages/{id}` — the detail page the reply button lives on.
+ *   2. `POST /api/messages/{id}/reply` — 403 for everyone before the fix.
+ *   3. the outbound `MessageChannelLink`, proving the answer was actually routed
+ *      back to the channel rather than filed as an internal message.
+ *
+ * Driven via the env-gated test-seed fixture (`OM_ENABLE_TEST_CHANNEL_SEEDING`)
+ * and the REAL `ingest_inbound_message` command, so nothing about the message
+ * under test is short-circuited; skips when the gate is off.
+ */
+const APP_ROOT = process.env.OM_TEST_APP_ROOT?.trim()
+  ? path.resolve(process.env.OM_TEST_APP_ROOT as string)
+  : path.resolve(process.cwd(), 'apps/mercato')
+
+if (!process.env.OM_TEST_APP_ROOT?.trim()) {
+  loadEnv({ path: path.resolve(APP_ROOT, '.env') })
+  process.env.QUEUE_BASE_DIR = path.resolve(APP_ROOT, '.mercato/queue')
+}
+
+const EVENTS_QUEUE = 'events'
+const OUTBOUND_QUEUE = 'communication-channels-outbound'
+
+/**
+ * The outbound path is asynchronous: `messages.message.sent` reaches the bridge
+ * through the events queue, which enqueues the delivery job. Drain both, then
+ * re-read the channel's health totals until the outbound record shows up.
+ */
+async function drainUntilOutbound(
+  request: APIRequestContext,
+  token: string,
+  channelId: string,
+  expectedTotal: number,
+): Promise<number> {
+  const deadline = Date.now() + 30_000
+  let lastTotal = 0
+  while (Date.now() < deadline) {
+    await drainIntegrationQueue(EVENTS_QUEUE, { appRoot: APP_ROOT })
+    await drainIntegrationQueue(OUTBOUND_QUEUE, { appRoot: APP_ROOT })
+    const healthResponse = await apiRequest(
+      request,
+      'GET',
+      `/api/communication_channels/channels/${channelId}/health`,
+      { token },
+    )
+    if (healthResponse.ok()) {
+      const health = await readJsonSafe<{ totalsLast24h?: number }>(healthResponse)
+      lastTotal = health?.totalsLast24h ?? 0
+      if (lastTotal >= expectedTotal) return lastTotal
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300))
+  }
+  return lastTotal
+}
+
+test.describe('TC-CHANNEL-REPLY-001: answering an inbound channel message', () => {
+  test('reads, replies to and delivers an answer on a channel-linked thread', async ({
+    request,
+  }) => {
+    test.slow()
+    let token: string | null = null
+    let channelId: string | null = null
+    try {
+      token = await getAuthToken(request, 'admin')
+      const seedingAvailable = await isChannelSeedingAvailable(request, token)
+      test.skip(
+        !seedingAvailable,
+        'OM_ENABLE_TEST_CHANNEL_SEEDING is not enabled in this environment; cannot connect a channel.',
+      )
+
+      const stamp = Date.now()
+      channelId = await seedConnectedChannel(request, token, {
+        displayName: `TC-CHANNEL-REPLY-001 ${stamp}`,
+        providerFlavor: 'chat',
+      })
+
+      const ingested = await ingestInboundChatMessage(request, token, {
+        channelId,
+        senderIdentifier: `chat-user-${stamp}`,
+        senderDisplayName: 'Karol Kapsa',
+        body: 'is anyone there?',
+        externalMessageId: `chat-message-${stamp}`,
+        externalConversationId: `chat-conversation-${stamp}`,
+      })
+      expect(ingested.status, 'the hub must accept the inbound message').toBe('created')
+      const inboundMessageId = ingested.messageId
+      expect(inboundMessageId, 'a platform message must have been composed').toBeTruthy()
+
+      // (1) The detail page the reply button lives on. Before #5535 this was a
+      // 403: the operator is neither the sender (the channel system user) nor a
+      // recipient (there is none on an unassigned conversation).
+      const detailResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/messages/${inboundMessageId}?skipMarkRead=1`,
+        { token },
+      )
+      expect(
+        detailResponse.status(),
+        'an operator must be able to open an inbound channel message',
+      ).toBe(200)
+      const detail = await readJsonSafe<{ thread?: Array<{ id?: string }> }>(detailResponse)
+      expect(
+        (detail?.thread ?? []).map((item) => item.id),
+        'the whole channel conversation must be visible, not only the operator own messages',
+      ).toContain(inboundMessageId)
+
+      // (2) The reply itself — the wall the issue reports.
+      const replyResponse = await apiRequest(
+        request,
+        'POST',
+        `/api/messages/${inboundMessageId}/reply`,
+        { token, data: { body: 'yes, we are here', bodyFormat: 'text' } },
+      )
+      expect(
+        replyResponse.status(),
+        'an operator must be able to answer an inbound channel message',
+      ).toBe(201)
+      const reply = await readJsonSafe<{ id?: string }>(replyResponse)
+      expect(reply?.id, 'the reply must have been persisted').toBeTruthy()
+
+      // (3) Delivery. One inbound record plus one outbound record for the answer;
+      // a reply that was filed as an internal message would leave the total at 1.
+      const total = await drainUntilOutbound(request, token, channelId, 2)
+      expect(
+        total,
+        'the answer must be routed back to the channel, not filed as an internal message',
+      ).toBeGreaterThanOrEqual(2)
+    } finally {
+      await deleteChannelIfExists(request, token, channelId)
+    }
+  })
+})

--- a/packages/core/src/modules/communication_channels/commands/ingest-inbound-message.ts
+++ b/packages/core/src/modules/communication_channels/commands/ingest-inbound-message.ts
@@ -18,6 +18,7 @@ import {
   MessageChannelLink,
 } from '../data/entities'
 import { normalizedInboundMessageSchema } from '../data/validators'
+import { buildInboundIdempotencyKey } from '../lib/inbound-message-origin'
 import { resolveCommunicationChannelsSystemUserId } from '../lib/system-user'
 import { isUniqueViolation } from '../lib/pg-errors'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -408,7 +409,7 @@ const ingestInboundMessageCommand: CommandHandler<IngestInboundMessageInput, Ing
       // composed by the first attempt instead of duplicating it. Mirrors the
       // (channel, externalMessageId) ExternalMessage anchor's natural key.
       idempotencyKey: m.externalMessageId
-        ? `cc:${input.channelId}:${m.externalMessageId}`
+        ? buildInboundIdempotencyKey(input.channelId, m.externalMessageId)
         : undefined,
       tenantId: input.scope.tenantId,
       organizationId: input.scope.organizationId,

--- a/packages/core/src/modules/communication_channels/di.ts
+++ b/packages/core/src/modules/communication_channels/di.ts
@@ -12,6 +12,7 @@ import { getChannelAdapterRegistry } from './lib/adapter-registry-singleton'
 import { ensureTestSeedAdapterRegistered } from './lib/test-seed'
 import { sendAsUser } from './lib/send-as-user'
 import { resolveChannelTypeSafely } from './lib/resolve-channel-type'
+import { resolveChannelThreadAccessSafely } from './lib/channel-thread-access'
 
 export function register(container: AppContainer) {
   // Test-only: register the network-free stub channel adapter when
@@ -43,5 +44,13 @@ export function register(container: AppContainer) {
     // (#4975); absent module or failed lookup reads as "unknown", which the
     // messages validator handles fail-closed.
     communicationChannelsResolveChannelType: asValue(resolveChannelTypeSafely),
+
+    // Cross-module channel-thread authorization. An inbound channel message has
+    // no platform sender and no recipients, so the messages module's
+    // sender-or-recipient reply guard denies every operator (#5535); it resolves
+    // this facade to fall back on the channel's own access rule for threads this
+    // module owns. Absent module or failed lookup reads as "internal thread",
+    // which leaves the participant rule in force.
+    communicationChannelsResolveChannelThreadAccess: asValue(resolveChannelThreadAccessSafely),
   })
 }

--- a/packages/core/src/modules/communication_channels/lib/__tests__/channel-thread-access.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/channel-thread-access.test.ts
@@ -1,0 +1,132 @@
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import {
+  resolveChannelThreadAccess,
+  resolveChannelThreadAccessSafely,
+} from '../channel-thread-access'
+
+const mockFindOne = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+const SCOPE = { tenantId: 'tenant-1', organizationId: 'org-1' }
+const OPERATOR = { userId: 'operator-1', features: ['messages.compose'] }
+
+function makeContainer() {
+  const em: any = { fork: () => em }
+  return { resolve: (name: string) => (name === 'em' ? em : null) } as any
+}
+
+const MAPPING = {
+  messageThreadId: 'thread-1',
+  externalConversationId: 'conv-1',
+  channelId: 'ch-1',
+}
+
+describe('resolveChannelThreadAccess (#5535)', () => {
+  beforeEach(() => mockFindOne.mockReset())
+
+  it('grants access to a shared channel thread for any feature-gated caller', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(MAPPING as never)
+      .mockResolvedValueOnce({ id: 'ch-1', channelType: 'discord', userId: null } as never)
+
+    const result = await resolveChannelThreadAccess(
+      makeContainer(),
+      SCOPE,
+      { messageThreadId: 'thread-1' },
+      OPERATOR,
+    )
+
+    expect(result).toEqual({
+      messageThreadId: 'thread-1',
+      externalConversationId: 'conv-1',
+      channelId: 'ch-1',
+      channelType: 'discord',
+      canAccess: true,
+    })
+  })
+
+  it('keeps a personal mailbox owner-only', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(MAPPING as never)
+      .mockResolvedValueOnce({ id: 'ch-1', channelType: 'email', userId: 'someone-else' } as never)
+
+    const result = await resolveChannelThreadAccess(
+      makeContainer(),
+      SCOPE,
+      { messageThreadId: 'thread-1' },
+      OPERATOR,
+    )
+
+    expect(result?.canAccess).toBe(false)
+  })
+
+  it('grants the owner access to their own personal mailbox thread', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(MAPPING as never)
+      .mockResolvedValueOnce({ id: 'ch-1', channelType: 'email', userId: 'operator-1' } as never)
+
+    const result = await resolveChannelThreadAccess(
+      makeContainer(),
+      SCOPE,
+      { messageThreadId: 'thread-1' },
+      OPERATOR,
+    )
+
+    expect(result?.canAccess).toBe(true)
+  })
+
+  it('resolves the thread of an external conversation', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(MAPPING as never)
+      .mockResolvedValueOnce({ id: 'ch-1', channelType: 'discord', userId: null } as never)
+
+    const result = await resolveChannelThreadAccess(
+      makeContainer(),
+      SCOPE,
+      { externalConversationId: 'conv-1' },
+      OPERATOR,
+    )
+
+    expect(result?.messageThreadId).toBe('thread-1')
+    expect(mockFindOne.mock.calls[0][2]).toMatchObject({ externalConversationId: 'conv-1' })
+  })
+
+  it('reports an internal thread as not channel-linked', async () => {
+    mockFindOne.mockResolvedValue(null as never)
+
+    expect(
+      await resolveChannelThreadAccess(makeContainer(), SCOPE, { messageThreadId: 'thread-1' }, OPERATOR),
+    ).toBeNull()
+    expect(await resolveChannelThreadAccess(makeContainer(), SCOPE, {}, OPERATOR)).toBeNull()
+  })
+
+  it('scopes every lookup to the caller tenant and organization', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(MAPPING as never)
+      .mockResolvedValueOnce({ id: 'ch-1', channelType: 'discord', userId: null } as never)
+
+    await resolveChannelThreadAccess(makeContainer(), SCOPE, { messageThreadId: 'thread-1' }, OPERATOR)
+
+    for (const call of mockFindOne.mock.calls) {
+      expect(call[2]).toMatchObject({ tenantId: 'tenant-1' })
+      expect(call[4]).toMatchObject({ tenantId: 'tenant-1', organizationId: 'org-1' })
+    }
+  })
+
+  it('degrades to "internal thread" instead of throwing when a lookup fails', async () => {
+    mockFindOne.mockRejectedValue(new Error('connection terminated') as never)
+
+    await expect(
+      resolveChannelThreadAccessSafely(
+        makeContainer(),
+        SCOPE,
+        { messageThreadId: 'thread-1' },
+        OPERATOR,
+      ),
+    ).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/communication_channels/lib/channel-thread-access.ts
+++ b/packages/core/src/modules/communication_channels/lib/channel-thread-access.ts
@@ -1,0 +1,133 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { AppContainer } from '@open-mercato/shared/lib/di/container'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+import { assertCanAccessChannel, channelOrgScopeWhere } from './access-control'
+import { ChannelThreadMapping, CommunicationChannel } from '../data/entities'
+
+const logger = createLogger('communication_channels').child({ component: 'channel-thread-access' })
+
+export type ChannelThreadScope = {
+  tenantId: string
+  organizationId: string | null
+}
+
+export type ChannelThreadReference = {
+  /** `messages.message.thread_id` of the thread the caller is acting on. */
+  messageThreadId?: string | null
+  /** `ExternalConversation.id`, as carried by a message's `sourceEntityId`. */
+  externalConversationId?: string | null
+}
+
+export type ChannelThreadActor = {
+  userId: string | null
+  features: string[]
+}
+
+export type ChannelThreadAccess = {
+  messageThreadId: string
+  externalConversationId: string
+  channelId: string
+  channelType: string
+  /** Whether {@link ChannelThreadActor} may act on the channel behind this thread. */
+  canAccess: boolean
+}
+
+/**
+ * Resolve the channel behind a message thread and decide whether the caller may
+ * act on it (#5535).
+ *
+ * An inbound channel message has a synthetic sender (the channel system user)
+ * and, when the conversation is unassigned, no `message_recipients` row at all.
+ * The `messages` module's sender-or-recipient predicate therefore denies every
+ * operator on such a thread, including a tenant admin — the participant test
+ * asks a question that a thread whose correspondent is not a platform user
+ * cannot answer. For those threads the authorization that actually applies is
+ * this module's own channel access rule, so `messages` resolves this facade
+ * from DI (mirroring `communicationChannelsResolveChannelType`) instead of
+ * reaching into these entities.
+ *
+ * `canAccess` reuses {@link assertCanAccessChannel}: a personal mailbox stays
+ * owner-only, a tenant-wide / shared channel is open to any caller the route
+ * already feature-gated. Returns `null` when the thread is not channel-linked —
+ * an internal message keeps the participant rule untouched.
+ *
+ * Always tenant/organization scoped: a thread that does not resolve inside the
+ * caller's scope reads as not channel-linked rather than being looked up
+ * globally.
+ */
+export async function resolveChannelThreadAccess(
+  container: AppContainer,
+  scope: ChannelThreadScope,
+  reference: ChannelThreadReference,
+  actor: ChannelThreadActor,
+): Promise<ChannelThreadAccess | null> {
+  const messageThreadId = reference.messageThreadId ?? null
+  const externalConversationId = reference.externalConversationId ?? null
+  if (!messageThreadId && !externalConversationId) return null
+
+  const em = (container.resolve('em') as EntityManager).fork()
+  const dscope = { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null }
+  const baseFilter = { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null }
+
+  const mapping = await findOneWithDecryption(
+    em,
+    ChannelThreadMapping,
+    messageThreadId ? { messageThreadId, ...baseFilter } : { externalConversationId, ...baseFilter },
+    undefined,
+    dscope,
+  )
+  if (!mapping) return null
+
+  const channel = await findOneWithDecryption(
+    em,
+    CommunicationChannel,
+    {
+      id: mapping.channelId,
+      tenantId: scope.tenantId,
+      ...channelOrgScopeWhere(scope.organizationId),
+      deletedAt: null,
+    },
+    undefined,
+    dscope,
+  )
+  if (!channel) return null
+
+  let canAccess = true
+  try {
+    assertCanAccessChannel(channel, actor.userId, actor.features)
+  } catch {
+    canAccess = false
+  }
+
+  return {
+    messageThreadId: mapping.messageThreadId,
+    externalConversationId: mapping.externalConversationId,
+    channelId: mapping.channelId,
+    channelType: channel.channelType,
+    canAccess,
+  }
+}
+
+/**
+ * Same contract, but never throws: a lookup failure degrades to "not
+ * channel-linked", which leaves the caller on its pre-existing rule. For the
+ * reply guard that is the fail-closed answer — the participant test still
+ * applies and a transient database error cannot widen access.
+ */
+export async function resolveChannelThreadAccessSafely(
+  container: AppContainer,
+  scope: ChannelThreadScope,
+  reference: ChannelThreadReference,
+  actor: ChannelThreadActor,
+): Promise<ChannelThreadAccess | null> {
+  try {
+    return await resolveChannelThreadAccess(container, scope, reference, actor)
+  } catch (err) {
+    logger.warn('channel thread access resolution failed, treating the thread as internal', { err })
+    return null
+  }
+}
+
+/** DI service type for cross-module callers (resolve `communicationChannelsResolveChannelThreadAccess`). */
+export type ResolveChannelThreadAccessService = typeof resolveChannelThreadAccessSafely

--- a/packages/core/src/modules/communication_channels/lib/inbound-message-origin.ts
+++ b/packages/core/src/modules/communication_channels/lib/inbound-message-origin.ts
@@ -1,0 +1,62 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { resolveCommunicationChannelsSystemUserId } from './system-user'
+
+/**
+ * Entity type a channel-backed conversation is exposed under on a message's
+ * `sourceEntityType`. Written by `commands/ingest-inbound-message.ts` and
+ * inherited by every operator message composed on the same conversation.
+ */
+export const EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE = 'communication_channels.external_conversation'
+
+/**
+ * Dedup key `ingest-inbound-message` stamps on the platform message it composes,
+ * so a retried ingest reuses the first attempt's message instead of duplicating
+ * it. The `cc:` prefix also identifies the message as ingest-authored — see
+ * {@link isIngestedInboundMessage}.
+ */
+export function buildInboundIdempotencyKey(channelId: string, externalMessageId: string): string {
+  return `cc:${channelId}:${externalMessageId}`
+}
+
+type InboundMessageOriginInput = {
+  message: {
+    senderUserId: string
+    sourceEntityType?: string | null
+    idempotencyKey?: string | null
+  }
+  /** The `MessageChannelLink` already loaded for this message, if any. */
+  existingLink: { direction: 'inbound' | 'outbound' } | null | undefined
+  tenantId: string
+}
+
+/**
+ * Whether a platform message in a channel-linked thread is the one
+ * `ingest-inbound-message` composed for an incoming message — as opposed to a
+ * message an operator wrote in the same conversation.
+ *
+ * The distinction matters because the messages module emits
+ * `messages.message.sent` for both, and only the operator's message may be
+ * delivered outbound. Before #5535 the discriminator was `sourceEntityType`
+ * alone, which every operator reply inherits from the message it answers — so
+ * operator replies were silently dropped along with the ingested messages.
+ *
+ * Three signals, checked cheapest-first, because the ingested message's inbound
+ * `MessageChannelLink` is written *after* the compose command emits its event
+ * and is therefore not guaranteed to be visible yet:
+ *
+ *   1. an inbound `MessageChannelLink` for this message — authoritative;
+ *   2. the `cc:` ingest dedup key ({@link buildInboundIdempotencyKey}) — set
+ *      whenever the provider supplied an external message id;
+ *   3. the tenant's channel system user as the sender — the ingest attribution
+ *      when the conversation has no assigned user.
+ */
+export async function isIngestedInboundMessage(
+  em: EntityManager,
+  { message, existingLink, tenantId }: InboundMessageOriginInput,
+): Promise<boolean> {
+  if (message.sourceEntityType !== EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE) return false
+  if (existingLink?.direction === 'inbound') return true
+  if (typeof message.idempotencyKey === 'string' && message.idempotencyKey.startsWith('cc:')) return true
+  const systemUserId = await resolveCommunicationChannelsSystemUserId(em, tenantId)
+  return message.senderUserId === systemUserId
+}

--- a/packages/core/src/modules/communication_channels/lib/outbound-delivery-intent.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-delivery-intent.ts
@@ -1,0 +1,50 @@
+type OutboundDeliveryIntentInput = {
+  message: {
+    visibility?: 'public' | 'internal' | null
+  }
+  /**
+   * `forwardedFrom` as carried by the `messages.message.sent` payload — the id of
+   * the message a `messages.messages.forward` was built from, absent on every
+   * other compose path.
+   */
+  forwardedFromMessageId?: string | null
+}
+
+/**
+ * Whether a platform message in a channel-linked thread was meant to leave the
+ * platform, i.e. to be delivered to the external correspondent.
+ *
+ * The outbound bridge's origin test (`isIngestedInboundMessage`) answers a
+ * narrower question — "did the ingest command compose this?" — and every
+ * *internal* message sharing the channel thread falls between the two. This
+ * predicate is the intent half, and it fails closed: only a message that is
+ * neither internal nor a forward is delivered.
+ *
+ * Two signals:
+ *
+ *   1. **`visibility === 'internal'`** — an internal note, or an internal
+ *      compose filed against the conversation with an explicit
+ *      `parentMessageId`. `api/route.ts` deliberately leaves such a compose on
+ *      its own thread, and it must not be delivered either.
+ *   2. **`forwardedFromMessageId`** — a forward. `forwardMessageCommand` copies
+ *      `visibility` from the message it forwards, so forwarding a *public*
+ *      inbound message produces a public forward whose body is the quoted
+ *      conversation plus the operator's own commentary about the correspondent.
+ *      Signal 1 cannot see it.
+ *
+ * Signal 2 reads the event payload rather than the `messages` row on purpose:
+ * nothing persisted distinguishes a forward from a reply — both set
+ * `parentMessageId` to the message they answer, and a `replyAll` reply carries
+ * platform recipient rows just like a forward does — so the recorded intent in
+ * the `messages.message.sent` payload is the only precise discriminator. Its
+ * absence reads as "not a forward", which is why signal 1 is checked
+ * independently rather than as a fallback.
+ */
+export function isOutboundDeliveryIntended({
+  message,
+  forwardedFromMessageId,
+}: OutboundDeliveryIntentInput): boolean {
+  if (message.visibility === 'internal') return false
+  if (typeof forwardedFromMessageId === 'string' && forwardedFromMessageId.length > 0) return false
+  return true
+}

--- a/packages/core/src/modules/communication_channels/subscribers/__tests__/outbound-bridge.message-intent.test.ts
+++ b/packages/core/src/modules/communication_channels/subscribers/__tests__/outbound-bridge.message-intent.test.ts
@@ -1,0 +1,224 @@
+import '@open-mercato/core/modules/messages/commands/messages'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { Message, MessageRecipient } from '@open-mercato/core/modules/messages/data/entities'
+import bridgeHandler from '../outbound-bridge'
+
+const enqueueMock = jest.fn(async () => 'job-id')
+jest.mock('../../lib/queue', () => {
+  const actual = jest.requireActual('../../lib/queue')
+  return {
+    ...actual,
+    getCommunicationChannelsQueue: jest.fn(() => ({ enqueue: enqueueMock })),
+  }
+})
+
+const emitMessagesEventMock = jest.fn(async () => {})
+jest.mock('@open-mercato/core/modules/messages/events', () => ({
+  emitMessagesEvent: (...args: unknown[]) => emitMessagesEventMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/messages/lib/attachments', () => ({
+  linkAttachmentsToMessage: jest.fn(),
+  linkLibraryAttachmentsToMessage: jest.fn(),
+  copyAttachmentsForForwardMessages: jest.fn(),
+}))
+
+/**
+ * Cross-module seam regression for @pkarw's blocker on #5645.
+ *
+ * The two mocked unit suites on either side of this seam each pass on their own:
+ * `messages` proves the forward command composes the message it should, and
+ * `communication_channels` proves the bridge enqueues an operator message in a
+ * channel thread. The leak lived exactly between them — a forward IS an operator
+ * message in a channel thread, so the bridge delivered the operator's private
+ * commentary about the correspondent TO that correspondent.
+ *
+ * These tests therefore run the real command, take the `messages.message.sent`
+ * payload and the `Message` row it actually produced, and feed both into the
+ * real subscriber. Nothing about the intent guard is restated here; the
+ * assertion is on what the two modules do to each other.
+ */
+describe('outbound bridge — delivery intent across the messages seam (#5645 review)', () => {
+  const tenantId = '44444444-4444-4444-8444-444444444444'
+  const organizationId = '55555555-5555-4555-8555-555555555555'
+  const threadId = '22222222-2222-4222-8222-222222222222'
+  const inboundMessageId = '11111111-1111-4111-8111-111111111111'
+  const composedMessageId = '33333333-3333-4333-8333-333333333333'
+  const operatorUserId = '66666666-6666-4666-8666-666666666666'
+  const colleagueUserId = '99999999-9999-4999-8999-999999999999'
+  const systemUserId = '00000000-0000-0000-0000-000000000000'
+  const externalConversationId = '77777777-7777-4777-8777-777777777777'
+
+  function inboundMessage(overrides: Record<string, unknown> = {}) {
+    return {
+      id: inboundMessageId,
+      threadId,
+      parentMessageId: null,
+      senderUserId: systemUserId,
+      subject: 'Where is my order?',
+      body: 'Where is my order?',
+      type: 'channel.discord',
+      visibility: 'public',
+      sourceEntityType: 'communication_channels.external_conversation',
+      sourceEntityId: externalConversationId,
+      externalEmail: null,
+      externalName: 'discord-user',
+      bodyFormat: 'text',
+      priority: 'normal',
+      sentAt: new Date('2026-08-26T10:00:00.000Z'),
+      createdAt: new Date('2026-08-26T10:00:00.000Z'),
+      deletedAt: null,
+      tenantId,
+      organizationId,
+      ...overrides,
+    }
+  }
+
+  /** Container the `messages` commands run against — records what they compose. */
+  function makeMessagesContainer(original: Record<string, unknown>) {
+    const created: Record<string, unknown>[] = []
+    const trx = {
+      create: jest.fn((entity: unknown, data: Record<string, unknown>) => {
+        if (entity !== Message) return { ...data }
+        const row = { id: composedMessageId, ...data }
+        created.push(row)
+        return row
+      }),
+      persist: jest.fn(function persist(this: unknown) { return this }),
+      flush: jest.fn(async () => {}),
+      find: jest.fn(async () => []),
+    }
+    const emFork = {
+      // The conversation is assigned to the operator, which is what gives them a
+      // `message_recipients` row on the inbound message and lets them forward or
+      // reply without the channel-thread fallback — the review's own scenario.
+      findOne: jest.fn(async (entity: unknown, where: Record<string, unknown>) => {
+        if (entity === Message) return where.id === original.id ? original : null
+        if (entity === MessageRecipient && where.recipientUserId === operatorUserId) {
+          return { messageId: inboundMessageId, recipientUserId: operatorUserId, status: 'read', deletedAt: null }
+        }
+        return null
+      }),
+      find: jest.fn(async () => []),
+      transactional: jest.fn(async (callback: (em: typeof trx) => Promise<void>) => callback(trx)),
+      fork: jest.fn(),
+    }
+    const container = {
+      resolve: (name: string) => (name === 'em' ? { fork: () => emFork } : null),
+    }
+    return { container, created }
+  }
+
+  /** Container the subscriber runs against — a shared channel with nothing delivered yet. */
+  function makeBridgeContainer(composed: Record<string, unknown>) {
+    const findOne = jest.fn()
+    findOne.mockResolvedValueOnce(composed) // Message re-fetch
+    findOne.mockResolvedValueOnce({ id: 'mapping-1', messageThreadId: threadId, channelId: 'ch-1' })
+    findOne.mockResolvedValueOnce(null) // no MessageChannelLink yet
+    findOne.mockResolvedValueOnce({ id: 'ch-1', userId: null }) // shared channel
+    return {
+      container: {
+        resolve: ((name: string) => (name === 'em' ? { fork: () => ({ findOne }) } : null)) as <T>(name: string) => T,
+      },
+    }
+  }
+
+  function sentEventPayload(): Record<string, unknown> {
+    const call = emitMessagesEventMock.mock.calls.find(([eventId]) => eventId === 'messages.message.sent')
+    if (!call) throw new Error('[internal] the command emitted no messages.message.sent event')
+    return call[1] as Record<string, unknown>
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('does not deliver a forward of a channel message to the external correspondent', async () => {
+    const original = inboundMessage()
+    const { container, created } = makeMessagesContainer(original)
+
+    await commandRegistry.get('messages.messages.forward')!.execute(
+      {
+        messageId: inboundMessageId,
+        recipients: [{ userId: colleagueUserId, type: 'to' }],
+        additionalBody: 'This customer is a known chargeback risk — how do we answer?',
+        sendViaEmail: false,
+        includeAttachments: false,
+        tenantId,
+        organizationId,
+        userId: operatorUserId,
+      },
+      { container, auth: { features: ['messages.compose'] } } as never,
+    )
+
+    const forwardRow = created[0]
+    // The forward really does look like an operator message in the channel thread —
+    // which is why the origin test alone could not tell it apart.
+    expect(forwardRow.sourceEntityType).toBe('communication_channels.external_conversation')
+    expect(forwardRow.threadId).toBe(threadId)
+    expect(forwardRow.senderUserId).toBe(operatorUserId)
+    expect(forwardRow.visibility).toBe('public')
+
+    await bridgeHandler(
+      sentEventPayload() as never,
+      makeBridgeContainer(forwardRow) as never,
+    )
+
+    expect(enqueueMock).not.toHaveBeenCalled()
+  })
+
+  it('does not deliver an internal-visibility message composed into the channel thread', async () => {
+    const original = inboundMessage({ visibility: 'internal' })
+    const { container, created } = makeMessagesContainer(original)
+
+    await commandRegistry.get('messages.messages.reply')!.execute(
+      {
+        messageId: inboundMessageId,
+        body: 'Internal note: do not answer until legal signs off.',
+        bodyFormat: 'text',
+        sendViaEmail: false,
+        replyAll: false,
+        tenantId,
+        organizationId,
+        userId: operatorUserId,
+      },
+      { container, auth: { features: ['messages.compose'] } } as never,
+    )
+
+    const internalRow = created[0]
+    expect(internalRow.visibility).toBe('internal')
+    expect(internalRow.parentMessageId).toBe(inboundMessageId)
+
+    await bridgeHandler(
+      sentEventPayload() as never,
+      makeBridgeContainer(internalRow) as never,
+    )
+
+    expect(enqueueMock).not.toHaveBeenCalled()
+  })
+
+  it('still delivers the operator public reply the fix exists for (#5535)', async () => {
+    const original = inboundMessage()
+    const { container, created } = makeMessagesContainer(original)
+
+    await commandRegistry.get('messages.messages.reply')!.execute(
+      {
+        messageId: inboundMessageId,
+        body: 'It ships tomorrow — sorry for the wait!',
+        bodyFormat: 'text',
+        sendViaEmail: false,
+        replyAll: false,
+        tenantId,
+        organizationId,
+        userId: operatorUserId,
+      },
+      { container, auth: { features: ['messages.compose'] } } as never,
+    )
+
+    await bridgeHandler(
+      sentEventPayload() as never,
+      makeBridgeContainer(created[0]) as never,
+    )
+
+    expect(enqueueMock).toHaveBeenCalledTimes(1)
+    expect((enqueueMock.mock.calls[0][0] as { messageId: string }).messageId).toBe(composedMessageId)
+  })
+})

--- a/packages/core/src/modules/communication_channels/subscribers/__tests__/outbound-bridge.test.ts
+++ b/packages/core/src/modules/communication_channels/subscribers/__tests__/outbound-bridge.test.ts
@@ -126,6 +126,74 @@ describe('outbound-bridge subscriber behaviour', () => {
     expect(enqueueMock).not.toHaveBeenCalled()
   })
 
+  // #5535 — `sourceEntityType` alone cannot tell an ingested inbound message
+  // apart from an operator's own message in the same conversation, because a
+  // reply inherits it from the message it answers. Before the fix every
+  // operator message in a channel thread was dropped here without a trace.
+  describe('inbound ingest vs operator message (#5535)', () => {
+    const EXTERNAL = 'communication_channels.external_conversation'
+    const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000'
+
+    it('skips the ingested inbound message identified by its inbound link', async () => {
+      const findOne = jest.fn()
+      findOne.mockResolvedValueOnce({
+        id: messageId,
+        threadId: 'thread-1',
+        senderUserId: 'assigned-operator',
+        sourceEntityType: EXTERNAL,
+      }) // Message
+      findOne.mockResolvedValueOnce({ id: 'mapping-1', messageThreadId: 'thread-1' }) // mapping
+      findOne.mockResolvedValueOnce({ id: 'link-1', direction: 'inbound', deliveryStatus: 'received' })
+      await handler({ messageId, tenantId }, makeCtx({ findOne }))
+      expect(enqueueMock).not.toHaveBeenCalled()
+    })
+
+    it('skips the ingested inbound message by its ingest dedup key before the link is visible', async () => {
+      const findOne = jest.fn()
+      findOne.mockResolvedValueOnce({
+        id: messageId,
+        threadId: 'thread-1',
+        senderUserId: 'assigned-operator',
+        sourceEntityType: EXTERNAL,
+        idempotencyKey: 'cc:ch-1:external-42',
+      }) // Message
+      findOne.mockResolvedValueOnce({ id: 'mapping-1', messageThreadId: 'thread-1' }) // mapping
+      findOne.mockResolvedValueOnce(null) // link not flushed yet
+      await handler({ messageId, tenantId }, makeCtx({ findOne }))
+      expect(enqueueMock).not.toHaveBeenCalled()
+    })
+
+    it('skips the ingested inbound message attributed to the channel system user', async () => {
+      const findOne = jest.fn()
+      findOne.mockResolvedValueOnce({
+        id: messageId,
+        threadId: 'thread-1',
+        senderUserId: SYSTEM_USER_ID,
+        sourceEntityType: EXTERNAL,
+      }) // Message
+      findOne.mockResolvedValueOnce({ id: 'mapping-1', messageThreadId: 'thread-1' }) // mapping
+      findOne.mockResolvedValueOnce(null) // link not flushed yet
+      await handler({ messageId, tenantId }, makeCtx({ findOne }))
+      expect(enqueueMock).not.toHaveBeenCalled()
+    })
+
+    it('delivers an operator reply that inherited the conversation source type', async () => {
+      const findOne = jest.fn()
+      findOne.mockResolvedValueOnce({
+        id: messageId,
+        threadId: 'thread-1',
+        senderUserId: 'operator-1',
+        sourceEntityType: EXTERNAL,
+      }) // Message
+      findOne.mockResolvedValueOnce({ id: 'mapping-1', messageThreadId: 'thread-1', channelId: 'ch-1' })
+      findOne.mockResolvedValueOnce(null) // no link yet — nothing was sent for this message
+      findOne.mockResolvedValueOnce({ id: 'ch-1', userId: null }) // shared channel
+      await handler({ messageId, tenantId, organizationId: 'org-1' }, makeCtx({ findOne }))
+      expect(enqueueMock).toHaveBeenCalledTimes(1)
+      expect((enqueueMock.mock.calls[0][0] as any).messageId).toBe(messageId)
+    })
+  })
+
   it('enqueues delivery when the message sender OWNS the per-user channel', async () => {
     const findOne = jest.fn()
     findOne.mockResolvedValueOnce({ id: messageId, threadId: 'thread-1', senderUserId: 'owner-b' }) // Message

--- a/packages/core/src/modules/communication_channels/subscribers/outbound-bridge.ts
+++ b/packages/core/src/modules/communication_channels/subscribers/outbound-bridge.ts
@@ -2,6 +2,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { ChannelThreadMapping, CommunicationChannel, MessageChannelLink } from '../data/entities'
 import { Message } from '../../messages/data/entities'
+import { isIngestedInboundMessage } from '../lib/inbound-message-origin'
 import { COMMUNICATION_CHANNELS_QUEUES, getCommunicationChannelsQueue } from '../lib/queue'
 import type { OutboundDeliveryPayload } from '../workers/outbound-delivery'
 
@@ -88,16 +89,6 @@ export default async function handler(
   if (message.sourceEntityType === 'communication_channels.send_as_user') {
     return
   }
-  // Inbound ingest path: when `ingest-inbound-message` composes a new platform
-  // Message for an incoming email, the messages module also emits
-  // `messages.message.sent` (the Message row is fresh and marked sent). Without
-  // this guard, we'd treat it as outbound and queue a redundant SMTP delivery —
-  // which fails because inbound MCLs carry recipient info in `channelPayload`,
-  // not `channelMetadata`, and the failure marker then leaks back onto the
-  // inbound link itself.
-  if (message.sourceEntityType === 'communication_channels.external_conversation') {
-    return
-  }
   if (!message.threadId) return // Internal-only; no channel routing.
 
   // (b) Look up the channel mapping by threadId.
@@ -126,6 +117,23 @@ export default async function handler(
     undefined,
     dscope,
   )
+  // (c1) Inbound ingest path: when `ingest-inbound-message` composes a platform
+  // Message for an incoming message, the messages module also emits
+  // `messages.message.sent` (the Message row is fresh and marked sent). Without
+  // this guard we'd treat it as outbound and queue a redundant delivery — which
+  // fails because inbound MCLs carry recipient info in `channelPayload`, not
+  // `channelMetadata`, and the failure marker then leaks back onto the inbound
+  // link itself.
+  //
+  // The guard used to be `sourceEntityType === external_conversation`, but an
+  // operator's reply inherits that value from the message it answers, so every
+  // operator message in a channel thread was dropped here — silently, which is
+  // the delivery half of #5535. `isIngestedInboundMessage` distinguishes the
+  // ingested message from an operator's own message in the same conversation.
+  if (await isIngestedInboundMessage(em, { message, existingLink, tenantId: payload.tenantId })) {
+    return
+  }
+
   if (
     existingLink &&
     (existingLink.deliveryStatus === 'queued' ||

--- a/packages/core/src/modules/communication_channels/subscribers/outbound-bridge.ts
+++ b/packages/core/src/modules/communication_channels/subscribers/outbound-bridge.ts
@@ -3,6 +3,7 @@ import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { ChannelThreadMapping, CommunicationChannel, MessageChannelLink } from '../data/entities'
 import { Message } from '../../messages/data/entities'
 import { isIngestedInboundMessage } from '../lib/inbound-message-origin'
+import { isOutboundDeliveryIntended } from '../lib/outbound-delivery-intent'
 import { COMMUNICATION_CHANNELS_QUEUES, getCommunicationChannelsQueue } from '../lib/queue'
 import type { OutboundDeliveryPayload } from '../workers/outbound-delivery'
 
@@ -39,6 +40,12 @@ type MessageSentPayload = {
   recipientUserIds?: string[]
   sendViaEmail?: boolean
   externalEmail?: string | null
+  /**
+   * Set by `messages.messages.forward` to the message the forward was built
+   * from. The only place an operator's delivery intent is recorded — see
+   * `lib/outbound-delivery-intent`.
+   */
+  forwardedFrom?: string | null
   tenantId: string
   organizationId?: string | null
 }
@@ -87,6 +94,15 @@ export default async function handler(
   )
   if (!message) return
   if (message.sourceEntityType === 'communication_channels.send_as_user') {
+    return
+  }
+  // (a1) Intent gate. The origin test at (c1) answers "did the ingest command
+  // compose this?"; this one answers "did an operator mean this to leave the
+  // platform?". Between them sits every internal message that shares the channel
+  // thread — most importantly a forward, whose body is the quoted conversation
+  // plus the operator's own commentary about the correspondent. Free (no query),
+  // so it runs before the mapping lookup.
+  if (!isOutboundDeliveryIntended({ message, forwardedFromMessageId: payload.forwardedFrom })) {
     return
   }
   if (!message.threadId) return // Internal-only; no channel routing.

--- a/packages/core/src/modules/messages/api/[id]/__tests__/route-enrichers.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/__tests__/route-enrichers.test.ts
@@ -13,6 +13,8 @@ jest.mock('@open-mercato/shared/lib/crud/enricher-runner', () => ({
 }))
 
 jest.mock('@open-mercato/core/modules/messages/lib/routeHelpers', () => ({
+  // Keep the real feature helpers — only the request-context entry points are stubbed.
+  ...jest.requireActual('@open-mercato/core/modules/messages/lib/routeHelpers'),
   resolveMessageContext: (...args: unknown[]) => resolveMessageContextMock(...args),
   hasOrganizationAccess: () => true,
 }))

--- a/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { GET, PATCH, DELETE } from '@open-mercato/core/modules/messages/api/[id]
 import { Message, MessageObject, MessageRecipient } from '@open-mercato/core/modules/messages/data/entities'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
 import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+import { authorizeFeatures } from '@open-mercato/shared/security/featurePolicy'
 
 const resolveMessageContextMock = jest.fn()
 const hasOrganizationAccessMock = jest.fn(() => true)
@@ -9,6 +10,10 @@ const findWithDecryptionMock = jest.fn()
 const findOneWithDecryptionMock = jest.fn()
 
 jest.mock('@open-mercato/core/modules/messages/lib/routeHelpers', () => ({
+  // Only the request-context entry points are stubbed. `canUseChannelThreadFallback`
+  // stays REAL so the RBAC gate is exercised against the fixture's container rather
+  // than against a stub that could agree with a broken route.
+  ...jest.requireActual('@open-mercato/core/modules/messages/lib/routeHelpers'),
   resolveMessageContext: (...args: unknown[]) => resolveMessageContextMock(...args),
   hasOrganizationAccess: (...args: unknown[]) => hasOrganizationAccessMock(...args),
 }))
@@ -914,7 +919,14 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
 
   function setupHarness(
     channelThreadAccess: unknown,
-    options: { registered?: boolean; features?: string[]; thread?: unknown[]; anchor?: unknown } = {},
+    options: {
+      registered?: boolean
+      features?: string[]
+      thread?: unknown[]
+      anchor?: unknown
+      /** `false` drops `rbacService` from the container entirely. */
+      rbac?: boolean
+    } = {},
   ) {
     const thread = options.thread ?? threadMessages
     const anchor = options.anchor ?? inboundMessage
@@ -936,12 +948,22 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
     ))
 
     const resolveChannelThreadAccess = jest.fn(async () => channelThreadAccess)
+    // The session JWT carries no `features` claim, so the route resolves the
+    // caller's grants through RBAC — the fixture mirrors that, wildcard matching
+    // included, rather than handing the route a features array it never sees.
+    const grantedFeatures = options.features ?? ['messages.view']
+    const rbacService = {
+      userHasAllFeatures: jest.fn(async (_userId: string, required: string[]) => (
+        authorizeFeatures(required, { grantedFeatures })
+      )),
+    }
     resolveMessageContextMock.mockResolvedValue({
       ctx: {
-        auth: { features: options.features ?? ['messages.view'] },
+        auth: { sub: operatorUserId },
         container: {
           resolve: (name: string) => {
             if (name === 'em') return em
+            if (name === 'rbacService') return options.rbac === false ? null : rbacService
             if (name === 'communicationChannelsResolveChannelThreadAccess') {
               return options.registered === false ? null : resolveChannelThreadAccess
             }
@@ -951,7 +973,7 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
       },
       scope: { tenantId, organizationId, userId: operatorUserId },
     })
-    return { resolveChannelThreadAccess }
+    return { resolveChannelThreadAccess, rbacService }
   }
 
   const grantedThread = {
@@ -972,16 +994,24 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
   }
 
   it('lets an operator open a message the channel behind its thread grants access to', async () => {
-    const { resolveChannelThreadAccess } = setupHarness(grantedThread)
+    const { resolveChannelThreadAccess, rbacService } = setupHarness(grantedThread)
 
     const response = await getDetail()
 
     expect(response.status).toBe(200)
+    // The gate is the RBAC call; `actor.features` is only the documented
+    // pass-through, and on a real request it is empty because the session JWT
+    // carries no `features` claim. Asserting that here keeps the two apart.
+    expect(rbacService.userHasAllFeatures).toHaveBeenCalledWith(
+      operatorUserId,
+      ['messages.view'],
+      { tenantId, organizationId },
+    )
     expect(resolveChannelThreadAccess).toHaveBeenCalledWith(
       expect.anything(),
       { tenantId, organizationId },
       { messageThreadId: threadId },
-      { userId: operatorUserId, features: ['messages.view'] },
+      { userId: operatorUserId, features: [] },
     )
   })
 
@@ -1042,6 +1072,18 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
 
       expect((await getDetail()).status).toBe(200)
       expect(resolveChannelThreadAccess).toHaveBeenCalled()
+    })
+
+    // QA regression (PR #5645): the first cut of this gate read
+    // `ctx.auth.features`, which is always empty on a real request — the session
+    // JWT has no `features` claim — so it returned 403 to every caller including
+    // a tenant admin, re-closing the journey #5535 opened. TC-CHANNEL-REPLY-001
+    // caught it against a live app; this pins it without one.
+    it('denies when RBAC cannot be consulted rather than trusting the session payload', async () => {
+      const { resolveChannelThreadAccess } = setupHarness(grantedThread, { rbac: false })
+
+      expect((await getDetail()).status).toBe(403)
+      expect(resolveChannelThreadAccess).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
@@ -912,28 +912,33 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
     },
   ]
 
-  function setupHarness(channelThreadAccess: unknown, options: { registered?: boolean } = {}) {
+  function setupHarness(
+    channelThreadAccess: unknown,
+    options: { registered?: boolean; features?: string[]; thread?: unknown[]; anchor?: unknown } = {},
+  ) {
+    const thread = options.thread ?? threadMessages
+    const anchor = options.anchor ?? inboundMessage
     const em = {
       findOne: jest.fn(async () => null),
       find: jest.fn(async (entity: unknown, where: Record<string, unknown>) => {
-        if (entity === Message && where.threadId === threadId) return threadMessages
+        if (entity === Message && where.threadId === threadId) return thread
         return []
       }),
     }
 
     findWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => {
-      if (entity === Message) return threadMessages
+      if (entity === Message) return thread
       if (entity === User) return []
       return []
     })
     findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => (
-      entity === Message ? inboundMessage : null
+      entity === Message ? anchor : null
     ))
 
     const resolveChannelThreadAccess = jest.fn(async () => channelThreadAccess)
     resolveMessageContextMock.mockResolvedValue({
       ctx: {
-        auth: { features: ['messages.view'] },
+        auth: { features: options.features ?? ['messages.view'] },
         container: {
           resolve: (name: string) => {
             if (name === 'em') return em
@@ -1007,5 +1012,83 @@ describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', (
     setupHarness(null, { registered: false })
 
     expect((await getDetail()).status).toBe(403)
+  })
+
+  // @pkarw's blocker on #5645: `assertCanAccessChannel` grants every SHARED
+  // channel unconditionally and documents its precondition as a caller the route
+  // already feature-gated — and this route is `requireAuth` only. Without a gate
+  // of its own the fallback handed any authenticated tenant user the whole
+  // external conversation. The fixture below is the one the review named: an
+  // actor holding NO features at all.
+  describe('feature gate on the channel fallback', () => {
+    it('denies a caller holding no features and never consults the channel at all', async () => {
+      const { resolveChannelThreadAccess } = setupHarness(grantedThread, { features: [] })
+
+      expect((await getDetail()).status).toBe(403)
+      expect(resolveChannelThreadAccess).not.toHaveBeenCalled()
+    })
+
+    it('denies a caller holding only unrelated features', async () => {
+      const { resolveChannelThreadAccess } = setupHarness(grantedThread, {
+        features: ['sales.view', 'catalog.view'],
+      })
+
+      expect((await getDetail()).status).toBe(403)
+      expect(resolveChannelThreadAccess).not.toHaveBeenCalled()
+    })
+
+    it('honors a wildcard grant rather than an exact feature-string match', async () => {
+      const { resolveChannelThreadAccess } = setupHarness(grantedThread, { features: ['messages.*'] })
+
+      expect((await getDetail()).status).toBe(200)
+      expect(resolveChannelThreadAccess).toHaveBeenCalled()
+    })
+  })
+
+  // Channel access means "you may work this conversation", not "you may read the
+  // notes other operators kept off it".
+  describe('internal-visibility messages stay participant-only', () => {
+    const internalNoteId = '44444444-4444-4444-8444-444444444444'
+    const threadWithInternalNote = [
+      ...threadMessages,
+      {
+        id: internalNoteId,
+        senderUserId: otherOperatorId,
+        sourceEntityType: 'communication_channels.external_conversation',
+        visibility: 'internal',
+        body: 'known chargeback risk — do not refund',
+        bodyFormat: 'text',
+        sentAt: new Date('2026-08-23T10:06:00.000Z'),
+      },
+    ]
+
+    it('hides another operator internal note from a caller who reached the thread via the channel', async () => {
+      setupHarness(grantedThread, { thread: threadWithInternalNote })
+
+      const payload = await (await getDetail()).json() as { thread?: Array<{ id?: string }> }
+
+      expect((payload.thread ?? []).map((item) => item.id)).not.toContain(internalNoteId)
+    })
+
+    it('keeps the caller own internal note visible', async () => {
+      setupHarness(grantedThread, {
+        thread: [
+          ...threadMessages,
+          { ...threadWithInternalNote[threadWithInternalNote.length - 1], senderUserId: operatorUserId },
+        ],
+      })
+
+      const payload = await (await getDetail()).json() as { thread?: Array<{ id?: string }> }
+
+      expect((payload.thread ?? []).map((item) => item.id)).toContain(internalNoteId)
+    })
+
+    it('denies opening another operator internal note directly, channel access notwithstanding', async () => {
+      setupHarness(grantedThread, {
+        anchor: { ...inboundMessage, visibility: 'internal', senderUserId: otherOperatorId },
+      })
+
+      expect((await getDetail()).status).toBe(403)
+    })
   })
 })

--- a/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
@@ -849,3 +849,163 @@ describe('messages /api/messages/[id] optimistic locking', () => {
     expect(commandBus.execute).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * #5535 — an inbound channel message is authored by the channel system user and,
+ * on an unassigned conversation, has no recipient rows, so the participant test
+ * above denied every operator: the detail page the reply button lives on could
+ * not even be opened. For a thread the channels hub owns, the hub's own access
+ * rule applies instead.
+ */
+describe('messages /api/messages/[id] GET on a channel-linked thread (#5535)', () => {
+  const operatorUserId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const systemUserId = '00000000-0000-0000-0000-000000000000'
+  const otherOperatorId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+  const tenantId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+  const organizationId = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+  const threadId = '11111111-1111-4111-8111-111111111111'
+  const anchorId = '22222222-2222-4222-8222-222222222222'
+
+  const inboundMessage = {
+    id: anchorId,
+    threadId,
+    senderUserId: systemUserId,
+    organizationId,
+    tenantId,
+    deletedAt: null,
+    isDraft: false,
+    type: 'channel.discord',
+    visibility: 'public',
+    sourceEntityType: 'communication_channels.external_conversation',
+    sourceEntityId: '77777777-7777-4777-8777-777777777777',
+    externalEmail: null,
+    externalName: 'discord-user',
+    parentMessageId: null,
+    subject: 'Incoming from Discord',
+    body: 'is anyone there?',
+    bodyFormat: 'text',
+    priority: 'normal',
+    sentAt: new Date('2026-08-23T10:00:00.000Z'),
+    actionData: null,
+    actionTaken: null,
+    actionTakenAt: null,
+    actionTakenByUserId: null,
+  }
+
+  const threadMessages = [
+    {
+      id: anchorId,
+      senderUserId: systemUserId,
+      externalName: 'discord-user',
+      sourceEntityType: 'communication_channels.external_conversation',
+      body: 'is anyone there?',
+      bodyFormat: 'text',
+      sentAt: new Date('2026-08-23T10:00:00.000Z'),
+    },
+    {
+      id: '33333333-3333-4333-8333-333333333333',
+      senderUserId: otherOperatorId,
+      sourceEntityType: 'communication_channels.external_conversation',
+      body: 'answered by a colleague',
+      bodyFormat: 'text',
+      sentAt: new Date('2026-08-23T10:05:00.000Z'),
+    },
+  ]
+
+  function setupHarness(channelThreadAccess: unknown, options: { registered?: boolean } = {}) {
+    const em = {
+      findOne: jest.fn(async () => null),
+      find: jest.fn(async (entity: unknown, where: Record<string, unknown>) => {
+        if (entity === Message && where.threadId === threadId) return threadMessages
+        return []
+      }),
+    }
+
+    findWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === Message) return threadMessages
+      if (entity === User) return []
+      return []
+    })
+    findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => (
+      entity === Message ? inboundMessage : null
+    ))
+
+    const resolveChannelThreadAccess = jest.fn(async () => channelThreadAccess)
+    resolveMessageContextMock.mockResolvedValue({
+      ctx: {
+        auth: { features: ['messages.view'] },
+        container: {
+          resolve: (name: string) => {
+            if (name === 'em') return em
+            if (name === 'communicationChannelsResolveChannelThreadAccess') {
+              return options.registered === false ? null : resolveChannelThreadAccess
+            }
+            return null
+          },
+        },
+      },
+      scope: { tenantId, organizationId, userId: operatorUserId },
+    })
+    return { resolveChannelThreadAccess }
+  }
+
+  const grantedThread = {
+    messageThreadId: threadId,
+    externalConversationId: '77777777-7777-4777-8777-777777777777',
+    channelId: '88888888-8888-4888-8888-888888888888',
+    channelType: 'discord',
+    canAccess: true,
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  function getDetail() {
+    return GET(
+      new Request(`http://localhost/api/messages/${anchorId}?skipMarkRead=1`),
+      { params: { id: anchorId } },
+    )
+  }
+
+  it('lets an operator open a message the channel behind its thread grants access to', async () => {
+    const { resolveChannelThreadAccess } = setupHarness(grantedThread)
+
+    const response = await getDetail()
+
+    expect(response.status).toBe(200)
+    expect(resolveChannelThreadAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      { tenantId, organizationId },
+      { messageThreadId: threadId },
+      { userId: operatorUserId, features: ['messages.view'] },
+    )
+  })
+
+  it('shows the whole conversation rather than only the operator own messages', async () => {
+    setupHarness(grantedThread)
+
+    const payload = await (await getDetail()).json() as { thread?: Array<{ id?: string }> }
+
+    expect((payload.thread ?? []).map((item) => item.id)).toEqual([
+      anchorId,
+      '33333333-3333-4333-8333-333333333333',
+    ])
+  })
+
+  it('still denies a caller the channel itself refuses', async () => {
+    setupHarness({ ...grantedThread, canAccess: false })
+
+    expect((await getDetail()).status).toBe(403)
+  })
+
+  it('still denies when the thread is not channel-linked', async () => {
+    setupHarness(null)
+
+    expect((await getDetail()).status).toBe(403)
+  })
+
+  it('still denies when the channels module is not installed', async () => {
+    setupHarness(null, { registered: false })
+
+    expect((await getDetail()).status).toBe(403)
+  })
+})

--- a/packages/core/src/modules/messages/api/[id]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/route.ts
@@ -9,6 +9,10 @@ import { User } from '../../../auth/data/entities'
 import { Message, MessageObject, MessageRecipient } from '../../data/entities'
 import { updateDraftSchema } from '../../data/validators'
 import { buildResolvedMessageActions } from '../../lib/actions'
+import {
+  EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE,
+  resolveMessageChannelThreadAccess,
+} from '../../lib/channelThreadAccess'
 import { MESSAGE_OPTIMISTIC_LOCK_RESOURCE_KIND } from '../../lib/constants'
 import { getMessageObjectType } from '../../lib/message-objects-registry'
 import { getMessageTypeOrDefault } from '../../lib/message-types-registry'
@@ -105,7 +109,23 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const isSender = message.senderUserId === scope.userId
   const isRecipient = Boolean(recipient)
 
-  if (!isSender && !isRecipient) {
+  // #5535: a message that arrived over a communication channel has the channel
+  // system user as its sender and, on an unassigned conversation, no recipient
+  // rows — so the participant test below denies every operator and the reply
+  // button is unreachable. For a thread the channels hub owns, that hub's access
+  // rule applies instead; an internal thread resolves to `null` and keeps the
+  // participant rule unchanged. Only channel-sourced messages pay the lookup.
+  const channelThread = message.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE
+    ? await resolveMessageChannelThreadAccess(
+      ctx.container,
+      { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null },
+      { messageThreadId: message.threadId ?? message.id },
+      { userId: scope.userId, features: resolveUserFeatures(ctx.auth) },
+    )
+    : null
+  const hasChannelThreadAccess = channelThread?.canAccess === true
+
+  if (!isSender && !isRecipient && !hasChannelThreadAccess) {
     return Response.json({ error: 'Access denied' }, { status: 403 })
   }
 
@@ -152,9 +172,15 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     })
     : []
   const visibleRecipientMessageIds = new Set(visibleRecipientRows.map((item) => item.messageId))
-  const actorVisibleThreadMessages = threadMessages.filter((threadMessage) => (
-    threadMessage.senderUserId === scope.userId || visibleRecipientMessageIds.has(threadMessage.id)
-  ))
+  // On a channel-linked thread the conversation IS the thread: the correspondent
+  // is not a platform user, so filtering by participation would hide the inbound
+  // messages and every other operator's answer, leaving the operator looking at
+  // half a conversation (#5535).
+  const actorVisibleThreadMessages = hasChannelThreadAccess
+    ? threadMessages
+    : threadMessages.filter((threadMessage) => (
+      threadMessage.senderUserId === scope.userId || visibleRecipientMessageIds.has(threadMessage.id)
+    ))
 
   const actorRecipientStatusByMessageId = new Map<string, string>()
   for (const row of visibleRecipientRows) {

--- a/packages/core/src/modules/messages/api/[id]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/route.ts
@@ -5,11 +5,13 @@ import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { applyResponseEnricherToRecord } from '@open-mercato/shared/lib/crud/enricher-runner'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { authorizeFeatures } from '@open-mercato/shared/security/featurePolicy'
 import { User } from '../../../auth/data/entities'
 import { Message, MessageObject, MessageRecipient } from '../../data/entities'
 import { updateDraftSchema } from '../../data/validators'
 import { buildResolvedMessageActions } from '../../lib/actions'
 import {
+  CHANNEL_THREAD_FALLBACK_FEATURE,
   EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE,
   resolveMessageChannelThreadAccess,
 } from '../../lib/channelThreadAccess'
@@ -115,17 +117,38 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   // button is unreachable. For a thread the channels hub owns, that hub's access
   // rule applies instead; an internal thread resolves to `null` and keeps the
   // participant rule unchanged. Only channel-sourced messages pay the lookup.
-  const channelThread = message.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE
+  //
+  // The fallback is feature-gated here rather than on the route, because
+  // `assertCanAccessChannel` — the rule behind `canAccess` — deliberately ignores
+  // features and returns for EVERY shared channel; its documented precondition is
+  // a caller the route already feature-gated, and this route is `requireAuth`
+  // only so that a participant can always read their own message. Without this
+  // gate the fallback would hand any authenticated tenant user the whole external
+  // conversation on a shared inbox.
+  const actorFeatures = resolveUserFeatures(ctx.auth)
+  const mayUseChannelFallback = authorizeFeatures(
+    [CHANNEL_THREAD_FALLBACK_FEATURE],
+    { grantedFeatures: actorFeatures },
+  )
+  const channelThread = mayUseChannelFallback
+    && message.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE
     ? await resolveMessageChannelThreadAccess(
       ctx.container,
       { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null },
       { messageThreadId: message.threadId ?? message.id },
-      { userId: scope.userId, features: resolveUserFeatures(ctx.auth) },
+      { userId: scope.userId, features: actorFeatures },
     )
     : null
   const hasChannelThreadAccess = channelThread?.canAccess === true
 
   if (!isSender && !isRecipient && !hasChannelThreadAccess) {
+    return Response.json({ error: 'Access denied' }, { status: 403 })
+  }
+
+  // Channel access says "you may work this conversation", not "you may read what
+  // other operators kept off it". An internal note stays participant-only however
+  // the caller reached the thread.
+  if (!isSender && !isRecipient && message.visibility === 'internal') {
     return Response.json({ error: 'Access denied' }, { status: 403 })
   }
 
@@ -176,11 +199,17 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   // is not a platform user, so filtering by participation would hide the inbound
   // messages and every other operator's answer, leaving the operator looking at
   // half a conversation (#5535).
+  //
+  // Internal notes are the exception: they are addressed to platform
+  // participants, so they keep the participant rule even on a channel thread.
+  const isThreadMessageParticipant = (threadMessage: { id: string; senderUserId?: string | null }) => (
+    threadMessage.senderUserId === scope.userId || visibleRecipientMessageIds.has(threadMessage.id)
+  )
   const actorVisibleThreadMessages = hasChannelThreadAccess
-    ? threadMessages
-    : threadMessages.filter((threadMessage) => (
-      threadMessage.senderUserId === scope.userId || visibleRecipientMessageIds.has(threadMessage.id)
+    ? threadMessages.filter((threadMessage) => (
+      threadMessage.visibility !== 'internal' || isThreadMessageParticipant(threadMessage)
     ))
+    : threadMessages.filter(isThreadMessageParticipant)
 
   const actorRecipientStatusByMessageId = new Map<string, string>()
   for (const row of visibleRecipientRows) {

--- a/packages/core/src/modules/messages/api/[id]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/route.ts
@@ -5,13 +5,11 @@ import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { applyResponseEnricherToRecord } from '@open-mercato/shared/lib/crud/enricher-runner'
 import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { authorizeFeatures } from '@open-mercato/shared/security/featurePolicy'
 import { User } from '../../../auth/data/entities'
 import { Message, MessageObject, MessageRecipient } from '../../data/entities'
 import { updateDraftSchema } from '../../data/validators'
 import { buildResolvedMessageActions } from '../../lib/actions'
 import {
-  CHANNEL_THREAD_FALLBACK_FEATURE,
   EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE,
   resolveMessageChannelThreadAccess,
 } from '../../lib/channelThreadAccess'
@@ -19,7 +17,7 @@ import { MESSAGE_OPTIMISTIC_LOCK_RESOURCE_KIND } from '../../lib/constants'
 import { getMessageObjectType } from '../../lib/message-objects-registry'
 import { getMessageTypeOrDefault } from '../../lib/message-types-registry'
 import { attachOperationMetadataHeader } from '../../lib/operationMetadata'
-import { hasOrganizationAccess, resolveMessageContext } from '../../lib/routeHelpers'
+import { canUseChannelThreadFallback, hasOrganizationAccess, resolveMessageContext } from '../../lib/routeHelpers'
 import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from '../guards'
 import {
   errorResponseSchema,
@@ -124,14 +122,13 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   // a caller the route already feature-gated, and this route is `requireAuth`
   // only so that a participant can always read their own message. Without this
   // gate the fallback would hand any authenticated tenant user the whole external
-  // conversation on a shared inbox.
+  // conversation on a shared inbox. The check goes through RBAC, not through
+  // `ctx.auth.features` — the session JWT carries no `features` claim at all, so
+  // reading it would deny everyone, tenant admin included.
   const actorFeatures = resolveUserFeatures(ctx.auth)
-  const mayUseChannelFallback = authorizeFeatures(
-    [CHANNEL_THREAD_FALLBACK_FEATURE],
-    { grantedFeatures: actorFeatures },
-  )
+  const mayUseChannelFallback = message.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE
+    && await canUseChannelThreadFallback(ctx, scope)
   const channelThread = mayUseChannelFallback
-    && message.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE
     ? await resolveMessageChannelThreadAccess(
       ctx.container,
       { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null },

--- a/packages/core/src/modules/messages/api/__tests__/compose-channel-type.test.ts
+++ b/packages/core/src/modules/messages/api/__tests__/compose-channel-type.test.ts
@@ -7,15 +7,19 @@ const conversationId = '66666666-6666-4666-8666-666666666666'
 const em = { fork: jest.fn(), find: jest.fn(), findOne: jest.fn() }
 const commandBusExecuteMock = jest.fn()
 const resolveChannelTypeMock = jest.fn()
+const resolveChannelThreadAccessMock = jest.fn()
 
 const container = {
   resolve: jest.fn((name: string) => {
     if (name === 'em') return em
     if (name === 'commandBus') return { execute: (...args: unknown[]) => commandBusExecuteMock(...args) }
     if (name === 'communicationChannelsResolveChannelType') return resolveChannelTypeMock
+    if (name === 'communicationChannelsResolveChannelThreadAccess') return resolveChannelThreadAccessMock
     throw new Error(`Unexpected container resolve: ${name}`)
   }),
 }
+
+const CHANNEL_THREAD_ID = '55555555-5555-4555-8555-555555555555'
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => container),
@@ -88,6 +92,15 @@ beforeEach(() => {
   em.fork.mockReturnValue(em)
   em.find.mockResolvedValue([])
   em.findOne.mockResolvedValue(null)
+  // #5535: a public compose naming a channel conversation is attached to that
+  // conversation's existing thread, so the default fixture resolves one.
+  resolveChannelThreadAccessMock.mockResolvedValue({
+    messageThreadId: CHANNEL_THREAD_ID,
+    externalConversationId: conversationId,
+    channelId: '77777777-7777-4777-8777-777777777777',
+    channelType: 'discord',
+    canAccess: true,
+  })
   commandBusExecuteMock.mockImplementation(async () => ({
     result: { id: messageId, threadId: 'thread-1' },
     logEntry: null,
@@ -230,5 +243,88 @@ describe('POST /api/messages — the channel-type lookup stays off the compose h
 
     await expect(composeMessage(composeRequest(publicComposeBody()))).rejects.toThrow()
     expect(resolveChannelTypeMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// #5535 — composing on a channel conversation used to open a brand-new thread:
+// 201, no ChannelThreadMapping, no outbound link, and nothing ever delivered.
+// A success response for a message that never leaves the building is worse than
+// a refusal, so the route now either threads the message onto the conversation
+// or says why it cannot.
+describe('POST /api/messages — channel conversation deliverability (#5535)', () => {
+  it('threads a public compose onto the conversation existing thread', async () => {
+    resolveChannelTypeMock.mockResolvedValue('discord')
+
+    const response = await composeMessage(composeRequest(publicComposeBody()))
+
+    expect(response.status).toBe(201)
+    expect(resolveChannelThreadAccessMock).toHaveBeenCalledWith(
+      container,
+      { tenantId, organizationId },
+      { externalConversationId: conversationId },
+      { userId, features: ['*'] },
+    )
+    expect(composeInput().parentMessageId).toBe(CHANNEL_THREAD_ID)
+  })
+
+  it('refuses with 409 when the conversation has no channel thread to deliver into', async () => {
+    resolveChannelTypeMock.mockResolvedValue('discord')
+    resolveChannelThreadAccessMock.mockResolvedValue(null)
+
+    const response = await composeMessage(composeRequest(publicComposeBody()))
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Conversation has no channel thread to deliver into',
+    })
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses with 403 when the caller may not act on the channel behind the thread', async () => {
+    resolveChannelTypeMock.mockResolvedValue('email')
+    resolveChannelThreadAccessMock.mockResolvedValue({
+      messageThreadId: CHANNEL_THREAD_ID,
+      externalConversationId: conversationId,
+      channelId: '77777777-7777-4777-8777-777777777777',
+      channelType: 'email',
+      canAccess: false,
+    })
+
+    const response = await composeMessage(
+      composeRequest(publicComposeBody({ externalEmail: 'jane@example.com' })),
+    )
+
+    expect(response.status).toBe(403)
+    expect(commandBusExecuteMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a caller-supplied parent message alone', async () => {
+    resolveChannelTypeMock.mockResolvedValue('discord')
+
+    const response = await composeMessage(
+      composeRequest(publicComposeBody({ parentMessageId: messageId })),
+    )
+
+    expect(response.status).toBe(201)
+    expect(resolveChannelThreadAccessMock).not.toHaveBeenCalled()
+    expect(composeInput().parentMessageId).toBe(messageId)
+  })
+
+  it('leaves drafts and internal notes on the conversation untouched', async () => {
+    const draft = await composeMessage(composeRequest(publicComposeBody({ isDraft: true })))
+    expect(draft.status).toBe(201)
+
+    const internalNote = await composeMessage(
+      composeRequest({
+        visibility: 'internal',
+        sourceEntityType: 'communication_channels.external_conversation',
+        sourceEntityId: conversationId,
+        subject: 'Note to the team',
+        body: 'Handled by phone',
+        recipients: [{ userId, type: 'to' }],
+      }),
+    )
+    expect(internalNote.status).toBe(201)
+    expect(resolveChannelThreadAccessMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -26,6 +26,7 @@ import {
   EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE,
   resolveMessageChannelThreadAccess,
 } from '../lib/channelThreadAccess'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { MESSAGE_ATTACHMENT_ENTITY_ID } from '../lib/constants'
 import { getMessageType } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
@@ -516,8 +517,14 @@ export async function POST(req: Request) {
       { userId: scope.userId, features: resolveUserFeatures(ctx.auth) },
     )
     if (!channelThread) {
+      const { translate } = await resolveTranslations()
       return Response.json(
-        { error: 'Conversation has no channel thread to deliver into' },
+        {
+          error: translate(
+            'messages.errors.conversationHasNoChannelThread',
+            'Conversation has no channel thread to deliver into',
+          ),
+        },
         { status: 409 },
       )
     }

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -22,6 +22,10 @@ import {
   composeSourceHintSchema,
   resolveComposeSourceChannelType,
 } from '../lib/composeSourceChannelType'
+import {
+  EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE,
+  resolveMessageChannelThreadAccess,
+} from '../lib/channelThreadAccess'
 import { MESSAGE_ATTACHMENT_ENTITY_ID } from '../lib/constants'
 import { getMessageType } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
@@ -489,6 +493,40 @@ export async function POST(req: Request) {
     }
   }
 
+  // #5535: composing on a channel conversation without naming a parent message
+  // used to open a brand-new thread. A fresh thread has no `ChannelThreadMapping`,
+  // so the outbound bridge had nothing to route on and the operator got a 201 for
+  // a message that was never delivered — a silent failure worse than a refusal.
+  // Attach the message to the conversation's existing thread instead, and refuse
+  // outright when there is no such thread to attach it to. Only messages meant to
+  // leave the platform are affected: a draft, or an internal note filed against
+  // the same conversation, is never delivered anyway and stays untouched.
+  let composeParentMessageId = input.parentMessageId
+  if (
+    isPublicVisibility &&
+    !input.isDraft &&
+    !input.parentMessageId &&
+    input.sourceEntityType === EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE &&
+    input.sourceEntityId
+  ) {
+    const channelThread = await resolveMessageChannelThreadAccess(
+      ctx.container,
+      { tenantId: scope.tenantId, organizationId: scope.organizationId ?? null },
+      { externalConversationId: input.sourceEntityId },
+      { userId: scope.userId, features: resolveUserFeatures(ctx.auth) },
+    )
+    if (!channelThread) {
+      return Response.json(
+        { error: 'Conversation has no channel thread to deliver into' },
+        { status: 409 },
+      )
+    }
+    if (!channelThread.canAccess) {
+      return Response.json({ error: 'Access denied' }, { status: 403 })
+    }
+    composeParentMessageId = channelThread.messageThreadId
+  }
+
   const guardResult = await runMessageMutationGuards(
     ctx.container,
     {
@@ -514,6 +552,7 @@ export async function POST(req: Request) {
   const { result, logEntry } = await commandBus.execute('messages.messages.compose', {
     input: {
       ...input,
+      parentMessageId: composeParentMessageId,
       sendViaEmail,
       tenantId: scope.tenantId,
       organizationId: scope.organizationId,

--- a/packages/core/src/modules/messages/commands/__tests__/messages.reply-channel-thread.test.ts
+++ b/packages/core/src/modules/messages/commands/__tests__/messages.reply-channel-thread.test.ts
@@ -1,0 +1,186 @@
+import '@open-mercato/core/modules/messages/commands/messages'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { Message, MessageRecipient } from '@open-mercato/core/modules/messages/data/entities'
+
+const emitMessagesEventMock = jest.fn(async () => {})
+
+jest.mock('@open-mercato/core/modules/messages/events', () => ({
+  emitMessagesEvent: (...args: unknown[]) => emitMessagesEventMock(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/messages/lib/attachments', () => ({
+  linkAttachmentsToMessage: jest.fn(),
+  linkLibraryAttachmentsToMessage: jest.fn(),
+  copyAttachmentsForForwardMessages: jest.fn(),
+}))
+
+/**
+ * #5535 — an inbound channel message has the channel system user as its sender
+ * and, on an unassigned conversation, no recipient rows at all. The
+ * sender-or-recipient reply guard therefore denied every operator, tenant admin
+ * included, so nobody could answer what a channel delivered.
+ */
+describe('messages.messages.reply on a channel-linked thread (#5535)', () => {
+  const inboundMessageId = '11111111-1111-4111-8111-111111111111'
+  const threadId = '22222222-2222-4222-8222-222222222222'
+  const replyMessageId = '33333333-3333-4333-8333-333333333333'
+  const tenantId = '44444444-4444-4444-8444-444444444444'
+  const organizationId = '55555555-5555-4555-8555-555555555555'
+  const operatorUserId = '66666666-6666-4666-8666-666666666666'
+  const systemUserId = '00000000-0000-0000-0000-000000000000'
+
+  const inboundMessage = {
+    id: inboundMessageId,
+    threadId,
+    senderUserId: systemUserId,
+    subject: 'Incoming from Discord',
+    type: 'channel.discord',
+    visibility: 'public',
+    sourceEntityType: 'communication_channels.external_conversation',
+    sourceEntityId: '77777777-7777-4777-8777-777777777777',
+    externalEmail: null,
+    externalName: 'discord-user',
+    bodyFormat: 'text',
+    priority: 'normal',
+    deletedAt: null,
+    tenantId,
+    organizationId,
+  }
+
+  function makeContainer(channelThreadAccess: unknown, options: { registered?: boolean } = {}) {
+    const trx = {
+      create: jest.fn((entity: unknown, data: Record<string, unknown>) => (
+        entity === Message ? { id: replyMessageId, ...data } : { ...data }
+      )),
+      persist: jest.fn(function persist(this: unknown) { return this }),
+      flush: jest.fn(async () => {}),
+    }
+
+    const emFork = {
+      findOne: jest.fn(async (entity: unknown, where: Record<string, unknown>) => {
+        if (entity === Message && where.id === inboundMessageId) return inboundMessage
+        return null
+      }),
+      find: jest.fn(async () => []),
+      transactional: jest.fn(async (callback: (em: typeof trx) => Promise<void>) => callback(trx)),
+      fork: jest.fn(),
+    }
+
+    const resolveChannelThreadAccess = jest.fn(async () => channelThreadAccess)
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return { fork: () => emFork }
+        if (name === 'eventBus') return { emitEvent: jest.fn(async () => {}) }
+        if (name === 'communicationChannelsResolveChannelThreadAccess') {
+          if (options.registered === false) throw new Error('[internal] service not registered')
+          return resolveChannelThreadAccess
+        }
+        return null
+      },
+    }
+    return { container, trx, resolveChannelThreadAccess }
+  }
+
+  function replyInput() {
+    return {
+      messageId: inboundMessageId,
+      body: 'Thanks for reaching out',
+      bodyFormat: 'text' as const,
+      sendViaEmail: false,
+      replyAll: false,
+      tenantId,
+      organizationId,
+      userId: operatorUserId,
+    }
+  }
+
+  function commandCtx(container: unknown, features: string[]) {
+    return {
+      container,
+      auth: { features },
+      organizationScope: null,
+      selectedOrganizationId: organizationId,
+      organizationIds: [organizationId],
+    }
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('lets an operator reply when the channel behind the thread grants access', async () => {
+    const command = commandRegistry.get('messages.messages.reply')
+    const { container, trx, resolveChannelThreadAccess } = makeContainer({
+      messageThreadId: threadId,
+      externalConversationId: '77777777-7777-4777-8777-777777777777',
+      channelId: '88888888-8888-4888-8888-888888888888',
+      channelType: 'discord',
+      canAccess: true,
+    })
+
+    const result = await command!.execute(
+      replyInput(),
+      commandCtx(container, ['messages.compose']) as never,
+    )
+
+    expect((result as { id: string }).id).toBe(replyMessageId)
+    expect(resolveChannelThreadAccess).toHaveBeenCalledWith(
+      container,
+      { tenantId, organizationId },
+      { messageThreadId: threadId },
+      { userId: operatorUserId, features: ['messages.compose'] },
+    )
+    const replyRow = trx.create.mock.calls.find(([entity]) => entity === Message)?.[1] as Record<string, unknown>
+    expect(replyRow.threadId).toBe(threadId)
+    expect(replyRow.parentMessageId).toBe(inboundMessageId)
+    expect(replyRow.senderUserId).toBe(operatorUserId)
+  })
+
+  it('still denies a caller the channel itself refuses (personal mailbox of another user)', async () => {
+    const command = commandRegistry.get('messages.messages.reply')
+    const { container } = makeContainer({
+      messageThreadId: threadId,
+      externalConversationId: '77777777-7777-4777-8777-777777777777',
+      channelId: '88888888-8888-4888-8888-888888888888',
+      channelType: 'email',
+      canAccess: false,
+    })
+
+    await expect(
+      command!.execute(replyInput(), commandCtx(container, ['messages.compose']) as never),
+    ).rejects.toThrow('Access denied')
+  })
+
+  it('keeps denying a non-participant on an internal thread', async () => {
+    const command = commandRegistry.get('messages.messages.reply')
+    const { container } = makeContainer(null)
+
+    await expect(
+      command!.execute(replyInput(), commandCtx(container, ['messages.compose']) as never),
+    ).rejects.toThrow('Access denied')
+  })
+
+  it('keeps denying when the channels module is not installed', async () => {
+    const command = commandRegistry.get('messages.messages.reply')
+    const { container } = makeContainer(null, { registered: false })
+
+    await expect(
+      command!.execute(replyInput(), commandCtx(container, ['messages.compose']) as never),
+    ).rejects.toThrow('Access denied')
+  })
+
+  it('does not consult the channel when the caller is already a participant', async () => {
+    const command = commandRegistry.get('messages.messages.reply')
+    const { container, resolveChannelThreadAccess } = makeContainer(null)
+    const emFork = (container.resolve('em') as { fork: () => { findOne: jest.Mock } }).fork()
+    emFork.findOne.mockImplementation(async (entity: unknown, where: Record<string, unknown>) => {
+      if (entity === Message && where.id === inboundMessageId) {
+        return { ...inboundMessage, senderUserId: operatorUserId }
+      }
+      if (entity === MessageRecipient) return null
+      return null
+    })
+
+    await command!.execute(replyInput(), commandCtx(container, ['messages.compose']) as never)
+
+    expect(resolveChannelThreadAccess).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/messages/commands/messages.ts
+++ b/packages/core/src/modules/messages/commands/messages.ts
@@ -13,6 +13,7 @@ import {
   updateDraftSchema,
 } from '../data/validators'
 import { linkAttachmentsToMessage, linkLibraryAttachmentsToMessage, copyAttachmentsForForwardMessages } from '../lib/attachments'
+import { resolveActorFeatures, resolveMessageChannelThreadAccess } from '../lib/channelThreadAccess'
 import { MESSAGE_ATTACHMENT_ENTITY_ID, MESSAGE_ENTITY_ID } from '../lib/constants'
 import { getMessageTypeOrDefault } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
@@ -698,7 +699,22 @@ const replyMessageCommand: CommandHandler<unknown, { id: string; externalEmail: 
       recipientUserId: input.userId,
       deletedAt: null,
     })
-    if (original.senderUserId !== input.userId && !ownRecipient) throw new Error('Access denied')
+    if (original.senderUserId !== input.userId && !ownRecipient) {
+      // A message that arrived over a communication channel has no platform
+      // participant to match: its sender is the channel system user and an
+      // unassigned conversation produces no recipient rows, so the
+      // sender-or-recipient test denies every operator — a tenant admin
+      // included (#5535). For a thread the channels hub owns, that hub's own
+      // access rule is the applicable one; an internal thread resolves to
+      // `null` here and keeps the participant rule unchanged.
+      const channelThread = await resolveMessageChannelThreadAccess(
+        ctx.container,
+        { tenantId: input.tenantId, organizationId: input.organizationId ?? null },
+        { messageThreadId: original.threadId ?? original.id },
+        { userId: input.userId, features: resolveActorFeatures(ctx.auth) },
+      )
+      if (!channelThread?.canAccess) throw new Error('Access denied')
+    }
 
     const messageType = getMessageTypeOrDefault(original.type)
     if (messageType.allowReply === false) throw new Error('Reply is not allowed for this message type')

--- a/packages/core/src/modules/messages/i18n/de.json
+++ b/packages/core/src/modules/messages/i18n/de.json
@@ -114,6 +114,7 @@
   "messages.errors.actionFailed": "Aktion konnte nicht ausgeführt werden.",
   "messages.errors.archiveSenderMessageUnsupported": "Du kannst von dir gesendete Nachrichten nicht archivieren.",
   "messages.errors.conversationActionFailed": "Konversation konnte nicht aktualisiert werden.",
+  "messages.errors.conversationHasNoChannelThread": "Diese Unterhaltung hat keinen Kanal-Thread, in den zugestellt werden kann",
   "messages.errors.deleteFailed": "Nachricht konnte nicht gelöscht werden.",
   "messages.errors.forwardPreviewFailed": "Weiterleitungs-Vorschau konnte nicht geladen werden.",
   "messages.errors.invalidContext": "Nachrichtenkontext fehlt.",

--- a/packages/core/src/modules/messages/i18n/en.json
+++ b/packages/core/src/modules/messages/i18n/en.json
@@ -114,6 +114,7 @@
   "messages.errors.actionFailed": "Failed to execute action.",
   "messages.errors.archiveSenderMessageUnsupported": "You cannot archive messages you sent.",
   "messages.errors.conversationActionFailed": "Failed to update conversation.",
+  "messages.errors.conversationHasNoChannelThread": "Conversation has no channel thread to deliver into",
   "messages.errors.deleteFailed": "Failed to delete message.",
   "messages.errors.forwardPreviewFailed": "Failed to load forward preview.",
   "messages.errors.invalidContext": "Message context is missing.",

--- a/packages/core/src/modules/messages/i18n/es.json
+++ b/packages/core/src/modules/messages/i18n/es.json
@@ -114,6 +114,7 @@
   "messages.errors.actionFailed": "No se pudo ejecutar la acción.",
   "messages.errors.archiveSenderMessageUnsupported": "No puedes archivar mensajes que enviaste.",
   "messages.errors.conversationActionFailed": "No se pudo actualizar la conversación.",
+  "messages.errors.conversationHasNoChannelThread": "La conversación no tiene un hilo de canal al que entregar el mensaje",
   "messages.errors.deleteFailed": "No se pudo eliminar el mensaje.",
   "messages.errors.forwardPreviewFailed": "No se pudo cargar la vista previa de reenvío.",
   "messages.errors.invalidContext": "Falta el contexto del mensaje.",

--- a/packages/core/src/modules/messages/i18n/ko.json
+++ b/packages/core/src/modules/messages/i18n/ko.json
@@ -114,6 +114,7 @@
   "messages.errors.actionFailed": "작업을 실행하지 못했습니다.",
   "messages.errors.archiveSenderMessageUnsupported": "본인이 보낸 메시지는 보관할 수 없습니다.",
   "messages.errors.conversationActionFailed": "대화 업데이트에 실패했습니다.",
+  "messages.errors.conversationHasNoChannelThread": "이 대화에는 메시지를 전달할 채널 스레드가 없습니다",
   "messages.errors.deleteFailed": "메시지 삭제에 실패했습니다.",
   "messages.errors.forwardPreviewFailed": "전달 미리보기를 불러오지 못했습니다.",
   "messages.errors.invalidContext": "메시지 컨텍스트가 없습니다.",

--- a/packages/core/src/modules/messages/i18n/pl.json
+++ b/packages/core/src/modules/messages/i18n/pl.json
@@ -114,6 +114,7 @@
   "messages.errors.actionFailed": "Nie udało się wykonać akcji.",
   "messages.errors.archiveSenderMessageUnsupported": "Nie możesz archiwizować wysłanych przez siebie wiadomości.",
   "messages.errors.conversationActionFailed": "Nie udało się zaktualizować konwersacji.",
+  "messages.errors.conversationHasNoChannelThread": "Ta konwersacja nie ma wątku kanału, do którego można dostarczyć wiadomość",
   "messages.errors.deleteFailed": "Nie udało się usunąć wiadomości.",
   "messages.errors.forwardPreviewFailed": "Nie udało się załadować podglądu przekazywanej wiadomości.",
   "messages.errors.invalidContext": "Brakuje kontekstu wiadomości.",

--- a/packages/core/src/modules/messages/lib/channelThreadAccess.ts
+++ b/packages/core/src/modules/messages/lib/channelThreadAccess.ts
@@ -23,6 +23,17 @@ export type ChannelThreadReference = {
   externalConversationId?: string | null
 }
 
+/**
+ * Feature a caller must hold before the channel-thread fallback may widen a
+ * route's participant test.
+ *
+ * The fallback delegates to `assertCanAccessChannel`, which grants every shared
+ * channel unconditionally and documents its precondition as "a caller the route
+ * already feature-gated". Routes that are `requireAuth`-only must therefore
+ * apply this gate themselves before consulting the facade.
+ */
+export const CHANNEL_THREAD_FALLBACK_FEATURE = 'messages.view'
+
 type ContainerLike = { resolve: <T = unknown>(name: string) => T }
 
 type ResolveChannelThreadAccessService = (

--- a/packages/core/src/modules/messages/lib/channelThreadAccess.ts
+++ b/packages/core/src/modules/messages/lib/channelThreadAccess.ts
@@ -1,0 +1,76 @@
+import { EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE } from './composeSourceChannelType'
+
+/**
+ * The subset of a resolved channel thread this module consumes. Structurally
+ * mirrors `communication_channels`' `ChannelThreadAccess` without importing it —
+ * the hub is an optional module and `messages` must not depend on its entities.
+ */
+export type ChannelThreadAccessInfo = {
+  messageThreadId: string
+  externalConversationId: string
+  channelId: string
+  channelType: string
+  canAccess: boolean
+}
+
+export type ChannelThreadScope = {
+  tenantId: string
+  organizationId: string | null
+}
+
+export type ChannelThreadReference = {
+  messageThreadId?: string | null
+  externalConversationId?: string | null
+}
+
+type ContainerLike = { resolve: <T = unknown>(name: string) => T }
+
+type ResolveChannelThreadAccessService = (
+  container: ContainerLike,
+  scope: ChannelThreadScope,
+  reference: ChannelThreadReference,
+  actor: { userId: string | null; features: string[] },
+) => Promise<ChannelThreadAccessInfo | null>
+
+function tryResolveChannelThreadAccessService(
+  container: ContainerLike,
+): ResolveChannelThreadAccessService | undefined {
+  try {
+    return container.resolve<ResolveChannelThreadAccessService>(
+      'communicationChannelsResolveChannelThreadAccess',
+    )
+  } catch {
+    // `communication_channels` is optional: without it no thread can be
+    // channel-linked, so "internal thread" is both correct and fail-closed.
+    return undefined
+  }
+}
+
+/** Granted features of the acting user, read defensively off the command context. */
+export function resolveActorFeatures(auth: unknown): string[] {
+  const features = (auth as { features?: unknown } | null | undefined)?.features
+  if (!Array.isArray(features)) return []
+  return features.filter((value): value is string => typeof value === 'string')
+}
+
+/**
+ * Resolve the channel thread a message belongs to, together with whether the
+ * acting user may act on it (#5535).
+ *
+ * Returns `null` for an internal thread, for a thread outside the caller's
+ * tenant/organization scope, and when the hub module is not installed — every
+ * caller treats `null` as "the pre-existing rule applies".
+ */
+export async function resolveMessageChannelThreadAccess(
+  container: ContainerLike,
+  scope: ChannelThreadScope,
+  reference: ChannelThreadReference,
+  actor: { userId: string | null; features: string[] },
+): Promise<ChannelThreadAccessInfo | null> {
+  if (!reference.messageThreadId && !reference.externalConversationId) return null
+  const resolveChannelThreadAccess = tryResolveChannelThreadAccessService(container)
+  if (!resolveChannelThreadAccess) return null
+  return resolveChannelThreadAccess(container, scope, reference, actor)
+}
+
+export { EXTERNAL_CONVERSATION_SOURCE_ENTITY_TYPE }

--- a/packages/core/src/modules/messages/lib/channelThreadAccess.ts
+++ b/packages/core/src/modules/messages/lib/channelThreadAccess.ts
@@ -36,12 +36,15 @@ function tryResolveChannelThreadAccessService(
   container: ContainerLike,
 ): ResolveChannelThreadAccessService | undefined {
   try {
-    return container.resolve<ResolveChannelThreadAccessService>(
+    const service = container.resolve<ResolveChannelThreadAccessService>(
       'communicationChannelsResolveChannelThreadAccess',
     )
+    return typeof service === 'function' ? service : undefined
   } catch {
     // `communication_channels` is optional: without it no thread can be
     // channel-linked, so "internal thread" is both correct and fail-closed.
+    // A container that answers with a non-callable instead of throwing reads
+    // the same way.
     return undefined
   }
 }

--- a/packages/core/src/modules/messages/lib/channelThreadAccess.ts
+++ b/packages/core/src/modules/messages/lib/channelThreadAccess.ts
@@ -60,7 +60,15 @@ function tryResolveChannelThreadAccessService(
   }
 }
 
-/** Granted features of the acting user, read defensively off the command context. */
+/**
+ * Granted features of the acting user, read defensively off the command context.
+ *
+ * These are **passed through** to `assertCanAccessChannel`, which currently
+ * discards them (`void userFeatures`) and keeps them on its signature only for
+ * the v2 admin-oversight rule. Nothing here authorizes anything: a route or
+ * command that needs a feature gate before widening its own participant test
+ * MUST apply {@link CHANNEL_THREAD_FALLBACK_FEATURE} itself.
+ */
 export function resolveActorFeatures(auth: unknown): string[] {
   const features = (auth as { features?: unknown } | null | undefined)?.features
   if (!Array.isArray(features)) return []
@@ -74,6 +82,9 @@ export function resolveActorFeatures(auth: unknown): string[] {
  * Returns `null` for an internal thread, for a thread outside the caller's
  * tenant/organization scope, and when the hub module is not installed — every
  * caller treats `null` as "the pre-existing rule applies".
+ *
+ * `actor.features` is a pass-through to the hub's own access rule, not an
+ * authorization input — see {@link resolveActorFeatures}.
  */
 export async function resolveMessageChannelThreadAccess(
   container: ContainerLike,

--- a/packages/core/src/modules/messages/lib/routeHelpers.ts
+++ b/packages/core/src/modules/messages/lib/routeHelpers.ts
@@ -1,4 +1,5 @@
 import { resolveRequestContext } from '@open-mercato/shared/lib/api/context'
+import { CHANNEL_THREAD_FALLBACK_FEATURE } from './channelThreadAccess'
 
 export function hasOrganizationAccess(
   scopeOrganizationId: string | null,
@@ -46,6 +47,33 @@ export async function parseRequestBodySafe(req: Request): Promise<unknown> {
     return JSON.parse(text)
   } catch {
     return {}
+  }
+}
+
+/**
+ * Whether the caller may fall back to the channels hub's access rule on a
+ * channel-linked thread (#5535).
+ *
+ * Resolved through RBAC, never through `ctx.auth.features`: the session JWT
+ * carries no `features` claim, so reading it here would deny every caller —
+ * a tenant admin included — and re-close the very journey #5535 opened. RBAC is
+ * also what makes the check wildcard-aware. Fails closed, like the sibling
+ * feature checks in this file.
+ */
+export async function canUseChannelThreadFallback(
+  ctx: Awaited<ReturnType<typeof resolveRequestContext>>['ctx'],
+  scope: MessageScope,
+): Promise<boolean> {
+  if (!scope.userId || !scope.tenantId) return false
+  try {
+    const rbac = ctx.container.resolve('rbacService') as RbacService | undefined
+    if (typeof rbac?.userHasAllFeatures !== 'function') return false
+    return await rbac.userHasAllFeatures(scope.userId, [CHANNEL_THREAD_FALLBACK_FEATURE], {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+    })
+  } catch {
+    return false
   }
 }
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-26-issue-5535-reply-inbound-channel-message.md
Status: complete

Closes #5535

## 🎯 Goal

An operator can answer an inbound channel message from the UI, and the answer actually reaches the correspondent. Before this change the reply button returned `403 Access denied` for every user on every inbound channel message — a tenant admin included — and the two compose paths that got around the 403 either delivered by accident or returned `201` for a message that was never sent.

## 🔍 Problem

`POST /api/messages/{id}/reply` — the endpoint `useReplySubmitOperation` calls — refused every operator on a message that arrived over a communication channel, so nobody could answer what a channel delivered. Composing on the channel's own conversation (`sourceEntityType` / `sourceEntityId`) returned `201` and produced a message with no outbound link at all: silent non-delivery on exactly the payload a UI naturally sends, which is worse than a refusal. Only `POST /api/messages` with `parentMessageId` worked, and no operator-facing surface sends that.

## 🔍 Root Cause

Three walls, all from asking a question about platform participants on a thread whose correspondent is not one.

1. **The reply guard.** `replyMessageCommand` (`messages/commands/messages.ts`) authorized with `original.senderUserId !== input.userId && !ownRecipient`. A message ingested by `communication_channels/commands/ingest-inbound-message.ts` is attributed to the channel system user (`COMMUNICATION_CHANNELS_SYSTEM_USER_ID`) and, when the conversation has no assigned user, carries zero `message_recipients` rows — so the predicate is false for every operator by construction. This is not an RBAC misconfiguration; it is a participant test applied where there are no platform participants.

2. **The delivery discriminator.** Even with the guard passed, the reply copies `sourceEntityType = 'communication_channels.external_conversation'` from the message it answers, and the outbound bridge returned early on exactly that value. That early return was meant to skip *ingested inbound* messages (whose `messages.message.sent` event would otherwise queue a redundant delivery), but every *operator* message in the same conversation inherits the same value — so operator messages were dropped silently alongside the ingested ones.

3. **The silent compose.** A compose naming an external conversation without a `parentMessageId` opened a brand-new thread. A fresh thread has no `ChannelThreadMapping`, so there was nothing to route on — and nothing said so.

## What Changed

- **`communication_channels/lib/channel-thread-access.ts` (new)** — soft-optional facade that resolves `ChannelThreadMapping` → `CommunicationChannel` from a `messageThreadId` or an `externalConversationId` and returns `{ messageThreadId, externalConversationId, channelId, channelType, canAccess }`. `canAccess` reuses `assertCanAccessChannel`, so a personal mailbox stays strictly owner-only and a shared channel stays open to any caller the route already feature-gated. Every lookup is tenant/organization-scoped; a thread outside the caller's scope reads as "not channel-linked". The `…Safely` variant degrades a lookup failure to `null`, which is the fail-closed answer — the participant test still applies.
- **`communication_channels/di.ts`** — registers it as `communicationChannelsResolveChannelThreadAccess`, next to the existing `communicationChannelsResolveChannelType` facade from #4975.
- **`messages/lib/channelThreadAccess.ts` (new)** — the `messages`-side `tryResolve` wrapper. The hub is an optional module, so `messages` structurally mirrors the return type rather than importing it, and an absent module resolves to `null` (no cross-module ORM relationship, per AGENTS.md § Cross-Module Coupling).
- **`messages/commands/messages.ts`** — `replyMessageCommand` consults the facade **only when the participant test has already failed**, and allows the reply when the channel behind the thread grants access. An internal thread, an absent hub, or a channel that refuses the caller all still raise `Access denied`.
- **`communication_channels/subscribers/outbound-bridge.ts`** — the blanket `sourceEntityType` early return is replaced by `isIngestedInboundMessage`, checked after the existing `MessageChannelLink` lookup so it costs no extra query in the common case.
- **`communication_channels/lib/inbound-message-origin.ts` (new)** — that predicate, plus `buildInboundIdempotencyKey` (now used by the ingest command, so the writer and the reader of the `cc:` key sit together). Three signals, cheapest first: an inbound `MessageChannelLink` for the message (authoritative), the `cc:` ingest dedup key, or the tenant's channel system user as sender. The ingest link is written *after* the compose command emits its event, so the last two cover the window where it is not yet visible — without them, narrowing the guard would risk re-introducing the redundant-delivery failure the old comment documents.
- **`messages/api/route.ts`** — a public, non-draft compose naming an external conversation is attached to that conversation's existing thread (`parentMessageId` = the mapping's `messageThreadId`) so it delivers; `409 Conversation has no channel thread to deliver into` when no mapping exists, and `403` when the caller may not act on the channel. Drafts and internal notes filed against the same conversation are never delivered anyway and are left untouched, as is any compose that already names a parent.

## 🧪 Tests

- `yarn build:packages` → `yarn generate` → `yarn build:packages` → `yarn i18n:check-sync` → `yarn i18n:check-usage` → `yarn typecheck` → `yarn test` → `yarn build:app` — the full configured gate, in order, all green (`yarn test`: 34/34 turbo tasks, exit 0). `yarn lint` additionally reports 0 errors (10 pre-existing warnings in untouched files).
- `communication_channels/lib/__tests__/channel-thread-access.test.ts` (new) — shared channel grants, another user's personal mailbox denies, the owner's own mailbox grants, resolution by conversation id, internal threads report `null`, every lookup is tenant/org-scoped, and a failing lookup degrades instead of throwing.
- `messages/commands/__tests__/messages.reply-channel-thread.test.ts` (new) — an operator replies on a channel thread and the reply lands in the original thread with the operator as sender; a refused channel, an internal thread, and an uninstalled hub all still raise `Access denied`; a caller who is already a participant never triggers the channel lookup.
- `communication_channels/subscribers/__tests__/outbound-bridge.test.ts` — the ingested message is skipped via each of the three signals (inbound link, `cc:` key, system-user sender), and an operator reply that inherited the conversation's `sourceEntityType` is enqueued for delivery.
- `messages/api/__tests__/compose-channel-type.test.ts` — threading onto the conversation's existing thread, the 409 and 403 refusals, an explicit `parentMessageId` left alone, and drafts/internal notes untouched.

## 💥 Breaking Changes

One deliberate behavior change on an HTTP path no production caller uses today: `POST /api/messages` with `sourceEntityType: 'communication_channels.external_conversation'`, a `sourceEntityId`, public visibility and no `parentMessageId` now returns `409` (or `403`) instead of the `201` that silently dropped the message. That is the point — the issue asks for the silent case to fail loudly. No database schema, event id, DI-name removal, or route-shape change; the DI service and both new lib modules are purely additive.

## Scope note

This does not touch #5528 (`send-as-user` and the composer's client-side email gate) — that is a separate wall in front of this one. Note that a *public* compose still routes through the `messages.email` feature check, which #5528 covers.


## Follow-up from the automated review (commit `1b687da9`)

The review of the first commit found the fix incomplete on the reported path and it was fixed before the review was submitted:

- **`GET /api/messages/{id}` applied the same participant test.** On an unassigned conversation the operator could not open the detail page the reply button lives on, and the thread slice filtered the conversation down to their own messages. The same channel-thread fallback now applies to the detail route, and a channel-linked thread renders whole — the correspondent is not a platform user, so participation cannot describe who belongs to that conversation. The lookup runs only for channel-sourced messages.
- **The `messages`-side facade wrapper trusted whatever the container returned.** It now requires a callable, so a container that answers unknown names with `null` instead of throwing reads as "hub not installed" rather than crashing the route.
- **`TC-CHANNEL-REPLY-001`** (new integration spec) drives the real ingest command and asserts read -> reply -> outbound delivery end to end. It was authored but **not executed** in the automated run, which had no application environment; it is not part of the CI gate and is listed for the QA pass.

Two findings were recorded and deliberately **not** fixed here: the new 409 message is a hardcoded English string consistent with every sibling error in the same handler (translating one of ten would be inconsistent; migrating that error surface is its own change), and the inbox **list** route still scopes by participation, so an inbound message on an unassigned conversation stays invisible in the listing even though it can now be opened and answered. That is a materially larger security surface than the two single-record guards this PR touches and deserves its own change and review — worth a follow-up issue.




## Follow-up from @pkarw's review (commits `1a2f1004` … `b82bc962`)

@pkarw's `CHANGES_REQUESTED` review found two blockers, both on the *widening* half of the change rather than the diagnosis. Both are fixed, each with a regression test that drives the cross-module seam the mocked suites could not see between.

- **The outbound bridge delivered internal and forwarded messages to the external correspondent.** Replacing the blanket `sourceEntityType` guard with `isIngestedInboundMessage` answered "did the ingest command compose this?" where the bridge asks "did an operator mean this to leave the platform?" — and between those sat every internal message sharing the channel thread, above all a **forward**, whose body is the quoted conversation plus the operator's own commentary about the customer. `communication_channels/lib/inbound-message-origin.ts` now has an intent counterpart, `lib/outbound-delivery-intent.ts`: a message is enqueued only when it is neither internal-visibility nor a forward. A `visibility === 'internal'` test alone is not enough — `forwardMessageCommand` copies `visibility` from the message it forwards, so a forward of a *public* inbound message is public too; the forward is identified by `forwardedFrom` on the `messages.message.sent` payload, the only place that intent is recorded (nothing persisted separates a forward from a reply — both set `parentMessageId`, and a `replyAll` reply carries platform recipient rows just the same).
- **`GET /api/messages/{id}`'s channel fallback was ungated.** `assertCanAccessChannel` ignores features by design and returns for every *shared* channel; its documented precondition is a caller the route already feature-gated, and this route is `requireAuth` only. The fallback now requires `messages.view` (wildcard-aware, via `authorizeFeatures`) before the facade is consulted at all. The gate sits on the fallback rather than on the route so that a participant can still read their own message without holding that feature; the other two fallback call sites (`POST /api/messages`, `POST /api/messages/{id}/reply`) already require `messages.compose`. Internal-visibility messages now stay participant-only however the caller reached the thread — in the thread slice and when opening such a message directly.
- **The review minor** — the new 409 string — is resolved by translating it (`messages.errors.conversationHasNoChannelThread`, shipped in all five locales) rather than by the `[internal]` opt-out, which is reserved for strings that are *not* user-facing. Only the string this PR introduced is migrated; the nine pre-existing plain errors in the same handler remain a separate change.
- **The review nit** — the inert `features` plumbing — is documented rather than deleted, since the argument mirrors `assertCanAccessChannel`'s own retained signature; `resolveActorFeatures` now says plainly that it is a pass-through and points at the feature gate that *is* the authorization decision.

### Tests added in this round

- `communication_channels/subscribers/__tests__/outbound-bridge.message-intent.test.ts` (new) — runs the real `messages.messages.forward` and `messages.messages.reply` commands and feeds the events and rows they produce into the real subscriber: a forward is not delivered, an internal-visibility message is not delivered, and the operator's public reply still is. Both negative cases were verified to fail with the guard removed.
- `messages/api/[id]/__tests__/route.test.ts` — six new cases: a caller with no features and a caller with only unrelated features are denied and never reach the facade, a wildcard grant is honored, another operator's internal note is hidden from a channel-access caller while the caller's own stays visible, and opening someone else's internal note directly is refused. Four of the six were verified to fail with the route change reverted.

The full configured validation gate was re-run in order on the final head and is green, plus `yarn lint` (0 errors). The inbox **list** route's participant scope remains out of scope and still deserves its own follow-up issue.
