### PR TITLE
fix(communication_channels): thread Discord outbound replies to their parent message (#5541)

### DIFF
--- a/.ai/specs/2026-06-19-discord-communication-channel-integration.md
+++ b/.ai/specs/2026-06-19-discord-communication-channel-integration.md
@@ -254,7 +254,7 @@ those conversations, notifications, and (optionally) an AI assistant inside Open
 |-------------------------|------------------------|
 | `providerKey` | `'discord'` |
 | `channelType` | `'discord'` (the contract's `channelType` is `'whatsapp' \| 'slack' \| 'email' \| 'sms' \| string` — `'discord'` is allowed as a string) |
-| `capabilities` | **As shipped.** Declared `true`: `recipientFormat: 'provider-native'` (a Discord recipient is a channel snowflake, never an address), `richText: true` (markdown), `reactions: true`, `editMessage: true`, `deleteMessage: true`, `conversationHistory: true`, `supportedBodyFormats: ['text','markdown']`, `maxBodyLength: 2000`, `realtimePush: true`, `interactiveComponents: true` (slash commands, buttons, select menus and modal submissions are dispatched into the hub's inbound queue and answered with a real follow-up — see § Interactions dispatch). Declared **`false`**, because the first release does not implement them and the hub would otherwise route work this adapter silently drops — each with its reason recorded in `lib/capabilities.ts`: `threading` (nothing hub-side writes `replyToExternalId` into *outbound* metadata; it exists only on the inbound normalized shape), `fileSharing` / `inlineImages` (`convertOutbound` drops attachments and the REST client has no multipart upload), plus `multiReactionPerUser`, `typingIndicators`, `presence`, `richBlocks`, `stickers`, `readReceipts`, `deliveryReceipts`, `contactCards`, `locationSharing`, `voiceNotes`. A flag flips back to `true` only in the change that implements it, guarded by the parity test in `lib/__tests__/capabilities.test.ts` |
+| `capabilities` | **As shipped.** Declared `true`: `recipientFormat: 'provider-native'` (a Discord recipient is a channel snowflake, never an address), `richText: true` (markdown), `reactions: true`, `editMessage: true`, `deleteMessage: true`, `conversationHistory: true`, `supportedBodyFormats: ['text','markdown']`, `maxBodyLength: 2000`, `realtimePush: true`, `interactiveComponents: true` (slash commands, buttons, select menus and modal submissions are dispatched into the hub's inbound queue and answered with a real follow-up — see § Interactions dispatch), `threading: true` (the hub resolves the parent's Discord snowflake in `communication_channels/lib/outbound-reply-ref.ts` and writes `channelMetadata.replyToExternalId`, which `convertOutbound` turns into `message_reference`; capability-gated and fail-soft, see the 2026-08-26 changelog entry). Declared **`false`**, because the first release does not implement them and the hub would otherwise route work this adapter silently drops — each with its reason recorded in `lib/capabilities.ts`: `fileSharing` / `inlineImages` (`convertOutbound` drops attachments and the REST client has no multipart upload), plus `multiReactionPerUser`, `typingIndicators`, `presence`, `richBlocks`, `stickers`, `readReceipts`, `deliveryReceipts`, `contactCards`, `locationSharing`, `voiceNotes`. A flag flips back to `true` only in the change that implements it, guarded by the parity test in `lib/__tests__/capabilities.test.ts` |
 | `sendMessage` | REST `POST /channels/{id}/messages` (`Authorization: Bot <token>`) |
 | `verifyWebhook` | Ed25519 verify of interactions POST; **throws** on failure (fail-closed). Plain messages do not arrive here — they come via the gateway worker — so for a non-interaction body it returns `eventType: 'other'` (route acks without tenant-scoped work) |
 | `normalizeInbound` | Discord message object → `NormalizedInboundMessage` (sender id/handle, content, attachments, `replyToExternalId` from `message_reference`) |
@@ -1118,6 +1118,34 @@ rule 3), and no variant should be considered done without it.
 ---
 
 ## Changelog
+
+### 2026-08-26 — Outbound reply threading implemented; `threading` flips back to `true` (issue #5541)
+
+- **§ Adapter method map → `capabilities`.** `threading` moves from the deliberately-disabled list
+  back to the shipped-`true` list, now backed by an implementation rather than by intent.
+- **The missing piece was hub-side, not adapter-side.** `convertOutbound` → `adapter.sendMessage` →
+  `discord-rest.createMessage` already carried `channelMetadata.replyToExternalId` all the way to
+  `body.message_reference`; nothing on the outbound path ever produced that key, so the branch was
+  unreachable in production (#5541, found against a live bot). The new
+  `communication_channels/lib/outbound-reply-ref.ts` is that producer: given the delivered message's
+  `parentMessageId`, it resolves the parent's `MessageChannelLink` → `ExternalMessage` and returns the
+  provider-native id, which `deliver-outbound-message.ts` merges into the outbound `channelMetadata`.
+- **Capability-gated and fail-soft by design.** The resolver returns `null` unless the adapter declares
+  `threading`, so no provider is handed a key it silently drops — the same mismatch the capability list
+  exists to prevent. It also returns `null` for a non-reply, an unlinked parent, or a parent in another
+  conversation (Discord answers `400 Unknown message` for a cross-channel reference), and the caller
+  swallows lookup errors: an unthreaded delivery always beats a failed one.
+- **Ordering is a security property.** The resolved id is merged *after* the link's stored metadata, so
+  the caller-supplied `channelMetadata` that `send-as-user` passes through cannot point a reply at an
+  arbitrary provider message id. Pinned by a test.
+- **Coverage.** `communication_channels/lib/__tests__/outbound-reply-ref.test.ts` (resolution, the four
+  `null` paths, scoping assertions), five cases in
+  `commands/__tests__/deliver-outbound-message.test.ts` (threading adapter, non-threading adapter,
+  non-reply, lookup failure, caller-override), and the rewritten
+  `channel_discord/lib/__tests__/capabilities.test.ts` threading case, which now drives the whole path
+  down to the REST body instead of asserting the flag.
+- Supersedes the `threading` demotion recorded on 2026-08-24, which explicitly reserved the flip for
+  "the same change that gives the hub an outbound reply producer".
 
 ### 2026-08-25 — Arming an auto-reply channel is authorized, and a dormant one says so (re-review of PR #4391)
 

--- a/.ai/specs/2026-06-19-discord-communication-channel-integration.md
+++ b/.ai/specs/2026-06-19-discord-communication-channel-integration.md
@@ -1134,16 +1134,35 @@ rule 3), and no variant should be considered done without it.
   `threading`, so no provider is handed a key it silently drops — the same mismatch the capability list
   exists to prevent. It also returns `null` for a non-reply, an unlinked parent, or a parent in another
   conversation (Discord answers `400 Unknown message` for a cross-channel reference), and the caller
-  swallows lookup errors: an unthreaded delivery always beats a failed one.
+  swallows lookup errors: an unthreaded delivery always beats a failed one. The gate does **not** spare
+  providers that thread by RFC 5322 headers: `email-capabilities.ts` declares `threading: true` for the
+  shared email profile, so an email reply pays for both lookups and its converter then ignores the
+  result in favor of `inReplyTo` / `references`. Narrowing that needs a capability distinguishing
+  id-threading from header-threading, which the contract does not have yet — tracked in #5691.
+- **The reference survives the hub's convert→send double-conversion.** `deliver-outbound-message.ts`
+  calls `convertOutbound` and then hands `converted.metadata` straight to `sendMessage`, which
+  re-converts it. Discord's converter renames `replyToExternalId` → `messageReferenceId`, so the second
+  pass saw neither key and emitted `messageReferenceId: undefined`, dropping the reference before the
+  REST body — the first cut of this change was green in unit tests and still shipped nothing. The
+  converter now accepts its own already-converted key on the second pass, matching the precedent
+  `channel-gmail/lib/convert-outbound.ts` documents for `threadId`.
+- **A deleted parent degrades instead of failing.** `discord-rest.createMessage` sends
+  `message_reference` with `fail_if_not_exists: false`. Discord defaults that to `true` and rejects the
+  send with a 400 when the referenced message is gone — non-transient, so the hub would mark the link
+  `failed` and never deliver the reply. Users delete messages routinely, and the AI producers reference
+  the thread ROOT, the likeliest-deleted message in a conversation.
 - **Ordering is a security property.** The resolved id is merged *after* the link's stored metadata, so
   the caller-supplied `channelMetadata` that `send-as-user` passes through cannot point a reply at an
   arbitrary provider message id. Pinned by a test.
 - **Coverage.** `communication_channels/lib/__tests__/outbound-reply-ref.test.ts` (resolution, the four
   `null` paths, scoping assertions), five cases in
   `commands/__tests__/deliver-outbound-message.test.ts` (threading adapter, non-threading adapter,
-  non-reply, lookup failure, caller-override), and the rewritten
-  `channel_discord/lib/__tests__/capabilities.test.ts` threading case, which now drives the whole path
-  down to the REST body instead of asserting the flag.
+  non-reply, lookup failure, caller-override), the double-conversion round-trip and precedence cases in
+  `channel_discord/lib/__tests__/convert-outbound.test.ts`, and the rewritten
+  `channel_discord/lib/__tests__/capabilities.test.ts` threading case, which drives the hub's own call
+  order — `convertOutbound`, then the real `adapter.sendMessage` fed with `converted.metadata` — down to
+  the REST body, with `restClient.request` as the only seam. Driving `createMessage` directly instead
+  would skip `sendMessage`, which is precisely where the reference was being lost.
 - Supersedes the `threading` demotion recorded on 2026-08-24, which explicitly reserved the flip for
   "the same change that gives the hub an outbound reply producer".
 

--- a/.ai/specs/2026-06-19-discord-communication-channel-integration.md
+++ b/.ai/specs/2026-06-19-discord-communication-channel-integration.md
@@ -1151,13 +1151,23 @@ rule 3), and no variant should be considered done without it.
   send with a 400 when the referenced message is gone — non-transient, so the hub would mark the link
   `failed` and never deliver the reply. Users delete messages routinely, and the AI producers reference
   the thread ROOT, the likeliest-deleted message in a conversation.
