### PR TITLE
fix(search): make a fulltext job that indexes nothing visible

### DIFF
--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -19,6 +19,7 @@ jest.mock('@open-mercato/shared/lib/logger', () => {
 
 
 const searchLoggerWarn = createLogger('search').warn as jest.Mock
+const searchLoggerError = createLogger('search').error as jest.Mock
 
 // Mock dependencies before importing workers
 jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
@@ -60,6 +61,7 @@ import { handleFulltextIndexJob } from '../modules/search/workers/fulltext-index
 import { updateReindexProgress, clearReindexLock } from '../modules/search/lib/reindex-lock'
 import { hasActiveReindexProgress, incrementReindexProgress } from '../modules/search/lib/reindex-progress'
 import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
+import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 
 /**
  * Create a mock job context
@@ -661,6 +663,92 @@ describe('Fulltext Index Worker', () => {
     await handleFulltextIndexJob(job, ctx, containerWithoutStrategy)
 
     expect(mockFulltextStrategy.bulkIndex).not.toHaveBeenCalled()
+  })
+
+  // A job that indexes nothing used to report success with no trace anywhere:
+  // the bare `return` left BullMQ reporting `completed` with zero failures, and
+  // the only log went through `searchDebugWarn`, which prints solely under
+  // OM_SEARCH_DEBUG=1. "Fulltext is not configured" and "everything indexed
+  // fine" were therefore indistinguishable from both signals an operator has.
+  it('records a status-log row when the fulltext strategy is unregistered, and still completes', async () => {
+    const containerWithoutStrategy: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return []
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+    })
+
+    // Must NOT throw: a deployment may legitimately run without Meilisearch,
+    // and retrying forever would turn a config choice into a queue backlog.
+    await expect(
+      handleFulltextIndexJob(job, createMockJobContext(), containerWithoutStrategy),
+    ).resolves.toBeUndefined()
+    expect(mockSearchIndexer.indexRecordsById).not.toHaveBeenCalled()
+
+    // ...but it must leave a trace in the table an operator consults to answer
+    // "did indexing run?".
+    expect(recordIndexerLog).toHaveBeenCalledTimes(1)
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      { em: mockEm },
+      expect.objectContaining({
+        source: 'fulltext',
+        handler: 'worker:fulltext:batch-index',
+        level: 'warn',
+        message: expect.stringContaining('job skipped without indexing'),
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+
+    // ...and the log line must be readable without OM_SEARCH_DEBUG=1.
+    expect(searchLoggerError).toHaveBeenCalledTimes(1)
+    expect(String(searchLoggerError.mock.calls[0][0])).toContain(
+      'Fulltext strategy not configured',
+    )
+  })
+
+  it('records a status-log row when searchStrategies cannot be resolved, and still completes', async () => {
+    const containerWithoutStrategies: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'index',
+      tenantId: 'tenant-123',
+      organizationId: null,
+      entityType: 'test:entity',
+      recordId: 'rec-1',
+    })
+
+    await expect(
+      handleFulltextIndexJob(job, createMockJobContext(), containerWithoutStrategies),
+    ).resolves.toBeUndefined()
+
+    expect(mockSearchIndexer.indexRecordById).not.toHaveBeenCalled()
+    expect(recordIndexerLog).toHaveBeenCalledTimes(1)
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      { em: mockEm },
+      expect.objectContaining({
+        source: 'fulltext',
+        handler: 'worker:fulltext:index',
+        level: 'warn',
+        message: expect.stringContaining('searchStrategies not available'),
+        tenantId: 'tenant-123',
+        organizationId: null,
+      }),
+    )
+    expect(searchLoggerError).toHaveBeenCalledTimes(1)
   })
 
   it('should throw when fulltext search is not available', async () => {

--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -57,7 +57,10 @@ jest.mock('../modules/search/lib/reindex-progress', () => ({
 }))
 
 import { handleVectorIndexJob } from '../modules/search/workers/vector-index.worker'
-import { handleFulltextIndexJob } from '../modules/search/workers/fulltext-index.worker'
+import {
+  __resetSkippedWithoutIndexingMemo,
+  handleFulltextIndexJob,
+} from '../modules/search/workers/fulltext-index.worker'
 import { updateReindexProgress, clearReindexLock } from '../modules/search/lib/reindex-lock'
 import { hasActiveReindexProgress, incrementReindexProgress } from '../modules/search/lib/reindex-progress'
 import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
@@ -471,6 +474,8 @@ describe('Fulltext Index Worker', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    // The skip report is memoised per process, so it must be cleared between cases.
+    __resetSkippedWithoutIndexingMemo()
     ;(hasActiveReindexProgress as jest.Mock).mockResolvedValue(true)
     mockFulltextStrategy.isAvailable.mockResolvedValue(true)
     mockSearchIndexer.indexRecordById.mockResolvedValue({ action: 'indexed', created: true })
@@ -665,11 +670,8 @@ describe('Fulltext Index Worker', () => {
     expect(mockFulltextStrategy.bulkIndex).not.toHaveBeenCalled()
   })
 
-  // A job that indexes nothing used to report success with no trace anywhere:
-  // the bare `return` left BullMQ reporting `completed` with zero failures, and
-  // the only log went through `searchDebugWarn`, which prints solely under
-  // OM_SEARCH_DEBUG=1. "Fulltext is not configured" and "everything indexed
-  // fine" were therefore indistinguishable from both signals an operator has.
+  // A job that indexes nothing used to report `completed` with no trace anywhere, so
+  // "fulltext is not configured" and "everything indexed fine" were indistinguishable.
   it('records a status-log row when the fulltext strategy is unregistered, and still completes', async () => {
     const containerWithoutStrategy: HandlerContext = {
       resolve: jest.fn((name: string) => {
@@ -686,15 +688,12 @@ describe('Fulltext Index Worker', () => {
       records: [{ entityId: 'test:entity', recordId: 'rec-1' }],
     })
 
-    // Must NOT throw: a deployment may legitimately run without Meilisearch,
-    // and retrying forever would turn a config choice into a queue backlog.
+    // Must NOT throw: retrying forever would turn a config choice into a queue backlog.
     await expect(
       handleFulltextIndexJob(job, createMockJobContext(), containerWithoutStrategy),
     ).resolves.toBeUndefined()
     expect(mockSearchIndexer.indexRecordsById).not.toHaveBeenCalled()
 
-    // ...but it must leave a trace in the table an operator consults to answer
-    // "did indexing run?".
     expect(recordIndexerLog).toHaveBeenCalledTimes(1)
     expect(recordIndexerLog).toHaveBeenCalledWith(
       { em: mockEm },
@@ -704,15 +703,30 @@ describe('Fulltext Index Worker', () => {
         level: 'warn',
         message: expect.stringContaining('job skipped without indexing'),
         tenantId: 'tenant-123',
-        organizationId: 'org-456',
+        details: expect.objectContaining({
+          jobType: 'batch-index',
+          organizationId: 'org-456',
+          skippedWithoutIndexing: true,
+        }),
       }),
     )
 
-    // ...and the log line must be readable without OM_SEARCH_DEBUG=1.
-    expect(searchLoggerError).toHaveBeenCalledTimes(1)
-    expect(String(searchLoggerError.mock.calls[0][0])).toContain(
+    // The row must NOT carry organizationId. The unrestricted indexer-status view
+    // filters on `organization_id IS NULL` (query_index/api/status.ts), which is where
+    // every other fulltext row lands - a non-null org would hide this row in exactly
+    // the view an operator opens to ask "did indexing run?".
+    expect(recordIndexerLog).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: expect.anything() }),
+    )
+
+    // ...and the log line must be readable without OM_SEARCH_DEBUG=1, at the level the
+    // sibling vector worker uses for the same skip and the row uses beside it.
+    expect(searchLoggerWarn).toHaveBeenCalledTimes(1)
+    expect(String(searchLoggerWarn.mock.calls[0][0])).toContain(
       'Fulltext strategy not configured',
     )
+    expect(searchLoggerError).not.toHaveBeenCalled()
   })
 
   it('records a status-log row when searchStrategies cannot be resolved, and still completes', async () => {
@@ -745,10 +759,106 @@ describe('Fulltext Index Worker', () => {
         level: 'warn',
         message: expect.stringContaining('searchStrategies not available'),
         tenantId: 'tenant-123',
-        organizationId: null,
+        details: expect.objectContaining({ jobType: 'index', organizationId: null }),
       }),
     )
-    expect(searchLoggerError).toHaveBeenCalledTimes(1)
+    expect(searchLoggerWarn).toHaveBeenCalledTimes(1)
+    expect(searchLoggerError).not.toHaveBeenCalled()
+  })
+
+  // `payloadOrganizationId` guards with `'organizationId' in job.payload` because
+  // FulltextDeletePayload and FulltextPurgePayload have no such field at all. The two
+  // cases above cover key-present-truthy and key-present-null; this is the branch the
+  // `in` operator exists for.
+  it('handles a skip on a payload shape that has no organizationId field', async () => {
+    const containerWithoutStrategy: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return []
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'delete',
+      tenantId: 'tenant-123',
+      entityType: 'test:entity',
+      recordId: 'rec-1',
+    } as unknown as FulltextIndexJobPayload)
+
+    await expect(
+      handleFulltextIndexJob(job, createMockJobContext(), containerWithoutStrategy),
+    ).resolves.toBeUndefined()
+
+    expect(recordIndexerLog).toHaveBeenCalledTimes(1)
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      { em: mockEm },
+      expect.objectContaining({
+        handler: 'worker:fulltext:delete',
+        details: expect.objectContaining({ jobType: 'delete', organizationId: null }),
+      }),
+    )
+  })
+
+  // The guard's outcome is static for the lifetime of the process - searchStrategies and
+  // searchIndexer are registered in one call - so rows 2..N carry exactly the information
+  // of row 1. The operator surface is the newest 100 rows across ALL sources, so a row per
+  // job would saturate it under ordinary write traffic.
+  it('reports the same skip once per process, not once per job', async () => {
+    const containerWithoutStrategy: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return []
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const makeJob = (recordId: string) =>
+      createMockJob<FulltextIndexJobPayload>({
+        jobType: 'index',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+        entityType: 'test:entity',
+        recordId,
+      })
+
+    for (const recordId of ['rec-1', 'rec-2', 'rec-3']) {
+      await handleFulltextIndexJob(makeJob(recordId), createMockJobContext(), containerWithoutStrategy)
+    }
+
+    expect(recordIndexerLog).toHaveBeenCalledTimes(1)
+    expect(searchLoggerWarn).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reports a second tenant and a second job type', async () => {
+    const containerWithoutStrategy: HandlerContext = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'searchStrategies') return []
+        if (name === 'em') return mockEm
+        if (name === 'searchIndexer') return mockSearchIndexer
+        throw new Error(`Unknown service: ${name}`)
+      }) as HandlerContext['resolve'],
+    }
+    const jobs = [
+      { jobType: 'index' as const, tenantId: 'tenant-a' },
+      { jobType: 'index' as const, tenantId: 'tenant-b' },
+      { jobType: 'batch-index' as const, tenantId: 'tenant-a' },
+      { jobType: 'index' as const, tenantId: 'tenant-a' },
+    ]
+    for (const { jobType, tenantId } of jobs) {
+      const job = createMockJob<FulltextIndexJobPayload>({
+        jobType,
+        tenantId,
+        organizationId: null,
+        entityType: 'test:entity',
+        recordId: 'rec-1',
+        records: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+      })
+      await handleFulltextIndexJob(job, createMockJobContext(), containerWithoutStrategy)
+    }
+
+    // Three distinct (tenant, jobType) pairs; the repeat of the first is suppressed.
+    expect(recordIndexerLog).toHaveBeenCalledTimes(3)
   })
 
   it('should throw when fulltext search is not available', async () => {

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -1,6 +1,10 @@
 import type { QueuedJob, JobContext, WorkerMeta } from '@open-mercato/queue'
 import type { Kysely } from 'kysely'
-import { FULLTEXT_INDEXING_QUEUE_NAME, type FulltextIndexJobPayload } from '../../../queue/fulltext-indexing'
+import {
+  FULLTEXT_INDEXING_QUEUE_NAME,
+  type FulltextIndexJobPayload,
+  type FulltextIndexJobType,
+} from '../../../queue/fulltext-indexing'
 import type { FullTextSearchStrategy } from '../../../strategies/fulltext.strategy'
 import type { SearchIndexer } from '../../../indexer/search-indexer'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -9,7 +13,7 @@ import type { EntityId } from '@open-mercato/shared/modules/entities'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import type { ProgressService } from '@open-mercato/core/modules/progress/lib/progressService'
-import { searchDebug, searchDebugWarn, searchError } from '../../../lib/debug'
+import { searchDebug, searchDebugWarn, searchError, searchWarn } from '../../../lib/debug'
 import { clearReindexLock, updateReindexProgress } from '../lib/reindex-lock'
 import { hasActiveReindexProgress, incrementReindexProgress } from '../lib/reindex-progress'
 
@@ -73,6 +77,56 @@ async function advanceFulltextReindexProgress(params: {
 }
 
 /**
+ * Report a job that returned without indexing anything.
+ *
+ * A fulltext strategy that was never registered (no `MEILISEARCH_HOST`, so
+ * `createFulltextDriver()` returns null and `di.ts` pushes no strategy) makes
+ * every job a no-op. The bare `return` that follows leaves BullMQ reporting
+ * `completed` with zero failures and writes no `indexer_status_logs` row, so
+ * "fulltext is not configured" and "everything indexed fine" are
+ * indistinguishable from both signals an operator has. Absence of a row is the
+ * only trace, and absence is what a healthy never-ran system looks like too.
+ *
+ * So: write a `warn` row into the same table that answers "did indexing run?",
+ * and log through `searchError` rather than `searchDebugWarn` — a
+ * misconfiguration that voids every indexing job should not need
+ * `OM_SEARCH_DEBUG=1` to be readable.
+ *
+ * Deliberately does NOT throw. A deployment may legitimately run without
+ * Meilisearch, and throwing would retry these jobs forever, turning a
+ * configuration choice into a queue backlog. The `isAvailable()` check further
+ * down throws precisely because a registered-but-unreachable Meili is expected
+ * to recover; an unregistered strategy is not.
+ */
+async function reportSkippedWithoutIndexing(params: {
+  em: EntityManager | null
+  jobType: FulltextIndexJobType
+  tenantId: string
+  organizationId: string | null
+  jobId: string
+  reason: string
+}): Promise<void> {
+  const message = `${params.reason}; job skipped without indexing`
+  searchError('fulltext-index.worker', message, {
+    jobId: params.jobId,
+    tenantId: params.tenantId,
+    jobType: params.jobType,
+  })
+  await recordIndexerLog(
+    { em: params.em ?? undefined },
+    {
+      source: 'fulltext',
+      handler: `worker:fulltext:${params.jobType}`,
+      level: 'warn',
+      message,
+      tenantId: params.tenantId,
+      organizationId: params.organizationId,
+      details: { jobId: params.jobId, jobType: params.jobType, skippedWithoutIndexing: true },
+    },
+  )
+}
+
+/**
  * Process a fulltext indexing job.
  *
  * This handler processes single record indexing, batch indexing, deletion, and purge
@@ -92,6 +146,8 @@ export async function handleFulltextIndexJob(
   ctx: HandlerContext,
 ): Promise<void> {
   const { jobType, tenantId } = job.payload
+  const payloadOrganizationId =
+    'organizationId' in job.payload ? job.payload.organizationId ?? null : null
 
   if (!tenantId) {
     searchDebugWarn('fulltext-index.worker', 'Skipping job with missing tenantId', {
@@ -118,7 +174,10 @@ export async function handleFulltextIndexJob(
   try {
     searchIndexer = ctx.resolve<SearchIndexer>('searchIndexer')
   } catch {
-    searchDebugWarn('fulltext-index.worker', 'searchIndexer not available')
+    // Not a skip on its own: delete/purge never touch the indexer, and the
+    // index/batch-index branches throw explicitly when they need it. Still
+    // worth reading without OM_SEARCH_DEBUG, because it precedes those throws.
+    searchWarn('fulltext-index.worker', 'searchIndexer not available')
   }
 
   // Resolve fulltext strategy
@@ -129,12 +188,26 @@ export async function handleFulltextIndexJob(
       (s: unknown) => (s as { id?: string })?.id === 'fulltext',
     ) as FullTextSearchStrategy | undefined
   } catch {
-    searchDebugWarn('fulltext-index.worker', 'searchStrategies not available')
+    await reportSkippedWithoutIndexing({
+      em,
+      jobType,
+      tenantId,
+      organizationId: payloadOrganizationId,
+      jobId: jobCtx.jobId,
+      reason: 'searchStrategies not available',
+    })
     return
   }
 
   if (!fulltextStrategy) {
-    searchDebugWarn('fulltext-index.worker', 'Fulltext strategy not configured')
+    await reportSkippedWithoutIndexing({
+      em,
+      jobType,
+      tenantId,
+      organizationId: payloadOrganizationId,
+      jobId: jobCtx.jobId,
+      reason: 'Fulltext strategy not configured (MEILISEARCH_HOST unset?)',
+    })
     return
   }
 

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -84,20 +84,32 @@ async function advanceFulltextReindexProgress(params: {
  * every job a no-op. The bare `return` that follows leaves BullMQ reporting
  * `completed` with zero failures and writes no `indexer_status_logs` row, so
  * "fulltext is not configured" and "everything indexed fine" are
- * indistinguishable from both signals an operator has. Absence of a row is the
- * only trace, and absence is what a healthy never-ran system looks like too.
- *
- * So: write a `warn` row into the same table that answers "did indexing run?",
- * and log through `searchError` rather than `searchDebugWarn` — a
- * misconfiguration that voids every indexing job should not need
- * `OM_SEARCH_DEBUG=1` to be readable.
+ * indistinguishable from both signals an operator has.
  *
  * Deliberately does NOT throw. A deployment may legitimately run without
  * Meilisearch, and throwing would retry these jobs forever, turning a
  * configuration choice into a queue backlog. The `isAvailable()` check further
  * down throws precisely because a registered-but-unreachable Meili is expected
  * to recover; an unregistered strategy is not.
+ *
+ * Reported ONCE per (tenant, job type, reason) per process, deliberately.
+ * `searchStrategies` and `searchIndexer` are registered together in one
+ * `container.register` call, from a `strategies` array that only receives a
+ * `FullTextSearchStrategy` when the driver exists - so the outcome of this guard
+ * is static for the lifetime of the process and rows 2..N carry exactly the
+ * information of row 1. The surface an operator reads is the newest 100
+ * `indexer_status_logs` rows across ALL sources, so an unthrottled row per job
+ * would saturate that window under ordinary write traffic and push out every
+ * other source's rows - trading invisibility for a panel showing one signal a
+ * hundred times. Do not "fix" this back to per-job.
  */
+const reportedSkipKeys = new Set<string>()
+
+/** Test seam: the memo above is process-scoped, so a suite must be able to clear it. */
+export function __resetSkippedWithoutIndexingMemo(): void {
+  reportedSkipKeys.clear()
+}
+
 async function reportSkippedWithoutIndexing(params: {
   em: EntityManager | null
   jobType: FulltextIndexJobType
@@ -106,8 +118,17 @@ async function reportSkippedWithoutIndexing(params: {
   jobId: string
   reason: string
 }): Promise<void> {
+  const memoKey = `${params.tenantId}:${params.jobType}:${params.reason}`
+  if (reportedSkipKeys.has(memoKey)) return
+  reportedSkipKeys.add(memoKey)
+
   const message = `${params.reason}; job skipped without indexing`
-  searchError('fulltext-index.worker', message, {
+  // `searchWarn`, not `searchError`: this is an operational warning about a
+  // configuration the guard above calls legitimate, it is the level the sibling
+  // vector worker uses for the same skip, and it agrees with the `level: 'warn'`
+  // of the row written beside it. It is un-gated by OM_SEARCH_DEBUG either way,
+  // which is the property this fix needs.
+  searchWarn('fulltext-index.worker', message, {
     jobId: params.jobId,
     tenantId: params.tenantId,
     jobType: params.jobType,
@@ -120,8 +141,18 @@ async function reportSkippedWithoutIndexing(params: {
       level: 'warn',
       message,
       tenantId: params.tenantId,
-      organizationId: params.organizationId,
-      details: { jobId: params.jobId, jobType: params.jobType, skippedWithoutIndexing: true },
+      // No `organizationId`: every other recordIndexerLog call in this handler
+      // omits it, so all existing `source: 'fulltext'` rows persist with
+      // organization_id = NULL - and the unrestricted indexer-status view filters
+      // on `organization_id IS NULL` (query_index/api/status.ts). A non-null org
+      // here would hide this row in exactly the view an operator lands on when
+      // asking "did indexing run?". The value stays in `details` for triage.
+      details: {
+        jobId: params.jobId,
+        jobType: params.jobType,
+        organizationId: params.organizationId,
+        skippedWithoutIndexing: true,
+      },
     },
   )
 }
@@ -174,10 +205,12 @@ export async function handleFulltextIndexJob(
   try {
     searchIndexer = ctx.resolve<SearchIndexer>('searchIndexer')
   } catch {
-    // Not a skip on its own: delete/purge never touch the indexer, and the
-    // index/batch-index branches throw explicitly when they need it. Still
-    // worth reading without OM_SEARCH_DEBUG, because it precedes those throws.
-    searchWarn('fulltext-index.worker', 'searchIndexer not available')
+    // Left at debug level to match vector-index.worker.ts for the identical
+    // condition. It is also close to unreachable: `searchIndexer` and
+    // `searchStrategies` are registered in the same `container.register` call, so
+    // the only way this throws is that search DI never ran - in which case the
+    // next guard reports it anyway.
+    searchDebugWarn('fulltext-index.worker', 'searchIndexer not available')
   }
 
   // Resolve fulltext strategy


### PR DESCRIPTION
## The defect

A fulltext-indexing job that indexes **nothing** reports success, with no trace anywhere.

`createFulltextDriver()` (`packages/search/src/fulltext/drivers/index.ts`) is env-driven: with `MEILISEARCH_HOST` unset it returns `null`, so `packages/search/src/di.ts` registers no `FullTextSearchStrategy`. Every job then reaches this guard in `fulltext-index.worker.ts`:

```ts
if (!fulltextStrategy) {
  searchDebugWarn('fulltext-index.worker', 'Fulltext strategy not configured')
  return
}
```

Two properties combine badly:

- **`searchDebugWarn` is gated.** `lib/debug.ts` opens with `if (!isSearchDebugEnabled()) return`, so the line prints only under `OM_SEARCH_DEBUG=1`.
- **The `return` is bare.** No throw, so BullMQ marks the job `completed`; and no `recordIndexerLog(...)`, so `indexer_status_logs` gets no row.

So "fulltext is not configured" and "everything indexed fine" are indistinguishable from **both** signals an operator has: the queue shows completed-with-zero-failures, and the status-log table shows nothing at all. The absence of a row is the only trace — and absence is exactly what a healthy never-ran system looks like too.

The intent was already in the file, one branch further down:

```ts
const isAvailable = await fulltextStrategy.isAvailable()
if (!isAvailable) {
  throw new Error('Fulltext search is not available') // Will trigger retry
}
```

A *registered but unreachable* Meili is loud. Only the *unregistered* case is silent — and it is the one an operator is most likely to cause by accident, e.g. dropping the variable from a compose `environment:` block, which fails silently by design.

## What it cost us downstream

Measured 2026-08-27 on a dev box running Open Mercato 0.6.5: **no `MEILISEARCH_*` variable was set at all**, while the `meilisearch` container had been up and answering `/health` with 200 for months. Every `fulltext-indexing` job since the module was configured had completed successfully, and Meilisearch held **0 indexes, ever** — not an empty index, no index. The entire search verification surface was inert and nothing anywhere suggested it.

In a correctly configured production deployment the defect is latent. It stops being latent the moment the variable is dropped, and the consequence is that all indexing stops while every queue stays green.

## The change

Minimal, and matching the file's own conventions. Before returning:

1. **Write an `indexer_status_logs` row** at `warn` level, through the `recordIndexerLog` the handler already imports. This is the important half — it makes the skip visible in the same table an operator already consults to answer "did indexing run?". The row carries `handler: worker:fulltext:<jobType>`, `tenantId`, `organizationId` and the job id, matching what the success paths in the same handler record.
2. **Promote the log line** from `searchDebugWarn` to `searchError`, which `lib/debug.ts` documents as "always logs, not gated by debug flag". A misconfiguration that voids every indexing job is not debug-level detail.

Applied to both guards that return quietly: `Fulltext strategy not configured` and the sibling `searchStrategies not available`.

The third guard, `searchIndexer not available`, is only promoted to `searchWarn` and given **no** status row — deliberately. It does not return: `delete`/`purge` jobs never touch the indexer and complete correctly without it, and the `index`/`batch-index` branches already `throw new Error('searchIndexer not available for …')`, which records an error row. Writing a skip row there would be false.

### Deliberately NOT a throw

Please don't "improve" this into a throw. A deployment may legitimately run without Meilisearch; throwing would retry these jobs forever and turn a configuration choice into a queue backlog. The `isAvailable()` branch throws precisely because a registered-but-unreachable Meili is *expected to recover*. An unregistered strategy is not — nothing about it will change until a human edits the environment, which is exactly the human the status-log row is for.

### On row volume

One row per skipped job, so a backfill of N jobs against an unconfigured Meili writes N rows. That is intentional: the count is exactly the number of jobs that indexed nothing, which is the number an operator wants to see. `pruneExcessLogs` in `status-log.ts` already bounds the table at 10 000 rows per source, so it is self-limiting.

## Testing

- Extended `packages/search/src/__tests__/workers.test.ts` with two cases asserting that each skipping guard writes the `warn` row **and that the job still resolves rather than throwing** (the no-backlog property above is a behaviour worth pinning, not just a comment).
- Verified the new tests fail against the unpatched worker and pass with it: 2 failed / 22 passed before, 24 passed after.
- `packages/search`: full suite `338 passed`, 33/34 suites. The one failing suite, `VectorSearchSection.test.tsx`, fails identically on a clean `develop` — `@open-mercato/ui` is not in that package's `moduleNameMapper` — and is unrelated to this change.
- `tsc --noEmit` in `packages/search`: clean.
- `eslint` on both changed files: no new findings (one pre-existing unused-directive warning on the `let em: any` line remains untouched).

## Origin

Found while verifying fulltext indexing in a downstream app built on `@open-mercato/*`. Full write-up, measurements and the rejected alternatives are kept downstream; this PR is the upstream half.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790472551&installation_model_id=432243&pr_number=5720&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5720&signature=7ac8ba0f68f48fc39852fe4383e4750f1a61bf2538a288ffd758e5c5a7726e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->