### PR TITLE
fix(query_index): include cf sorts in wantsCf so sort-only queries keep the ORM fallback (#5521)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -420,6 +420,26 @@ describe('HybridQueryEngine', () => {
     expect((mockLogger.warn.mock.calls[0] || [])[0]).toContain('Partial index coverage')
   })
 
+  test('keeps l10n-only sorts off the custom-field branch', async () => {
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: false, baseCount: 5, indexCount: 0 })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+
+    // Neither engine ever applies an `l10n:` ordering — both drop it while
+    // resolving sorts — so it must not pay the coverage probes or divert the
+    // query to the ORM engine for an ordering that is thrown away.
+    await engine.query('example:todo', {
+      fields: ['id'],
+      sort: [{ field: 'l10n:title', dir: SortDir.Asc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+    })
+
+    expect(fallback.query).not.toHaveBeenCalled()
+  })
+
   test('keeps base-column-only sorts off the custom-field branch', async () => {
     const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: false, baseCount: 5, indexCount: 0 })
     const em = buildEm(db)

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -376,6 +376,67 @@ describe('HybridQueryEngine', () => {
     expect(emitEvent).not.toHaveBeenCalled()
   })
 
+  test('falls back when a cf sort is the only custom-field signal and no index rows exist', async () => {
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: false, baseCount: 5, indexCount: 0 })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn().mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0 }) }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+
+    const opts = {
+      fields: ['id'],
+      sort: [{ field: 'cf:priority', dir: SortDir.Asc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+    }
+    await engine.query('example:todo', opts)
+
+    expect(fallback.query).toHaveBeenCalledWith('example:todo', opts)
+  })
+
+  test('falls back and warns on partial coverage when a cf sort is the only custom-field signal', async () => {
+    process.env.FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES = 'false'
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: true, baseCount: 10, indexCount: 1 })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn().mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0 }) }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+    mockLogger.warn.mockClear()
+
+    // The auto-reindex debounce is process-global; opting out keeps this test
+    // from consuming the slot a later test asserts on.
+    const result = await engine.query('example:todo', {
+      fields: ['id'],
+      sort: [{ field: 'cf:priority', dir: SortDir.Asc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+      skipAutoReindex: true,
+    })
+
+    expect(fallback.query).toHaveBeenCalled()
+    expect(result.meta?.partialIndexWarning).toEqual(expect.objectContaining({
+      entity: 'example:todo', baseCount: 10, indexedCount: 1,
+    }))
+    expect((mockLogger.warn.mock.calls[0] || [])[0]).toContain('Partial index coverage')
+  })
+
+  test('keeps base-column-only sorts off the custom-field branch', async () => {
+    const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: false, baseCount: 5, indexCount: 0 })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const emitEvent = jest.fn().mockResolvedValue(undefined)
+    const engine = new HybridQueryEngine(em, fallback as any, () => ({ emitEvent }))
+
+    await engine.query('example:todo', {
+      fields: ['id'],
+      sort: [{ field: 'id', dir: SortDir.Desc }],
+      organizationId: 'org1',
+      tenantId: 't1',
+    })
+
+    expect(fallback.query).not.toHaveBeenCalled()
+  })
+
   test('falls back and warns on partial coverage', async () => {
     process.env.FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES = 'false'
     const db = createFakeKysely({ baseTable: 'todos', hasIndexAny: true, baseCount: 10, indexCount: 1 })

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -352,10 +352,19 @@ export class HybridQueryEngine implements QueryEngine {
 
       const normalizedFilters = normalizeFilters(opts.filters)
       const cfFilters = normalizedFilters.filter((filter) => filter.field.startsWith('cf:') || filter.field.startsWith('l10n:'))
+      // `applySort` orders `cf:` sorts off the left-joined index doc, so a
+      // sort-only custom-field query depends on the index just as much as a cf
+      // filter does — without this disjunct it would skip the coverage guards
+      // below and silently order by a NULL expression on an empty index (#5521).
+      const cfSorts = (opts.sort || []).filter((sort) => {
+        const field = String(sort.field)
+        return field.startsWith('cf:') || field.startsWith('l10n:')
+      })
       const coverageScope = this.resolveCoverageSnapshotScope(opts)
       const wantsCf = (
         (opts.fields || []).some((field) => typeof field === 'string' && (field.startsWith('cf:') || field.startsWith('l10n:'))) ||
         cfFilters.length > 0 ||
+        cfSorts.length > 0 ||
         (Array.isArray(opts.includeCustomFields) && opts.includeCustomFields.length > 0)
       )
 

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -356,15 +356,15 @@ export class HybridQueryEngine implements QueryEngine {
       // sort-only custom-field query depends on the index just as much as a cf
       // filter does — without this disjunct it would skip the coverage guards
       // below and silently order by a NULL expression on an empty index (#5521).
-      const cfSorts = (opts.sort || []).filter((sort) => {
-        const field = String(sort.field)
-        return field.startsWith('cf:') || field.startsWith('l10n:')
-      })
+      // Only `cf:` qualifies: neither engine ever applies an `l10n:` ordering —
+      // both drop it while resolving sorts — so counting it here would pay the
+      // coverage probes and the ORM diversion for an ordering that is discarded.
+      const hasCfSort = (opts.sort || []).some((sort) => String(sort.field).startsWith('cf:'))
       const coverageScope = this.resolveCoverageSnapshotScope(opts)
       const wantsCf = (
         (opts.fields || []).some((field) => typeof field === 'string' && (field.startsWith('cf:') || field.startsWith('l10n:'))) ||
         cfFilters.length > 0 ||
-        cfSorts.length > 0 ||
+        hasCfSort ||
         (Array.isArray(opts.includeCustomFields) && opts.includeCustomFields.length > 0)
       )
 

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -244,6 +244,12 @@ function createFakeKysely(overrides?: FakeData) {
   return db
 }
 
+// Selects are recorded verbatim, so a plain column arrives as a string while an
+// aggregated cf projection arrives as Kysely's aliased raw builder.
+function selectAliases(call: any): string[] {
+  return call._ops.selects.map((s: any) => (typeof s === 'string' ? s : String(s?.alias ?? '')))
+}
+
 describe('BasicQueryEngine (Kysely)', () => {
   test('pluralizes entity names ending with y correctly', async () => {
     const fakeDb = createFakeKysely()
@@ -285,6 +291,39 @@ describe('BasicQueryEngine (Kysely)', () => {
     expect(hasCfOrder).toBe(true)
     const hasExtJoin = baseCall._ops.joins.length > 0
     expect(hasExtJoin).toBe(true)
+  })
+
+  test('a cf sort alone projects and joins the key it orders by', async () => {
+    const fakeDb = createFakeKysely()
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+    await engine.query('auth:user', {
+      fields: ['id', 'email'],
+      sort: [{ field: 'cf:vip', dir: SortDir.Asc }],
+      organizationId: '1',
+      tenantId: 't1',
+    })
+    const baseCall = fakeDb._calls.find((b: any) => b._ops.table === 'users')
+    expect(baseCall._ops.orderBys).toContainEqual(['cf_vip', 'asc'])
+    // Ordering by an alias the query never selected is a Postgres 42703, so the
+    // sort has to bring its own projection and joins along (#5521).
+    expect(selectAliases(baseCall)).toContain('cf_vip')
+    expect(baseCall._ops.joins.length).toBeGreaterThan(0)
+  })
+
+  test('a cf sort that resolves to no definition is dropped, not ordered by', async () => {
+    const fakeDb = createFakeKysely()
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+    await engine.query('auth:user', {
+      fields: ['id', 'email'],
+      sort: [{ field: 'cf:no_such_key', dir: SortDir.Asc }],
+      organizationId: '1',
+      tenantId: 't1',
+    })
+    const baseCall = fakeDb._calls.find((b: any) => b._ops.table === 'users')
+    // Dropping an unresolvable sort is what the base-column branch already does;
+    // the alternative here was an ORDER BY over a column that is never selected.
+    expect(baseCall._ops.orderBys).toEqual([])
+    expect(selectAliases(baseCall)).not.toContain('cf_no_such_key')
   })
 
   test('customFieldSources join additional profiles for custom fields', async () => {

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -863,6 +863,16 @@ export class BasicQueryEngine implements QueryEngine {
       for (const f of cfFilters) {
         if (typeof f.field === 'string' && f.field.startsWith('cf:')) cfKeys.add(f.field.slice(3))
       }
+      // A `cf:` sort needs the same joins and value expression as a `cf:` field or
+      // filter: the sort loop below orders by an aggregated alias that only exists
+      // once the key reached `cfKeys`. Without this, a sort-only custom-field query
+      // emitted `ORDER BY "cf_<key>"` against a column it never selected (#5521).
+      // The count shape never sorts, so it stays out of this.
+      if (!isCountProjection) {
+        for (const s of (opts.sort || [])) {
+          if (typeof s.field === 'string' && s.field.startsWith('cf:')) cfKeys.add(s.field.slice(3))
+        }
+      }
       if (projection === 'full' && opts.includeCustomFields === true) {
         if (entityIdToSource.size > 0) {
           const entityIdList = Array.from(entityIdToSource.keys())
@@ -1202,7 +1212,13 @@ export class BasicQueryEngine implements QueryEngine {
               cfSelectedAliases.push(alias)
             }
           }
-          if (!requiresPlaintextSort) q = q.orderBy(alias, (s.dir ?? 'asc') as any)
+          // Only order by an alias the projection actually carries. A key that
+          // resolved to no expression is dropped rather than emitted as an
+          // unselected alias, which is what the base-column branch above already
+          // does when `resolveBaseColumn` returns null.
+          if (!requiresPlaintextSort && cfSelectedAliases.includes(alias)) {
+            q = q.orderBy(alias, (s.dir ?? 'asc') as any)
+          }
         } else {
           if (!requiresPlaintextSort) q = q.orderBy(qualify(s.field), (s.dir ?? 'asc') as any)
         }


### PR DESCRIPTION
Closes #5521

## 🎯 Goal

Sorting a CRUD list by a custom field (`?sortField=cf_<key>`) no longer returns silently mis-ordered rows when the query index is empty or under-populated for that entity — the query now falls back to the ORM engine exactly as it already does for custom-field *filters*.

## 🔍 Problem

`HybridQueryEngine.query()` decided whether a query "wants custom fields" (`wantsCf`) from three signals: a `cf:`/`l10n:` entry in `opts.fields`, a non-empty set of normalized `cf:`/`l10n:` filters, and — precisely — `Array.isArray(opts.includeCustomFields) && opts.includeCustomFields.length > 0`. That third disjunct counts only the **array** form: the boolean `true` form does not qualify, and `true` is exactly what `makeCrudRoute` passes on every list request (`packages/shared/src/lib/crud/factory.ts`). That asymmetry looks like a bug and is not one — it is why the defect was reachable from every CRUD list route in the first place, and it should stay: making the boolean form count would put the coverage probes and the fallback on *every* list query in the app rather than only cf-sorted ones. `opts.sort` was not among the three signals at all. A query that only *sorts* by a custom field therefore skipped the whole custom-field branch, and with it every safety guard that branch owns.

The CRUD factory makes this trivially reachable: `normalizeSortFieldSelector` in `packages/shared/src/lib/crud/factory.ts` passes any unmapped `sortField` straight through and rewrites `cf_<key>` → `cf:<key>`, so every list endpoint accepts `?sortField=cf_<key>`. The same request with `&fields=cf:<key>` added behaved correctly — the outcome differed only by which option happened to carry the `cf:` reference.

## 🔍 Root Cause

`applySort` (`packages/core/src/modules/query_index/lib/engine.ts`) does support `cf:` sort fields: it builds `buildCfTextExprSql(...)` and emits an `ORDER BY` reading the `entity_indexes` alias `ei`. That join is a **LEFT** join (`applyEntityIndexesJoin`), so when no index row exists the sort expression evaluates to `NULL` for every row instead of raising — the failure is silent by construction.

With `wantsCf === false`, the guard block was never entered, so none of these ran:

- `entityHasActiveCustomFields(...)`
- the `indexAnyRows` check and its "no index rows → fall back to the ORM engine" return
- the partial-index coverage gap check (and its `partialIndexWarning` / auto-reindex scheduling)

The result: an `ORDER BY` over an all-`NULL` expression, returning rows in effectively arbitrary order while reporting success.

## What Changed

- `packages/core/src/modules/query_index/lib/engine.ts` — derive `hasCfSort` from `opts.sort` next to the existing `cfFilters` and add it as a fourth disjunct of `wantsCf`. A sort-only custom-field query now enters the guard block and falls back when the index cannot answer it. The test is deliberately `cf:`-only, not the `cf:`/`l10n:` pair used for filters: neither engine ever *applies* an `l10n:` ordering — both drop it while resolving sorts — so counting it would pay `entityHasActiveCustomFields` + `indexAnyRows` + the coverage probes, and possibly divert the whole request to the slower ORM engine, to produce an ordering that is then thrown away.
- `packages/shared/src/lib/query/engine.ts` — **make the fallback engine actually able to answer the query this PR now routes to it.** `BasicQueryEngine` builds its `cfKeys` set (which drives the `custom_field_defs`/`custom_field_values` joins and the `cfValueExprByKey` expression) from `opts.fields`, `cfFilters` and `includeCustomFields` — `opts.sort` was missing there too, the same omission one layer down. Because the `ORDER BY` was emitted outside the `if (expr)` guard, a sort-only `cf:` query produced `ORDER BY "cf_<key>"` against an alias the query never selected: Postgres `42703`, a 500 where the pre-PR behavior was a mis-ordered 200. Two changes fix it symmetrically with the one above: `cf:` sort keys now feed `cfKeys` (for every projection that actually sorts — the count shape is excluded because it never sorts), and the `orderBy` only fires for an alias the projection carries, so an unresolvable cf sort is **dropped** rather than emitted. Dropping is what the base-column branch already does when `resolveBaseColumn` returns null, so the two branches now agree.

  This was latent rather than live — every current caller that can produce a `cf:` sort also sets `includeCustomFields`, which populated `cfKeys` by a route that happened to work. This PR is what makes that path load-bearing, so it is fixed here rather than deferred.
- **Second, less obvious effect worth a reviewer's attention:** widening `wantsCf` also flips `shouldAttachCustomSources` (`engine.ts:499`) for these queries. A cf sort that also passed `customFieldSources` previously built its `ORDER BY` over the base `ei` alias alone, because the extra sources were never appended to `indexSources`; `buildCfTextExprSql` now coalesces across every declared source, which is what such a sort always meant. That is a latent correctness improvement riding along with this fix, not a regression — flagged here because it is not apparent from the diff.
- `hasCustomFieldFilters` / `needsIndexRowset` are **deliberately unchanged**. Those govern the count-query shape and exist to carry custom-field *predicates* into a correlated `EXISTS`; a sort contributes no predicate, so widening them would add a pointless `EXISTS` to every sorted count for no correctness gain.

## 🧪 Tests

Four regression tests in `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts`:

- **`falls back when a cf sort is the only custom-field signal and no index rows exist`** — locks in the `indexAnyRows` fallback for a sort-only `cf:` query carrying no cf fields, filters, or `includeCustomFields`.
- **`falls back and warns on partial coverage when a cf sort is the only custom-field signal`** — locks in the coverage-gap path, asserting both the fallback and the `partialIndexWarning` metadata. It passes `skipAutoReindex: true` because `scheduleAutoReindex`'s debounce is process-global module state that a later existing test asserts on; without the opt-out this test consumed that slot and broke the neighbouring case through test ordering.
- **`keeps l10n-only sorts off the custom-field branch`** — a negative control for the `cf:`-only narrowing: an `l10n:` sort must not pay the probes or divert to the ORM engine for an ordering both engines discard.
- **`keeps base-column-only sorts off the custom-field branch`** — a negative control proving the widened predicate did not become over-broad; a plain `id` sort must still take the index path.

Two more in `packages/shared/src/lib/query/__tests__/engine.test.ts`, driving the real `BasicQueryEngine` through this repo's `createFakeKysely` recorder so they assert on the SQL actually built, not on a stubbed hand-off:

- **`a cf sort alone projects and joins the key it orders by`** — the positive case: options of exactly the shape the hybrid engine now forwards (`fields: ['id','email']`, a `cf:` sort, no `includeCustomFields`) must produce the `cf_vip` alias in both `orderBys` **and** `selects`, with the cf joins present. Before the fix this recorded an `orderBy` with zero joins and no matching select — the `42703`.
- **`a cf sort that resolves to no definition is dropped, not ordered by`** — the drop path: an unresolvable key yields no `orderBy` at all.

All three production changes were **mutation-checked**, each mutation failing exactly one test and no others: removing the `cfKeys` sort feed fails the positive shared test; restoring the unguarded `orderBy` fails the drop test; widening `hasCfSort` back to include `l10n:` fails the new l10n negative control. The three tests added for the review findings are load-bearing, not decorative.

**Validation gate — run in full locally this time.** An earlier revision of this description noted that most of the gate had been left to CI because the worktree had no `node_modules` of its own. That is no longer true: dependencies were installed in the worktree and the complete `validation.commands` sequence was executed in order, in local (non-Docker) mode.

- ✅ `yarn build:packages` (×2), `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all exit 0. `yarn generate` produced **no** changes to committed files.
- ✅ **`yarn test`** for the two packages this PR touches, run standalone: `@open-mercato/core` **11,684 passed** / 1,453 suites, `@open-mercato/shared` **2,042 passed** / 185 suites. The two `catalog products/variants route enricher config` failures reported on the earlier revision are gone — they were caused by absent `#generated/*` artifacts and disappear once `yarn generate` + `yarn build:packages` have run.
- ⚠️ The repo-wide `yarn test` task exits 1 on **`@open-mercato/cli`** — 5 failures in `resolveEnvironment › falls back to standalone mode with rootDir = cwd` and `resolver enterprise module toggle › …`. These are environment/location-dependent (they depend on where the checkout sits on disk) and are unrelated to this diff, which touches no CLI or module-resolution code. Turbo aborts the remaining tasks on that failure, which is why `core` and `shared` were run directly.

## 💥 Breaking Changes

None to any contract surface — no exported API, HTTP route, response shape, event id, DB schema, or DI change.

There is one **intended behavior change**: a list route already sorting by `cf_*` against a partially-indexed entity will now fall back to `BasicQueryEngine` (slower, and surfacing `meta.partialIndexWarning`) and may schedule an auto-reindex, where previously it silently returned mis-ordered rows from the index. That is the guard working as designed.

## Follow-up (not addressed here)

- **#5674 — `cf:` sorts order as text regardless of field kind, with no stable tiebreak.** The reporter's second observation is a real but **separate** defect this PR neither causes nor cures: both engines order `cf:` sorts **as text** regardless of the field's `kind` (`buildCfTextExprSql` yields jsonb `->>`, which is always text; the ORM fallback casts every kind to `::text`), so a numeric custom field sorts lexicographically — `'10240' < '1024' < '2048' < '512'`. Neither engine appends a stable `id` tiebreak either, leaving paginated results with ties or NULLs unstable across pages. Fixing that means kind-aware sort expressions in both engines and is well out of scope for this guard fix.
- **#5706 — `Mutation tests` reports green on diffs it never mutates.** `scripts/stryker/scope.mjs` freezes the mutation allowlist to `shared`, so this `core`-only diff resolved to an empty matrix and the `mutate` job reported `skipping`, not a passing mutation run. Filed from review feedback so the check's green is not read as coverage of the new predicate; the predicate was mutation-tested by hand instead (see 🧪 Tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790340448&installation_model_id=432243&pr_number=5670&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5670&signature=bf504153cf7bd93421c39bed7cb233fd853e06b70538185e92de44bb199a6987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