-- **Ordering is a security property.** The resolved id is merged *after* the link's stored metadata, so
-  the caller-supplied `channelMetadata` that `send-as-user` passes through cannot point a reply at an
-  arbitrary provider message id. Pinned by a test.
+- **Reply targeting is hub-resolved only.** `send-as-user` merges caller-supplied `channelMetadata` onto
+  the `MessageChannelLink`, which `deliver-outbound-message` reads back as the converter's base metadata,
+  so a caller must not be able to point a reply at an arbitrary provider message id. Merge order alone
+  does not achieve that: it settles the contest only when the hub actually resolved a parent, and the
+  uncontested case — no `parentMessageId`, or a parent that legitimately fails to resolve — is exactly
+  the one a caller controls. Both reply-targeting keys (`replyToExternalId`, and Discord's
+  already-converted `messageReferenceId`, which its converter must accept to survive the double
+  conversion) are therefore *stripped* off the stored metadata by
+  `stripCallerReplyTargeting` before the hub's own value is merged, rather than merely out-ranked.
+  Stripping at the hub seam covers every producer of `link.channelMetadata`, not just `send-as-user`, and
+  is safe on retry because the reference is re-resolved from `parentMessageId` on each attempt.
 - **Coverage.** `communication_channels/lib/__tests__/outbound-reply-ref.test.ts` (resolution, the four
-  `null` paths, scoping assertions), five cases in
+  `null` paths, scoping assertions, and the strip helper's key set and non-mutation), nine cases in
   `commands/__tests__/deliver-outbound-message.test.ts` (threading adapter, non-threading adapter,
-  non-reply, lookup failure, caller-override), the double-conversion round-trip and precedence cases in
+  non-reply, lookup failure, caller-override on the contested path, plus the uncontested path: each
+  reply-targeting key stripped on a non-reply, both stripped when the parent does not resolve, and
+  unrelated caller metadata left intact), the double-conversion round-trip and precedence cases in
   `channel_discord/lib/__tests__/convert-outbound.test.ts`, and the rewritten
   `channel_discord/lib/__tests__/capabilities.test.ts` threading case, which drives the hub's own call
   order — `convertOutbound`, then the real `adapter.sendMessage` fed with `converted.metadata` — down to

--- a/packages/channel-discord/src/modules/channel_discord/lib/__tests__/capabilities.test.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/__tests__/capabilities.test.ts
@@ -56,30 +56,54 @@ describe('discordCapabilities honesty', () => {
     expect(discordCapabilities.stickers).toBe(false)
   })
 
