### PR TITLE
fix(auth): resolve the resend-invite email origin from the request, not its URL string

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
@@ -314,4 +314,28 @@ describe('POST /api/auth/users/resend-invite', () => {
     expect(mockFlush).toHaveBeenCalledTimes(1)
     expect(mockSendEmail).toHaveBeenCalledTimes(1)
   })
+
+  test('sends the invite behind a reverse proxy whose forwarded host matches APP_URL', async () => {
+    process.env = {
+      ...process.env,
+      APP_URL: 'https://app.example.com',
+      NODE_ENV: 'production',
+      JWT_SECRET: 'test-jwt-secret',
+    }
+
+    const res = await POST(makeRequest(
+      { id: userId },
+      'https://localhost:6789/api/auth/users/resend-invite',
+      {
+        host: 'app.example.com',
+        'x-forwarded-host': 'app.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    ))
+
+    expect(res.status).toBe(200)
+    expect(mockNativeUpdate).toHaveBeenCalledTimes(1)
+    expect(mockFlush).toHaveBeenCalledTimes(1)
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/core/src/modules/auth/api/users/resend-invite/route.ts
+++ b/packages/core/src/modules/auth/api/users/resend-invite/route.ts
@@ -139,7 +139,7 @@ export async function POST(req: Request) {
 
   let base: string
   try {
-    base = getSecurityEmailBaseUrl(req.url)
+    base = getSecurityEmailBaseUrl(req)
   } catch (error) {
     const mapped = mapSecurityEmailUrlError(error, {
       scope: 'auth.users.resend-invite',

--- a/packages/shared/src/lib/__tests__/url.test.ts
+++ b/packages/shared/src/lib/__tests__/url.test.ts
@@ -89,6 +89,23 @@ describe('security email URL helpers', () => {
     expect(() => assertAllowedAppOrigin(request, env)).not.toThrow()
   })
 
+  test('cannot see forwarded headers when the request is passed as a URL string', () => {
+    const env = {
+      APP_URL: 'https://app.example.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://localhost:6789/api/auth/users/resend-invite', {
+      headers: {
+        host: 'app.example.com',
+        'x-forwarded-host': 'app.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(() => assertAllowedAppOrigin(request, env)).not.toThrow()
+    expect(() => assertAllowedAppOrigin(request.url, env)).toThrow(AppOriginRejectedError)
+  })
+
   test('allows loopback origin mismatches outside production', () => {
     const env = {
       APP_URL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary

`POST /api/auth/users/resend-invite` returned **400 `Invalid request origin`** behind any reverse proxy, while the create-user and password-reset invite paths on the same deployment worked fine.

The route passed `req.url` (a **string**) to `getSecurityEmailBaseUrl`, whereas the working reset path passes `req` (a **`Request`**). `readRequestOriginCandidates` returns early on a string input (`packages/shared/src/lib/url.ts:105`) before any header is read, so `x-forwarded-host` was never considered and only the container-internal origin survived the check.

This made the endpoint unusable in every proxied deployment, not just one configuration.

Fixes #5382

## Changes

- `packages/core/src/modules/auth/api/users/resend-invite/route.ts` — pass `req` instead of `req.url`, matching `api/reset.ts`. Host-header-poisoning protection from #1267/#1268/#1523 is unchanged: `getSecurityEmailBaseUrl` still returns the configured `APP_URL` for the email body and still validates the origin — it only lets the check see the forwarded headers it was designed to read.
- `packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts` — regression test reproducing the issue's deployment shape (container on an internal port, `x-forwarded-host` matching `APP_URL`, `NODE_ENV=production`). Verified to fail with `400` before the fix and pass with `200` after.
- `packages/shared/src/lib/__tests__/url.test.ts` — pins the underlying asymmetry: the same request passes `assertAllowedAppOrigin` as a `Request` and is rejected as a URL string.

This is the only string call site in the repository — every other caller of `getSecurityEmailBaseUrl` / `toSecurityEmailUrl` already passes a `Request` or no argument.

## Not addressed here

The issue also raises that the `string` branch of `RequestInput` is a footgun (any caller passing a string silently loses proxy-header awareness) and that the no-argument call skips origin validation entirely. Both change a shared helper's public contract, so they are left for a maintainer decision rather than folded into this fix. The new `url.test.ts` case documents the current behaviour so the trap is at least visible.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

Run locally (Node, non-Docker):

- `yarn build:packages` — 25/25 successful
- `yarn generate` — clean
- `npx tsc --noEmit` in `packages/core` — 0 errors
- `npx tsc --noEmit` in `packages/shared` — 0 errors
- `npx jest src/modules/auth/api/__tests__/resend-invite.route.test.ts` in `packages/core` — 14/14 passed
- `npx jest src/lib/__tests__/url.test.ts` in `packages/shared` — 22/22 passed

The regression test was verified in both directions: reverting the one-line fix makes it fail with exactly the `400 Invalid request origin` the issue reports.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No user-facing strings, generated files, or contract surfaces touched.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: the defect is in argument passing on a single API route and is fully covered by the route-level regression test; reproducing it end to end would need a reverse-proxy deployment fixture.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, one-line bug fix.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

> I do not have `triage` permission, so I cannot apply labels. Suggested: `bug`, `priority-medium`, `risk-low`, `skip-qa` — the change touches no UI-rendering file, leaves the database structure and API surface unchanged, breaks no `BACKWARD_COMPATIBILITY.md` contract, and ships automated tests for the behavior it changes, which is the automated-verification exemption in `AGENTS.md` → PR Workflow.

### Design System Compliance

Not applicable — no UI files touched.

## Linked issues

Fixes #5382

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341412&installation_model_id=432243&pr_number=5671&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5671&signature=ae4d3b361e797e3203e23a01af2c69f43e729a0b3d97b4fab63be0b900ed20ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->