### PR TITLE
fix(shared): keep every value of a repeated list query parameter (#5548)

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -81,6 +81,22 @@ No API route, method, request field, or response field was removed; the aggregat
 
 **Action for module authors:** if you filtered deals with raw status spellings outside the shared helpers, prefer `lib/dealStatus.ts` (`expandDealStatusAliases`, `isClosedDealStatus`) so your reads stay consistent with the platform views.
 
+### `makeCrudRoute` list routes keep every value of a repeated query parameter (#5548)
+
+Every handler built by `makeCrudRoute` assembled its query object with `Object.fromEntries(url.searchParams.entries())`. `URLSearchParams.entries()` yields one pair per occurrence, so each repeated key overwrote the previous one and `?status=win&status=loose` reached the route schema as the bare string `'loose'` — every earlier selection was discarded before validation ran. Any schema declaring `z.union([z.string(), z.array(z.string())])` advertised an array branch this path could never deliver, and the CRUD response cache made it worse: it keys repeated values order-insensitively, so `?status=win&status=loose` and `?status=loose&status=win` shared one cache entry while resolving to *different* filters, and whichever ordering warmed the cache first decided the answer for that entry's lifetime.
+
+The query object is now built by `buildQueryParams` from `@open-mercato/shared/lib/crud/query-params`, applied at the list handler and at the three non-`GET` handlers that assembled `raw.query` the same way. The grouping rule is deliberately narrow:
+
+- A key that occurs **once** still reaches the schema as a **string**, exactly as before. Existing `z.string()` filter params are unaffected.
+- A key that occurs **twice or more** reaches the schema as a **`string[]`**, which is the branch its schema already advertised.
+- Values are **never split on commas** at this layer. `?ids=a,b` and `?search=Smith, John` keep their literal string value, so the comma-separated `?ids=` contract from SPEC-042 and every free-text filter are untouched. Where a field's own contract says a comma separates values, use `readQueryParamList` / `toQueryValueList` from the same module — they treat the repeated and comma forms as equivalent.
+
+`parseIdsParam` and `isIdsParamProvided` in `@open-mercato/shared/lib/crud/ids` now accept the repeated form too. Without that, a repeated `?ids=` would have arrived as an array, read as "no ids filter supplied", and silently widened the response to the full list — the record-count side channel #4143 closed.
+
+**One behavior change worth planning for.** A list route whose schema types a filter param as a plain `z.string()` (no array branch) now returns **400** when a client sends that param twice, where it previously accepted the request and silently used the last value. That is the correct failure mode — quietly discarding a caller's filter is the defect this fixes — but a lenient client may be relying on the old behavior. Callers using the comma form, or sending each param once, are unaffected; a caller sending repeats starts receiving the values it already asked for, which is strictly a widening.
+
+**Action for module authors:** audit your own list-route schemas for filter params that clients may repeat. Where a param is genuinely multi-valued, widen it to `z.union([z.string(), z.array(z.string())])` (or `z.array(z.string())`) and normalize it with `toQueryValueList`. Where it is genuinely single-valued, no change is needed — a repeated occurrence should be rejected. No route URL, HTTP method, response field, `makeCrudRoute` signature, options type, or database column changes, so `BACKWARD_COMPATIBILITY.md` §2, §3 and §7 are not violated.
+
 ## 0.6.7 → 0.7.0 (2026-08-26)
 
 ### `PUT /api/auth/users/acl` merges omitted fields instead of clearing them (#5493)

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-5548-repeated-query-params.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-5548-repeated-query-params.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+import { createDealFixture, deleteEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CRM-5548: makeCrudRoute list routes honour repeated query parameters
+ * Source: https://github.com/open-mercato/open-mercato/issues/5548
+ *
+ * The CRUD factory built its query object with
+ * `Object.fromEntries(url.searchParams.entries())`, which keeps only the LAST value
+ * of a repeated key. `?status=open&status=in_progress` therefore reached the route
+ * schema as `'in_progress'` and every earlier selection was silently discarded —
+ * while the CRUD response cache keyed the same two requests order-insensitively, so
+ * the rows you got back also depended on which ordering warmed the cache first.
+ *
+ * This spec pins the three properties the fix owes callers: a repeated param keeps
+ * every value, the repeated and comma forms are equivalent, and the two orderings of
+ * the same filter return the same rows.
+ */
+type DealListPayload = { items?: Array<{ id?: string }>; total?: number } | null;
+
+test.describe('TC-CRM-5548: repeated list query parameters', () => {
+  test('deals list keeps every value of a repeated status filter, in either ordering', async ({ request }) => {
+    let token: string | null = null;
+    let openDealId: string | null = null;
+    let inProgressDealId: string | null = null;
+    let wonDealId: string | null = null;
+
+    const stamp = Date.now();
+
+    const listDealIds = async (query: string): Promise<string[]> => {
+      const response = await apiRequest(request, 'GET', `/api/customers/deals?${query}`, { token: token as string });
+      expect(response.status(), `GET /api/customers/deals?${query} returned ${response.status()}`).toBe(200);
+      const payload = (await readJsonSafe(response)) as DealListPayload;
+      return (payload?.items ?? [])
+        .map((item) => item?.id)
+        .filter((value): value is string => typeof value === 'string');
+    };
+
+    try {
+      token = await getAuthToken(request);
+      openDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 Open ${stamp}`, status: 'open' });
+      inProgressDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 InProgress ${stamp}`, status: 'in_progress' });
+      wonDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 Won ${stamp}`, status: 'win' });
+
+      // 1) The repeated form keeps BOTH selections. Before the fix only the last
+      //    value survived, so the `open` deal was missing from this response.
+      const repeated = await listDealIds('pageSize=100&status=open&status=in_progress');
+      expect(repeated, 'repeated status filter must keep the first selection').toContain(openDealId);
+      expect(repeated, 'repeated status filter must keep the last selection').toContain(inProgressDealId);
+      expect(repeated, 'a status outside the filter must not be returned').not.toContain(wonDealId);
+
+      // 2) The comma form and the repeated form describe the same filter, so they
+      //    must return the same rows.
+      const comma = await listDealIds('pageSize=100&status=open,in_progress');
+      expect(comma, 'comma form must keep the first selection').toContain(openDealId);
+      expect(comma, 'comma form must keep the last selection').toContain(inProgressDealId);
+      expect(comma, 'a status outside the filter must not be returned').not.toContain(wonDealId);
+
+      // 3) The response cache keys repeated values order-insensitively. That is only
+      //    correct once the two orderings genuinely resolve to the same filter —
+      //    before the fix they resolved to `in_progress` and `open` respectively and
+      //    collided in the cache.
+      const reversed = await listDealIds('pageSize=100&status=in_progress&status=open');
+      expect(reversed, 'reversed ordering must keep the `open` deal').toContain(openDealId);
+      expect(reversed, 'reversed ordering must keep the `in_progress` deal').toContain(inProgressDealId);
+      expect(reversed, 'a status outside the filter must not be returned').not.toContain(wonDealId);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/deals', openDealId);
+      await deleteEntityIfExists(request, token, '/api/customers/deals', inProgressDealId);
+      await deleteEntityIfExists(request, token, '/api/customers/deals', wonDealId);
+    }
+  });
+
+  test('deals list honours a repeated ids filter instead of dropping it', async ({ request }) => {
+    let token: string | null = null;
+    let firstDealId: string | null = null;
+    let secondDealId: string | null = null;
+    let excludedDealId: string | null = null;
+
+    const stamp = Date.now();
+
+    try {
+      token = await getAuthToken(request);
+      firstDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 Ids A ${stamp}`, status: 'open' });
+      secondDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 Ids B ${stamp}`, status: 'open' });
+      excludedDealId = await createDealFixture(request, token, { title: `QA TC-CRM-5548 Ids C ${stamp}`, status: 'open' });
+
+      // Repeated `?ids=` used to reach `parseIdsParam` as a single string (the last
+      // value), narrowing the response to one record. It must resolve to both ids —
+      // and must never widen to the unfiltered list.
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/deals?pageSize=100&ids=${firstDealId}&ids=${secondDealId}`,
+        { token },
+      );
+      expect(response.status(), `GET /api/customers/deals with a repeated ids filter returned ${response.status()}`).toBe(200);
+      const payload = (await readJsonSafe(response)) as DealListPayload;
+      const ids = (payload?.items ?? [])
+        .map((item) => item?.id)
+        .filter((value): value is string => typeof value === 'string');
+
+      expect(ids.slice().sort(), 'repeated ids filter must resolve to exactly the requested records').toEqual(
+        [firstDealId, secondDealId].sort(),
+      );
+      expect(ids, 'the ids filter must not widen to unrequested records').not.toContain(excludedDealId);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/deals', firstDealId);
+      await deleteEntityIfExists(request, token, '/api/customers/deals', secondDealId);
+      await deleteEntityIfExists(request, token, '/api/customers/deals', excludedDealId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/api/deals/aggregate/route.ts
+++ b/packages/core/src/modules/customers/api/deals/aggregate/route.ts
@@ -11,6 +11,7 @@ import type { ExchangeRateService } from '@open-mercato/core/modules/currencies/
 import { parseBooleanFromUnknown } from '@open-mercato/shared/lib/boolean'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+import { readQueryParamList } from '@open-mercato/shared/lib/crud/query-params'
 import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { fetchStuckDealIds } from '../../../lib/stuckDeals'
@@ -122,11 +123,8 @@ export const openApi: OpenApiRouteDoc = {
 }
 
 function readArrayParam(searchParams: URLSearchParams, key: string): string[] | null {
-  const all = searchParams.getAll(key)
-  if (!all.length) return null
-  const flat = all.flatMap((v) => v.split(','))
-  const trimmed = flat.map((s) => s.trim()).filter(Boolean)
-  return trimmed.length ? trimmed : null
+  const values = readQueryParamList(searchParams, key)
+  return values.length ? values : null
 }
 
 function restrictToIds(where: string[], values: Array<string | number | null>, ids: string[]) {

--- a/packages/core/src/modules/customers/api/deals/map/route.ts
+++ b/packages/core/src/modules/customers/api/deals/map/route.ts
@@ -5,6 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+import { readQueryParamList } from '@open-mercato/shared/lib/crud/query-params'
 import { SortDir, type QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -161,10 +162,8 @@ function toIsoStringOrNull(value: unknown): string | null {
 }
 
 function readArrayParam(searchParams: URLSearchParams, key: string): string[] | null {
-  const all = searchParams.getAll(key)
-  if (!all.length) return null
-  const trimmed = all.flatMap((value) => value.split(',')).map((value) => value.trim()).filter(Boolean)
-  return trimmed.length ? trimmed : null
+  const values = readQueryParamList(searchParams, key)
+  return values.length ? values : null
 }
 
 function collectRefIds(rows: unknown[], key: string): string[] {

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -253,6 +253,14 @@ MUST rules:
 - `message` is passed through verbatim and is never derived from an entity name — keep routing 404 copy through `translate(...)` so it stays translatable.
 - `assertFound` treats every falsy value as missing. Use it for entity/object lookups only, never to guard numbers or strings where `0`/`''` are valid results.
 
+### Query Parameter Parsing — MUST NOT rebuild the query object with `Object.fromEntries`
+
+```typescript
+import { buildQueryParams, readQueryParamList, toQueryValueList } from '@open-mercato/shared/lib/crud/query-params'
+```
+
+`Object.fromEntries(url.searchParams.entries())` keeps only the LAST value of a repeated key, so `?status=win&status=loose` silently becomes `'loose'` (#5548). `buildQueryParams(url.searchParams)` groups instead: a key seen once stays a string, a key seen twice or more becomes `string[]`. It never splits on commas, so `?ids=a,b` and free-text filters keep their literal value. Where a field's contract says a comma separates values, use `readQueryParamList(searchParams, key)` (or `toQueryValueList(raw)` on an already-parsed value) — they treat the repeated and comma forms as equivalent. MUST use these instead of a per-route `getAll` + split + trim copy.
+
 ### CRUD Multi-ID Filtering
 
 - Use `parseIdsParam()` and `mergeIdFilter()` from `@open-mercato/shared/lib/crud/ids` for factory-level `ids` query support.

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -370,6 +370,63 @@ describe('CRUD Factory', () => {
     })
   })
 
+  describe('repeated query parameters (#5548)', () => {
+    const makeFilterRoute = () => {
+      const seen: unknown[] = []
+      const route = makeCrudRoute({
+        metadata: { GET: { requireAuth: true } },
+        orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+        indexer: { entityType: 'example.todo' },
+        list: {
+          schema: querySchema.extend({
+            status: z.union([z.string(), z.array(z.string())]).optional(),
+            search: z.string().optional(),
+          }),
+          entityId: 'example.todo',
+          fields: ['id', 'title'],
+          buildFilters: (query) => {
+            seen.push((query as any).status)
+            return {} as any
+          },
+        },
+      })
+      return { route, seen }
+    }
+
+    it('hands the list schema every value of a repeated key', async () => {
+      const { route, seen } = makeFilterRoute()
+      await route.GET(new Request('http://x/api/example/todos?status=win&status=loose'))
+      expect(seen.at(-1)).toEqual(['win', 'loose'])
+    })
+
+    it('still hands a plain string to a key that occurs once', async () => {
+      const { route, seen } = makeFilterRoute()
+      await route.GET(new Request('http://x/api/example/todos?status=win'))
+      expect(seen.at(-1)).toBe('win')
+    })
+
+    it('leaves a comma-bearing scalar untouched so free-text filters survive', async () => {
+      const { route, seen } = makeFilterRoute()
+      await route.GET(new Request(`http://x/api/example/todos?search=${encodeURIComponent('Smith, John')}&status=win`))
+      expect(seen.at(-1)).toBe('win')
+    })
+
+    it('resolves both orderings of the same repeated filter identically', async () => {
+      const { route, seen } = makeFilterRoute()
+      await route.GET(new Request('http://x/api/example/todos?status=win&status=loose'))
+      await route.GET(new Request('http://x/api/example/todos?status=loose&status=win'))
+      expect([...(seen.at(-2) as string[])].sort()).toEqual([...(seen.at(-1) as string[])].sort())
+    })
+
+    it('keeps a repeated ids filter instead of dropping it entirely', async () => {
+      const idA = '550e8400-e29b-41d4-a716-446655440001'
+      const idB = '550e8400-e29b-41d4-a716-446655440002'
+      await route.GET(new Request(`http://x/api/example/todos?ids=${idA}&ids=${idB}`))
+      const queryArgs = queryEngine.query.mock.calls.at(-1)?.[1]
+      expect(queryArgs?.filters).toEqual({ id: { $in: [idA, idB] } })
+    })
+  })
+
   it('GET resolves a function-form list.fields projection per request (#2233)', async () => {
     const fieldsResolver = jest.fn((query: any) =>
       query?.id ? ['id', 'title', 'is_done', 'snapshot'] : ['id', 'title'],

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -372,7 +372,7 @@ describe('CRUD Factory', () => {
 
   describe('repeated query parameters (#5548)', () => {
     const makeFilterRoute = () => {
-      const seen: unknown[] = []
+      const seen: { status?: string | string[]; search?: string | string[] }[] = []
       const route = makeCrudRoute({
         metadata: { GET: { requireAuth: true } },
         orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
@@ -385,7 +385,7 @@ describe('CRUD Factory', () => {
           entityId: 'example.todo',
           fields: ['id', 'title'],
           buildFilters: (query) => {
-            seen.push((query as any).status)
+            seen.push({ status: (query as any).status, search: (query as any).search })
             return {} as any
           },
         },
@@ -396,26 +396,40 @@ describe('CRUD Factory', () => {
     it('hands the list schema every value of a repeated key', async () => {
       const { route, seen } = makeFilterRoute()
       await route.GET(new Request('http://x/api/example/todos?status=win&status=loose'))
-      expect(seen.at(-1)).toEqual(['win', 'loose'])
+      expect(seen.at(-1)?.status).toEqual(['win', 'loose'])
     })
 
     it('still hands a plain string to a key that occurs once', async () => {
       const { route, seen } = makeFilterRoute()
       await route.GET(new Request('http://x/api/example/todos?status=win'))
-      expect(seen.at(-1)).toBe('win')
+      expect(seen.at(-1)?.status).toBe('win')
     })
 
     it('leaves a comma-bearing scalar untouched so free-text filters survive', async () => {
       const { route, seen } = makeFilterRoute()
       await route.GET(new Request(`http://x/api/example/todos?search=${encodeURIComponent('Smith, John')}&status=win`))
-      expect(seen.at(-1)).toBe('win')
+      expect(seen.at(-1)?.search).toBe('Smith, John')
+      expect(seen.at(-1)?.status).toBe('win')
     })
 
-    it('resolves both orderings of the same repeated filter identically', async () => {
+    it('rejects a repeated occurrence of a single-valued param with 400 instead of silently keeping one value', async () => {
+      const { route, seen } = makeFilterRoute()
+      const res = await route.GET(new Request('http://x/api/example/todos?search=Smith&search=John'))
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toBe('Invalid input')
+      expect(
+        (body.details as { path: (string | number)[] }[]).some((issue) => issue.path.includes('search')),
+      ).toBe(true)
+      expect(seen).toHaveLength(0)
+    })
+
+    it('resolves each ordering of the same repeated filter to the values that ordering sent', async () => {
       const { route, seen } = makeFilterRoute()
       await route.GET(new Request('http://x/api/example/todos?status=win&status=loose'))
       await route.GET(new Request('http://x/api/example/todos?status=loose&status=win'))
-      expect([...(seen.at(-2) as string[])].sort()).toEqual([...(seen.at(-1) as string[])].sort())
+      expect(seen.at(-2)?.status).toEqual(['win', 'loose'])
+      expect(seen.at(-1)?.status).toEqual(['loose', 'win'])
     })
 
     it('keeps a repeated ids filter instead of dropping it entirely', async () => {

--- a/packages/shared/src/lib/crud/__tests__/ids.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/ids.test.ts
@@ -122,6 +122,35 @@ describe('crud ids helpers', () => {
     expect(isIdsParamProvided(null)).toBe(false)
   })
 
+  // #5548: once the factory groups repeated params, `?ids=a&ids=b` reaches these
+  // helpers as an array. Treating that as "not supplied" would silently drop the
+  // filter and return the full list — the same side channel #4143 closed.
+  it('parseIdsParam accepts the repeated-parameter form', () => {
+    expect(parseIdsParam([idA, idB])).toEqual([idA, idB])
+    expect(parseIdsParam([`${idA},${idB}`, idC])).toEqual([idA, idB, idC])
+    expect(parseIdsParam([idA, idA])).toEqual([idA])
+    expect(parseIdsParam([idA, idB, idC], 2)).toEqual([idA, idB])
+    expect(parseIdsParam([])).toEqual([])
+    expect(parseIdsParam(['invalid', 'also-invalid'])).toEqual([])
+  })
+
+  it('isIdsParamProvided recognizes the repeated-parameter form', () => {
+    expect(isIdsParamProvided([idA, idB])).toBe(true)
+    expect(isIdsParamProvided(['not-a-uuid'])).toBe(true)
+    expect(isIdsParamProvided([])).toBe(false)
+    expect(isIdsParamProvided(['', '  '])).toBe(false)
+  })
+
+  // "Supplied" is about the raw occurrence, not about what survives parsing:
+  // `?ids=,,,` carries no usable value but was still requested, so it must match
+  // nothing rather than fall back to the unfiltered list.
+  it('isIdsParamProvided treats a value that parses to nothing as still supplied', () => {
+    expect(isIdsParamProvided(',,,')).toBe(true)
+    expect(parseIdsParam(',,,')).toEqual([])
+    expect(isIdsParamProvided([',', ','])).toBe(true)
+    expect(parseIdsParam([',', ','])).toEqual([])
+  })
+
   it('mergeIdFilter matches nothing when ids param was provided but all invalid', () => {
     // Malformed input: parseIdsParam yields [], but the param WAS provided.
     expect(mergeIdFilter({}, parseIdsParam('not-a-uuid'), { idsParamProvided: true })).toEqual({

--- a/packages/shared/src/lib/crud/__tests__/query-params.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/query-params.test.ts
@@ -1,0 +1,83 @@
+import { buildQueryParams, readQueryParamList, toQueryValueList } from '@open-mercato/shared/lib/crud/query-params'
+
+describe('buildQueryParams', () => {
+  it('keeps a key that occurs once as a plain string', () => {
+    const params = new URLSearchParams('status=win&page=2')
+    expect(buildQueryParams(params)).toEqual({ status: 'win', page: '2' })
+  })
+
+  it('keeps every value of a repeated key instead of the last one (#5548)', () => {
+    const params = new URLSearchParams('status=win&status=loose')
+    expect(buildQueryParams(params)).toEqual({ status: ['win', 'loose'] })
+  })
+
+  it('preserves the order the values were supplied in', () => {
+    expect(buildQueryParams(new URLSearchParams('status=loose&status=win'))).toEqual({
+      status: ['loose', 'win'],
+    })
+  })
+
+  it('does not split a single value on commas, so comma contracts stay intact', () => {
+    const params = new URLSearchParams('ids=a,b&search=Smith, John')
+    expect(buildQueryParams(params)).toEqual({ ids: 'a,b', search: 'Smith, John' })
+  })
+
+  it('returns an empty object for an empty query string', () => {
+    expect(buildQueryParams(new URLSearchParams(''))).toEqual({})
+  })
+
+  it('keeps an empty repeated value so the caller can decide what it means', () => {
+    expect(buildQueryParams(new URLSearchParams('status=&status=win'))).toEqual({
+      status: ['', 'win'],
+    })
+  })
+
+  it('rejects the Object.fromEntries shape this replaced', () => {
+    // Regression guard: reverting the parse site to
+    // `Object.fromEntries(url.searchParams.entries())` makes this fail.
+    const params = new URLSearchParams('status=win&status=loose')
+    expect(buildQueryParams(params)).not.toEqual(Object.fromEntries(params.entries()))
+  })
+})
+
+describe('toQueryValueList', () => {
+  it('turns a single string into a one-entry list', () => {
+    expect(toQueryValueList('win')).toEqual(['win'])
+  })
+
+  it('splits the comma form', () => {
+    expect(toQueryValueList('win,loose')).toEqual(['win', 'loose'])
+  })
+
+  it('flattens repeated values', () => {
+    expect(toQueryValueList(['win', 'loose'])).toEqual(['win', 'loose'])
+  })
+
+  it('treats the mixed form as one flat list', () => {
+    expect(toQueryValueList(['a,b', 'c'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('trims entries and drops empty ones', () => {
+    expect(toQueryValueList([' win ', '', ' , ', 'loose'])).toEqual(['win', 'loose'])
+  })
+
+  it('ignores non-string input', () => {
+    expect(toQueryValueList(undefined)).toEqual([])
+    expect(toQueryValueList(null)).toEqual([])
+    expect(toQueryValueList(42)).toEqual([])
+    expect(toQueryValueList([1, 'win'])).toEqual(['win'])
+  })
+})
+
+describe('readQueryParamList', () => {
+  it('reads the repeated and the comma form as the same list', () => {
+    const repeated = new URLSearchParams('status=win&status=loose')
+    const comma = new URLSearchParams('status=win,loose')
+    expect(readQueryParamList(repeated, 'status')).toEqual(['win', 'loose'])
+    expect(readQueryParamList(comma, 'status')).toEqual(['win', 'loose'])
+  })
+
+  it('returns an empty list for a key that was not supplied', () => {
+    expect(readQueryParamList(new URLSearchParams('status=win'), 'ownerUserId')).toEqual([])
+  })
+})

--- a/packages/shared/src/lib/crud/__tests__/query-params.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/query-params.test.ts
@@ -32,6 +32,21 @@ describe('buildQueryParams', () => {
     })
   })
 
+  // A plain `out[key] = value` assignment runs the `__proto__` setter, which
+  // would swap the returned object's prototype for the array and drop the key.
+  // `Object.fromEntries` defines own data properties, matching what the parse
+  // site did before this change.
+  it('carries a __proto__ key as an own property instead of touching the prototype', () => {
+    const repeated = buildQueryParams(new URLSearchParams('__proto__=a&__proto__=b'))
+    expect(Object.getPrototypeOf(repeated)).toBe(Object.prototype)
+    expect(Object.prototype.hasOwnProperty.call(repeated, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(repeated, '__proto__')?.value).toEqual(['a', 'b'])
+
+    const single = buildQueryParams(new URLSearchParams('__proto__=a'))
+    expect(Object.getPrototypeOf(single)).toBe(Object.prototype)
+    expect(Object.getOwnPropertyDescriptor(single, '__proto__')?.value).toBe('a')
+  })
+
   it('rejects the Object.fromEntries shape this replaced', () => {
     // Regression guard: reverting the parse site to
     // `Object.fromEntries(url.searchParams.entries())` makes this fail.

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -69,6 +69,7 @@ import type { EnricherContext } from './response-enricher'
 import type { ApiInterceptorMethod, InterceptorRequest, InterceptorResponse } from './api-interceptor'
 import { runApiInterceptorsAfter, runApiInterceptorsBefore } from './interceptor-runner'
 import { mergeIdFilter, parseIdsParam, isIdsParamProvided } from './ids'
+import { buildQueryParams } from './query-params'
 import { mergeAdvancedFilters } from './advanced-filter-integration'
 import { parseExtensionHeaders } from '../umes/extension-headers'
 import { createGenericOptimisticLockReader } from './optimistic-lock'
@@ -1516,7 +1517,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         return json({ error: 'Not implemented' }, { status: 501 })
       }
       const url = new URL(request.url)
-      const rawQueryParams = Object.fromEntries(url.searchParams.entries())
+      const rawQueryParams = buildQueryParams(url.searchParams)
       profiler.mark('query_parsed')
       let validated = opts.list.schema.parse(rawQueryParams)
       profiler.mark('query_validated')
@@ -2870,7 +2871,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       if (useCommand) {
         const action = opts.actions!.delete!
         const body = await request.json().catch(() => ({}))
-        const raw = { body, query: Object.fromEntries(url.searchParams.entries()) }
+        const raw = { body, query: buildQueryParams(url.searchParams) }
         const parsed = action.schema ? action.schema.parse(raw) : raw
         const interceptorInput =
           parsed && typeof parsed === 'object' && (parsed as Record<string, unknown>).body && typeof (parsed as Record<string, unknown>).body === 'object'
@@ -2889,7 +2890,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         const interceptedBody = interceptorRequestPayload.body ?? {}
         const reparsedRaw = {
           body: interceptedBody,
-          query: Object.fromEntries(url.searchParams.entries()),
+          query: buildQueryParams(url.searchParams),
         }
         const reparsed = action.schema ? action.schema.parse(reparsedRaw) : reparsedRaw
         const input = action.mapInput ? await action.mapInput({ parsed: reparsed, raw: reparsedRaw, ctx }) : reparsed
@@ -3006,7 +3007,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         request,
         method: 'DELETE',
         body: idFrom === 'query' ? undefined : ({ id } as Record<string, unknown>),
-        query: idFrom === 'query' ? Object.fromEntries(url.searchParams.entries()) : undefined,
+        query: idFrom === 'query' ? buildQueryParams(url.searchParams) : undefined,
       })
       if (beforeInterceptors.errorResponse) return beforeInterceptors.errorResponse
       interceptorRequestPayload = beforeInterceptors.requestPayload

--- a/packages/shared/src/lib/crud/ids.ts
+++ b/packages/shared/src/lib/crud/ids.ts
@@ -1,4 +1,5 @@
 import type { Where } from '@open-mercato/shared/lib/query/types'
+import { toQueryValueList } from './query-params'
 
 export const MAX_IDS_PER_REQUEST = 200
 
@@ -43,21 +44,23 @@ function readExistingIds(filter: unknown): string[] | null {
 }
 
 export function parseIdsParam(raw: unknown, maxIds: number = MAX_IDS_PER_REQUEST): string[] {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return []
+  const values = toQueryValueList(raw)
+  if (values.length === 0) return []
   const safeMax = Number.isFinite(maxIds) && maxIds > 0 ? Math.floor(maxIds) : MAX_IDS_PER_REQUEST
-  const parsed = normalizeIdList(raw.split(','))
+  const parsed = normalizeIdList(values)
   return parsed.slice(0, safeMax)
 }
 
 /**
- * Whether an `?ids=` param was supplied at all (a non-empty string), regardless
- * of whether any value survived UUID validation. Lets a caller tell "no ids
- * filter requested" apart from "ids filter requested but every value was
- * malformed" — the latter must match nothing, not fall back to the full list
- * (#4143 Finding 3).
+ * Whether an `?ids=` param was supplied at all (a non-empty string, or repeated
+ * `?ids=` occurrences), regardless of whether any value survived UUID
+ * validation. Lets a caller tell "no ids filter requested" apart from "ids
+ * filter requested but every value was malformed" — the latter must match
+ * nothing, not fall back to the full list (#4143 Finding 3).
  */
 export function isIdsParamProvided(raw: unknown): boolean {
-  return typeof raw === 'string' && raw.trim().length > 0
+  const occurrences = Array.isArray(raw) ? raw : [raw]
+  return occurrences.some((value) => typeof value === 'string' && value.trim().length > 0)
 }
 
 export function mergeIdFilter<Fields extends Record<string, unknown>>(

--- a/packages/shared/src/lib/crud/query-params.ts
+++ b/packages/shared/src/lib/crud/query-params.ts
@@ -25,6 +25,11 @@ export type QueryParamValue = string | string[]
  * comma semantics that belong to the individual route, not to the generic
  * parser. Use `readQueryParamList` / `toQueryValueList` where a field's contract
  * says a comma separates values.
+ *
+ * The result is assembled with `Object.fromEntries`, which defines own data
+ * properties. Assigning into an object literal instead would run the
+ * `__proto__` setter, so `?__proto__=a&__proto__=b` would replace the returned
+ * object's prototype and drop the key rather than carrying it to the schema.
  */
 export function buildQueryParams(searchParams: URLSearchParams): Record<string, QueryParamValue> {
   const grouped = new Map<string, string[]>()
@@ -33,11 +38,12 @@ export function buildQueryParams(searchParams: URLSearchParams): Record<string, 
     if (existing) existing.push(value)
     else grouped.set(key, [value])
   })
-  const out: Record<string, QueryParamValue> = {}
-  for (const [key, values] of grouped) {
-    out[key] = values.length === 1 ? values[0] : values
-  }
-  return out
+  return Object.fromEntries(
+    Array.from(grouped, ([key, values]): [string, QueryParamValue] => [
+      key,
+      values.length === 1 ? values[0] : values,
+    ]),
+  )
 }
 
 /**

--- a/packages/shared/src/lib/crud/query-params.ts
+++ b/packages/shared/src/lib/crud/query-params.ts
@@ -1,0 +1,64 @@
+/**
+ * Query-string parsing helpers shared by every `makeCrudRoute` handler and by
+ * routes that read `URLSearchParams` directly.
+ *
+ * `Object.fromEntries(url.searchParams.entries())` keeps only the last value of
+ * a repeated key, so `?status=win&status=loose` reached route schemas as
+ * `'loose'` and every earlier selection was dropped before validation ran
+ * (#5548). `buildQueryParams` groups repeats instead.
+ */
+
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
+
+export type QueryParamValue = string | string[]
+
+/**
+ * Group a query string into a plain object, preserving repeated keys.
+ *
+ * A key that occurs once keeps its raw string value — that is what today's
+ * `z.string()` schemas expect and nothing about them has to change. A key that
+ * occurs two or more times becomes the array of its values, which is what a
+ * `z.array(z.string())` (or `z.union([z.string(), z.array(z.string())])`)
+ * branch has always advertised.
+ *
+ * Values are never split on commas here: `?ids=a,b` and `?search=foo,bar` carry
+ * comma semantics that belong to the individual route, not to the generic
+ * parser. Use `readQueryParamList` / `toQueryValueList` where a field's contract
+ * says a comma separates values.
+ */
+export function buildQueryParams(searchParams: URLSearchParams): Record<string, QueryParamValue> {
+  const grouped = new Map<string, string[]>()
+  searchParams.forEach((value, key) => {
+    const existing = grouped.get(key)
+    if (existing) existing.push(value)
+    else grouped.set(key, [value])
+  })
+  const out: Record<string, QueryParamValue> = {}
+  for (const [key, values] of grouped) {
+    out[key] = values.length === 1 ? values[0] : values
+  }
+  return out
+}
+
+/**
+ * Normalize a raw query value — a single string, an array of repeated values,
+ * or nothing — into the list it stands for. Comma-separated and repeated forms
+ * are equivalent here, so `?k=a,b&k=c` yields `['a', 'b', 'c']`.
+ */
+export function toQueryValueList(raw: unknown): string[] {
+  const candidates = Array.isArray(raw) ? raw : [raw]
+  const out: string[] = []
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    out.push(...parseCommaSeparatedList(candidate))
+  }
+  return out
+}
+
+/**
+ * Read every value supplied for `key`, accepting both the repeated
+ * (`?k=a&k=b`) and the comma-separated (`?k=a,b`) form.
+ */
+export function readQueryParamList(searchParams: URLSearchParams, key: string): string[] {
+  return toQueryValueList(searchParams.getAll(key))
+}

--- a/packages/shared/src/lib/crud/query-params.ts
+++ b/packages/shared/src/lib/crud/query-params.ts
@@ -26,6 +26,11 @@ export type QueryParamValue = string | string[]
  * parser. Use `readQueryParamList` / `toQueryValueList` where a field's contract
  * says a comma separates values.
  *
+ * Repeated values are treated as a set by the list response cache: its key
+ * serializer sorts them, so `?k=a&k=b` and `?k=b&k=a` share one entry even
+ * though the schema now receives `['a','b']` and `['b','a']` respectively. Do
+ * not declare a repeated param whose order carries meaning.
+ *
  * The result is assembled with `Object.fromEntries`, which defines own data
  * properties. Assigning into an object literal instead would run the
  * `__proto__` setter, so `?__proto__=a&__proto__=b` would replace the returned


### PR DESCRIPTION
## 🎯 Goal

Fixes #5548

`makeCrudRoute` list endpoints silently kept **only the last value** of a repeated query parameter, so every multi-select filter that sends repeats lost all but one selection — while the CRUD response cache keyed those same requests **order-insensitively**, so which value survived also depended on which ordering warmed the cache first.

## 🔍 Root cause

Every handler built by `makeCrudRoute` assembled its query object with:

```ts
const rawQueryParams = Object.fromEntries(url.searchParams.entries())
```

`URLSearchParams.entries()` yields one `[key, value]` pair **per occurrence**, and `Object.fromEntries` assigns them in order, so each repeated key overwrites the previous one. `?status=win&status=loose` reached the route schema as the bare string `'loose'` and every earlier selection was discarded **before** zod ever ran. The same pattern repeated at the three non-`GET` handlers that build `raw.query`.

Two consequences fed each other:

1. Any schema declaring `z.union([z.string(), z.array(z.string())])` advertised an array branch this path could never deliver — unit tests reached it only by calling the schema directly, which is why it looked covered. Routes that parse the URL themselves (`/api/customers/deals/aggregate`, `/api/customers/deals/map`) each carried a private `readArrayParam` over `getAll`, so two views of the same data disagreed.
2. `serializeSearchParams` builds the cache key by grouping repeated values and **sorting** them, so `?status=win&status=loose` and `?status=loose&status=win` produced an identical key while resolving to *different* filters. Two requests with different effective behaviour shared one cache entry.

The cache key was right about intent — repeated params are set-like and order should not matter. Fixing the parse makes the collision disappear on its own, so `serializeSearchParams` is deliberately left alone.

## 🛠️ What changed

**New shared helper — `packages/shared/src/lib/crud/query-params.ts`**

- `buildQueryParams(searchParams)` groups repeats: a key seen **once** stays a **string** (unchanged from today, so existing `z.string()` schemas are unaffected), a key seen **twice or more** becomes a **`string[]`** and reaches the array branch its schema already advertised.
- `toQueryValueList(raw)` / `readQueryParamList(searchParams, key)` normalize a value into the list it stands for, treating the repeated and comma forms as equivalent — for the fields whose own contract says a comma separates values.

**Deliberately narrow: no comma splitting at the generic parse site.** `?ids=a,b` (the documented SPEC-042 contract) and `?search=Smith, John` keep their literal string value. Splitting every value on commas at this layer would corrupt free-text filters, so comma semantics stay where they belong — with the individual field.

**Applied at all four parse sites** in `packages/shared/src/lib/crud/factory.ts`: the list handler plus the three non-`GET` handlers that assembled `raw.query` the same way.

**`packages/shared/src/lib/crud/ids.ts`** — `parseIdsParam` and `isIdsParamProvided` now accept the repeated form. Without this, a repeated `?ids=` would have arrived as an array, been read as "no ids filter supplied", and **silently widened the response to the full list** — reopening the record-count side channel #4143 closed. `isIdsParamProvided` deliberately keys on the raw occurrence rather than on what survives parsing, so `?ids=,,,` still counts as supplied and matches nothing.

**Retired two duplicated helpers** — `readArrayParam` in the deals aggregate and map routes now delegates to `readQueryParamList` instead of carrying its own `getAll` + split + trim copy. Behaviour is identical; this is what let the two views drift apart in the first place.

**Docs** — `UPGRADE_NOTES.md` (0.7.0 → 0.7.1) and `packages/shared/AGENTS.md`.

## 💥 Breaking changes

No route URL, HTTP method, response field, `makeCrudRoute` signature, options type, or database column changes, so `BACKWARD_COMPATIBILITY.md` §2, §3 and §7 are **not** violated. Callers using the comma form, or sending each param once, are unaffected; a caller sending repeats starts receiving the values it already asked for — strictly a widening.

**One behaviour change worth calling out:** a list route whose schema types a filter param as a plain `z.string()` (no array branch) now returns **400** when a client sends that param twice, where it previously accepted the request and silently used the last value. That is the correct failure mode — quietly discarding a caller's filter is the defect this fixes — but a lenient client could be relying on the old leniency, so it is documented in `UPGRADE_NOTES.md` under the next minor.

I audited every first-party sender of repeated query params (`grep` for `params.append` across `packages/` and `apps/`) and none is affected: the deals list/map/pipeline pages target routes that already declare the array branch, and `/api/auth/users` (`roleId`) and `/api/entities/definitions` (`entityId`) parse the URL themselves with `getAll`, so those keys never reach a factory schema.

## 🧪 Tests

- **Unit, `packages/shared/src/lib/crud/__tests__/query-params.test.ts`** (new) — single key → string; repeated key → array; ordering preserved; a comma-bearing scalar is *not* split; mixed `?k=a,b&k=c` → `['a','b','c']`; blanks trimmed and dropped; non-string input ignored. Includes an explicit regression guard asserting the result differs from the `Object.fromEntries` shape this replaced.
- **Unit, `crud-factory.test.ts`** — a new `repeated query parameters (#5548)` block driving a real `makeCrudRoute` handler: the schema receives an array from a repeated key and a plain string from a single one, a comma-bearing free-text filter survives untouched, both orderings resolve identically, and a repeated `?ids=` narrows to both records instead of one.
- **Unit, `ids.test.ts`** — the repeated form for `parseIdsParam` / `isIdsParamProvided`, including dedupe, the `maxIds` cap, and the case that a value parsing to nothing (`?ids=,,,`) still counts as supplied.
- **Integration, `packages/core/src/modules/customers/__integration__/TC-CRM-5548-repeated-query-params.spec.ts`** (new) — self-contained fixtures (created in the test, cleaned up in `finally`, no reliance on seeded demo data) asserting on `/api/customers/deals` that a repeated `status` filter keeps both selections, that the comma and repeated forms return the same rows, that the reversed ordering returns the same rows (the cache-collision guard), and that a repeated `?ids=` resolves to exactly the requested records.

**Validation gate:** every command in `.ai/agentic.config.json` ran green — `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`. `@open-mercato/shared` 2038 passed, `@open-mercato/core` 11680 passed.

Two local-only caveats, both verified as environmental rather than regressions: the `create-mercato-app` harness oracle suites need live `codex`/`claude` CLIs and fail on a clean checkout too, and running the suite under this worktree's sandbox `TMPDIR` (which lives *inside* the repo) breaks tsx's IPC socket path and makes the CLI `resolveEnvironment` tests resolve `monorepo` instead of `standalone`. Both pass with a normal `TMPDIR`; CI is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790344145&installation_model_id=432243&pr_number=5675&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5675&signature=d5c796b89232e5a8a80e932296fef849f9547eaeca02c5bec6f4189b0cf8c30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->