### PR TITLE
fix(data-sync): validate schedule before persisting it (#5506)

### DIFF
--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -1,0 +1,84 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+
+const mockEm = {
+  create: jest.fn((_entityClass: unknown, data: Record<string, unknown>) => ({ ...data })),
+  persist: jest.fn(),
+  flush: jest.fn(async () => undefined),
+}
+
+const mockScheduler = {
+  register: jest.fn(async () => {
+    throw new Error('Failed to calculate next run time for schedule: some-id')
+  }),
+  unregister: jest.fn(async () => undefined),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async () => null),
+  findAndCountWithDecryption: jest.fn(async () => [[], 0]),
+}))
+
+jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({
+  readJsonSafe: jest.fn((req: Request) => req.json()),
+}))
+
+const { createSyncScheduleService } = jest.requireActual('../../../lib/sync-schedule-service')
+
+const scheduleService = createSyncScheduleService(mockEm, mockScheduler)
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'dataSyncScheduleService') return scheduleService
+    if (token === 'commandOptimisticLockGuardService') return null
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+import { POST } from '../route'
+
+function request() {
+  return new Request('http://localhost/api/data_sync/schedules', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      integrationId: 'sync_excel',
+      entityType: 'customers.person',
+      direction: 'import',
+      scheduleType: 'interval',
+      scheduleValue: '3600',
+      timezone: 'UTC',
+      fullSync: false,
+      isEnabled: true,
+    }),
+  })
+}
+
+describe('data_sync schedule save write ordering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+  })
+
+  it('does not persist the schedule when the scheduler rejects an unparseable value', async () => {
+    const res = await POST(request())
+
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toContain('Failed to calculate next run time')
+
+    expect(mockScheduler.register).toHaveBeenCalledTimes(1)
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
@@ -40,11 +40,11 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
     return schedulerService
   }
 
-  function buildScheduleName(row: SyncSchedule): string {
+  function buildScheduleName(row: { integrationId: string; entityType: string; direction: 'import' | 'export' }): string {
     return `Data sync: ${row.integrationId} ${row.entityType} ${row.direction}`
   }
 
-  function buildScheduleDescription(row: SyncSchedule): string {
+  function buildScheduleDescription(row: { integrationId: string; entityType: string; direction: 'import' | 'export' }): string {
     return `Scheduled ${row.direction} for ${row.integrationId} (${row.entityType})`
   }
 
@@ -156,8 +156,36 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
         })
       }
 
+      const id = existing?.id ?? randomUUID()
+      const scheduledJobId = existing?.scheduledJobId ?? id
+
+      // Validate the schedule (and register it with the scheduler) before writing
+      // the SyncSchedule row — an unparseable scheduleValue must not leave a
+      // persisted row with no working schedule behind it.
+      await requireScheduler().register({
+        id: scheduledJobId,
+        name: buildScheduleName(input),
+        description: buildScheduleDescription(input),
+        scopeType: 'organization',
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        scheduleType: input.scheduleType,
+        scheduleValue: input.scheduleValue,
+        timezone: input.timezone,
+        targetType: 'queue',
+        targetQueue: 'data-sync-scheduled',
+        targetPayload: {
+          scheduleId: id,
+          scope,
+        },
+        requireFeature: 'data_sync.run',
+        sourceType: 'module',
+        sourceModule: 'data_sync',
+        isEnabled: input.isEnabled,
+      })
+
       const row = existing ?? em.create(SyncSchedule, {
-        id: randomUUID(),
+        id,
         integrationId: input.integrationId,
         entityType: input.entityType,
         direction: input.direction,
@@ -178,35 +206,13 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
       row.timezone = input.timezone
       row.fullSync = input.fullSync
       row.isEnabled = input.isEnabled
-      row.scheduledJobId = row.scheduledJobId ?? row.id
+      row.scheduledJobId = scheduledJobId
 
       if (!existing) {
         em.persist(row)
       }
 
       await em.flush()
-
-      await requireScheduler().register({
-        id: row.scheduledJobId,
-        name: buildScheduleName(row),
-        description: buildScheduleDescription(row),
-        scopeType: 'organization',
-        organizationId: scope.organizationId,
-        tenantId: scope.tenantId,
-        scheduleType: row.scheduleType,
-        scheduleValue: row.scheduleValue,
-        timezone: row.timezone,
-        targetType: 'queue',
-        targetQueue: 'data-sync-scheduled',
-        targetPayload: {
-          scheduleId: row.id,
-          scope,
-        },
-        requireFeature: 'data_sync.run',
-        sourceType: 'module',
-        sourceModule: 'data_sync',
-        isEnabled: row.isEnabled,
-      })
 
       return row
     },


### PR DESCRIPTION
Fixes the server-side half of #5506 — the write-ordering defect. The issue also reports a
client-side gap (the documented interval format is not enforced before submit, `aria-invalid`
is not set, and the save button stays enabled); that half needs a UI change and is tracked
separately in #5872, so **#5506 should stay open until #5872 lands**. Review follow-up on the
remaining orphaned-`ScheduledJob` window: #5871.

## 🎯 Goal
Data sync schedules are rejected (422) atomically — an unparseable interval/cron value no longer leaves a broken, unschedulable row behind.

## 🔍 Problem
`POST /api/data_sync/schedules` wrote the `SyncSchedule` row and flushed it to the database *before* asking the scheduler to compute `nextRunAt`. When the interval value couldn't be parsed (e.g. `3600` instead of `1h`), the scheduler threw, the endpoint answered 422 — but the row was already committed with `nextRunAt: null`. The UI then showed "Harmonogram cykliczny aktywny" for a schedule that could never run, and the 422 body leaked the freshly-created row's primary key.

## 🔍 Root Cause
`saveSchedule()` in `packages/core/src/modules/data_sync/lib/sync-schedule-service.ts` built, persisted, and flushed the `SyncSchedule` entity, and only afterwards called `schedulerService.register(...)`. `SchedulerService.register()` (`packages/scheduler`) computes `nextRunAt` via `calculateNextRunForWrite` and throws synchronously — before it ever touches its own `ScheduledJob` table — when the value can't be parsed. Because the `SyncSchedule` write had already committed by that point, the thrown error only produced the 422 HTTP response; the invalid row stayed in the database.

## What Changed
- `packages/core/src/modules/data_sync/lib/sync-schedule-service.ts` — reordered `saveSchedule()` so `schedulerService.register(...)` is called first, using a pre-generated `id`/`scheduledJobId` and the raw `input` fields (not the persisted row). The `SyncSchedule` entity is only created/updated and flushed once `register()` resolves without throwing. `buildScheduleName`/`buildScheduleDescription` now take a narrow `{ integrationId, entityType, direction }` shape so they can run before the row exists. Response contract (201 on success, 422 with the scheduler's error message on failure) and upsert/idempotency behavior are unchanged.

## 🧪 Tests
- Added `packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts`: a rejecting scheduler now produces a 422 and `em.create`/`em.persist`/`em.flush` are never called. Verified this test fails against the pre-fix code with the exact reported symptom (row gets created/flushed despite the scheduler rejecting it), and passes after the fix.
- Full validation gate (`.ai/agentic.config.json`): `build:packages` → `generate` → `build:packages` → `i18n:check-sync` → `i18n:check-usage` → `typecheck` → `test` → `build:app` — all green, except the pre-existing, environment-specific `packages/cli/src/lib/__tests__/dev-env-reload.test.ts` inotify-exhaustion timeout (unrelated package; documented pre-existing flake on this host, not introduced by this change).
- `packages/core` (227 tests, includes the existing `data_sync/api/schedules/__tests__/optimistic-lock.test.ts` suite) and `packages/scheduler` (420 tests) also run directly in isolation — 100% pass.

## 💥 Breaking Changes
None — request/response shapes, DI wiring, and upsert semantics are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790333362&installation_model_id=432243&pr_number=5661&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5661&signature=22c181c38cce0c9a50cbd21d90b8fcd45cb1f322d6a006cbed7007aa63be9e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
