### PR TITLE
fix(customers): chunk the ActivitiesSection author lookup and stop caching its failures (#5632)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
@@ -10,6 +10,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { Kbd } from '@open-mercato/ui/primitives/kbd'
 import { ActivityTimelineFilters } from './ActivityTimelineFilters'
 import { ActivityTimeline } from './ActivityTimeline'
+import { resolveAuthorUserNames } from './authorUserLookup'
 import type { ActivitySummary, InteractionSummary } from './types'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
@@ -314,25 +315,14 @@ export function ActivitiesSection({
     }
     if (unresolvedIds.size === 0) return
 
-    for (const uid of unresolvedIds) resolvedUserIdsRef.current.add(uid)
-
     const controller = new AbortController()
-    readApiResultOrThrow<{ items?: Array<Record<string, unknown>> }>(
-      `/api/auth/users?ids=${[...unresolvedIds].join(',')}`,
-      { signal: controller.signal },
-    )
-      .then((data) => {
-        const users = Array.isArray(data?.items) ? data.items : []
-        const nameMap = new Map<string, string>()
-        for (const user of users) {
-          const userId = typeof user.id === 'string' ? user.id : null
-          const name = typeof user.display_name === 'string' && user.display_name.trim()
-            ? user.display_name.trim()
-            : typeof user.email === 'string'
-              ? user.email
-              : null
-          if (userId && name) nameMap.set(userId, name)
-        }
+    resolveAuthorUserNames([...unresolvedIds], controller.signal)
+      .then(({ names: nameMap, resolvedIds }) => {
+        if (controller.signal.aborted) return
+        // Only ids the server actually answered for are remembered. Marking an id whose request
+        // failed — or one the server silently dropped past its `?ids=` cap — would leave that
+        // author blank for the life of the component, even though the next attempt would work.
+        for (const uid of resolvedIds) resolvedUserIdsRef.current.add(uid)
         if (nameMap.size > 0) {
           setActivities((prev) =>
             prev.map((a) => {

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.authorLookup.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.authorLookup.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards issue #5632: the activity timeline resolves author ids through
+ * `GET /api/auth/users?ids=`, which slices silently at `MAX_USER_LOOKUP_IDS`. The lookup must
+ * therefore chunk at that cap, and it must remember only the ids the server actually answered for
+ * — otherwise ids the server dropped, and ids whose request failed outright, render blank for the
+ * life of the component. Sibling coverage:
+ * `packages/core/src/modules/devices/__tests__/use-device-user-labels.test.tsx`.
+ */
+import { waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { MAX_USER_LOOKUP_IDS } from '@open-mercato/core/modules/auth/lib/userIdFilter'
+import { ActivitiesSection } from '../ActivitiesSection'
+
+const readApiResultOrThrowMock = jest.fn()
+const apiCallMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCallOrThrow: jest.fn(),
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: jest.fn(),
+  updateCrud: jest.fn(),
+  deleteCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 'scope-v1',
+}))
+
+jest.mock('@open-mercato/core/modules/dictionaries/components/dictionaryAppearance', () => ({
+  renderDictionaryColor: jest.fn(),
+  renderDictionaryIcon: jest.fn(),
+}))
+
+jest.mock('../hooks/useCustomerDictionary', () => ({
+  useCustomerDictionary: () => ({ data: { map: {} } }),
+  ensureCustomerDictionary: jest.fn(async () => ({ entries: [], map: {} })),
+  invalidateCustomerDictionary: jest.fn(async () => undefined),
+}))
+
+jest.mock('../hooks/useCustomFieldDisplay', () => ({
+  useCustomFieldDisplay: () => ({
+    definitions: [],
+    dictionaryMapsByKey: {},
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+jest.mock('../CustomFieldValuesList', () => ({
+  CustomFieldValuesList: () => null,
+}))
+
+jest.mock('../ActivityTimelineFilters', () => ({
+  ActivityTimelineFilters: () => null,
+}))
+
+const activityTimelineMock = jest.fn(() => null)
+jest.mock('../ActivityTimeline', () => ({
+  ActivityTimeline: (props: unknown) => {
+    activityTimelineMock(props)
+    return null
+  },
+}))
+
+const AUTHOR_COUNT = 150
+
+/** Real UUIDs — the route validates `?ids=` entries as UUIDs, so placeholder ids would not be representative. */
+function authorId(index: number): string {
+  const suffix = String(index).padStart(12, '0')
+  return `00000000-0000-4000-8000-${suffix}`
+}
+
+const AUTHOR_IDS = Array.from({ length: AUTHOR_COUNT }, (_, index) => authorId(index))
+
+function interactionsFor(ids: readonly string[]) {
+  return {
+    items: ids.map((id, index) => ({
+      id: `interaction-${index}`,
+      interactionType: 'note',
+      status: 'done',
+      occurredAt: '2026-03-29T09:00:00.000Z',
+      scheduledAt: null,
+      createdAt: '2026-03-29T09:00:00.000Z',
+      updatedAt: '2026-03-29T09:00:00.000Z',
+      authorUserId: id,
+      authorName: null,
+    })),
+  }
+}
+
+function renderSection() {
+  return renderWithProviders(
+    <ActivitiesSection
+      entityId="company-5632"
+      useCanonicalInteractions
+      addActionLabel="Log activity"
+      emptyState={{ title: 'No activities logged yet', actionLabel: 'Log activity' }}
+    />,
+  )
+}
+
+function idsOf(url: string): string[] {
+  return (new URLSearchParams(String(url).split('?')[1]).get('ids') ?? '').split(',').filter(Boolean)
+}
+
+/** The `?ids=` values of every `/api/auth/users` request issued so far, in call order. */
+function userLookupBatches(): string[][] {
+  return apiCallMock.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.startsWith('/api/auth/users?'))
+    .map(idsOf)
+}
+
+function okResponse(items: Array<Record<string, unknown>>) {
+  return { ok: true, status: 200, result: { items }, response: {} as Response, cacheStatus: null }
+}
+
+function failedResponse() {
+  return { ok: false, status: 403, result: null, response: {} as Response, cacheStatus: null }
+}
+
+function authorNamesFromTimeline(): Record<string, string | null> {
+  const calls = activityTimelineMock.mock.calls
+  const lastProps = calls[calls.length - 1]?.[0] as { activities?: Array<Record<string, unknown>> } | undefined
+  const entries: Record<string, string | null> = {}
+  for (const activity of lastProps?.activities ?? []) {
+    entries[String(activity.authorUserId)] = (activity.authorName as string | null) ?? null
+  }
+  return entries
+}
+
+beforeEach(() => {
+  readApiResultOrThrowMock.mockReset()
+  apiCallMock.mockReset()
+  activityTimelineMock.mockClear()
+  readApiResultOrThrowMock.mockResolvedValue(interactionsFor(AUTHOR_IDS))
+})
+
+describe('ActivitiesSection author lookup', () => {
+  it('chunks the lookup at the route cap instead of dropping the overflow ids', async () => {
+    apiCallMock.mockResolvedValue(okResponse([]))
+
+    renderSection()
+
+    await waitFor(() => expect(userLookupBatches().length).toBe(2))
+    const [first, second] = userLookupBatches()
+    // 150 unresolved authors, a server that slices silently at 100: one request would lose 50 ids.
+    expect(first).toHaveLength(MAX_USER_LOOKUP_IDS)
+    expect(second).toHaveLength(AUTHOR_COUNT - MAX_USER_LOOKUP_IDS)
+    // The timeline sort decides the id order, so assert coverage rather than sequence: every
+    // author is asked for exactly once across the batches.
+    expect([...first, ...second].sort()).toEqual([...AUTHOR_IDS].sort())
+  })
+
+  it('asks for as many rows as the batch holds, so pagination cannot truncate the answer', async () => {
+    apiCallMock.mockResolvedValue(okResponse([]))
+
+    renderSection()
+
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalled())
+    // The route's pageSize defaults to 50 — a 100-id batch would come back half-answered.
+    const [url] = apiCallMock.mock.calls[0]
+    const params = new URLSearchParams(String(url).split('?')[1])
+    expect(params.get('pageSize')).toBe(String(MAX_USER_LOOKUP_IDS))
+    expect(params.get('page')).toBe('1')
+  })
+
+  it('does not let a 403 on the lookup redirect the whole detail page', async () => {
+    apiCallMock.mockResolvedValue(okResponse([]))
+
+    renderSection()
+
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalled())
+    const [, init] = apiCallMock.mock.calls[0]
+    expect((init as RequestInit & { headers: Record<string, string> }).headers['x-om-forbidden-redirect']).toBe('0')
+  })
+
+  it('retries a failed batch and stops asking for ids the server answered for', async () => {
+    // Batch 1 succeeds but matches rows for only half of the ids it was given; batch 2 fails
+    // outright. Both halves are derived from the ids actually requested, because the timeline sort
+    // — not this file — decides which author lands in which batch.
+    const answeredWithoutRow: string[] = []
+    let failedBatch: string[] = []
+    let callIndex = 0
+    apiCallMock.mockImplementation(async (url: string) => {
+      const ids = idsOf(url)
+      callIndex += 1
+      if (callIndex === 1) {
+        answeredWithoutRow.push(...ids.slice(50))
+        return okResponse(ids.slice(0, 50).map((id, index) => ({ id, name: `Author ${index}` })))
+      }
+      if (callIndex === 2) {
+        failedBatch = ids
+        return failedResponse()
+      }
+      return okResponse(ids.map((id, index) => ({ id, name: `Late ${index}` })))
+    })
+
+    renderSection()
+
+    // The names resolved by batch 1 re-render the timeline, which re-runs the lookup effect.
+    await waitFor(() => expect(userLookupBatches().length).toBe(3))
+
+    const retried = userLookupBatches()[2]
+    // The failed batch is retried in full...
+    expect([...retried].sort()).toEqual([...failedBatch].sort())
+    // ...while the ids batch 1 answered for but matched no row are never asked for again.
+    expect(answeredWithoutRow).toHaveLength(MAX_USER_LOOKUP_IDS - 50)
+    for (const id of answeredWithoutRow) {
+      expect(retried).not.toContain(id)
+    }
+
+    await waitFor(() => expect(authorNamesFromTimeline()[failedBatch[0]]).toBe('Late 0'))
+    expect(userLookupBatches()).toHaveLength(3)
+  })
+
+  it('labels an author with the display name the route returns', async () => {
+    readApiResultOrThrowMock.mockResolvedValue(interactionsFor([AUTHOR_IDS[0]]))
+    apiCallMock.mockResolvedValue(okResponse([
+      { id: AUTHOR_IDS[0], name: 'Ada Lovelace', email: 'ada@example.com' },
+    ]))
+
+    renderSection()
+
+    // `name` is what `/api/auth/users` emits; the email is only the fallback.
+    await waitFor(() => expect(authorNamesFromTimeline()[AUTHOR_IDS[0]]).toBe('Ada Lovelace'))
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.authorLookup.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.authorLookup.test.tsx
@@ -68,7 +68,9 @@ jest.mock('../ActivityTimeline', () => ({
   },
 }))
 
-const AUTHOR_COUNT = 150
+// Derived from the cap rather than hard-coded, so raising `MAX_USER_LOOKUP_IDS` keeps this suite
+// asserting "one full batch plus a partial one" instead of silently collapsing to a single request.
+const AUTHOR_COUNT = MAX_USER_LOOKUP_IDS + 50
 
 /** Real UUIDs — the route validates `?ids=` entries as UUIDs, so placeholder ids would not be representative. */
 function authorId(index: number): string {
@@ -163,12 +165,15 @@ describe('ActivitiesSection author lookup', () => {
 
     renderSection()
 
-    await waitFor(() => expect(apiCallMock).toHaveBeenCalled())
-    // The route's pageSize defaults to 50 — a 100-id batch would come back half-answered.
-    const [url] = apiCallMock.mock.calls[0]
-    const params = new URLSearchParams(String(url).split('?')[1])
-    expect(params.get('pageSize')).toBe(String(MAX_USER_LOOKUP_IDS))
-    expect(params.get('page')).toBe('1')
+    await waitFor(() => expect(userLookupBatches().length).toBe(2))
+    // The route's pageSize defaults to 50 — a 100-id batch would come back half-answered. Assert
+    // the relationship (page size equals this batch's own id count) rather than a literal, so the
+    // check still means something if the cap moves.
+    for (const [url] of apiCallMock.mock.calls) {
+      const params = new URLSearchParams(String(url).split('?')[1])
+      expect(params.get('page')).toBe('1')
+      expect(params.get('pageSize')).toBe(String(idsOf(String(url)).length))
+    }
   })
 
   it('does not let a 403 on the lookup redirect the whole detail page', async () => {

--- a/packages/core/src/modules/customers/components/detail/authorUserLookup.ts
+++ b/packages/core/src/modules/customers/components/detail/authorUserLookup.ts
@@ -1,0 +1,85 @@
+"use client"
+
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { MAX_USER_LOOKUP_IDS } from '@open-mercato/core/modules/auth/lib/userIdFilter'
+
+type AuthUserItem = {
+  id?: unknown
+  name?: unknown
+  display_name?: unknown
+  email?: unknown
+}
+
+// Imported rather than restated: `parseIdsParam` slices past the route's cap without complaining,
+// so a client batch larger than the server accepts loses the overflow ids silently.
+const MAX_IDS_PER_LOOKUP = MAX_USER_LOOKUP_IDS
+
+/**
+ * The outcome of a batch lookup. `resolvedIds` lists the ids the server actually answered for —
+ * an id that came back without a row (deleted user) still counts as resolved, an id whose request
+ * failed does not. Callers cache on `resolvedIds`, so a transient failure is retried rather than
+ * remembered as a permanent blank.
+ */
+export type AuthorUserLookup = {
+  names: Map<string, string>
+  resolvedIds: string[]
+}
+
+function toName(item: AuthUserItem | null | undefined): [string, string] | null {
+  if (!item || typeof item.id !== 'string' || !item.id.trim()) return null
+  const name = typeof item.name === 'string' && item.name.trim() ? item.name.trim() : null
+  const displayName = typeof item.display_name === 'string' && item.display_name.trim()
+    ? item.display_name.trim()
+    : null
+  const email = typeof item.email === 'string' && item.email.trim() ? item.email.trim() : null
+  const label = name ?? displayName ?? email
+  return label ? [item.id.trim(), label] : null
+}
+
+// A viewer of a customer record does not necessarily hold `auth.users.list`, so this lookup must be
+// allowed to fail: `x-om-forbidden-redirect: 0` keeps a 403 from bouncing the whole detail page to
+// /login, and `null` signals that the call itself failed. Callers must not confuse that with a
+// successful call that matched nobody — caching the former would remember a transient error forever.
+async function fetchBatch(ids: string[], signal?: AbortSignal): Promise<AuthUserItem[] | null> {
+  const params = new URLSearchParams()
+  params.set('page', '1')
+  // The route's pageSize defaults to 50, so a batch larger than that would be truncated by
+  // pagination even after it survived the `?ids=` cap.
+  params.set('pageSize', String(ids.length))
+  // URLSearchParams encodes on toString(); pre-encoding here would double-escape the commas.
+  params.set('ids', ids.join(','))
+  const call = await apiCall<{ items?: AuthUserItem[] }>(
+    `/api/auth/users?${params.toString()}`,
+    { headers: { 'x-om-forbidden-redirect': '0' }, signal },
+    { fallback: null },
+  ).catch(() => null)
+  if (!call || !call.ok) return null
+  return call.result?.items ?? []
+}
+
+/**
+ * Batch id → display-name resolution for activity authors already on screen, so an author whose
+ * name was not denormalized onto the activity still renders a name instead of a bare UUID.
+ */
+export async function resolveAuthorUserNames(
+  ids: readonly string[],
+  signal?: AbortSignal,
+): Promise<AuthorUserLookup> {
+  const unique = Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean)))
+  const names = new Map<string, string>()
+  const resolvedIds: string[] = []
+  for (let offset = 0; offset < unique.length; offset += MAX_IDS_PER_LOOKUP) {
+    if (signal?.aborted) break
+    const batch = unique.slice(offset, offset + MAX_IDS_PER_LOOKUP)
+    const items = await fetchBatch(batch, signal)
+    // One failed batch must not cost the batches that did answer, and its ids stay unresolved so
+    // the next render retries them.
+    if (items === null) continue
+    for (const item of items) {
+      const entry = toName(item)
+      if (entry) names.set(entry[0], entry[1])
+    }
+    resolvedIds.push(...batch)
+  }
+  return { names, resolvedIds }
+}


### PR DESCRIPTION
Closes #5632

## 🎯 Goal

A customer or company detail page with more than 100 distinct activity authors on screen showed some of them as blank instead of a name, permanently — and a single failed lookup blanked *every* author for the life of the component. This PR makes the timeline's author lookup resolve all of them, and retry the ones it could not.

## 🔍 Problem

`ActivitiesSection` resolves author ids through `GET /api/auth/users?ids=`. #5634 made that parameter actually filter (it was previously accepted and ignored), so the behaviour improved — but only up to the route's cap. Split out of the review of #5617 (finding 5).

Two defects, both in `ActivitiesSection.tsx:308-322`:

1. **No chunking.** Every unresolved id went into one request. `resolveUserIdFilter` slices at `MAX_USER_LOOKUP_IDS = 100` and returns no error, so with 150 authors on screen the last 50 were dropped server-side silently. The call also omitted `pageSize`, so the route's default of 50 truncated anything larger than that even after it survived the cap.
2. **The failure was cached.** Line 317 added every id to `resolvedUserIdsRef` *before* awaiting the fetch. Combined with (1), the dropped ids were marked resolved and never retried; and if the request itself threw — a 403 for a viewer without `auth.users.list`, or a network error — the whole set was marked resolved and every author rendered blank until the component remounted.

## 🔍 Root Cause

The effect recorded *intent* rather than *outcome*. `resolvedUserIdsRef` is a "do not ask again" cache, but it was populated from the request, not the response, so it could not distinguish three different things the old code collapsed together: an id the server answered for and matched, an id the server answered for and matched nothing (a deleted user — genuinely resolved), and an id the server never answered for at all. Only the first two are safe to cache.

This is the same defect `6a03f4c27` fixed in `useDeviceUserLabels`. That fix was deliberately kept devices-local, so this sibling call site still carried it.

## What Changed

- **`packages/core/src/modules/customers/components/detail/authorUserLookup.ts` (new).** The lookup moves out of the effect body into `resolveAuthorUserNames(ids, signal)`, modelled on `devices/backend/devices/userOptions.ts`. It dedupes and trims the ids, chunks at `MAX_USER_LOOKUP_IDS` **imported** from `@open-mercato/core/modules/auth/lib/userIdFilter` (not restated — per the issue, and the same correction #5634 applied to the devices copy), sets `pageSize` to the batch length so pagination cannot truncate a full batch, and returns `{ names, resolvedIds }`. A batch whose request fails is skipped without contributing to `resolvedIds`, so one failed batch does not cost the batches that did answer.
- **`ActivitiesSection.tsx`.** The pre-emptive cache write is gone. The effect now adds only `resolvedIds` to `resolvedUserIdsRef`, inside `.then`, after checking `controller.signal.aborted`. An id the server answered for but matched no row still counts as resolved; an id whose request failed is left unresolved and retried on the next id-set change.
- **Two adjacent defects in the same rewritten block.** The mapper read `user.display_name`, but `/api/auth/users` emits `name` (`auth/api/users/route.ts:496`) — so every author silently fell through to the email branch. `name` is now preferred, with `display_name` and email kept as fallbacks, so no existing label regresses. The call also lacked `x-om-forbidden-redirect: '0'`, meaning a viewer holding `customers.*` but not `auth.users.list` had the whole detail page bounced to /login by a lookup that is supposed to degrade to bare ids; it now degrades, matching the devices sibling.

The helper is deliberately customers-local. The issue left "shared helper or two call sites" as an implementation call, and the devices version is devices-local today — extracting a shared module would mean moving the devices code too, which is out of scope for a fix.

## 🧪 Tests

Local runner (no compose `app` container up), full `validation.commands` gate:

| Gate | Result |
|---|---|
| `yarn build:packages` → `yarn generate` → `yarn build:packages` | pass (no generated-file drift) |
| `yarn i18n:check-sync` | pass — all five locales in sync |
| `yarn i18n:check-usage` | pass (advisory unused-key report only) |
| `yarn typecheck` | pass (27/27) |
| `yarn test` | 33 of 34 workspace tasks pass — see below |
| `yarn build:app` | pass |

**One known-unrelated failure:** `create-mercato-app#test` fails on this host in the harness oracle suites (`agent-harness-release.test.ts`, `business-writable-oracles.test.ts`, `writable-ast-oracles.test.ts`), which shell out to the `codex`/`claude` CLIs and enforce a 120s `yarn typecheck` budget this machine misses. Verified pre-existing rather than assumed: stashing this branch's changes and re-running that workspace on clean `develop` reproduces the same suites failing, with a larger failure set. This PR touches nothing under `packages/create-app`.

New coverage — `packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.authorLookup.test.tsx`, modelled on `devices/__tests__/use-device-user-labels.test.tsx`, five cases:

- 150 authors produce **two** `/api/auth/users` requests of 100 and 50, together covering every id exactly once (asserted as coverage, not sequence — the timeline sort decides the order).
- Each batch sends `page=1` and `pageSize` equal to its own size, so the route's default 50 cannot truncate it.
- The request carries `x-om-forbidden-redirect: '0'`.
- Batch 1 succeeds matching rows for only half its ids while batch 2 fails: the failed batch is retried **in full**, the answered-but-unmatched ids are **never** asked for again, and the retry then resolves them.
- An author is labelled by `name`, not the email fallback.

All five fail against the pre-fix `ActivitiesSection.tsx` and pass with it. The 70 existing `customers/components/detail` suites (312 tests) still pass.

`yarn lint` covers only `@open-mercato/app`, so it does not reach these files; `yarn typecheck` does.

## 💥 Breaking Changes

None. No API route, response shape, component prop, schema, ACL feature, or exported contract changes — `resolveAuthorUserNames` is a new module-internal helper. The one user-visible difference is intended: an author who has a display name is now labelled with it instead of their email address.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790327738&installation_model_id=432243&pr_number=5654&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5654&signature=b7b5551bdcda0e2fef91641ea1dd9ae3dc9e482fc8fdc14d27c8c96ab04985dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->