### PR TITLE
fix(customer_accounts): open the portal at the organization slug (#5668)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/portalUrlHydration.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/portalUrlHydration.test.ts
@@ -60,3 +60,40 @@ describe('customer_accounts portal address hydration (regression for issue #5457
     expect(source).toMatch(/from '(?:\.\.\/)+lib\/portalUrl'/)
   })
 })
+
+// The "Open Portal" action linked to `${origin}/portal`, but portal pages only
+// exist under `frontend/[orgSlug]/portal/**`, so the link always 404'd.
+const PORTAL_LINK_SURFACES = [
+  {
+    entrypoint: 'backend/customer_accounts/users/page.tsx',
+    client: 'backend/customer_accounts/users/PortalUsersPageClient.tsx',
+  },
+  {
+    entrypoint: 'backend/customer_accounts/settings/page.tsx',
+    client: 'backend/customer_accounts/settings/CustomerAccountsSettingsPageClient.tsx',
+  },
+]
+
+describe('customer_accounts "Open Portal" link (regression for issue #5668)', () => {
+  it.each(PORTAL_LINK_SURFACES)('$entrypoint resolves the organization slug on the server', ({ entrypoint }) => {
+    const source = readSource(entrypoint)
+    expect(source).toMatch(/resolveCurrentOrgPortalSlug\(\)/)
+    expect(source).toMatch(/portalOrgSlug=\{portalOrgSlug\}/)
+  })
+
+  it.each(PORTAL_LINK_SURFACES)('$client takes the slug as a prop and never links without it', ({ client }) => {
+    const source = readSource(client)
+    expect(source).toMatch(/portalOrgSlug\?: string \| null/)
+    expect(source).toMatch(/buildPortalRootUrl\(portalOrigin, portalOrgSlug\)/)
+    // A slugless call would rebuild the 404 link this regression is about.
+    expect(source).not.toMatch(/buildPortalRootUrl\(portalOrigin\)/)
+  })
+
+  // The slug resolver reaches for the EntityManager, so it must stay out of the
+  // module client components import — otherwise the ORM lands in the browser bundle.
+  it('keeps the ORM-backed slug lookup out of the client-imported portalUrl module', () => {
+    const source = readSource('lib/portalUrl.ts')
+    expect(source).not.toMatch(/@mikro-orm/)
+    expect(source).not.toMatch(/organizationLookup/)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/CustomerAccountsSettingsPageClient.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/CustomerAccountsSettingsPageClient.tsx
@@ -15,13 +15,17 @@ const DEMO_CREDENTIALS = [
 
 export type CustomerAccountsSettingsPageClientProps = {
   portalOrigin: string
+  portalOrgSlug?: string | null
 }
 
-export function CustomerAccountsSettingsPageClient({ portalOrigin }: CustomerAccountsSettingsPageClientProps) {
+export function CustomerAccountsSettingsPageClient({ portalOrigin, portalOrgSlug = null }: CustomerAccountsSettingsPageClientProps) {
   const t = useT()
 
   const portalUrl = useMemo(() => buildPortalUrlPattern(portalOrigin), [portalOrigin])
-  const portalRootUrl = useMemo(() => buildPortalRootUrl(portalOrigin), [portalOrigin])
+  const portalRootUrl = useMemo(
+    () => (portalOrgSlug ? buildPortalRootUrl(portalOrigin, portalOrgSlug) : null),
+    [portalOrigin, portalOrgSlug],
+  )
 
   return (
     <>
@@ -47,13 +51,15 @@ export function CustomerAccountsSettingsPageClient({ portalOrigin }: CustomerAcc
               {portalUrl}
             </code>
           </div>
-          <div>
-            <Button type="button" variant="outline" size="sm" asChild>
-              <a href={portalRootUrl} target="_blank" rel="noopener noreferrer">
-                {t('customer_accounts.settings.portal_access.open_portal', 'Open Portal')}
-              </a>
-            </Button>
-          </div>
+          {portalRootUrl ? (
+            <div>
+              <Button type="button" variant="outline" size="sm" asChild>
+                <a href={portalRootUrl} target="_blank" rel="noopener noreferrer">
+                  {t('customer_accounts.settings.portal_access.open_portal', 'Open Portal')}
+                </a>
+              </Button>
+            </div>
+          ) : null}
           <p className="text-xs text-muted-foreground">
             {t(
               'customer_accounts.settings.portal_access.slug_note',

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/settings/page.tsx
@@ -1,15 +1,17 @@
 import { headers } from 'next/headers'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { resolvePortalRequestOrigin } from '../../../lib/portalUrl'
+import { resolveCurrentOrgPortalSlug } from '../../../lib/portalOrgSlug'
 import { CustomerAccountsSettingsPageClient } from './CustomerAccountsSettingsPageClient'
 
 export default async function CustomerAccountsSettingsPage() {
   const portalOrigin = resolvePortalRequestOrigin(await headers())
+  const portalOrgSlug = await resolveCurrentOrgPortalSlug()
   return (
     <Page>
       {/* space-y-6 preserves the gap the page header previously got as a direct <Page> child. */}
       <PageBody className="space-y-6">
-        <CustomerAccountsSettingsPageClient portalOrigin={portalOrigin} />
+        <CustomerAccountsSettingsPageClient portalOrigin={portalOrigin} portalOrgSlug={portalOrgSlug} />
       </PageBody>
     </Page>
   )

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/PortalUsersPageClient.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/PortalUsersPageClient.tsx
@@ -229,9 +229,10 @@ function CreateUserDialog({
 
 export type PortalUsersPageClientProps = {
   portalOrigin: string
+  portalOrgSlug?: string | null
 }
 
-export function PortalUsersPageClient({ portalOrigin }: PortalUsersPageClientProps) {
+export function PortalUsersPageClient({ portalOrigin, portalOrgSlug = null }: PortalUsersPageClientProps) {
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const t = useT()
   const router = useRouter()
@@ -521,17 +522,19 @@ export function PortalUsersPageClient({ portalOrigin }: PortalUsersPageClientPro
                 {t('customer_accounts.admin.portalInfo.openConfiguration', 'Open Configuration')}
               </Link>
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              asChild
-            >
-              <a href={buildPortalRootUrl(portalOrigin)} target="_blank" rel="noopener noreferrer">
-                <Globe className="size-4" />
-                {t('customer_accounts.admin.portalInfo.open', 'Open Portal')}
-              </a>
-            </Button>
+            {portalOrgSlug ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                asChild
+              >
+                <a href={buildPortalRootUrl(portalOrigin, portalOrgSlug)} target="_blank" rel="noopener noreferrer">
+                  <Globe className="size-4" />
+                  {t('customer_accounts.admin.portalInfo.open', 'Open Portal')}
+                </a>
+              </Button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
@@ -1,14 +1,16 @@
 import { headers } from 'next/headers'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { resolvePortalRequestOrigin } from '../../../lib/portalUrl'
+import { resolveCurrentOrgPortalSlug } from '../../../lib/portalOrgSlug'
 import { PortalUsersPageClient } from './PortalUsersPageClient'
 
 export default async function CustomerAccountsPage() {
   const portalOrigin = resolvePortalRequestOrigin(await headers())
+  const portalOrgSlug = await resolveCurrentOrgPortalSlug()
   return (
     <Page>
       <PageBody className="space-y-4">
-        <PortalUsersPageClient portalOrigin={portalOrigin} />
+        <PortalUsersPageClient portalOrigin={portalOrigin} portalOrgSlug={portalOrgSlug} />
       </PageBody>
     </Page>
   )

--- a/packages/core/src/modules/customer_accounts/lib/__tests__/portalOrgSlug.test.ts
+++ b/packages/core/src/modules/customer_accounts/lib/__tests__/portalOrgSlug.test.ts
@@ -1,0 +1,77 @@
+/** @jest-environment node */
+
+const getAuthFromCookies = jest.fn()
+const createRequestContainer = jest.fn()
+const findOrganizationInTenant = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromCookies: (...args: unknown[]) => getAuthFromCookies(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainer(...args),
+}))
+
+jest.mock('../organizationLookup', () => ({
+  findOrganizationInTenant: (...args: unknown[]) => findOrganizationInTenant(...args),
+}))
+
+import { resolveCurrentOrgPortalSlug } from '../portalOrgSlug'
+
+const em = { marker: 'entity-manager' }
+
+function containerResolving(name: string, value: unknown) {
+  return { resolve: jest.fn((requested: string) => (requested === name ? value : null)) }
+}
+
+describe('resolveCurrentOrgPortalSlug (regression for issue #5668)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createRequestContainer.mockResolvedValue(containerResolving('em', em))
+  })
+
+  it('returns the slug of the organization the session is scoped to', async () => {
+    getAuthFromCookies.mockResolvedValue({ orgId: 'org-1', tenantId: 'tenant-1' })
+    findOrganizationInTenant.mockResolvedValue({ slug: 'acme' })
+
+    await expect(resolveCurrentOrgPortalSlug()).resolves.toBe('acme')
+    // The (id, tenant_id) pair MUST travel together so the lookup cannot cross tenants.
+    expect(findOrganizationInTenant).toHaveBeenCalledWith(em, 'org-1', 'tenant-1')
+  })
+
+  it('trims surrounding whitespace off the stored slug', async () => {
+    getAuthFromCookies.mockResolvedValue({ orgId: 'org-1', tenantId: 'tenant-1' })
+    findOrganizationInTenant.mockResolvedValue({ slug: '  acme  ' })
+
+    await expect(resolveCurrentOrgPortalSlug()).resolves.toBe('acme')
+  })
+
+  it.each([
+    ['there is no session', null],
+    ['the session has no active organization', { orgId: null, tenantId: 'tenant-1' }],
+    ['the session has no tenant', { orgId: 'org-1', tenantId: null }],
+  ])('returns null when %s', async (_case, auth) => {
+    getAuthFromCookies.mockResolvedValue(auth)
+
+    await expect(resolveCurrentOrgPortalSlug()).resolves.toBeNull()
+    expect(findOrganizationInTenant).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['the organization is missing', null],
+    ['the organization has no slug', { slug: null }],
+    ['the stored slug is blank', { slug: '   ' }],
+  ])('returns null when %s', async (_case, organization) => {
+    getAuthFromCookies.mockResolvedValue({ orgId: 'org-1', tenantId: 'tenant-1' })
+    findOrganizationInTenant.mockResolvedValue(organization)
+
+    await expect(resolveCurrentOrgPortalSlug()).resolves.toBeNull()
+  })
+
+  it('degrades to null instead of throwing when the lookup fails', async () => {
+    getAuthFromCookies.mockResolvedValue({ orgId: 'org-1', tenantId: 'tenant-1' })
+    findOrganizationInTenant.mockRejectedValue(new Error('[internal] database unavailable'))
+
+    await expect(resolveCurrentOrgPortalSlug()).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/__tests__/portalUrl.test.ts
+++ b/packages/core/src/modules/customer_accounts/lib/__tests__/portalUrl.test.ts
@@ -124,3 +124,33 @@ describe('portal URL builders', () => {
     expect(buildPortalRootUrl('https://demo.openmercato.com/')).toBe('https://demo.openmercato.com/portal')
   })
 })
+
+// Portal pages only exist under `frontend/[orgSlug]/portal/**`, so the admin
+// "Open Portal" action must carry the organization segment — without it the
+// link resolved to a 404 (#5668).
+describe('portal entry point for a resolved organization (regression for issue #5668)', () => {
+  it('places the organization slug ahead of the portal segment', () => {
+    expect(buildPortalRootUrl('https://demo.openmercato.com', 'acme')).toBe('https://demo.openmercato.com/acme/portal')
+    expect(buildPortalRootUrl('http://localhost:3000', 'acme')).toBe('http://localhost:3000/acme/portal')
+  })
+
+  it('never doubles the separator when the origin carries a trailing slash', () => {
+    expect(buildPortalRootUrl('https://demo.openmercato.com/', 'acme')).toBe('https://demo.openmercato.com/acme/portal')
+  })
+
+  it('degrades to a root-relative path when the origin is unresolvable', () => {
+    expect(buildPortalRootUrl('', 'acme')).toBe('/acme/portal')
+  })
+
+  it('keeps the legacy slugless shape when no slug is supplied', () => {
+    expect(buildPortalRootUrl('https://demo.openmercato.com', null)).toBe('https://demo.openmercato.com/portal')
+    expect(buildPortalRootUrl('https://demo.openmercato.com', undefined)).toBe('https://demo.openmercato.com/portal')
+    expect(buildPortalRootUrl('https://demo.openmercato.com', '   ')).toBe('https://demo.openmercato.com/portal')
+  })
+
+  it('escapes a slug that would otherwise alter the path structure', () => {
+    expect(buildPortalRootUrl('https://demo.openmercato.com', 'acme/../admin')).toBe(
+      'https://demo.openmercato.com/acme%2F..%2Fadmin/portal',
+    )
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/portalOrgSlug.ts
+++ b/packages/core/src/modules/customer_accounts/lib/portalOrgSlug.ts
@@ -1,0 +1,40 @@
+// Server-only resolution of the signed-in admin's organization slug, used to
+// build the "Open Portal" link on the customer-accounts admin pages.
+//
+// Deliberately kept out of `portalUrl.ts`: that module is imported by client
+// components, and pulling the ORM in there would drag MikroORM into the browser
+// bundle. Keep every EntityManager import on this side of the boundary.
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { findOrganizationInTenant } from './organizationLookup'
+
+type EntityManagerResolver = {
+  resolve(name: 'em'): EntityManager
+}
+
+/**
+ * Resolve the slug of the organization the current admin session is scoped to,
+ * or null when there is no session, no active organization, or the organization
+ * has no slug yet. Callers render the portal link only for a non-null result —
+ * a slugless portal URL cannot resolve (#5668).
+ */
+export async function resolveCurrentOrgPortalSlug(): Promise<string | null> {
+  try {
+    const auth = await getAuthFromCookies()
+    const organizationId = auth?.orgId
+    const tenantId = auth?.tenantId
+    if (!organizationId || !tenantId) return null
+
+    const container = await createRequestContainer()
+    const em = (container as Awaited<ReturnType<typeof createRequestContainer>> & EntityManagerResolver).resolve('em')
+    const organization = await findOrganizationInTenant(em, organizationId, tenantId)
+    const slug = organization?.slug?.trim()
+    return slug && slug.length > 0 ? slug : null
+  } catch {
+    // The portal link is a convenience action — a lookup failure must not take
+    // the whole admin page down, so degrade to hiding the button.
+    return null
+  }
+}

--- a/packages/core/src/modules/customer_accounts/lib/portalUrl.ts
+++ b/packages/core/src/modules/customer_accounts/lib/portalUrl.ts
@@ -106,7 +106,18 @@ export function buildPortalUrlPattern(origin: string | null | undefined): string
   return `${normalizeOrigin(origin)}/${PORTAL_ORG_SLUG_PLACEHOLDER}/portal`
 }
 
-/** Portal entry point used by the "Open Portal" action on admin pages. */
-export function buildPortalRootUrl(origin: string | null | undefined): string {
-  return `${normalizeOrigin(origin)}/portal`
+/**
+ * Portal entry point used by the "Open Portal" action on admin pages.
+ *
+ * Portal pages are only ever mounted at `frontend/[orgSlug]/portal/**`, so a URL
+ * without the organization segment cannot resolve and renders a 404 (#5668).
+ * The slug stays optional to keep this signature backward compatible; callers
+ * that cannot resolve one should hide the action rather than link to the
+ * slugless fallback.
+ */
+export function buildPortalRootUrl(origin: string | null | undefined, orgSlug?: string | null): string {
+  const base = normalizeOrigin(origin)
+  const slug = typeof orgSlug === 'string' ? orgSlug.trim() : ''
+  if (!slug) return `${base}/portal`
+  return `${base}/${encodeURIComponent(slug)}/portal`
 }


### PR DESCRIPTION
Closes #5668

## 🎯 Goal
The "Open Portal" button on the customer-accounts admin pages should land the operator on their organization's actual portal instead of a 404 page.

## 🔍 Problem
On `/backend/customer_accounts/users` and `/backend/customer_accounts/settings`, clicking `Open Portal` navigated to `http://localhost:3000/portal`, which renders `404 – This page could not be found`. The expected destination is `http://localhost:3000/{org-slug}/portal`.

## 🔍 Root Cause
`buildPortalRootUrl` in `packages/core/src/modules/customer_accounts/lib/portalUrl.ts` returned `${normalizeOrigin(origin)}/portal`, with no organization segment. Portal pages are only ever mounted under `frontend/[orgSlug]/portal/**` — `packages/core/AGENTS.md` states `[orgSlug]` MUST be the first segment because portal auth and tenant resolution both assume it — so a slugless `/portal` can never match a route. The module already owns the correct convention in `lib/customerUrl.ts`, where `urlForCustomerOrg` builds `${base}/${orgSlug}/portal${path}` for every customer-facing email link; these two admin buttons were the surfaces that bypassed it.

## What Changed
- `lib/portalUrl.ts` — `buildPortalRootUrl` gains an optional second `orgSlug` argument and emits `${origin}/${encodeURIComponent(slug)}/portal`. With no slug it returns exactly the previous string, so the exported signature stays backward compatible. `buildPortalUrlPattern` and its `[org-slug]` placeholder are untouched: those render documentation of the URL shape, not an href.
- `lib/portalOrgSlug.ts` (new, server-only) — `resolveCurrentOrgPortalSlug()` reads the session's `orgId`/`tenantId` via `getAuthFromCookies()` and resolves the slug through the tenant-bound `findOrganizationInTenant` helper, whose `(id, tenant_id)` pairing prevents a cross-tenant read. It returns `null` for every miss — no session, no active organization, an organization without a slug, or a failed lookup — so a transient database problem hides one button instead of taking the admin page down. It deliberately lives outside `portalUrl.ts`, which client components import: an `EntityManager` import there would pull MikroORM into the browser bundle.
- `backend/customer_accounts/users/page.tsx` and `backend/customer_accounts/settings/page.tsx` — resolve the slug server-side alongside the existing `resolvePortalRequestOrigin(await headers())` call and pass it down as a `portalOrgSlug` prop, preserving the #5457 contract that the portal address is never derived in the client.
- `PortalUsersPageClient.tsx` and `CustomerAccountsSettingsPageClient.tsx` — accept `portalOrgSlug`, build the href from it, and render the `Open Portal` button only when a slug is available. An organization with no slug now gets no button rather than a knowingly broken link; the settings card already explains how slugs are generated and links to Manage Organizations for exactly that case.

## 🧪 Tests
- `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — the full configured gate, run locally, all green. `@open-mercato/shared` (184 suites / 2015 tests) and `@open-mercato/cli` (95 suites / 1806 tests) each flaked once under turbo's parallel scheduler on the run machine and pass standalone; `shared` was also green in one of the full runs. Every package is verified, though not all within a single turbo invocation.
- `lib/__tests__/portalUrl.test.ts` — new `#5668` block locking in the slug-bearing URL, trailing-slash normalization, root-relative degradation when the origin is unresolvable, the unchanged slugless fallback for `null` / `undefined` / blank, and slug escaping so a hostile slug cannot alter the path structure. These assertions fail against the pre-fix implementation.
- `lib/__tests__/portalOrgSlug.test.ts` (new) — covers the happy path while asserting the lookup receives the `(orgId, tenantId)` pair together, slug trimming, every `null` path (no session, no organization, no tenant, missing organization, null or blank slug), and graceful degradation when the lookup throws.
- `__tests__/portalUrlHydration.test.ts` — the existing #5457 guard gains a `#5668` section asserting both entrypoints resolve the slug server-side, both clients take it as a prop and never call the slugless builder, and `portalUrl.ts` stays free of ORM imports so the client bundle cannot pick up MikroORM.

## 💥 Breaking Changes
None. `buildPortalRootUrl`'s new parameter is optional and the no-slug call returns the previous string byte for byte, so existing callers and the original test expectations are unaffected. `portalOrgSlug` is likewise an optional prop on both client components.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790422491&installation_model_id=432243&pr_number=5698&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5698&signature=ab283f63add1ccb0051325b9cd06e3f7f5e0fd7b2d954c3bc0e2b9ff9e7a23b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->