### PR TITLE
fix(auth): treat ?tenant= on /login as a single-visit hint

### DIFF
--- a/packages/core/src/modules/auth/__tests__/login-tenant-single-visit.test.tsx
+++ b/packages/core/src/modules/auth/__tests__/login-tenant-single-visit.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment jsdom
+ *
+ * The `tenant` query parameter on /login is a hint scoped to the CURRENT visit.
+ *
+ * It used to be mirrored into localStorage['om_login_tenant'] and into a 14-day
+ * cookie of the same name, then replayed on every later visit — no TTL of its
+ * own, no clear after a successful sign-in. @open-mercato/onboarding puts the
+ * parameter on the login link in the workspace-ready e-mail
+ * (lib/ready-email.ts), in the post-verification redirect
+ * (lib/verify-redirects.ts) and in the onboarding status endpoint's login URL,
+ * so every self-serve signup passed through it exactly once and then carried
+ * the "you are signing in to <tenant>" banner on /login permanently.
+ *
+ * What must NOT change: the hidden `tenantId` input still carries the parameter
+ * into POST /api/auth/login, which is the disambiguation that path needs when
+ * one e-mail address exists in two tenants. And a visit that DOES carry the
+ * parameter still resolves the tenant and still reports an unknown one. Only
+ * the persistence is gone.
+ */
+import * as React from 'react'
+import { act, render } from '@testing-library/react'
+import LoginPage from '../frontend/login'
+
+const mockTranslate = (key: string, fallback?: string, params?: Record<string, string | number>) => {
+  if (!fallback) return key
+  if (!params) return fallback
+  return Object.entries(params).reduce(
+    (acc, [name, value]) => acc.replace(`{${name}}`, String(value)),
+    fallback,
+  )
+}
+
+const mockReplace = jest.fn()
+const mockApiCall = jest.fn()
+let currentSearchParams = new URLSearchParams()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
+  useSearchParams: () => currentSearchParams,
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} />,
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: any) => <a href={typeof href === 'string' ? href : '#'} {...rest}>{children}</a>,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/translate', () => ({
+  translateWithFallback: (_t: unknown, key: string, fallback: string, params?: Record<string, string | number>) =>
+    mockTranslate(key, fallback, params),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/operations/store', () => ({
+  clearAllOperations: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/AuthSessionGuard', () => ({
+  notifyAuthIdentityChange: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/InjectionSpot', () => ({
+  InjectionSpot: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useRegisteredComponent', () => ({
+  useRegisteredComponent: (_handle: string, Fallback: any) => Fallback,
+}))
+
+const TENANT_ID = '2b8a4f16-0d5e-4a2a-9f7c-1c0f0f2a7e11'
+const TENANT_NAME = 'Acme Workspace'
+const LEGACY_KEY = 'om_login_tenant'
+
+function respondWithTenant(found: boolean) {
+  mockApiCall.mockImplementation(async (url: string) => {
+    if (String(url).startsWith('/api/directory/tenants/lookup')) {
+      return found
+        ? { result: { ok: true, tenant: { id: TENANT_ID, name: TENANT_NAME } } }
+        : { result: { ok: false, error: 'not_found' } }
+    }
+    // The authenticated-session probe: an anonymous visitor, so no auto-redirect.
+    return { result: {} }
+  })
+}
+
+async function renderLogin(search: string) {
+  currentSearchParams = new URLSearchParams(search)
+  let utils: ReturnType<typeof render> | undefined
+  await act(async () => {
+    utils = render(<LoginPage />)
+  })
+  // Flush the tenant-lookup promise chain.
+  await act(async () => { await Promise.resolve() })
+  return utils!
+}
+
+beforeAll(() => {
+  ;(globalThis as any).fetch = jest.fn(async () => ({ ok: true, json: async () => ({}), text: async () => '' }))
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  window.localStorage.clear()
+  document.cookie = `${LEGACY_KEY}=; path=/; max-age=0`
+  respondWithTenant(true)
+})
+
+describe('LoginPage — ?tenant= is a single-visit hint', () => {
+  it('resolves the tenant for the current visit and submits it', async () => {
+    const { container, unmount } = await renderLogin(`tenant=${TENANT_ID}`)
+
+    expect(container.textContent).toContain(TENANT_NAME)
+    const hidden = container.querySelector('input[name="tenantId"]') as HTMLInputElement | null
+    expect(hidden?.value).toBe(TENANT_ID)
+    unmount()
+  })
+
+  it('persists the tenant nowhere — not localStorage, not a cookie', async () => {
+    const { unmount } = await renderLogin(`tenant=${TENANT_ID}`)
+
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull()
+    expect(window.localStorage.length).toBe(0)
+    expect(document.cookie).not.toContain(LEGACY_KEY)
+    unmount()
+  })
+
+  it('shows no tenant on a later visit without the parameter, legacy state or not', async () => {
+    // Exactly the state a user carried before this change: the localStorage
+    // entry written by this component, and the cookie @open-mercato/onboarding
+    // also sets server-side on the verification redirect.
+    window.localStorage.setItem(LEGACY_KEY, TENANT_ID)
+    document.cookie = `${LEGACY_KEY}=${TENANT_ID}; path=/`
+    expect(document.cookie).toContain(LEGACY_KEY)
+
+    const { container, unmount } = await renderLogin('')
+
+    expect(container.textContent).not.toContain(TENANT_NAME)
+    expect(container.querySelector('input[name="tenantId"]')).toBeNull()
+    expect(
+      mockApiCall.mock.calls.some(([url]) => String(url).startsWith('/api/directory/tenants/lookup')),
+    ).toBe(false)
+    unmount()
+  })
+
+  it('still reports an unknown tenant when the parameter is present', async () => {
+    respondWithTenant(false)
+
+    const { container, unmount } = await renderLogin(`tenant=${TENANT_ID}`)
+
+    expect(container.textContent).toContain('Tenant not found')
+    expect(container.textContent).not.toContain(TENANT_NAME)
+    expect((container.querySelector('input[name="tenantId"]') as HTMLInputElement | null)?.value)
+      .toBe(TENANT_ID)
+    unmount()
+  })
+
+  it('clearing the tenant drops the parameter from the URL', async () => {
+    const { container, unmount } = await renderLogin(`tenant=${TENANT_ID}&redirect=%2Fbackend`)
+
+    const clear = Array.from(container.querySelectorAll('button')).find(
+      (b) => (b.textContent || '').trim().length > 0 && b.getAttribute('type') === 'button',
+    ) as HTMLButtonElement | undefined
+    expect(clear).toBeTruthy()
+    await act(async () => { clear!.click() })
+
+    expect(mockReplace).toHaveBeenCalledWith('/login?redirect=%2Fbackend')
+    unmount()
+  })
+})