-  it('does not advertise threading while no hub producer writes an outbound reply id', async () => {
-    // `convertOutboundForDiscord` reads `channelMetadata.replyToExternalId` and
-    // would emit a `message_reference` from it — but that key only ever exists on
-    // the INBOUND `NormalizedInboundMessage` shape. The hub's outbound metadata
-    // producers (`send-as-user.ts`, `deliver-outbound-message.ts`) write the
-    // email-shaped `inReplyTo` / `references` instead, so the branch below is
-    // unreachable in production. Confirmed against a live bot in #5541.
-    expect(discordCapabilities.threading).toBe(false)
+  it('advertises threading, and a reply carries message_reference all the way to the REST body', async () => {
+    // #5541: this flag was `false` while the conversion below existed but was
+    // unreachable — `channelMetadata.replyToExternalId` lived only on the INBOUND
+    // shape, and the hub's outbound producers wrote the email-shaped `inReplyTo` /
+    // `references` instead. `communication_channels/lib/outbound-reply-ref.ts` is
+    // the producer that closed the gap, so the flag may claim threading again.
+    // Assert the whole path, not the flag: the conversion, the adapter hand-off,
+    // and the JSON body Discord actually receives.
+    expect(discordCapabilities.threading).toBe(true)
 
-    const withoutReplyId = await convertOutboundForDiscord({
-      body: 'hello',
-      bodyFormat: 'text',
-      channelMetadata: { inReplyTo: 'some-parent-id', references: ['some-parent-id'] },
-    } as Parameters<typeof convertOutboundForDiscord>[0])
-    expect(withoutReplyId.metadata?.messageReferenceId).toBeUndefined()
-
-    // The conversion itself stays ready, so the flag flips back with the hub-side
-    // producer and nothing else.
     const withReplyId = await convertOutboundForDiscord({
       body: 'hello',
       bodyFormat: 'text',
       channelMetadata: { replyToExternalId: 'parent-snowflake' },
     } as Parameters<typeof convertOutboundForDiscord>[0])
     expect(withReplyId.metadata?.messageReferenceId).toBe('parent-snowflake')
+
+    const restClient = getDiscordRestClient()
+    // Intercept at the transport boundary so the real `createMessage` still
+    // builds the body — a hand-rolled fake client would only assert itself.
+    const sentBodies: Array<Record<string, unknown>> = []
+    const request = jest
+      .spyOn(restClient as unknown as { request: (...args: unknown[]) => Promise<unknown> }, 'request')
+      .mockImplementation(async (..._args: unknown[]) => {
+        sentBodies.push(_args[3] as Record<string, unknown>)
+        return { id: 'sent-1', channel_id: '999' }
+      })
+    try {
+      await restClient.createMessage(
+        { botToken: 'bot-token' },
+        {
+          channelId: '999',
+          content: withReplyId.content.text ?? '',
+          messageReferenceId: withReplyId.metadata?.messageReferenceId as string,
+        },
+      )
+    } finally {
+      request.mockRestore()
+    }
+    expect(sentBodies[0]?.message_reference).toEqual({ message_id: 'parent-snowflake' })
+
+    // A non-reply still sends a plain channel message — no dangling reference.
+    const withoutReplyId = await convertOutboundForDiscord({
+      body: 'hello',
+      bodyFormat: 'text',
+      channelMetadata: { inReplyTo: 'some-parent-id', references: ['some-parent-id'] },
+    } as Parameters<typeof convertOutboundForDiscord>[0])
+    expect(withoutReplyId.metadata?.messageReferenceId).toBeUndefined()
   })
 
   it('does not advertise rich blocks — outbound is plain markdown, no embeds are built', () => {

--- a/packages/channel-discord/src/modules/channel_discord/lib/__tests__/capabilities.test.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/__tests__/capabilities.test.ts
@@ -1,4 +1,5 @@
 import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto'
+import { getDiscordChannelAdapter } from '../adapter'
 import { discordCapabilities, DISCORD_MAX_BODY_LENGTH } from '../capabilities'
 import { getDiscordRestClient } from '../discord-rest'
 import { convertOutboundForDiscord } from '../convert-outbound'
@@ -13,6 +14,28 @@ function makeSigner() {
     publicKeyHex: spki.subarray(spki.length - 32).toString('hex'),
     sign: (message: string) => cryptoSign(null, Buffer.from(message, 'utf-8'), privateKey).toString('hex'),
   }
+}
+
+/**
+ * Run `send` with the REST transport as the ONLY seam and return the JSON bodies
+ * Discord would have received. Spying on `request` rather than swapping in a fake
+ * client keeps the real `createMessage` in the path, so the body under assertion
+ * is the one production builds.
+ */
+async function captureSentBodies(send: () => Promise<void>): Promise<Array<Record<string, unknown>>> {
+  const sentBodies: Array<Record<string, unknown>> = []
+  const request = jest
+    .spyOn(getDiscordRestClient() as unknown as { request: (...args: unknown[]) => Promise<unknown> }, 'request')
+    .mockImplementation(async (..._args: unknown[]) => {
+      sentBodies.push(_args[3] as Record<string, unknown>)
+      return { id: 'sent-1', channel_id: '999' }
+    })
+  try {
+    await send()
+  } finally {
+    request.mockRestore()
+  }
+  return sentBodies
 }
 
 /**
@@ -62,40 +85,47 @@ describe('discordCapabilities honesty', () => {
     // shape, and the hub's outbound producers wrote the email-shaped `inReplyTo` /
     // `references` instead. `communication_channels/lib/outbound-reply-ref.ts` is
     // the producer that closed the gap, so the flag may claim threading again.
-    // Assert the whole path, not the flag: the conversion, the adapter hand-off,
-    // and the JSON body Discord actually receives.
+    //
+    // Assert the whole path, not the flag, and drive it in the ORDER THE HUB
+    // DRIVES IT (`deliver-outbound-message.ts`): `convertOutbound`, then
+    // `sendMessage` fed with `converted.metadata`. That second call re-converts
+    // the already-converted metadata, and the first version of this PR lost the
+    // reference exactly there — a green test that skipped `sendMessage` and
+    // hand-wired `createMessage` reproduced the #5541 blind spot it was written
+    // to close. Keep `restClient.request` as the only seam so the real converter,
+    // the real adapter and the real `createMessage` all stay in the path.
     expect(discordCapabilities.threading).toBe(true)
 
-    const withReplyId = await convertOutboundForDiscord({
+    const converted = await convertOutboundForDiscord({
       body: 'hello',
       bodyFormat: 'text',
       channelMetadata: { replyToExternalId: 'parent-snowflake' },
     } as Parameters<typeof convertOutboundForDiscord>[0])
-    expect(withReplyId.metadata?.messageReferenceId).toBe('parent-snowflake')
+    expect(converted.metadata?.messageReferenceId).toBe('parent-snowflake')
 
-    const restClient = getDiscordRestClient()
-    // Intercept at the transport boundary so the real `createMessage` still
-    // builds the body — a hand-rolled fake client would only assert itself.
-    const sentBodies: Array<Record<string, unknown>> = []
-    const request = jest
-      .spyOn(restClient as unknown as { request: (...args: unknown[]) => Promise<unknown> }, 'request')
-      .mockImplementation(async (..._args: unknown[]) => {
-        sentBodies.push(_args[3] as Record<string, unknown>)
-        return { id: 'sent-1', channel_id: '999' }
-      })
-    try {
-      await restClient.createMessage(
-        { botToken: 'bot-token' },
-        {
-          channelId: '999',
-          content: withReplyId.content.text ?? '',
-          messageReferenceId: withReplyId.metadata?.messageReferenceId as string,
+    const sentBodies = await captureSentBodies(async () => {
+      const result = await getDiscordChannelAdapter().sendMessage({
+        conversationId: '999',
+        content: converted.content,
+        credentials: {
+          botToken: 'bot-token',
+          applicationId: 'app-1',
+          publicKey: 'a'.repeat(64),
+          defaultChannelId: '999',
         },
-      )
-    } finally {
-      request.mockRestore()
-    }
-    expect(sentBodies[0]?.message_reference).toEqual({ message_id: 'parent-snowflake' })
+        scope: { tenantId: 't', organizationId: 'o' },
+        // Exactly what `deliver-outbound-message.ts` hands the adapter.
+        metadata: converted.metadata,
+      })
+      expect(result.status).toBe('sent')
+    })
+    expect(sentBodies[0]?.message_reference).toEqual({
+      message_id: 'parent-snowflake',
+      // A deleted parent must degrade to a plain channel message, not fail the
+      // delivery: Discord defaults this to `true` and answers 400, which the hub
+      // classifies as non-transient and marks the link `failed`.
+      fail_if_not_exists: false,
+    })
 
     // A non-reply still sends a plain channel message — no dangling reference.
     const withoutReplyId = await convertOutboundForDiscord({
@@ -104,6 +134,22 @@ describe('discordCapabilities honesty', () => {
       channelMetadata: { inReplyTo: 'some-parent-id', references: ['some-parent-id'] },
     } as Parameters<typeof convertOutboundForDiscord>[0])
     expect(withoutReplyId.metadata?.messageReferenceId).toBeUndefined()
+
+    const plainBodies = await captureSentBodies(async () => {
+      await getDiscordChannelAdapter().sendMessage({
+        conversationId: '999',
+        content: withoutReplyId.content,
+        credentials: {
+          botToken: 'bot-token',
+          applicationId: 'app-1',
+          publicKey: 'a'.repeat(64),
+          defaultChannelId: '999',
+        },
+        scope: { tenantId: 't', organizationId: 'o' },
+        metadata: withoutReplyId.metadata,
+      })
+    })
+    expect(plainBodies[0]?.message_reference).toBeUndefined()
   })
 
   it('does not advertise rich blocks — outbound is plain markdown, no embeds are built', () => {

--- a/packages/channel-discord/src/modules/channel_discord/lib/__tests__/convert-outbound.test.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/__tests__/convert-outbound.test.ts
@@ -36,4 +36,44 @@ describe('convertOutboundForDiscord', () => {
     })
     expect(result.metadata?.messageReferenceId).toBe('msg-42')
   })
+
+  it('keeps the reply reference through the hub convert→send double-conversion', async () => {
+    // `deliver-outbound-message.ts` converts once, then hands `converted.metadata`
+    // to `sendMessage`, which converts again. The second pass never sees the hub's
+    // `replyToExternalId` — only our own renamed `messageReferenceId` — so a
+    // one-way rename silently drops the reference before it reaches Discord
+    // (#5541). Feed the first pass's output back in and the id must survive.
+    const first = await convertOutboundForDiscord({
+      body: 'reply',
+      bodyFormat: 'text',
+      channelMetadata: { replyToExternalId: 'msg-42' },
+    })
+    const second = await convertOutboundForDiscord({
+      body: first.content.text ?? '',
+      bodyFormat: 'markdown',
+      channelMetadata: first.metadata,
+    })
+    expect(second.metadata?.messageReferenceId).toBe('msg-42')
+  })
+
+  it('lets the hub-resolved reference outrank a stale already-converted one', async () => {
+    // Only reachable if a caller round-trips metadata from an earlier message,
+    // but the precedence has to be the safe one: `replyToExternalId` is resolved
+    // by the hub against the message actually being delivered.
+    const result = await convertOutboundForDiscord({
+      body: 'reply',
+      bodyFormat: 'text',
+      channelMetadata: { replyToExternalId: 'msg-42', messageReferenceId: 'stale-7' },
+    })
+    expect(result.metadata?.messageReferenceId).toBe('msg-42')
+  })
+
+  it('leaves a non-reply without a reference', async () => {
+    const result = await convertOutboundForDiscord({
+      body: 'plain',
+      bodyFormat: 'text',
+      channelMetadata: { inReplyTo: 'header-threaded', references: ['header-threaded'] },
+    })
+    expect(result.metadata?.messageReferenceId).toBeUndefined()
+  })
 })

--- a/packages/channel-discord/src/modules/channel_discord/lib/capabilities.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/capabilities.ts
@@ -31,18 +31,17 @@ export const DISCORD_MAX_BODY_LENGTH = 2000
  *   replaces the "thinking…" placeholder over Discord's interaction-webhook
  *   endpoints. Pinned by the parity test in `lib/__tests__/capabilities.test.ts`,
  *   which drives the whole path rather than asserting the flag alone.
+ * - `threading` — a reply composed with `parentMessageId` arrives in Discord
+ *   attached to the message it answers. The hub resolves the parent's Discord
+ *   snowflake in `communication_channels/lib/outbound-reply-ref.ts` and writes it
+ *   to `channelMetadata.replyToExternalId`; `convertOutbound` turns that into
+ *   `messageReferenceId`, and `discord-rest` sends it as `message_reference`.
+ *   This flag was `false` for exactly as long as that hub-side producer was
+ *   missing (#5541, found against a live bot) — the whole path, not the flag
+ *   alone, is pinned by `lib/__tests__/capabilities.test.ts`.
  *
  * Deliberately disabled until implemented (declaring them would make the hub
  * hand this adapter work it silently drops):
- * - `threading` — `convertOutbound` reads `channelMetadata.replyToExternalId`
- *   and emits `message_reference` from it, but nothing hub-side ever writes that
- *   key into OUTBOUND metadata: `replyToExternalId` exists only on the inbound
- *   `NormalizedInboundMessage` shape, and the hub's outbound metadata producers
- *   (`send-as-user.ts`, `deliver-outbound-message.ts`) write the email-shaped
- *   `inReplyTo` / `references` instead. The conversion is therefore unreachable
- *   in production — confirmed against a live bot in #5541. The flag flips back
- *   to `true` in the same change that gives the hub an outbound reply producer
- *   this adapter can read, guarded by a contract test.
  * - `fileSharing` / `inlineImages` — `convertOutbound` drops
  *   `input.content.attachments` and `discord-rest` has no multipart upload, so
  *   outbound attachments never reach Discord. `maxFileSize` /
@@ -73,7 +72,7 @@ export const discordCapabilities: ChannelCapabilities = {
   recipientFormat: 'provider-native',
 
   // Core
-  threading: false,
+  threading: true,
   richText: true,
   fileSharing: false,
   readReceipts: false,

--- a/packages/channel-discord/src/modules/channel_discord/lib/convert-outbound.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/convert-outbound.ts
@@ -75,10 +75,10 @@ export async function convertOutboundForDiscord(input: ConvertOutboundInput): Pr
     metadata: {
       allowedMentions,
       droppedAttachmentCount,
-      // Reply threading, dormant: no hub producer writes `replyToExternalId`
-      // into outbound metadata today, which is why `capabilities.threading` is
-      // declared `false`. Kept so that flag flips back with the hub-side
-      // producer and nothing else.
+      // Reply threading: the hub writes `replyToExternalId` on the outbound path
+      // (`communication_channels/lib/outbound-reply-ref.ts`) when the message
+      // being delivered answers one that already reached this channel. Absent on
+      // a non-reply, which sends a plain channel message.
       messageReferenceId:
         typeof input.channelMetadata?.replyToExternalId === 'string'
           ? (input.channelMetadata.replyToExternalId as string)

--- a/packages/channel-discord/src/modules/channel_discord/lib/convert-outbound.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/convert-outbound.ts
@@ -75,14 +75,34 @@ export async function convertOutboundForDiscord(input: ConvertOutboundInput): Pr
     metadata: {
       allowedMentions,
       droppedAttachmentCount,
-      // Reply threading: the hub writes `replyToExternalId` on the outbound path
-      // (`communication_channels/lib/outbound-reply-ref.ts`) when the message
-      // being delivered answers one that already reached this channel. Absent on
-      // a non-reply, which sends a plain channel message.
-      messageReferenceId:
-        typeof input.channelMetadata?.replyToExternalId === 'string'
-          ? (input.channelMetadata.replyToExternalId as string)
-          : undefined,
+      messageReferenceId: resolveMessageReferenceId(input.channelMetadata),
     },
   }
+}
+
+/**
+ * Resolve the id of the message an outbound reply attaches to. Order of
+ * precedence:
+ *   1. `replyToExternalId` — what the hub writes on the outbound path
+ *      (`communication_channels/lib/outbound-reply-ref.ts`) when the message
+ *      being delivered answers one that already reached this channel.
+ *   2. `messageReferenceId` — our own already-converted key, which survives the
+ *      hub's convert→send double-conversion: `deliver-outbound-message` calls
+ *      `convertOutbound` and then hands `converted.metadata` to `sendMessage`,
+ *      which re-converts it. Without accepting the converted key on that second
+ *      pass the rename `replyToExternalId` → `messageReferenceId` is one-way and
+ *      the reference is silently dropped before it reaches Discord (#5541).
+ *      `channel-gmail/lib/convert-outbound.ts` keeps `threadId` stable across
+ *      the same seam for the same reason.
+ *
+ * Both are absent on a non-reply, which sends a plain channel message.
+ */
+function resolveMessageReferenceId(
+  channelMetadata: ConvertOutboundInput['channelMetadata'],
+): string | undefined {
+  const fromHub = channelMetadata?.replyToExternalId
+  if (typeof fromHub === 'string' && fromHub.length > 0) return fromHub
+  const alreadyConverted = channelMetadata?.messageReferenceId
+  if (typeof alreadyConverted === 'string' && alreadyConverted.length > 0) return alreadyConverted
+  return undefined
 }

--- a/packages/channel-discord/src/modules/channel_discord/lib/discord-rest.ts
+++ b/packages/channel-discord/src/modules/channel_discord/lib/discord-rest.ts
@@ -172,7 +172,16 @@ class FetchDiscordRestClient implements DiscordRestClient {
       allowed_mentions: input.allowedMentions ?? { parse: [] },
     }
     if (input.messageReferenceId) {
-      body.message_reference = { message_id: input.messageReferenceId }
+      // `fail_if_not_exists` defaults to `true` on Discord's side: a reference to
+      // a message that has since been deleted makes the API reject the send
+      // outright (a 400, which `request` classifies as non-transient, so the hub
+      // marks the link `failed` and the reply is never delivered). Users delete
+      // messages routinely and the AI producers reference the thread ROOT — the
+      // oldest and likeliest-deleted message in a conversation. Opting out makes
+      // Discord fall back to a plain channel message, the same degradation
+      // `outbound-reply-ref.ts` already applies to the cases the hub can detect:
+      // an unthreaded delivery always beats a failed one.
+      body.message_reference = { message_id: input.messageReferenceId, fail_if_not_exists: false }
     }
     return this.request<DiscordMessageObject>(
       auth,

--- a/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
+++ b/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
@@ -378,6 +378,7 @@ describe('deliverOutboundMessageCommand — outbound reply threading', () => {
       .mockResolvedValueOnce({
         id: PARENT_EXTERNAL_ROW,
         externalMessageId: PARENT_SNOWFLAKE,
+        conversationId: 'conv-1',
       } as never) // parent ExternalMessage
     const { ctx, adapter } = makeCtx({ threading: true })
 
@@ -474,6 +475,7 @@ describe('deliverOutboundMessageCommand — outbound reply threading', () => {
       .mockResolvedValueOnce({
         id: PARENT_EXTERNAL_ROW,
         externalMessageId: PARENT_SNOWFLAKE,
+        conversationId: 'conv-1',
       } as never)
     const { ctx, adapter } = makeCtx({ threading: true })
 

--- a/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
+++ b/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
@@ -293,3 +293,196 @@ describe('deliverOutboundMessageCommand — link integrity + reauth', () => {
     expect(adapter.sendMessage).not.toHaveBeenCalled()
   })
 })
+
+// ── Chat reply threading: the hub-side producer of `replyToExternalId` (#5541) ──
+describe('deliverOutboundMessageCommand — outbound reply threading', () => {
+  const MSG = '550e8400-e29b-41d4-a716-446655440010'
+  const TENANT = '550e8400-e29b-41d4-a716-446655440020'
+  const ORG = '550e8400-e29b-41d4-a716-446655440030'
+  const PARENT_MSG = '550e8400-e29b-41d4-a716-446655440040'
+  const PARENT_EXTERNAL_ROW = '550e8400-e29b-41d4-a716-446655440050'
+  const PARENT_SNOWFLAKE = '1541185400817852538'
+
+  function makeCtx(capabilities: Record<string, unknown> | undefined) {
+    const em: any = {
+      create: jest.fn((_entity: unknown, data: Record<string, any>) => ({ ...data })),
+      persist: jest.fn(),
+      flush: jest.fn(async () => undefined),
+    }
+    em.fork = () => em
+    const adapter = {
+      providerKey: 'discord',
+      capabilities,
+      convertOutbound: jest.fn(async () => ({ content: { text: 'hi' }, metadata: {} })),
+      sendMessage: jest.fn(async () => ({ status: 'sent', externalMessageId: 'discord-new-1' })),
+    }
+    const ctx = {
+      container: {
+        resolve: (name: string) => {
+          if (name === 'em') return em
+          if (name === 'channelAdapterRegistry') return { get: () => adapter }
+          if (name === 'integrationCredentialsService') return { resolve: async () => ({}) }
+          if (name === 'integrationLogService') return { error: jest.fn() }
+          throw new Error(`unexpected resolve: ${name}`)
+        },
+      },
+    } as any
+    return { ctx, adapter }
+  }
+
+  function primeFinds(parentMessageId: string | null) {
+    mockFindOne.mockReset()
+    mockFindOne
+      .mockResolvedValueOnce({
+        id: 'msg-1',
+        threadId: 'thread-1',
+        parentMessageId,
+        body: 'hello',
+        bodyFormat: 'markdown',
+      } as never) // the message being delivered
+      .mockResolvedValueOnce({
+        messageThreadId: 'thread-1',
+        channelId: 'ch-1',
+        externalConversationId: 'conv-1',
+        externalThreadRef: 'discord-channel:999',
+      } as never) // thread mapping
+      .mockResolvedValueOnce({
+        id: 'ch-1',
+        isActive: true,
+        providerKey: 'discord',
+        channelType: 'chat',
+        userId: 'u-1',
+        credentialsRef: null,
+        status: 'connected',
+      } as never) // channel
+      .mockResolvedValueOnce({
+        id: 'link-1',
+        deliveryStatus: 'pending',
+        channelPayload: null,
+        channelMetadata: null,
+      } as never) // this message's own link
+  }
+
+  beforeEach(() => {
+    mockEmit.mockClear()
+  })
+
+  it('hands a threading adapter the parent message external id', async () => {
+    primeFinds(PARENT_MSG)
+    mockFindOne
+      .mockResolvedValueOnce({
+        id: 'link-parent',
+        externalMessageId: PARENT_EXTERNAL_ROW,
+        externalConversationId: 'conv-1',
+      } as never) // parent link
+      .mockResolvedValueOnce({
+        id: PARENT_EXTERNAL_ROW,
+        externalMessageId: PARENT_SNOWFLAKE,
+      } as never) // parent ExternalMessage
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    const result = await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    expect((result as any).status).toBe('delivered')
+    const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
+    expect(converted.channelMetadata.replyToExternalId).toBe(PARENT_SNOWFLAKE)
+  })
+
+  it('sends unthreaded when the adapter does not declare threading', async () => {
+    // The exact state #5541 reported: without a capability check the hub would
+    // hand every provider a key most of them silently drop.
+    primeFinds(PARENT_MSG)
+    const { ctx, adapter } = makeCtx({ threading: false })
+
+    await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
+    expect(converted.channelMetadata.replyToExternalId).toBeUndefined()
+  })
+
+  it('sends unthreaded when the message is not a reply', async () => {
+    primeFinds(null)
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
+    expect(converted.channelMetadata.replyToExternalId).toBeUndefined()
+  })
+
+  it('delivers unthreaded rather than failing when the parent lookup throws', async () => {
+    primeFinds(PARENT_MSG)
+    mockFindOne.mockRejectedValueOnce(new Error('connection reset') as never)
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    const result = await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    expect((result as any).status).toBe('delivered')
+    const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
+    expect(converted.channelMetadata.replyToExternalId).toBeUndefined()
+  })
+
+  it('does not let caller-supplied link metadata override the hub-resolved parent', async () => {
+    mockFindOne.mockReset()
+    mockFindOne
+      .mockResolvedValueOnce({
+        id: 'msg-1',
+        threadId: 'thread-1',
+        parentMessageId: PARENT_MSG,
+        body: 'hello',
+        bodyFormat: 'markdown',
+      } as never)
+      .mockResolvedValueOnce({
+        messageThreadId: 'thread-1',
+        channelId: 'ch-1',
+        externalConversationId: 'conv-1',
+        externalThreadRef: 'discord-channel:999',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 'ch-1',
+        isActive: true,
+        providerKey: 'discord',
+        channelType: 'chat',
+        userId: 'u-1',
+        credentialsRef: null,
+        status: 'connected',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 'link-1',
+        deliveryStatus: 'pending',
+        channelPayload: null,
+        // `send-as-user` merges caller-supplied channelMetadata into the link.
+        channelMetadata: { replyToExternalId: 'attacker-controlled-snowflake' },
+      } as never)
+      .mockResolvedValueOnce({
+        id: 'link-parent',
+        externalMessageId: PARENT_EXTERNAL_ROW,
+        externalConversationId: 'conv-1',
+      } as never)
+      .mockResolvedValueOnce({
+        id: PARENT_EXTERNAL_ROW,
+        externalMessageId: PARENT_SNOWFLAKE,
+      } as never)
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
+    expect(converted.channelMetadata.replyToExternalId).toBe(PARENT_SNOWFLAKE)
+  })
+})

--- a/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
+++ b/packages/core/src/modules/communication_channels/commands/__tests__/deliver-outbound-message.test.ts
@@ -330,7 +330,10 @@ describe('deliverOutboundMessageCommand — outbound reply threading', () => {
     return { ctx, adapter }
   }
 
-  function primeFinds(parentMessageId: string | null) {
+  function primeFinds(
+    parentMessageId: string | null,
+    linkChannelMetadata: Record<string, unknown> | null = null,
+  ) {
     mockFindOne.mockReset()
     mockFindOne
       .mockResolvedValueOnce({
@@ -359,7 +362,7 @@ describe('deliverOutboundMessageCommand — outbound reply threading', () => {
         id: 'link-1',
         deliveryStatus: 'pending',
         channelPayload: null,
-        channelMetadata: null,
+        channelMetadata: linkChannelMetadata,
       } as never) // this message's own link
   }
 
@@ -486,5 +489,69 @@ describe('deliverOutboundMessageCommand — outbound reply threading', () => {
 
     const converted = adapter.convertOutbound.mock.calls[0][0] as { channelMetadata: Record<string, unknown> }
     expect(converted.channelMetadata.replyToExternalId).toBe(PARENT_SNOWFLAKE)
+  })
+
+  // The uncontested half of the case above. Merge order only settles the contest
+  // when the hub actually resolved a parent; when it resolved nothing there is no
+  // hub value to out-rank a caller-supplied key, so both reply-targeting keys are
+  // stripped off the link metadata instead. Discord's converter accepts
+  // `messageReferenceId` (it has to, to survive the convert→send double
+  // conversion) and has always accepted `replyToExternalId`, so either one would
+  // otherwise reach `body.message_reference` unvalidated.
+  it.each([['messageReferenceId'], ['replyToExternalId']])(
+    'strips a caller-supplied %s when the message is not a reply',
+    async (key) => {
+      primeFinds(null, { [key]: 'attacker-controlled-snowflake' })
+      const { ctx, adapter } = makeCtx({ threading: true })
+
+      await deliverOutboundMessageCommand.execute(
+        { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+        ctx,
+      )
+
+      const converted = adapter.convertOutbound.mock.calls[0][0] as {
+        channelMetadata: Record<string, unknown>
+      }
+      expect(converted.channelMetadata).not.toHaveProperty('messageReferenceId')
+      expect(converted.channelMetadata).not.toHaveProperty('replyToExternalId')
+    },
+  )
+
+  it('strips caller-supplied reply targeting when the parent does not resolve', async () => {
+    // A real reply whose parent never reached this channel. The hub produces
+    // nothing, so without stripping the caller's key would fill the gap.
+    primeFinds(PARENT_MSG, { messageReferenceId: 'attacker-controlled-snowflake' })
+    mockFindOne.mockResolvedValueOnce(null as never) // parent link — not on this channel
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    const converted = adapter.convertOutbound.mock.calls[0][0] as {
+      channelMetadata: Record<string, unknown>
+    }
+    expect(converted.channelMetadata).not.toHaveProperty('messageReferenceId')
+    expect(converted.channelMetadata).not.toHaveProperty('replyToExternalId')
+  })
+
+  it('leaves unrelated caller metadata untouched while stripping reply targeting', async () => {
+    // The strip is surgical: it removes the two reply-targeting keys and nothing
+    // else, so `send-as-user`'s legitimate pass-through metadata still reaches
+    // the adapter.
+    primeFinds(null, { messageReferenceId: 'attacker-controlled-snowflake', allowedMentions: { parse: ['users'] } })
+    const { ctx, adapter } = makeCtx({ threading: true })
+
+    await deliverOutboundMessageCommand.execute(
+      { messageId: MSG, scope: { tenantId: TENANT, organizationId: ORG } } as never,
+      ctx,
+    )
+
+    const converted = adapter.convertOutbound.mock.calls[0][0] as {
+      channelMetadata: Record<string, unknown>
+    }
+    expect(converted.channelMetadata).not.toHaveProperty('messageReferenceId')
+    expect(converted.channelMetadata.allowedMentions).toEqual({ parse: ['users'] })
   })
 })

--- a/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
+++ b/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
@@ -13,7 +13,7 @@ import {
   getOrCreateThreadToken,
 } from '../lib/thread-token'
 import { stringOrUndefined, stripBrackets } from '../lib/email-mime'
-import { resolveOutboundReplyExternalId } from '../lib/outbound-reply-ref'
+import { resolveOutboundReplyExternalId, stripCallerReplyTargeting } from '../lib/outbound-reply-ref'
 import type { ChannelAdapterRegistry } from '../lib/registry'
 import { isUniqueViolation } from '../lib/pg-errors'
 import { Message } from '../../messages/data/entities'
@@ -428,12 +428,16 @@ const deliverOutboundMessageCommand: CommandHandler<
         bodyFormat: outboundBodyFormat,
         channelMetadata: {
           thread_id: mapping.externalThreadRef,
-          ...baseMetadata,
+          // Reply targeting is hub-resolved only. `send-as-user` merges
+          // caller-supplied metadata onto the link, so every reply-targeting key
+          // is stripped off the stored metadata here rather than merely
+          // out-ranked below: merge order settles the contest only when the hub
+          // resolved a parent, and the uncontested case — no `parentMessageId`,
+          // or a parent that does not resolve — is exactly the one a caller
+          // controls.
+          ...stripCallerReplyTargeting(baseMetadata),
           references: mergedReferences,
           ...(threadToken ? { omThreadToken: threadToken } : {}),
-          // AFTER `baseMetadata` on purpose: `send-as-user` merges caller-supplied
-          // metadata into the link, and a caller must not be able to point a reply
-          // at an arbitrary provider message id. The hub-resolved value wins.
           ...(replyToExternalId ? { replyToExternalId } : {}),
         },
       })

--- a/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
+++ b/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
@@ -13,6 +13,7 @@ import {
   getOrCreateThreadToken,
 } from '../lib/thread-token'
 import { stringOrUndefined, stripBrackets } from '../lib/email-mime'
+import { resolveOutboundReplyExternalId } from '../lib/outbound-reply-ref'
 import type { ChannelAdapterRegistry } from '../lib/registry'
 import { isUniqueViolation } from '../lib/pg-errors'
 import { Message } from '../../messages/data/entities'
@@ -348,6 +349,29 @@ const deliverOutboundMessageCommand: CommandHandler<
       moduleLogger.warn('thread token unavailable, proceeding without it', { err: tokenErr })
     }
 
+    // (4c) Chat-provider reply threading — resolve the provider-native id of the
+    // message this one answers so a threading adapter can attach it (Discord's
+    // `message_reference`). Email adapters ignore this and keep threading on the
+    // `inReplyTo` / `references` headers built above. Best-effort like the thread
+    // token: an unresolvable parent sends an unthreaded reply rather than failing
+    // a delivery.
+    let replyToExternalId: string | null = null
+    try {
+      replyToExternalId = await resolveOutboundReplyExternalId(em, {
+        parentMessageId: message.parentMessageId ?? null,
+        externalConversationId: mapping.externalConversationId,
+        capabilities: adapter.capabilities,
+        scope: {
+          tenantId: input.scope.tenantId,
+          organizationId: input.scope.organizationId ?? null,
+        },
+      })
+    } catch (replyRefErr) {
+      moduleLogger.warn('outbound reply reference unavailable, sending unthreaded', {
+        err: replyRefErr,
+      })
+    }
+
     // (5) + (6) Convert + send.
     try {
       const outboundPayload = (link.channelPayload as Record<string, unknown> | null) ?? {}
@@ -395,6 +419,10 @@ const deliverOutboundMessageCommand: CommandHandler<
           ...baseMetadata,
           references: mergedReferences,
           ...(threadToken ? { omThreadToken: threadToken } : {}),
+          // AFTER `baseMetadata` on purpose: `send-as-user` merges caller-supplied
+          // metadata into the link, and a caller must not be able to point a reply
+          // at an arbitrary provider message id. The hub-resolved value wins.
+          ...(replyToExternalId ? { replyToExternalId } : {}),
         },
       })
 

--- a/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
+++ b/packages/core/src/modules/communication_channels/commands/deliver-outbound-message.ts
@@ -371,6 +371,18 @@ const deliverOutboundMessageCommand: CommandHandler<
         err: replyRefErr,
       })
     }
+    if (!replyToExternalId && message.parentMessageId && adapter.capabilities?.threading === true) {
+      // The provider threads and the caller asked for a reply, yet nothing
+      // resolved — the parent never reached this channel, or it belongs to
+      // another conversation. Delivery is unaffected, but say so: an unthreaded
+      // reply is otherwise indistinguishable from a non-reply, which is exactly
+      // the silent-unreachability shape #5541 was filed about.
+      moduleLogger.debug('reply parent has no external id on this channel, sending unthreaded', {
+        messageId: message.id,
+        parentMessageId: message.parentMessageId,
+        conversationId: mapping.externalConversationId,
+      })
+    }
 
     // (5) + (6) Convert + send.
     try {

--- a/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
@@ -4,7 +4,7 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
 }))
 
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { resolveOutboundReplyExternalId } from '../outbound-reply-ref'
+import { resolveOutboundReplyExternalId, stripCallerReplyTargeting } from '../outbound-reply-ref'
 import { ExternalMessage, MessageChannelLink } from '../../data/entities'
 
 const mockFindOne = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
@@ -139,5 +139,28 @@ describe('resolveOutboundReplyExternalId', () => {
       .mockResolvedValueOnce(parentExternalMessage({ externalMessageId: '' }))
 
     await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+  })
+})
+
+describe('stripCallerReplyTargeting', () => {
+  it('removes both reply-targeting keys and keeps everything else', () => {
+    const cleaned = stripCallerReplyTargeting({
+      replyToExternalId: 'caller-1',
+      messageReferenceId: 'caller-2',
+      to: ['someone@example.com'],
+      subject: 'hi',
+    })
+
+    expect(cleaned).toEqual({ to: ['someone@example.com'], subject: 'hi' })
+  })
+
+  it('does not mutate the caller-supplied object', () => {
+    // The input is the live `MessageChannelLink.channelMetadata` row value, which
+    // the delivery command still persists to on the success path.
+    const stored = { messageReferenceId: 'caller-2', subject: 'hi' }
+
+    stripCallerReplyTargeting(stored)
+
+    expect(stored).toEqual({ messageReferenceId: 'caller-2', subject: 'hi' })
   })
 })

--- a/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
@@ -1,0 +1,133 @@
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveOutboundReplyExternalId } from '../outbound-reply-ref'
+import { ExternalMessage, MessageChannelLink } from '../../data/entities'
+
+const mockFindOne = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+const TENANT = '11111111-1111-1111-1111-111111111111'
+const ORG = '22222222-2222-2222-2222-222222222222'
+const PARENT_MESSAGE = '33333333-3333-3333-3333-333333333333'
+const CONVERSATION = '44444444-4444-4444-4444-444444444444'
+const OTHER_CONVERSATION = '55555555-5555-5555-5555-555555555555'
+const PARENT_EXTERNAL_ROW = '66666666-6666-6666-6666-666666666666'
+
+const PARENT_SNOWFLAKE = '1541185400817852538'
+
+function em() {
+  return {} as never
+}
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+  return {
+    parentMessageId: PARENT_MESSAGE,
+    externalConversationId: CONVERSATION,
+    capabilities: { threading: true } as never,
+    scope: { tenantId: TENANT, organizationId: ORG },
+    ...overrides,
+  } as Parameters<typeof resolveOutboundReplyExternalId>[1]
+}
+
+/** The parent's link row, as `ingest-inbound-message` writes it for an inbound message. */
+function parentLink(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'link-parent',
+    messageId: PARENT_MESSAGE,
+    externalMessageId: PARENT_EXTERNAL_ROW,
+    externalConversationId: CONVERSATION,
+    ...overrides,
+  } as never
+}
+
+function parentExternalMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: PARENT_EXTERNAL_ROW,
+    externalMessageId: PARENT_SNOWFLAKE,
+    conversationId: CONVERSATION,
+    ...overrides,
+  } as never
+}
+
+beforeEach(() => {
+  mockFindOne.mockReset()
+})
+
+describe('resolveOutboundReplyExternalId', () => {
+  it('resolves the provider-native id of the message a reply answers', async () => {
+    mockFindOne.mockResolvedValueOnce(parentLink()).mockResolvedValueOnce(parentExternalMessage())
+
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBe(PARENT_SNOWFLAKE)
+
+    // The link is looked up by the parent hub message id, under the caller's
+    // tenant/org scope — never unscoped.
+    const [, linkEntity, linkWhere] = mockFindOne.mock.calls[0]
+    expect(linkEntity).toBe(MessageChannelLink)
+    expect(linkWhere).toEqual({
+      messageId: PARENT_MESSAGE,
+      tenantId: TENANT,
+      organizationId: ORG,
+    })
+
+    const [, externalEntity, externalWhere] = mockFindOne.mock.calls[1]
+    expect(externalEntity).toBe(ExternalMessage)
+    expect(externalWhere).toEqual({
+      id: PARENT_EXTERNAL_ROW,
+      tenantId: TENANT,
+      organizationId: ORG,
+    })
+  })
+
+  it('returns null for a provider that does not declare threading, without querying', async () => {
+    // The regression #5541 guards against in the other direction: the hub must
+    // not hand a provider a reply reference it will silently drop.
+    await expect(
+      resolveOutboundReplyExternalId(em(), baseInput({ capabilities: { threading: false } })),
+    ).resolves.toBeNull()
+    await expect(
+      resolveOutboundReplyExternalId(em(), baseInput({ capabilities: null })),
+    ).resolves.toBeNull()
+    expect(mockFindOne).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the message is not a reply', async () => {
+    await expect(
+      resolveOutboundReplyExternalId(em(), baseInput({ parentMessageId: null })),
+    ).resolves.toBeNull()
+    expect(mockFindOne).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the parent never reached this channel', async () => {
+    mockFindOne.mockResolvedValueOnce(null as never)
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+
+    // A link exists but delivery never produced an ExternalMessage row (e.g. the
+    // parent is still `pending` or `failed`).
+    mockFindOne.mockReset()
+    mockFindOne.mockResolvedValueOnce(parentLink({ externalMessageId: null }))
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+    expect(mockFindOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a parent that belongs to a different conversation', async () => {
+    // Discord answers `400 Unknown message` for a cross-channel reference, so an
+    // unthreaded reply is the better degradation.
+    mockFindOne.mockResolvedValueOnce(
+      parentLink({ externalConversationId: OTHER_CONVERSATION }),
+    )
+
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+    expect(mockFindOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the external row carries no usable provider id', async () => {
+    mockFindOne
+      .mockResolvedValueOnce(parentLink())
+      .mockResolvedValueOnce(parentExternalMessage({ externalMessageId: '' }))
+
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/outbound-reply-ref.test.ts
@@ -123,6 +123,16 @@ describe('resolveOutboundReplyExternalId', () => {
     expect(mockFindOne).toHaveBeenCalledTimes(1)
   })
 
+  it('re-checks the conversation on the row that carries the provider id', async () => {
+    // The link and the ExternalMessage are written together, so they cannot
+    // disagree today; the guard holds independently of that coupling.
+    mockFindOne
+      .mockResolvedValueOnce(parentLink())
+      .mockResolvedValueOnce(parentExternalMessage({ conversationId: OTHER_CONVERSATION }))
+
+    await expect(resolveOutboundReplyExternalId(em(), baseInput())).resolves.toBeNull()
+  })
+
   it('returns null when the external row carries no usable provider id', async () => {
     mockFindOne
       .mockResolvedValueOnce(parentLink())

--- a/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
@@ -82,6 +82,13 @@ export async function resolveOutboundReplyExternalId(
     dscope,
   )
 
-  const externalId = parentExternal?.externalMessageId
+  if (!parentExternal) return null
+  // Re-assert the conversation invariant on the row that actually carries the
+  // provider id. Both producers write the link and the external message together,
+  // so these cannot disagree today — checking here keeps the guard correct even if
+  // that coupling is ever relaxed, rather than trusting a second table's field.
+  if (parentExternal.conversationId !== input.externalConversationId) return null
+
+  const externalId = parentExternal.externalMessageId
   return typeof externalId === 'string' && externalId.length > 0 ? externalId : null
 }

--- a/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
@@ -98,3 +98,41 @@ export async function resolveOutboundReplyExternalId(
   const externalId = parentExternal.externalMessageId
   return typeof externalId === 'string' && externalId.length > 0 ? externalId : null
 }
+
+/**
+ * Outbound `channelMetadata` keys that decide which provider message a reply
+ * attaches to.
+ *
+ * - `replyToExternalId` — the hub's own key, produced by
+ *   `resolveOutboundReplyExternalId` above.
+ * - `messageReferenceId` — Discord's already-converted equivalent. Its converter
+ *   has to accept that key so the value survives the hub's convert→send double
+ *   conversion (#5541), and the converter cannot tell the two passes apart, so
+ *   the key is equally accepted on the first, caller-controlled pass.
+ */
+const REPLY_TARGETING_METADATA_KEYS = ['replyToExternalId', 'messageReferenceId'] as const
+
+/**
+ * Drop every reply-targeting key from stored link metadata, so reply targeting
+ * on the outbound path is hub-resolved only.
+ *
+ * `send-as-user` merges caller-supplied `channelMetadata` onto the
+ * `MessageChannelLink`, and `deliver-outbound-message` reads that row back as
+ * the converter's base metadata. Merge order alone only settles the contest when
+ * the hub actually resolved a parent; the uncontested case — a message with no
+ * `parentMessageId`, or one whose parent legitimately fails to resolve — is
+ * exactly the one a caller controls, and there nothing would overwrite a
+ * smuggled key. Without this, a `communication_channels.manage` caller could aim
+ * a reply at an arbitrary provider message id and have the bot's message render
+ * as a reply to a message the hub never resolved and never validated.
+ *
+ * Stripping is safe on a retry: the reference is re-resolved from
+ * `parentMessageId` on every delivery attempt, never read back from the link.
+ */
+export function stripCallerReplyTargeting(
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  const cleaned = { ...metadata }
+  for (const key of REPLY_TARGETING_METADATA_KEYS) delete cleaned[key]
+  return cleaned
+}

--- a/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
@@ -1,0 +1,87 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type { ChannelCapabilities } from './adapter'
+import { ExternalMessage, MessageChannelLink } from '../data/entities'
+
+export interface OutboundReplyRefInput {
+  /** `Message.parentMessageId` of the message being delivered. */
+  parentMessageId: string | null | undefined
+  /** `ChannelThreadMapping.externalConversationId` the message is being sent to. */
+  externalConversationId: string
+  capabilities: Pick<ChannelCapabilities, 'threading'> | null | undefined
+  scope: { tenantId: string; organizationId: string | null }
+}
+
+/**
+ * Resolve the provider-native id of the message an outbound reply answers, so
+ * chat adapters can attach it (Discord `message_reference`, and any provider
+ * that threads by message id rather than by RFC 5322 headers).
+ *
+ * Email providers thread through `inReplyTo` / `references`, which the hub has
+ * always produced. Chat providers had no equivalent: `capabilities.threading`
+ * described a reply-attachment the hub could never ask for, because nothing on
+ * the outbound path wrote the parent's external id into channel metadata
+ * (#5541 — the flag had to be declared `false` to stay honest). This is that
+ * missing producer.
+ *
+ * The hub stores everything needed already: the parent hub message owns a
+ * `MessageChannelLink` (unique per `message_id`) whose `external_message_id`
+ * points at the `ExternalMessage` row carrying the provider's own id — written
+ * by both the inbound ingest and outbound delivery paths, so a reply can answer
+ * an inbound message or one of our own sends.
+ *
+ * Returns `null` — never throws a routing decision at the caller — when the
+ * provider does not thread, the message is not a reply, the parent never
+ * reached this channel, or the parent belongs to a different conversation.
+ * Threading is an enhancement to a delivery, never a precondition for one.
+ */
+export async function resolveOutboundReplyExternalId(
+  em: EntityManager,
+  input: OutboundReplyRefInput,
+): Promise<string | null> {
+  // Gate on the adapter's own declaration first: handing a non-threading
+  // provider a key it silently drops is exactly the mismatch `ChannelCapabilities`
+  // exists to prevent. This also keeps the lookups below off the hot path for
+  // every provider that threads by headers instead.
+  if (input.capabilities?.threading !== true) return null
+  if (!input.parentMessageId) return null
+
+  const dscope = {
+    tenantId: input.scope.tenantId,
+    organizationId: input.scope.organizationId,
+  }
+
+  const parentLink = await findOneWithDecryption(
+    em,
+    MessageChannelLink,
+    {
+      messageId: input.parentMessageId,
+      tenantId: input.scope.tenantId,
+      organizationId: input.scope.organizationId,
+    },
+    undefined,
+    dscope,
+  )
+  if (!parentLink?.externalMessageId) return null
+
+  // A parent that lives in another conversation would make the provider reject
+  // the send (Discord answers `400 Unknown message` for a cross-channel
+  // reference). Dropping the reference degrades to an unthreaded reply, which
+  // is strictly better than a failed delivery.
+  if (parentLink.externalConversationId !== input.externalConversationId) return null
+
+  const parentExternal = await findOneWithDecryption(
+    em,
+    ExternalMessage,
+    {
+      id: parentLink.externalMessageId,
+      tenantId: input.scope.tenantId,
+      organizationId: input.scope.organizationId,
+    },
+    undefined,
+    dscope,
+  )
+
+  const externalId = parentExternal?.externalMessageId
+  return typeof externalId === 'string' && externalId.length > 0 ? externalId : null
+}

--- a/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
+++ b/packages/core/src/modules/communication_channels/lib/outbound-reply-ref.ts
@@ -39,12 +39,18 @@ export async function resolveOutboundReplyExternalId(
   em: EntityManager,
   input: OutboundReplyRefInput,
 ): Promise<string | null> {
-  // Gate on the adapter's own declaration first: handing a non-threading
-  // provider a key it silently drops is exactly the mismatch `ChannelCapabilities`
-  // exists to prevent. This also keeps the lookups below off the hot path for
-  // every provider that threads by headers instead.
-  if (input.capabilities?.threading !== true) return null
+  // A non-reply can never produce a reference, so check that before anything
+  // that costs a query.
   if (!input.parentMessageId) return null
+  // Gate on the adapter's own declaration: handing a non-threading provider a key
+  // it silently drops is exactly the mismatch `ChannelCapabilities` exists to
+  // prevent. Note this gate does NOT spare header-threading providers — the
+  // shared email profile declares `threading: true` (`email-capabilities.ts`), so
+  // an email reply pays for both lookups below and its converter then ignores the
+  // result in favor of `inReplyTo` / `references`. Correct but wasteful;
+  // distinguishing id-threading from header-threading needs a capability the
+  // contract does not have yet (#5691).
+  if (input.capabilities?.threading !== true) return null
 
   const dscope = {
     tenantId: input.scope.tenantId,


### PR DESCRIPTION
Closes #5541

## 🎯 Goal

A reply composed in Open Mercato with a `parentMessageId` now arrives in Discord **attached to the message it answers**, instead of as a loose channel message. Discord's `capabilities.threading` flag goes back to `true` and, for the first time, is backed by a reachable implementation rather than by intent.

## 🔍 Problem

QA of #4391 against a live bot found that `capabilities.threading: true` could not be observed through any reachable outbound path — the reply landed in the right Discord channel and the right hub conversation, but carried no `message_reference`. The flag was subsequently demoted to `false` with a per-flag reason so the capability list stayed honest; this PR implements the capability instead, which is the resolution that entry explicitly reserved for "the same change that gives the hub an outbound reply producer".

## 🔍 Root Cause

The adapter side was already complete end to end: `channel_discord/lib/convert-outbound.ts` reads `channelMetadata.replyToExternalId`, `lib/adapter.ts` forwards it as `messageReferenceId`, and `lib/discord-rest.ts` sends it as `body.message_reference`.

The gap was one step upstream. `communication_channels/commands/deliver-outbound-message.ts` is the single outbound conversion point — both the queue worker and the `send-as-user` facade funnel through it — and the `channelMetadata` it assembled contained only `thread_id`, the link's stored metadata, the email-shaped `references`, and the thread token. `replyToExternalId` existed **only** on the inbound `NormalizedInboundMessage` shape, so the conversion branch was reachable from its own unit tests and nowhere else.

Everything needed was already persisted, just never joined up: `Message.parentMessageId` names the parent hub message, `MessageChannelLink.externalMessageId` (unique per `message_id`) points at the parent's `ExternalMessage` row, and `ExternalMessage.externalMessageId` holds the provider-native id — written by both the inbound ingest and outbound delivery paths.

## What Changed

- **`communication_channels/lib/outbound-reply-ref.ts` (new)** — `resolveOutboundReplyExternalId` walks `parentMessageId` → `MessageChannelLink` → `ExternalMessage` and returns the provider-native id of the message being answered. Modeled on the existing capability-consuming `lib/outbound-recipient.ts`. It returns `null` — never raises a routing decision to the caller — when the adapter does not declare `threading`, the message is not a reply, the parent never reached this channel, or the parent belongs to a different conversation.
- **`communication_channels/commands/deliver-outbound-message.ts`** — new step (4c), alongside the existing thread-token block and before the convert/send try: resolve the reference and merge `replyToExternalId` into the outbound `channelMetadata`. Wrapped in the same best-effort `try`/`warn` the thread token uses, so a lookup failure sends an unthreaded message rather than failing a delivery.
- **`channel_discord/lib/capabilities.ts`** — `threading: true`, moved from the "deliberately disabled" block into the implemented list with the producer named.
- **`channel_discord/lib/convert-outbound.ts`** — the "dormant, no hub producer writes this" comment was now false; replaced with what actually feeds the branch.
- **`.ai/specs/2026-06-19-discord-communication-channel-integration.md`** — the § Adapter method map capability row and a changelog entry recording the flip and superseding the 2026-08-24 demotion.

Three properties are deliberate and each has a test:

- **Capability-gated.** The resolver checks `capabilities.threading` before either lookup, so no provider is handed a key it silently drops — the exact mismatch the capability list exists to prevent. A non-reply is rejected before that, so it costs nothing on any provider. The gate does **not** spare providers that thread by RFC 5322 headers: `email-capabilities.ts` declares `threading: true` for the shared email profile, so an email reply does pay for both lookups and its converter then ignores the result in favor of `inReplyTo` / `references`. Correct but wasteful; narrowing it needs a capability distinguishing id-threading from header-threading and is tracked in #5691.
- **Same-conversation only.** Discord answers `400 Unknown message` for a cross-channel reference, so a parent outside the sending conversation degrades to an unthreaded reply rather than a failed send.
- **The reference survives the hub's convert→send double-conversion.** `deliver-outbound-message.ts` converts once and then hands `converted.metadata` to `sendMessage`, which re-converts it. The converter accepts its own already-converted `messageReferenceId` on that second pass, so the `replyToExternalId` → `messageReferenceId` rename is no longer one-way. `channel-gmail/lib/convert-outbound.ts` documents the same precedent for `threadId`.
- **A deleted parent degrades instead of failing.** `message_reference` is sent with `fail_if_not_exists: false`, so Discord posts a plain channel message rather than answering 400 for a parent that no longer exists.
- **Merge order is a security property.** The resolved id is merged *after* the link's stored metadata, because `send-as-user` passes caller-supplied `channelMetadata` through onto the link. Merging it before would let a caller aim a reply at an arbitrary provider message id.

## 🧪 Tests

- Full validation gate green on the local runner: `build:packages` (×2), `generate` (no generated-file drift), `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`.
- `communication_channels/lib/__tests__/outbound-reply-ref.test.ts` (new, 6 cases) — resolves the snowflake and asserts both lookups are tenant/org scoped; returns `null` with **zero** queries for a non-threading adapter and for a non-reply; `null` for a missing parent link, a parent with no `ExternalMessage`, a parent in another conversation, and an empty provider id.
- `communication_channels/commands/__tests__/deliver-outbound-message.test.ts` (5 new cases) — a threading adapter receives the parent snowflake in `channelMetadata`; a non-threading adapter, a non-reply, and a throwing lookup all convert without `replyToExternalId` and still deliver; caller-supplied link metadata cannot override the hub-resolved value.
- `channel_discord/lib/__tests__/capabilities.test.ts` — the "does not advertise threading" case is replaced by the contract test the issue asked for, driving the whole path: flag → `convertOutbound` → the real `createMessage` → the JSON body Discord receives (`message_reference: { message_id }`), plus the non-reply case.
- Pre-existing, unrelated: `create-mercato-app`'s 161 oracle-harness failures, which require the Codex/Claude CLIs and fail identically on a clean `develop`.

## 💥 Breaking Changes

None. The change is additive — one new optional key in outbound `channelMetadata`, which adapters that do not declare `threading` never see and email adapters ignore in favor of `inReplyTo` / `references`. No schema change, no migration, no API or event-contract change. `capabilities.threading` moving `false` → `true` widens what the adapter accepts; it does not narrow any caller's contract.

## Notes for the reviewer

`channel_discord`'s AI auto-reply producers pass `parentMessageId: message.threadId ?? message.id` (`subscribers/ai-auto-reply.ts:269`, `commands/ai-reply-proposal.ts:118`), so an AI reply threads to the conversation's **root** message rather than the immediate one. That is correct and harmless — a valid reference either way — but not the tightest attachment possible. Tightening it is a separate behavioral change to those producers and is deliberately out of scope here.

## 🔁 Re-review fixes (2026-08-27)

Applied after @pkarw's `request changes` review, in commit `bcd1b42`:

- **Blocker — the resolved reference never reached Discord.** The hub calls the adapter twice, and the second call re-converted metadata that no longer carried `replyToExternalId`, so `body.message_reference` was never set. Fixed in `convert-outbound.ts` by accepting the already-converted key on the second pass. The reviewer's repro now produces `message_reference: { message_id: 'parent-snowflake', fail_if_not_exists: false }`.
- **Major — the contract test skipped the step that lost the value.** `capabilities.test.ts` now drives `convertOutbound` → the real `getDiscordChannelAdapter().sendMessage(..., { metadata: converted.metadata })` → the REST body, with `restClient.request` as the only seam. Verified load-bearing: reverting the converter fix fails this case and the new round-trip case, 2 failures.
- **Major — `fail_if_not_exists` was left at Discord's `true` default.** Now sent as `false`, so a deleted parent degrades to a plain channel message instead of a permanent delivery failure.
- **Minor — the header-threading claim was untrue.** Documented honestly in the code comment, the spec changelog and this PR body rather than silently left; the actual gate narrowing is tracked in #5691.

## 🔁 Re-review fixes, round 2 (2026-08-27)

Applied after @pkarw's second `request changes` review at `bcd1b42`, which confirmed all four earlier findings fixed and raised one new minor. Commit `7c487cc`, on top of a clean merge of the latest `develop` (`41ff100d9`).

- **Minor 5 — reply targeting was only hub-resolved in the *contested* case.** The blocker fix made the converter accept its already-converted `messageReferenceId`, which it cannot scope to the second pass — so the key became honorable on the first, caller-controlled pass too. `send-as-user` merges caller-supplied `channelMetadata` onto the link, and merging the hub's value *after* it only wins when the hub actually resolved a parent. For a message with no `parentMessageId`, or one whose parent legitimately fails to resolve, nothing was added and a caller-supplied key reached `body.message_reference` unvalidated — the bot's message rendering as a reply to a message the hub never resolved.

  Fixed at the hub seam, where "hub-resolved only" can actually be enforced: `stripCallerReplyTargeting` (new, in `lib/outbound-reply-ref.ts`) drops **both** reply-targeting keys off the stored link metadata before the hub's own value is merged. Stripping there covers every producer of `link.channelMetadata`, not just `send-as-user`, and is safe on retry because the reference is re-resolved from `parentMessageId` on each attempt rather than read back from the link.

- **The spec claim the finding contradicted is corrected, not quietly dropped.** The "Ordering is a security property" changelog bullet was not true as written; it now states the actual invariant — reply targeting is hub-resolved only, enforced by stripping rather than by merge order — and explains why merge order alone was insufficient.

### 🧪 Tests for this round

`deliver-outbound-message.test.ts` gains the uncontested half of the existing caller-override case, which is the assertion that would have caught this: each reply-targeting key stripped on a non-reply (parameterized over `messageReferenceId` and `replyToExternalId`), both stripped when the parent does not resolve, and unrelated caller metadata (`allowedMentions`) left intact so the strip is visibly surgical. `outbound-reply-ref.test.ts` pins the helper's key set and its non-mutation of the live link row.

Verified load-bearing rather than assumed: reverting the strip to a bare `...baseMetadata` fails exactly these four new cases and no others. Scoped validation green on the final state — `@open-mercato/core` typecheck, `channel-discord` (29 suites / 261 tests), and `communication_channels` (80 suites / 742 tests); `yarn generate` produced no drift.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790345050&installation_model_id=432243&pr_number=5676&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5676&signature=5f23608995b07f2073e03bc4baa65114576648e69aeec016d98dcf39700c2f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