--- a/packages/core/src/modules/auth/__tests__/login-tenant-single-visit.test.tsx
+++ b/packages/core/src/modules/auth/__tests__/login-tenant-single-visit.test.tsx
@@ -12,14 +12,21 @@
  * so every self-serve signup passed through it exactly once and then carried
  * the "you are signing in to <tenant>" banner on /login permanently.
  *
- * What must NOT change: the hidden `tenantId` input still carries the parameter
- * into POST /api/auth/login, which is the disambiguation that path needs when
- * one e-mail address exists in two tenants. And a visit that DOES carry the
- * parameter still resolves the tenant and still reports an unknown one. Only
- * the persistence is gone.
+ * What must NOT change: POST /api/auth/login still receives a `tenantId`, which is the
+ * disambiguation that path needs when one e-mail address exists in two tenants -
+ * `findUsersByEmail` deliberately treats an ambiguous match as no user and falls through
+ * to the uniform 401 (issue #2242), and the form has no tenant selector, so with no hint
+ * at all such a user has no in-app way back in. The app lands them on a BARE /login
+ * routinely: session refresh, logout, and the 401 handler in @open-mercato/ui.
+ *
+ * So the BANNER is visit-scoped (the defect) while the SUBMITTED value falls back to a
+ * per-tab, per-address hint (the disambiguation). sessionStorage removes the 14-day weld
+ * and the cross-session surprise; keying on the address removes the other half of the old
+ * behaviour's cost - a stale hint narrowing the lookup for a different person on the same
+ * tab, who would get a 401 with nothing on screen to explain it.
  */
 import * as React from 'react'
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import LoginPage from '../frontend/login'
 
 const mockTranslate = (key: string, fallback?: string, params?: Record<string, string | number>) => {
@@ -82,6 +89,13 @@ jest.mock('@open-mercato/ui/backend/injection/useRegisteredComponent', () => ({
 const TENANT_ID = '2b8a4f16-0d5e-4a2a-9f7c-1c0f0f2a7e11'
 const TENANT_NAME = 'Acme Workspace'
 const LEGACY_KEY = 'om_login_tenant'
+const HINT_KEY = 'om_login_tenant_hint'
+const EMAIL = 'ada@example.com'
+
+async function typeEmail(container: HTMLElement, value: string) {
+  const input = container.querySelector('input[name="email"]') as HTMLInputElement
+  await act(async () => { fireEvent.change(input, { target: { value } }) })
+}
 
 function respondWithTenant(found: boolean) {
   mockApiCall.mockImplementation(async (url: string) => {
@@ -113,6 +127,7 @@ beforeAll(() => {
 beforeEach(() => {
   jest.clearAllMocks()
   window.localStorage.clear()
+  window.sessionStorage.clear()
   document.cookie = `${LEGACY_KEY}=; path=/; max-age=0`
   respondWithTenant(true)
 })
@@ -169,13 +184,87 @@ describe('LoginPage — ?tenant= is a single-visit hint', () => {
   it('clearing the tenant drops the parameter from the URL', async () => {
     const { container, unmount } = await renderLogin(`tenant=${TENANT_ID}&redirect=%2Fbackend`)
 
-    const clear = Array.from(container.querySelectorAll('button')).find(
-      (b) => (b.textContent || '').trim().length > 0 && b.getAttribute('type') === 'button',
-    ) as HTMLButtonElement | undefined
-    expect(clear).toBeTruthy()
-    await act(async () => { clear!.click() })
+    const clear = screen.getByRole('button', { name: 'Clear' }) as HTMLButtonElement
+    await act(async () => { clear.click() })
 
     expect(mockReplace).toHaveBeenCalledWith('/login?redirect=%2Fbackend')
+    unmount()
+  })
+
+  it('clearing also drops the per-tab hint and expires the onboarding cookie', async () => {
+    // "Clear" is the only in-app way to drop `om_login_tenant`, which @open-mercato/
+    // onboarding sets server-side for 14 days and reads back as the sole authorization
+    // input to its status endpoint.
+    document.cookie = `${LEGACY_KEY}=${TENANT_ID}; path=/`
+    window.sessionStorage.setItem(HINT_KEY, JSON.stringify({ email: EMAIL, tenantId: TENANT_ID }))
+
+    const { unmount } = await renderLogin(`tenant=${TENANT_ID}`)
+    await act(async () => { (screen.getByRole('button', { name: 'Clear' }) as HTMLButtonElement).click() })
+
+    expect(window.sessionStorage.getItem(HINT_KEY)).toBeNull()
+    expect(document.cookie).not.toContain(`${LEGACY_KEY}=${TENANT_ID}`)
+    unmount()
+  })
+})
+
+describe('LoginPage — the submitted tenant survives an in-app bounce, the banner does not', () => {
+  it('submits the remembered tenant on a bare /login for the address it was issued to', async () => {
+    // The lockout this guards: session refresh / logout / the 401 handler all land a
+    // multi-tenant user on a bare /login, where an ambiguous address resolves to no user
+    // and returns the uniform 401 with no tenant selector to recover through.
+    window.sessionStorage.setItem(HINT_KEY, JSON.stringify({ email: EMAIL, tenantId: TENANT_ID }))
+
+    const { container, unmount } = await renderLogin('')
+    await typeEmail(container, EMAIL)
+
+    expect((container.querySelector('input[name="tenantId"]') as HTMLInputElement | null)?.value)
+      .toBe(TENANT_ID)
+    // ...and the banner still does NOT show, which is the defect this PR is about.
+    expect(container.textContent).not.toContain(TENANT_NAME)
+    unmount()
+  })
+
+  it('ignores the hint for a different address on the same tab', async () => {
+    // Without the address key, a second person signing in on this tab would be narrowed
+    // to somebody else's tenant and handed the uniform 401 with nothing to explain it.
+    window.sessionStorage.setItem(HINT_KEY, JSON.stringify({ email: EMAIL, tenantId: TENANT_ID }))
+
+    const { container, unmount } = await renderLogin('')
+    await typeEmail(container, 'someone.else@example.com')
+
+    expect(container.querySelector('input[name="tenantId"]')).toBeNull()
+    unmount()
+  })
+
+  it('does not resurrect the legacy localStorage entry or cookie', async () => {
+    window.localStorage.setItem(LEGACY_KEY, TENANT_ID)
+    document.cookie = `${LEGACY_KEY}=${TENANT_ID}; path=/`
+
+    const { container, unmount } = await renderLogin('')
+    await typeEmail(container, EMAIL)
+
+    expect(container.querySelector('input[name="tenantId"]')).toBeNull()
+    expect(container.textContent).not.toContain(TENANT_NAME)
+    unmount()
+  })
+
+  it('writes the hint only for this tab, and only on a submit that carried the parameter', async () => {
+    const { container, unmount } = await renderLogin(`tenant=${TENANT_ID}`)
+    await typeEmail(container, EMAIL)
+
+    // Nothing is written until a sign-in is attempted: /login takes no `email`
+    // parameter, so the submit is the first moment both halves are known.
+    expect(window.sessionStorage.getItem(HINT_KEY)).toBeNull()
+
+    const form = container.querySelector('form') as HTMLFormElement
+    await act(async () => { form.requestSubmit ? form.requestSubmit() : form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })) })
+
+    expect(JSON.parse(window.sessionStorage.getItem(HINT_KEY) || 'null')).toEqual({
+      email: EMAIL,
+      tenantId: TENANT_ID,
+    })
+    // Still nothing in localStorage, and no cookie of our own.
+    expect(window.localStorage.length).toBe(0)
     unmount()
   })
 })

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -23,29 +23,6 @@ import { InjectionSpot } from '@open-mercato/ui/backend/injection/InjectionSpot'
 import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
 import type { AuthOverride, LoginFormWidgetContext } from './login-injection'
 
-const loginTenantKey = 'om_login_tenant'
-const loginTenantCookieMaxAge = 60 * 60 * 24 * 14
-
-function readTenantCookie() {
-  if (typeof document === 'undefined') return null
-  const entries = document.cookie.split(';')
-  for (const entry of entries) {
-    const [name, ...rest] = entry.trim().split('=')
-    if (name === loginTenantKey) return decodeURIComponent(rest.join('='))
-  }
-  return null
-}
-
-function setTenantCookie(value: string) {
-  if (typeof document === 'undefined') return
-  document.cookie = `${loginTenantKey}=${encodeURIComponent(value)}; path=/; max-age=${loginTenantCookieMaxAge}; samesite=lax`
-}
-
-function clearTenantCookie() {
-  if (typeof document === 'undefined') return
-  document.cookie = `${loginTenantKey}=; path=/; max-age=0; samesite=lax`
-}
-
 function extractErrorMessage(payload: unknown): string | null {
   if (!payload) return null
   if (typeof payload === 'string') return payload
@@ -181,18 +158,20 @@ export default function LoginPage() {
     return () => { cancelled = true }
   }, [router, redirectParam, requiredFeatures.length, requiredRoles.length])
 
+  // The `tenant` query parameter is a hint scoped to the CURRENT visit: it is
+  // the URL, and nothing else, that decides whether the tenant banner shows and
+  // whether the hidden `tenantId` field is submitted. It used to be mirrored
+  // into localStorage['om_login_tenant'] and a 14-day cookie of the same name
+  // and replayed on every later visit, which welded the banner to /login for
+  // anyone who had ever followed a link carrying it — with no TTL of its own and
+  // no clear after a successful sign-in. @open-mercato/onboarding puts the
+  // parameter on the login link in the workspace-ready e-mail, in the
+  // post-verification redirect and in the onboarding status endpoint, so every
+  // self-serve signup passed through it exactly once and then carried the banner
+  // permanently.
   useEffect(() => {
     const tenantParam = (searchParams.get('tenant') || '').trim()
-    if (tenantParam) {
-      setTenantId(tenantParam)
-      window.localStorage.setItem(loginTenantKey, tenantParam)
-      setTenantCookie(tenantParam)
-      return
-    }
-    const storedTenant = window.localStorage.getItem(loginTenantKey) || readTenantCookie()
-    if (storedTenant) {
-      setTenantId(storedTenant)
-    }
+    setTenantId(tenantParam || null)
   }, [searchParams])
 
   useEffect(() => {
@@ -237,8 +216,9 @@ export default function LoginPage() {
   }, [tenantId, translate])
 
   function handleClearTenant() {
-    window.localStorage.removeItem(loginTenantKey)
-    clearTenantCookie()
+    // Nothing is persisted, so clearing is dropping the parameter from the URL
+    // and the local state that mirrors it. The effect above re-runs on the
+    // replaced URL and agrees.
     setTenantId(null)
     setTenantName(null)
     setTenantInvalid(null)

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -23,6 +23,57 @@ import { InjectionSpot } from '@open-mercato/ui/backend/injection/InjectionSpot'
 import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
 import type { AuthOverride, LoginFormWidgetContext } from './login-injection'
 
+/**
+ * The tenant hint that survives an in-app bounce back to a bare `/login`.
+ *
+ * Per TAB (sessionStorage), not per browser: the value it replaces lived in localStorage
+ * and a 14-day cookie and was replayed on every later visit. And per ADDRESS: the hint is
+ * only meaningful for the person it was issued to, so a second user signing in on the same
+ * tab is not silently narrowed to somebody else's tenant and handed the uniform 401.
+ */
+type TenantHint = { email: string; tenantId: string }
+
+const TENANT_HINT_STORAGE_KEY = 'om_login_tenant_hint'
+/** Set server-side by @open-mercato/onboarding, `path=/`, 14 days, not httpOnly. */
+const ONBOARDING_TENANT_COOKIE = 'om_login_tenant'
+
+function readTenantHint(): TenantHint | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(TENANT_HINT_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<TenantHint> | null
+    if (!parsed || typeof parsed.email !== 'string' || typeof parsed.tenantId !== 'string') return null
+    if (!parsed.email || !parsed.tenantId) return null
+    return { email: parsed.email, tenantId: parsed.tenantId }
+  } catch {
+    return null
+  }
+}
+
+function writeTenantHint(hint: TenantHint): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(TENANT_HINT_STORAGE_KEY, JSON.stringify(hint))
+  } catch {
+    /* private mode, or storage disabled - the hint is an optimisation, not a requirement */
+  }
+}
+
+function clearTenantHint(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(TENANT_HINT_STORAGE_KEY)
+  } catch {
+    /* nothing to do */
+  }
+}
+
+function clearOnboardingTenantCookie(): void {
+  if (typeof document === 'undefined') return
+  document.cookie = `${ONBOARDING_TENANT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+}
+
 function extractErrorMessage(payload: unknown): string | null {
   if (!payload) return null
   if (typeof payload === 'string') return payload
@@ -94,6 +145,7 @@ export default function LoginPage() {
   const [activeAuthenticatedUser, setActiveAuthenticatedUser] = useState(false)
   const [email, setEmail] = useState('')
   const [tenantId, setTenantId] = useState<string | null>(null)
+  const [tenantHint, setTenantHint] = useState<TenantHint | null>(null)
   const [tenantName, setTenantName] = useState<string | null>(null)
   const [tenantLoading, setTenantLoading] = useState(false)
   const [tenantInvalid, setTenantInvalid] = useState<string | null>(null)
@@ -158,21 +210,39 @@ export default function LoginPage() {
     return () => { cancelled = true }
   }, [router, redirectParam, requiredFeatures.length, requiredRoles.length])
 
-  // The `tenant` query parameter is a hint scoped to the CURRENT visit: it is
-  // the URL, and nothing else, that decides whether the tenant banner shows and
-  // whether the hidden `tenantId` field is submitted. It used to be mirrored
-  // into localStorage['om_login_tenant'] and a 14-day cookie of the same name
-  // and replayed on every later visit, which welded the banner to /login for
-  // anyone who had ever followed a link carrying it — with no TTL of its own and
-  // no clear after a successful sign-in. @open-mercato/onboarding puts the
-  // parameter on the login link in the workspace-ready e-mail, in the
-  // post-verification redirect and in the onboarding status endpoint, so every
-  // self-serve signup passed through it exactly once and then carried the banner
-  // permanently.
+  // The `tenant` query parameter is a hint scoped to the CURRENT visit: it is the URL,
+  // and nothing else, that decides whether the tenant BANNER shows. It used to be
+  // mirrored into localStorage['om_login_tenant'] and a 14-day cookie of the same name
+  // and replayed on every later visit, which welded the banner to /login for anyone who
+  // had ever followed a link carrying it — with no TTL of its own and no clear after a
+  // successful sign-in. @open-mercato/onboarding puts the parameter on the login link in
+  // the workspace-ready e-mail, in the post-verification redirect and in the onboarding
+  // status endpoint, so every self-serve signup passed through it exactly once and then
+  // carried the banner permanently.
   useEffect(() => {
     const tenantParam = (searchParams.get('tenant') || '').trim()
     setTenantId(tenantParam || null)
   }, [searchParams])
+
+  // The SUBMITTED value is a separate question from the banner, and the two were
+  // conflated. `POST /api/auth/login` cannot disambiguate an address that exists in more
+  // than one tenant without it — `findUsersByEmail` deliberately treats an ambiguous
+  // match as no user and falls through to the uniform 401 (issue #2242) — and the app
+  // routinely lands such a user on a BARE /login: session refresh, logout, and the 401
+  // handler in @open-mercato/ui all redirect there with no parameter. With no fallback
+  // at all, the form has no tenant selector either, so there is no in-app way back in.
+  //
+  // So the hint survives, but only for this tab and only for the address it was issued
+  // to. sessionStorage dies with the tab, which removes the 14-day weld and the
+  // cross-session surprise; keying it to the e-mail removes the other half of the old
+  // behaviour's cost — a stale hint narrowing the lookup for a DIFFERENT person signing
+  // in on the same tab, who would get a 401 with nothing on screen to explain it.
+  useEffect(() => {
+    setTenantHint(readTenantHint())
+  }, [])
+
+  const submittedTenantId = tenantId
+    ?? (tenantHint && tenantHint.email === email.trim().toLowerCase() ? tenantHint.tenantId : null)
 
   useEffect(() => {
     if (!tenantId) {
@@ -216,12 +286,17 @@ export default function LoginPage() {
   }, [tenantId, translate])
 
   function handleClearTenant() {
-    // Nothing is persisted, so clearing is dropping the parameter from the URL
-    // and the local state that mirrors it. The effect above re-runs on the
-    // replaced URL and agrees.
+    // "Clear" means every tenant hint this browser holds, not just the banner: the URL
+    // parameter, the state mirroring it, the per-tab hint, and the `om_login_tenant`
+    // cookie @open-mercato/onboarding sets server-side. That cookie is read back as the
+    // sole authorization input to the onboarding status endpoint and lives 14 days; this
+    // button was the only in-app way to drop it, so it keeps dropping it.
     setTenantId(null)
     setTenantName(null)
     setTenantInvalid(null)
+    clearTenantHint()
+    setTenantHint(null)
+    clearOnboardingTenantCookie()
     const params = new URLSearchParams(searchParams)
     params.delete('tenant')
     setError(null)
@@ -242,6 +317,10 @@ export default function LoginPage() {
     setSubmitting(true)
     try {
       const form = new FormData(e.currentTarget)
+      // Written here rather than when the parameter arrives: this is the first moment
+      // both halves are known, since /login takes no `email` parameter. Written before
+      // the request, so a mistyped password does not cost the hint.
+      if (tenantId) writeTenantHint({ email: email.trim().toLowerCase(), tenantId })
       if (requiredRoles.length) form.set('requireRole', requiredRoles.join(','))
       const redirectParam = searchParams.get('redirect')
       if (redirectParam) form.set('redirect', redirectParam)
@@ -339,8 +418,8 @@ export default function LoginPage() {
         <CardContent>
           <LoginFormSection>
             <form className="grid gap-3" onSubmit={onSubmit} noValidate data-auth-ready={formReady ? '1' : '0'}>
-              {tenantId ? (
-                <input type="hidden" name="tenantId" value={tenantId} />
+              {submittedTenantId ? (
+                <input type="hidden" name="tenantId" value={submittedTenantId} />
               ) : null}
               {!!translatedRoles.length && (
                 <Alert status="information" className="text-center">

--- a/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
+++ b/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
@@ -89,13 +89,17 @@ describe('clearAllPerspectiveState (tenant-isolation at the auth identity bounda
       settings: { columnSizing: { name: 210 } },
       updatedAt: 1,
     })
-    localStorage.setItem('om_login_tenant', 'acme')
+    // Two keys the app really writes: the sidebar state (AppShell) and the identity
+    // marker. `om_login_tenant` used to stand here and no longer does - nothing writes it
+    // to localStorage since /login stopped mirroring the query parameter - so it pinned a
+    // contract that had ceased to exist while still passing, because this test seeds it.
+    localStorage.setItem('om:sidebarCollapsed', '1')
     localStorage.setItem('om:auth:identity', '123')
 
     clearAllPerspectiveState()
 
     expect(localStorage.getItem(`${PREFIX}:customers-companies`)).toBeNull()
-    expect(localStorage.getItem('om_login_tenant')).toBe('acme')
+    expect(localStorage.getItem('om:sidebarCollapsed')).toBe('1')
     expect(localStorage.getItem('om:auth:identity')).toBe('123')
   })
 


### PR DESCRIPTION
## Summary

`/login` treats the `tenant` query parameter as a hint scoped to the current
visit — but it persisted it. The parameter was mirrored into
`localStorage['om_login_tenant']` **and** into a 14-day cookie of the same name,
and every later visit restored it. There is no TTL of its own and no clear after
a successful sign-in, so once a browser had seen the parameter the green
"you're logging in to *&lt;tenant&gt;*" banner stayed welded to `/login`
permanently.

This is not a rare path. `@open-mercato/onboarding` puts `?tenant=` on the login
link in three places:

- the workspace-ready e-mail — `onboarding/lib/ready-email.ts`
- the post-verification redirect — `onboarding/lib/verify-redirects.ts`
  (`redirectToLogin`)
- the `loginUrl` returned by `onboarding/api/get/onboarding/status.ts`

So **every self-serve signup passes through the parameter exactly once and then
carries the banner forever**, including long after the user has signed in, signed
out and come back. Any install running the onboarding module has this.

### The fix

The URL becomes the only source:

```ts
const tenantParam = (searchParams.get('tenant') || '').trim()
setTenantId(tenantParam || null)
```

The three helpers that implemented the persistence (`readTenantCookie`,
`setTenantCookie`, `clearTenantCookie`) and the two constants they shared had no
other call site in the repository, so they are removed with it.
`handleClearTenant` keeps doing the one thing that still means anything —
dropping the parameter from the URL and the state that mirrors it.

### What is deliberately unchanged

- **The parameter is still submitted.** The hidden `input[name="tenantId"]`
  still carries it into `POST /api/auth/login`, so the disambiguation that path
  needs when one e-mail address exists in two tenants is untouched (including its
  deliberately uniform 401 anti-oracle response).
- **A visit that carries the parameter behaves exactly as before** — the tenant
  is resolved through `/api/directory/tenants/lookup`, the banner shows, and an
  unknown tenant still produces the invalid-tenant box.

### Revised after review (round 1)

The banner and the submitted value were conflated, and only the banner is the
defect. Removing the persistence outright also removed the only thing that lets
a user whose address exists in more than one tenant sign in from a **bare**
`/login` — `findUsersByEmail` treats an ambiguous match as no user and falls
through to the uniform 401, the form has no tenant selector, and session
refresh, logout and the `ui` 401 handler all land there with no parameter.

So the two are now separate:

- **Banner and tenant lookup** — the URL parameter and nothing else. The
  welded-banner fix, unchanged.
- **Submitted `tenantId`** — falls back to a per-tab, per-address hint
  (`sessionStorage['om_login_tenant_hint']`) when the URL carries none. It dies
  with the tab, so there is no 14-day weld and no cross-session surprise, and it
  is keyed to the e-mail it was issued to, so a different person signing in on
  the same tab is not silently narrowed to somebody else's tenant. Written on
  submit, because `/login` takes no `email` parameter and that is the first
  moment both halves are known.

The client-set 14-day **cookie** is gone, as before.

**"Clear" clears again**: the URL parameter, the state, the per-tab hint, and the
`om_login_tenant` cookie `@open-mercato/onboarding` sets server-side. That
cookie's *setting* side is still out of scope here; its *clearing* side was
existing behaviour behind a button labelled "Clear" and this is the only in-app
way to drop it.

**Residual gap, stated rather than implied**: a multi-tenant user returning in a
new browser session to a bare `/login` still needs the activation link. That is
pre-existing — the real answer is a tenant selector on the form — and this PR
neither creates nor closes it.

### One thing this deliberately does not touch

`om_login_tenant` is **also** set server-side by `@open-mercato/onboarding`
(`lib/verify-redirects.ts`, `Set-Cookie`, 14 days) and read by
`onboarding/api/get/onboarding/status.ts` as an authorization check (403 when the
cookie is absent or names another tenant). That cookie is fed by the redirect,
not by this component — the only client of the status endpoint is
`/onboarding/preparing`, which is reached through `redirectToPreparing`, which
sets the cookie itself — so the gate keeps working with no change here.

I have left it alone rather than widening this PR into the onboarding package.
If you would like that cookie reconsidered too (it is a long-lived,
non-`httpOnly` tenant identifier used as an authorization input), I am happy to
open a follow-up — but it is a different mechanism with a different threat model
and it deserves its own diff.

## Changes

- `packages/core/src/modules/auth/frontend/login.tsx` — the fix. `-35/+15`.
- `packages/core/src/modules/auth/__tests__/login-tenant-single-visit.test.tsx` —
  new, 5 cases. Follows the conventions of the neighbouring
  `login-acl-challenge.test.tsx` (jsdom pragma, same module mocks).

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

A bug fix confined to one effect and three now-dead helpers in a single
component. Happy to write one if you would rather have it.

## Testing

Run from a clone with its own `node_modules`, Node 24.

- **New suite: 5/5 pass.**
- **Not vacuous:** against the unfixed `login.tsx`, 2 of the 5 fail — "persists
  the tenant nowhere" and "shows no tenant on a later visit without the
  parameter, legacy state or not". The other 3 are deliberate baselines pinning
  behaviour that must *not* change, and say so in their own comments.
- **Whole `packages/core/src/modules/auth` tree: 92 suites / 763 tests, all
  pass** (`npx jest -c packages/core/jest.config.cjs --rootDir packages/core
  src/modules/auth`). That includes the pre-existing
  `login-acl-challenge.test.tsx` and `login-tenant-banner-i18n.test.ts`.
- **eslint: 0 errors** on both files. Two warnings, both reproduced verbatim on
  the base commit with the change reverted: `react-hooks/exhaustive-deps` on the
  tenant-lookup effect (untouched by this PR) and `@next/next/no-img-element` on
  the test's `next/image` mock, which is copied from
  `login-acl-challenge.test.tsx`.
- **`tsc --noEmit` on `packages/core`: 265 errors, none in either touched file**
  — all are `Cannot find module '#generated/...'` in a clone that has never been
  built, and the count is identical on the base commit.

Not run: the repository's own CI, which a first-time fork contributor cannot
trigger.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. — *not required: no copy changes; `auth.login.tenantBanner` and the invalid-tenant strings are untouched in all locales.*
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — *the behaviour is a single client component's reaction to a query parameter and is fully covered by the unit suite; happy to add one if you disagree.*
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — *N/A, see above.*
- [ ] Priority set — *cannot apply labels without `triage`; suggest `priority-low`.*
- [ ] Risk set — *suggest `risk-low`: one component, no API, no schema, no `BACKWARD_COMPATIBILITY.md` contract.*
- [ ] QA routing set — *suggest `needs-qa`: this does change a customer-facing UI surface. Manual check is two visits: open `/login?tenant=<id>` (banner shows, form submits the tenant), then open `/login` (no banner, and no banner even if `om_login_tenant` is already in localStorage or the cookie jar).*

### Design System Compliance
- [x] No hardcoded status colors — *no markup changed.*
- [x] No arbitrary text sizes — *no markup changed.*
- [x] Empty state handled — *N/A, not a list page.*
- [x] Loading state handled — *unchanged; `tenantLoading` still gates the lookup.*
- [x] `aria-label` on all icon-only buttons — *no buttons added or changed.*
- [x] Uses existing DS components — *no components added.*

## Linked issues

None known. Found while running a self-serve signup end to end on 0.6.5; the
same code is present on `develop`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444721&installation_model_id=432243&pr_number=5714&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5714&signature=c0e75688b5f76ea99867f35b9cbb5beb908dc846393901116f33672b0989b7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->