### PR TITLE
fix(warranty_claims): localize the remaining API error responses instead of leaking i18n keys (#5522)

### DIFF
--- a/packages/core/src/modules/warranty_claims/__integration__/TC-WC-021-return-label-seam.spec.ts
+++ b/packages/core/src/modules/warranty_claims/__integration__/TC-WC-021-return-label-seam.spec.ts
@@ -141,7 +141,10 @@ test.describe('TC-WC-021: warranty claim return-label seam', () => {
         invalidStatusResponse.status(),
         `draft generated return label should be rejected: ${JSON.stringify(invalidStatusBody)}`,
       ).toBe(400)
-      expect(invalidStatusBody?.error).toBe('warranty_claims.errors.returnLabelInvalidStatus')
+      expect(
+        invalidStatusBody?.error,
+        'the rejection should read as a localized sentence, not a raw i18n key',
+      ).toBe('Return labels can only be created for approved claims that are awaiting return.')
     } finally {
       await restoreWarrantyClaimSettings(request, adminToken, settingsBefore)
       await cancelThenDeleteClaimIfPossible(request, adminToken, draftClaimId)

--- a/packages/core/src/modules/warranty_claims/__integration__/TC-WC-024-ai-assess.spec.ts
+++ b/packages/core/src/modules/warranty_claims/__integration__/TC-WC-024-ai-assess.spec.ts
@@ -125,7 +125,10 @@ test.describe('TC-WC-024: warranty claim AI assess API', () => {
       })
       expect(unlinkedResponse.status(), 'an attachment not linked to the claim should be rejected').toBe(400)
       const unlinkedBody = await readJsonSafe<{ error?: string }>(unlinkedResponse)
-      expect(unlinkedBody?.error).toBe('warranty_claims.errors.attachmentNotLinked')
+      expect(
+        unlinkedBody?.error,
+        'the rejection should read as a localized sentence, not a raw i18n key',
+      ).toBe('The attachment is not linked to this claim.')
 
       const assessResponse = await apiRequest(request, 'POST', '/api/warranty_claims/ai/assess', {
         token: adminToken,

--- a/packages/core/src/modules/warranty_claims/__tests__/ai-assess.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/ai-assess.test.ts
@@ -475,7 +475,7 @@ describe('warranty claim AI assessment packet', () => {
     }))
 
     expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ error: 'warranty_claims.errors.attachmentNotLinked' })
+    await expect(response.json()).resolves.toEqual({ error: 'The attachment is not linked to this claim.' })
     expect(createModelFactoryMock).not.toHaveBeenCalled()
     expect(generateObjectMock).not.toHaveBeenCalled()
     expect(commandExecuteMock).not.toHaveBeenCalled()

--- a/packages/core/src/modules/warranty_claims/__tests__/ai-assess.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/ai-assess.test.ts
@@ -106,6 +106,13 @@ jest.mock('../lib/settings', () => ({
   })),
 }))
 
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: () => createRequestContainerMock(),
 }))

--- a/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
@@ -38,6 +38,19 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () =>
   getCustomerAuthFromRequest: (...args: unknown[]) => getCustomerAuthMock(...args),
 }))
 
+const runRouteMutationGuardsMock = jest.fn()
+jest.mock('@open-mercato/shared/lib/crud/route-mutation-guard', () => ({
+  runRouteMutationGuards: (...args: unknown[]) => runRouteMutationGuardsMock(...args),
+}))
+
+const findOneWithDecryptionMock = jest.fn()
+const findWithDecryptionMock = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  ...jest.requireActual('@open-mercato/shared/lib/encryption/find'),
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+}))
+
 import { GET as assigneesGET } from '../api/assignees/route'
 import { GET as portalClaimsGET, POST as portalClaimsPOST } from '../api/portal/claims/route'
 import {
@@ -55,6 +68,9 @@ import { POST as salesReturnPOST } from '../api/sales-return/route'
 import { POST as replacementOrderPOST } from '../api/replacement-order/route'
 import { POST as returnLabelPOST } from '../api/return-label/route'
 import { POST as aiAssessPOST } from '../api/ai/assess/route'
+import { GET as claimEventsGET } from '../api/events/route'
+import { GET as riskGET } from '../api/risk/route'
+import { GET as vendorRecoverySuggestionsGET } from '../api/vendor-recovery-suggestions/route'
 
 const RAW_I18N_KEY = /^warranty_claims\./
 
@@ -87,6 +103,9 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
     resolveAssigneeDisplayNamesMock.mockResolvedValue(new Map())
     getCustomerAuthMock.mockResolvedValue(null)
     containerStub.resolve.mockImplementation((token: string) => (token === 'em' ? { fork: () => ({}) } : undefined))
+    runRouteMutationGuardsMock.mockResolvedValue({ ok: true, modifiedPayload: null, runAfterSuccess: jest.fn() })
+    findOneWithDecryptionMock.mockResolvedValue(null)
+    findWithDecryptionMock.mockResolvedValue([])
   })
 
   describe('GET /api/warranty_claims/assignees', () => {
@@ -362,6 +381,35 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
       expect(error).not.toMatch(RAW_I18N_KEY)
     })
 
+    it('returns a localized 404 from return-label when the claim is outside the caller scope', async () => {
+      const { status, error } = await readError(
+        await returnLabelPOST(actionRequest('return-label', { claimId: randomUUID() })),
+      )
+      expect(status).toBe(404)
+      expect(error).toBe('Claim not found.')
+    })
+
+    it('returns a localized 404 from ai/assess when the claim is outside the caller scope', async () => {
+      const tenantId = randomUUID()
+      const organizationId = randomUUID()
+      getAuthMock.mockResolvedValue({ sub: 'user-1', tenantId, orgId: organizationId })
+      resolveOrganizationScopeForRequestMock.mockResolvedValue({
+        tenantId,
+        selectedId: organizationId,
+        filterIds: [organizationId],
+        allowedIds: [organizationId],
+      })
+      const { status, error } = await readError(
+        await aiAssessPOST(actionRequest('ai/assess', {
+          claimId: randomUUID(),
+          attachmentId: randomUUID(),
+          kind: 'proof',
+        })),
+      )
+      expect(status).toBe(404)
+      expect(error).toBe('Claim not found.')
+    })
+
     it('translates the keyed zod message the return-label route surfaces (#5287)', async () => {
       const { status, error } = await readError(
         await returnLabelPOST(actionRequest('return-label', {
@@ -373,10 +421,26 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
       expect(error).not.toMatch(RAW_I18N_KEY)
     })
   })
+
+  describe('claim-scoped read routes (#5522)', () => {
+    const readRoutes: Array<[string, (req: Request) => Promise<Response>]> = [
+      ['events', claimEventsGET],
+      ['risk', riskGET],
+      ['vendor-recovery-suggestions', vendorRecoverySuggestionsGET],
+    ]
+
+    it.each(readRoutes)('returns a localized 404 from %s when the claim is outside the caller scope', async (path, handler) => {
+      const { status, error } = await readError(
+        await handler(new Request(`http://localhost/api/warranty_claims/${path}?claimId=${randomUUID()}`)),
+      )
+      expect(status).toBe(404)
+      expect(error).toBe('Claim not found.')
+    })
+  })
 })
 
 
-describe('no warranty_claims API route ships a raw i18n key as its error message (#5522)', () => {
+describe('no warranty_claims API route file inlines a raw i18n key in an error payload (#5522)', () => {
   const apiDir = join(__dirname, '..', 'api')
 
   function routeSources(dir: string): string[] {
@@ -388,7 +452,9 @@ describe('no warranty_claims API route ships a raw i18n key as its error message
   }
 
   it('keeps every error payload behind translate()', () => {
-    const offenders = routeSources(apiDir).flatMap((file) =>
+    const files = routeSources(apiDir)
+    expect(files.length).toBeGreaterThan(20)
+    const offenders = files.flatMap((file) =>
       readFileSync(file, 'utf8')
         .split('\n')
         .map((line, index) => ({ line, index }))

--- a/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
@@ -1,11 +1,14 @@
 /** @jest-environment node */
 import { randomUUID } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 // The translator resolves each key to its fallback sentence, so a raw i18n key
 // that leaks straight into the response body (the #5512 defect) is trivially
 // distinguishable from a genuinely localized message.
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
     translate: (_key: string, fallback?: string) => fallback ?? _key,
   }),
 }))
@@ -37,6 +40,21 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () =>
 
 import { GET as assigneesGET } from '../api/assignees/route'
 import { GET as portalClaimsGET, POST as portalClaimsPOST } from '../api/portal/claims/route'
+import {
+  DELETE as portalAttachmentsDELETE,
+  GET as portalAttachmentsGET,
+  POST as portalAttachmentsPOST,
+} from '../api/portal/attachments/route'
+import { GET as portalEventsGET, POST as portalEventsPOST } from '../api/portal/events/route'
+import { GET as portalClaimDetailGET } from '../api/portal/claims/[id]/route'
+import { POST as portalClaimSubmitPOST } from '../api/portal/claims/[id]/submit/route'
+import { POST as portalClaimWithdrawPOST } from '../api/portal/claims/[id]/withdraw/route'
+import { POST as receivingPOST } from '../api/receiving/route'
+import { POST as creditMemoPOST } from '../api/credit-memo/route'
+import { POST as salesReturnPOST } from '../api/sales-return/route'
+import { POST as replacementOrderPOST } from '../api/replacement-order/route'
+import { POST as returnLabelPOST } from '../api/return-label/route'
+import { POST as aiAssessPOST } from '../api/ai/assess/route'
 
 const RAW_I18N_KEY = /^warranty_claims\./
 
@@ -68,6 +86,7 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
     })
     resolveAssigneeDisplayNamesMock.mockResolvedValue(new Map())
     getCustomerAuthMock.mockResolvedValue(null)
+    containerStub.resolve.mockImplementation((token: string) => (token === 'em' ? { fork: () => ({}) } : undefined))
   })
 
   describe('GET /api/warranty_claims/assignees', () => {
@@ -171,5 +190,211 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
       expect(body.ok).toBe(false)
       expect(error).not.toMatch(RAW_I18N_KEY)
     })
+  })
+
+  describe('portal claim attachments, events and detail routes (#5522)', () => {
+    const claimRouteContext = (id: string) => ({ params: Promise.resolve({ id }) })
+
+    it('returns a localized 401 on the attachments route when there is no portal session', async () => {
+      const { status, body, error } = await readError(
+        await portalAttachmentsGET(new Request('http://localhost/api/warranty_claims/portal/attachments')),
+      )
+      expect(status).toBe(401)
+      expect(body.ok).toBe(false)
+      expect(error).toBe('Unauthorized')
+    })
+
+    it('returns a localized 403 on the attachments route when the account is not linked', async () => {
+      getCustomerAuthMock.mockResolvedValue({ ...LINKED_PORTAL_AUTH, customerEntityId: null })
+      const { status, error } = await readError(
+        await portalAttachmentsGET(new Request('http://localhost/api/warranty_claims/portal/attachments')),
+      )
+      expect(status).toBe(403)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 400 when the attachment id is not a uuid', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalAttachmentsGET(
+          new Request('http://localhost/api/warranty_claims/portal/attachments?attachmentId=nope'),
+        ),
+      )
+      expect(status).toBe(400)
+      expect(error).toBe('Invalid input')
+    })
+
+    it('returns a localized 400 when the attachment list query is invalid', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalAttachmentsGET(new Request('http://localhost/api/warranty_claims/portal/attachments')),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 400 when an upload is not multipart', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalAttachmentsPOST(new Request('http://localhost/api/warranty_claims/portal/attachments', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+        })),
+      )
+      expect(status).toBe(400)
+      expect(error).toBe('Invalid input')
+    })
+
+    it('returns a localized 400 when a delete carries no attachment id', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalAttachmentsDELETE(new Request('http://localhost/api/warranty_claims/portal/attachments', {
+          method: 'DELETE',
+        })),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 401 on the portal events route without a session', async () => {
+      const { status, error } = await readError(
+        await portalEventsGET(new Request('http://localhost/api/warranty_claims/portal/events')),
+      )
+      expect(status).toBe(401)
+      expect(error).toBe('Unauthorized')
+    })
+
+    it('returns a localized 400 when the events query has no claim id', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalEventsGET(new Request('http://localhost/api/warranty_claims/portal/events')),
+      )
+      expect(status).toBe(400)
+      expect(error).toBe('Invalid input')
+    })
+
+    it('returns a localized 400 when a portal comment body is not valid JSON', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalEventsPOST(new Request('http://localhost/api/warranty_claims/portal/events', {
+          method: 'POST',
+          body: '{not-json',
+        })),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 404 on the claim detail route when the id is blank', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalClaimDetailGET(
+          new Request('http://localhost/api/warranty_claims/portal/claims/'),
+          claimRouteContext(''),
+        ),
+      )
+      expect(status).toBe(404)
+      expect(error).toBe('Claim not found.')
+    })
+
+    it('returns a localized 404 on submit when the claim id is not a uuid', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalClaimSubmitPOST(
+          new Request('http://localhost/api/warranty_claims/portal/claims/nope/submit', { method: 'POST' }),
+          claimRouteContext('nope'),
+        ),
+      )
+      expect(status).toBe(404)
+      expect(error).toBe('Claim not found.')
+    })
+
+    it('returns a localized 404 on withdraw when the claim id is not a uuid', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, error } = await readError(
+        await portalClaimWithdrawPOST(
+          new Request('http://localhost/api/warranty_claims/portal/claims/nope/withdraw', { method: 'POST' }),
+          claimRouteContext('nope'),
+        ),
+      )
+      expect(status).toBe(404)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+  })
+
+  describe('staff claim action routes (#5522)', () => {
+    const actionRoutes: Array<[string, (req: Request) => Promise<Response>]> = [
+      ['receiving', receivingPOST],
+      ['credit-memo', creditMemoPOST],
+      ['sales-return', salesReturnPOST],
+      ['replacement-order', replacementOrderPOST],
+      ['return-label', returnLabelPOST],
+      ['ai/assess', aiAssessPOST],
+    ]
+
+    function actionRequest(path: string, body: unknown): Request {
+      return new Request(`http://localhost/api/warranty_claims/${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    }
+
+    it.each(actionRoutes)('returns a localized 401 from %s when the caller is unauthenticated', async (path, handler) => {
+      getAuthMock.mockResolvedValue(null)
+      const { status, error } = await readError(await handler(actionRequest(path, {})))
+      expect(status).toBe(401)
+      expect(error).toBe('Unauthorized')
+    })
+
+    it.each(actionRoutes)('returns a localized 400 from %s when no organization can be resolved', async (path, handler) => {
+      getAuthMock.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: null })
+      resolveOrganizationScopeForRequestMock.mockResolvedValue(null)
+      const { status, error } = await readError(await handler(actionRequest(path, {})))
+      expect(status).toBe(400)
+      expect(error).toBe('Organization context is required.')
+    })
+
+    it.each(actionRoutes)('returns a localized 400 from %s when the body fails validation', async (path, handler) => {
+      const { status, error } = await readError(await handler(actionRequest(path, {})))
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('translates the keyed zod message the return-label route surfaces (#5287)', async () => {
+      const { status, error } = await readError(
+        await returnLabelPOST(actionRequest('return-label', {
+          claimId: '11111111-1111-4111-8111-111111111111',
+          labelUrl: 'not-a-url',
+        })),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+  })
+})
+
+
+describe('no warranty_claims API route ships a raw i18n key as its error message (#5522)', () => {
+  const apiDir = join(__dirname, '..', 'api')
+
+  function routeSources(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) return routeSources(full)
+      return entry.isFile() && entry.name.endsWith('.ts') ? [full] : []
+    })
+  }
+
+  it('keeps every error payload behind translate()', () => {
+    const offenders = routeSources(apiDir).flatMap((file) =>
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .map((line, index) => ({ line, index }))
+        .filter(({ line }) => /error: 'warranty_claims\./.test(line))
+        .map(({ index }) => `${file.slice(apiDir.length + 1)}:${index + 1}`),
+    )
+    expect(offenders).toEqual([])
   })
 })

--- a/packages/core/src/modules/warranty_claims/api/ai/assess/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/ai/assess/route.ts
@@ -323,7 +323,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ status: 'ok', assessment })
     }
 
-    await requireScopedClaim(context.em, input.claimId, scope)
+    await requireScopedClaim(context.em, input.claimId, scope, {}, translate('warranty_claims.errors.notFound', 'Claim not found.'))
     const line = input.lineId ? await loadScopedLine(context.em, scope, input.claimId, input.lineId, translate) : null
     await verifyAttachmentLinkedToTarget(context, {
       attachmentId: input.attachmentId,

--- a/packages/core/src/modules/warranty_claims/api/ai/assess/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/ai/assess/route.ts
@@ -8,6 +8,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -109,7 +110,7 @@ function isSuperAdmin(auth: CommandRuntimeContext['auth']): boolean {
 function buildAuthContext(context: AssessRouteContext): AiChatRequestContext {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return {
     tenantId: context.tenantId,
@@ -123,7 +124,7 @@ function buildAuthContext(context: AssessRouteContext): AiChatRequestContext {
 function buildAttachmentAuthContext(context: AssessRouteContext): Exclude<AuthContext, null> {
   const auth = context.ctx.auth
   if (!auth?.sub) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return {
     ...auth,
@@ -133,16 +134,19 @@ function buildAttachmentAuthContext(context: AssessRouteContext): Exclude<AuthCo
   }
 }
 
-async function resolveAssessContext(req: Request): Promise<AssessRouteContext> {
+async function resolveAssessContext(
+  req: Request,
+  translate: AssessRouteContext['translate'],
+): Promise<AssessRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -157,7 +161,7 @@ async function resolveAssessContext(req: Request): Promise<AssessRouteContext> {
     organizationId,
     container,
     em: container.resolve<EntityManager>('em').fork(),
-    translate: (key: string) => key,
+    translate,
   }
 }
 
@@ -172,7 +176,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -196,6 +200,7 @@ async function loadScopedLine(
   scope: WarrantyClaimScope,
   claimId: string,
   lineId: string,
+  translate: AssessRouteContext['translate'],
 ): Promise<WarrantyClaimLine> {
   const line = await findOneWithDecryption(
     em,
@@ -211,7 +216,7 @@ async function loadScopedLine(
     scope,
   )
   if (!line) {
-    throw new CrudHttpError(404, { error: 'warranty_claims.errors.notFound' })
+    throw new CrudHttpError(404, { error: translate('warranty_claims.errors.notFound', 'Claim not found.') })
   }
   return line
 }
@@ -237,7 +242,7 @@ async function verifyAttachmentLinkedToTarget(
     ],
   }) : false
   if (!linked) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.attachmentNotLinked' })
+    throw new CrudHttpError(400, { error: context.translate('warranty_claims.errors.attachmentNotLinked', 'The attachment is not linked to this claim.') })
   }
 }
 
@@ -278,12 +283,13 @@ async function persistAssessmentPayload(
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveAssessContext(req)
+    const context = await resolveAssessContext(req, translate)
     const payload = toRecord(await readJsonSafe(req, {}))
     const parsed = toAssessInput(payload, context)
     if (parsed.kind === 'damage' && !parsed.lineId) {
-      throw new CrudHttpError(400, { error: 'warranty_claims.errors.invalidInput' })
+      throw new CrudHttpError(400, { error: translate('warranty_claims.errors.invalidInput', 'Invalid input') })
     }
 
     const guarded = parsed.lineId ? await runGuard(req, context, parsed as AssessBodyInput & { lineId: string }) : null
@@ -295,9 +301,9 @@ export async function POST(req: Request) {
 
     if (input.kind === 'damage') {
       if (!input.lineId) {
-        throw new CrudHttpError(400, { error: 'warranty_claims.errors.invalidInput' })
+        throw new CrudHttpError(400, { error: translate('warranty_claims.errors.invalidInput', 'Invalid input') })
       }
-      const line = await loadScopedLine(context.em, scope, input.claimId, input.lineId)
+      const line = await loadScopedLine(context.em, scope, input.claimId, input.lineId, translate)
       await verifyAttachmentLinkedToTarget(context, {
         attachmentId: input.attachmentId,
         claimId: input.claimId,
@@ -318,7 +324,7 @@ export async function POST(req: Request) {
     }
 
     await requireScopedClaim(context.em, input.claimId, scope)
-    const line = input.lineId ? await loadScopedLine(context.em, scope, input.claimId, input.lineId) : null
+    const line = input.lineId ? await loadScopedLine(context.em, scope, input.claimId, input.lineId, translate) : null
     await verifyAttachmentLinkedToTarget(context, {
       attachmentId: input.attachmentId,
       claimId: input.claimId,
@@ -345,10 +351,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ status: 'aiUnavailable' })
     }
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.ai.assess.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/credit-memo/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/credit-memo/route.ts
@@ -6,6 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -58,24 +59,23 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['warranty_claims.claim.manage', 'sales.credit_memos.manage'] },
 }
 
-function translateKey(key: string): string {
-  return key
-}
-
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
+async function resolveActionContext(
+  req: Request,
+  translate: ActionRouteContext['translate'],
+): Promise<ActionRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -88,7 +88,7 @@ async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
     },
     tenantId: auth.tenantId,
     organizationId,
-    translate: translateKey,
+    translate,
   }
 }
 
@@ -114,7 +114,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -134,8 +134,9 @@ async function runGuard(
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveActionContext(req)
+    const context = await resolveActionContext(req, translate)
     const requestInput = toCreditMemoRequest(toRecord(await readJsonSafe(req, {})))
     const guarded = await runGuard(req, context, requestInput)
     if (!guarded.ok) {
@@ -149,7 +150,7 @@ export async function POST(req: Request) {
       'warranty_claims.claim.create_credit_memo',
       { input: toCommandInput(guardedInput, context), ctx: context.ctx },
     )
-    if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+    if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
     await guarded.runAfterSuccess()
     return NextResponse.json({
       creditMemoId: result.creditMemoId,
@@ -160,10 +161,10 @@ export async function POST(req: Request) {
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.credit-memo.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/events/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/events/route.ts
@@ -130,7 +130,7 @@ export async function GET(req: Request) {
     const context = await resolveEventContext(req)
     const url = new URL(req.url)
     const query = eventListQuerySchema.parse({ claimId: url.searchParams.get('claimId') ?? undefined })
-    const claim = await requireScopedClaim(context.em, query.claimId, context.scope)
+    const claim = await requireScopedClaim(context.em, query.claimId, context.scope, {}, context.translate('warranty_claims.errors.notFound', 'Claim not found.'))
     const events = await findWithDecryption(
       context.em,
       WarrantyClaimEvent,

--- a/packages/core/src/modules/warranty_claims/api/portal/attachments/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/attachments/route.ts
@@ -9,7 +9,7 @@ import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mer
 import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { createLogger } from '@open-mercato/shared/lib/logger'
-import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import type { CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { Attachment, AttachmentPartition } from '@open-mercato/core/modules/attachments/data/entities'
 import { buildAttachmentImageUrl, slugifyAttachmentFileName } from '@open-mercato/core/modules/attachments/lib/imageUrls'
 import { StorageDriverFactory } from '@open-mercato/core/modules/attachments/lib/drivers'
@@ -28,6 +28,7 @@ import { WARRANTY_CLAIM_RESOURCE_KIND } from '../../../commands/shared'
 import { CUSTOMER_VISIBLE_ATTACHMENT_TAG, isCustomerVisibleAttachment } from '../../../lib/attachmentVisibility'
 import { loadPortalOwnedClaim } from '../../../lib/portalClaimAccess'
 import { resolvePortalAttachmentUploadService } from '../../../lib/portalAttachmentUpload'
+import { resolveLinkedCustomerAuth } from '../../../lib/portalAuthGuard'
 
 const CLAIM_ATTACHMENT_ENTITY_ID = 'warranty_claims:warranty_claim'
 const logger = createLogger('warranty_claims').child({ route: 'portal-attachments' })
@@ -80,13 +81,9 @@ function toIso(value: Date | string | null | undefined): string | null {
 }
 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
-  const auth = await getCustomerAuthFromRequest(req)
-  if (!auth) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.unauthorized' }, { status: 401 })
-  }
-  if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.customerAccountNotLinked' }, { status: 403 })
-  }
+  const authOrResponse = await resolveLinkedCustomerAuth(req)
+  if (authOrResponse instanceof Response) return authOrResponse
+  const auth = authOrResponse
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   return {
@@ -241,18 +238,19 @@ async function deletePortalAttachment(context: PortalContext, attachment: Attach
 }
 
 async function streamOwnedAttachment(context: PortalContext, attachmentId: string): Promise<Response> {
+  const { translate } = await resolveTranslations()
   const owned = await loadOwnedVisibleAttachment(context, attachmentId)
   if (!owned) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const { attachment } = owned
   const partition = await context.em.findOne(AttachmentPartition, { code: attachment.partitionCode })
   if (!partition) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.load_failed' }, { status: 500 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.load_failed', 'Failed to load warranty claim data.') }, { status: 500 })
   }
   const access = checkAttachmentAccess(attachmentAuth(context), attachment, partition, { requireAuthForPublic: true })
   if (!access.ok) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const driver = await (await resolveStorageDriverFactory(context)).resolveForPartition(attachment.partitionCode, {
     tenantId: attachment.tenantId ?? '',
@@ -262,7 +260,7 @@ async function streamOwnedAttachment(context: PortalContext, attachmentId: strin
   try {
     buffer = (await driver.read(attachment.partitionCode, attachment.storagePath)).buffer
   } catch {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const headers: Record<string, string> = {
     'Cache-Control': 'private, max-age=60',
@@ -279,12 +277,13 @@ export async function GET(req: Request) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const url = new URL(req.url)
   const attachmentId = url.searchParams.get('attachmentId')
   if (attachmentId) {
     const attachmentIdParsed = z.string().uuid().safeParse(attachmentId)
     if (!attachmentIdParsed.success) {
-      return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     return streamOwnedAttachment(context, attachmentIdParsed.data)
   }
@@ -294,11 +293,11 @@ export async function GET(req: Request) {
     pageSize: url.searchParams.get('pageSize') ?? undefined,
   })
   if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const claim = await loadOwnedClaim(context, parsed.data.claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const filter = {
     entityId: CLAIM_ATTACHMENT_ENTITY_ID,
@@ -343,12 +342,12 @@ async function handleUpload(req: Request, replacement: boolean): Promise<Respons
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { t, translate } = await resolveTranslations()
   const contentType = req.headers.get('content-type') || ''
   if (!contentType.toLowerCase().includes('multipart/form-data')) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   if (!isMultipartRequestWithinUploadLimit(req.headers.get('content-length'))) {
-    const { t } = await resolveTranslations()
     return NextResponse.json({
       ok: false,
       error: t('attachments.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.'),
@@ -364,15 +363,15 @@ async function handleUpload(req: Request, replacement: boolean): Promise<Respons
     ? z.string().uuid().safeParse(form.get('attachmentId') ?? undefined)
     : null
   if (!parsed.success || (replacement && !parsedAttachmentId?.success)) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const claim = await loadOwnedClaim(context, parsed.data.claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const file = form.get('file')
   if (!(file instanceof File)) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.portal.detail.fileRequired' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.portal.detail.fileRequired', 'Choose a file before uploading.') }, { status: 400 })
   }
   const buffer = Buffer.from(await file.arrayBuffer())
 
@@ -381,7 +380,7 @@ async function handleUpload(req: Request, replacement: boolean): Promise<Respons
     ? await loadOwnedVisibleAttachment(context, attachmentId)
     : null
   if (replacement && (!replacementTarget || replacementTarget.claim.id !== claim.id)) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
 
   const guarded = await runPortalAttachmentGuard(req, context, claim.id, replacement ? 'update' : 'create', {
@@ -397,7 +396,7 @@ async function handleUpload(req: Request, replacement: boolean): Promise<Respons
 
   const uploadService = resolvePortalAttachmentUploadService(context.container)
   if (!uploadService) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.portal.detail.attachmentError' }, { status: 503 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.portal.detail.attachmentError', 'Attachment upload failed.') }, { status: 503 })
   }
 
   let attachment: Attachment
@@ -414,7 +413,6 @@ async function handleUpload(req: Request, replacement: boolean): Promise<Respons
     })
   } catch (error) {
     if (isScopedAttachmentUploadError(error)) {
-      const { t } = await resolveTranslations()
       const [key, fallback] = ATTACHMENT_ERROR_TRANSLATIONS[error.code]
         ?? ['warranty_claims.portal.detail.attachmentError', 'Attachment upload failed.']
       return NextResponse.json(
@@ -451,16 +449,17 @@ export async function DELETE(req: Request) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const url = new URL(req.url)
   const parsed = deleteQuerySchema.safeParse({
     attachmentId: url.searchParams.get('attachmentId') ?? undefined,
   })
   if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const owned = await loadOwnedVisibleAttachment(context, parsed.data.attachmentId)
   if (!owned) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const guarded = await runPortalAttachmentGuard(req, context, owned.claim.id, 'delete', {
     claimId: owned.claim.id,

--- a/packages/core/src/modules/warranty_claims/api/portal/attachments/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/attachments/route.ts
@@ -237,8 +237,11 @@ async function deletePortalAttachment(context: PortalContext, attachment: Attach
   }
 }
 
-async function streamOwnedAttachment(context: PortalContext, attachmentId: string): Promise<Response> {
-  const { translate } = await resolveTranslations()
+async function streamOwnedAttachment(
+  context: PortalContext,
+  attachmentId: string,
+  translate: (key: string, fallback?: string) => string,
+): Promise<Response> {
   const owned = await loadOwnedVisibleAttachment(context, attachmentId)
   if (!owned) {
     return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
@@ -285,7 +288,7 @@ export async function GET(req: Request) {
     if (!attachmentIdParsed.success) {
       return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
-    return streamOwnedAttachment(context, attachmentIdParsed.data)
+    return streamOwnedAttachment(context, attachmentIdParsed.data, translate)
   }
   const parsed = attachmentQuerySchema.safeParse({
     claimId: url.searchParams.get('claimId') ?? undefined,

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/route.ts
@@ -3,10 +3,12 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import type { CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { WarrantyClaim, WarrantyClaimLine } from '../../../../data/entities'
 import { loadPortalOwnedClaim } from '../../../../lib/portalClaimAccess'
+import { resolveLinkedCustomerAuth } from '../../../../lib/portalAuthGuard'
 
 export const metadata = {
   GET: { requireAuth: false },
@@ -40,13 +42,9 @@ async function resolveClaimId(ctx: RouteContext): Promise<string | null> {
 }
 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
-  const auth = await getCustomerAuthFromRequest(req)
-  if (!auth) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.unauthorized' }, { status: 401 })
-  }
-  if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.customerAccountNotLinked' }, { status: 403 })
-  }
+  const authOrResponse = await resolveLinkedCustomerAuth(req)
+  if (authOrResponse instanceof Response) return authOrResponse
+  const auth = authOrResponse
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   return {
@@ -108,9 +106,10 @@ export async function GET(req: Request, ctx: RouteContext) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const claimId = await resolveClaimId(ctx)
   if (!claimId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const scope = { tenantId: context.tenantId, organizationId: context.organizationId }
   const claim = await loadPortalOwnedClaim(
@@ -123,7 +122,7 @@ export async function GET(req: Request, ctx: RouteContext) {
     claimId,
   )
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const lines = await findWithDecryption(
     context.em,

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/shared.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/shared.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
-import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import type { CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { WarrantyClaim } from '../../../../data/entities'
 import { WARRANTY_CLAIM_RESOURCE_KIND } from '../../../../commands/shared'
 import { loadPortalOwnedClaim } from '../../../../lib/portalClaimAccess'
+import { resolveLinkedCustomerAuth } from '../../../../lib/portalAuthGuard'
 
 export type PortalClaimActionRouteContext = { params: Promise<{ id: string }> }
 
@@ -34,13 +34,9 @@ export async function resolvePortalClaimId(ctx: PortalClaimActionRouteContext): 
 }
 
 export async function resolvePortalActionContext(req: Request): Promise<PortalClaimActionContext | Response> {
-  const auth = await getCustomerAuthFromRequest(req)
-  if (!auth) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.unauthorized' }, { status: 401 })
-  }
-  if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.customerAccountNotLinked' }, { status: 403 })
-  }
+  const authOrResponse = await resolveLinkedCustomerAuth(req)
+  if (authOrResponse instanceof Response) return authOrResponse
+  const auth = authOrResponse
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const commandAuth: NonNullable<AuthContext> = {

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/submit/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/submit/route.ts
@@ -21,16 +21,16 @@ export async function POST(req: Request, ctx: PortalClaimActionRouteContext) {
   const contextOrResponse = await resolvePortalActionContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const claimId = await resolvePortalClaimId(ctx)
   if (!claimId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const claim = await loadOwnedClaim(context, claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   if (claim.status !== 'draft') {
-    const { translate } = await resolveTranslations()
     return NextResponse.json(
       { ok: false, error: translate('warranty_claims.errors.invalidTransition', 'That status change is not allowed.') },
       { status: 400 },

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/withdraw/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/[id]/withdraw/route.ts
@@ -23,16 +23,16 @@ export async function POST(req: Request, ctx: PortalClaimActionRouteContext) {
   const contextOrResponse = await resolvePortalActionContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const claimId = await resolvePortalClaimId(ctx)
   if (!claimId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const claim = await loadOwnedClaim(context, claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   if (!PORTAL_WITHDRAWABLE_STATUSES.has(claim.status)) {
-    const { translate } = await resolveTranslations()
     return NextResponse.json(
       { ok: false, error: translate('warranty_claims.errors.invalidTransition', 'That status change is not allowed.') },
       { status: 400 },

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
@@ -10,7 +10,8 @@ import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mer
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { createLogger } from '@open-mercato/shared/lib/logger'
-import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import type { CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import { resolveLinkedCustomerAuth } from '../../../lib/portalAuthGuard'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { WarrantyClaim, WarrantyClaimLine } from '../../../data/entities'
 import {
@@ -153,14 +154,9 @@ function serializePortalClaim(claim: WarrantyClaim, lines: WarrantyClaimLine[]) 
 }
 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
-  const { translate } = await resolveTranslations()
-  const auth = await getCustomerAuthFromRequest(req)
-  if (!auth) {
-    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') }, { status: 401 })
-  }
-  if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.customerAccountNotLinked', 'Customer account is not linked to a customer record') }, { status: 403 })
-  }
+  const authOrResponse = await resolveLinkedCustomerAuth(req)
+  if (authOrResponse instanceof Response) return authOrResponse
+  const auth = authOrResponse
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const commandAuth: NonNullable<AuthContext> = {

--- a/packages/core/src/modules/warranty_claims/api/portal/events/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/events/route.ts
@@ -6,13 +6,15 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import type { CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { WarrantyClaim, WarrantyClaimEvent } from '../../../data/entities'
 import type { CommentClaimInput } from '../../../data/validators'
 import { WARRANTY_CLAIM_RESOURCE_KIND } from '../../../commands/shared'
 import { loadPortalOwnedClaim } from '../../../lib/portalClaimAccess'
+import { resolveLinkedCustomerAuth } from '../../../lib/portalAuthGuard'
 
 export const metadata = {
   GET: { requireAuth: false },
@@ -70,13 +72,9 @@ function serializeEvent(event: WarrantyClaimEvent) {
 }
 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
-  const auth = await getCustomerAuthFromRequest(req)
-  if (!auth) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.unauthorized' }, { status: 401 })
-  }
-  if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.customerAccountNotLinked' }, { status: 403 })
-  }
+  const authOrResponse = await resolveLinkedCustomerAuth(req)
+  if (authOrResponse instanceof Response) return authOrResponse
+  const auth = authOrResponse
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const commandAuth: NonNullable<AuthContext> = {
@@ -145,14 +143,15 @@ export async function GET(req: Request) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   const url = new URL(req.url)
   const parsed = eventQuerySchema.safeParse({ claimId: url.searchParams.get('claimId') ?? undefined })
   if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const claim = await loadOwnedClaim(context, parsed.data.claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const events = await findWithDecryption(
     context.em,
@@ -168,19 +167,20 @@ export async function POST(req: Request) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   let body: unknown
   try {
     body = await req.json()
   } catch {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const parsed = portalCommentSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const claim = await loadOwnedClaim(context, parsed.data.claimId)
   if (!claim) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.notFound' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.notFound', 'Claim not found.') }, { status: 404 })
   }
   const input: CommentClaimInput = {
     claimId: claim.id,

--- a/packages/core/src/modules/warranty_claims/api/receiving/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/receiving/route.ts
@@ -6,6 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -62,20 +63,19 @@ function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-function translateKey(key: string): string {
-  return key
-}
-
-async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
+async function resolveActionContext(
+  req: Request,
+  translate: ActionRouteContext['translate'],
+): Promise<ActionRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -88,7 +88,7 @@ async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
     },
     tenantId: auth.tenantId,
     organizationId,
-    translate: translateKey,
+    translate,
   }
 }
 
@@ -125,7 +125,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -148,26 +148,28 @@ async function executeReceivingAction(
   commandBus: CommandBus,
   action: ReceivingAction,
   ctx: CommandRuntimeContext,
+  translate: ActionRouteContext['translate'],
 ): Promise<{ lineId: string; claimId: string }> {
   if (action.kind === 'release') {
     const { result } = await commandBus.execute<ClaimLineReleaseQuarantineInput, { lineId: string; claimId: string }>(
       'warranty_claims.claim_line.release_quarantine',
       { input: action.input, ctx },
     )
-    if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+    if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
     return result
   }
   const { result } = await commandBus.execute<ClaimLineReceiveInput, { lineId: string; claimId: string }>(
     'warranty_claims.claim_line.receive',
     { input: action.input, ctx },
   )
-  if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+  if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
   return result
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveActionContext(req)
+    const context = await resolveActionContext(req, translate)
     const payload = toRecord(await readJsonSafe(req, {}))
     const action = toReceivingAction(payload, context)
     const guarded = await runGuard(req, context, action)
@@ -177,7 +179,7 @@ export async function POST(req: Request) {
     const commandAction = guarded.modifiedPayload ? toGuardedAction(action.kind, guarded.modifiedPayload) : action
 
     const commandBus = context.ctx.container.resolve('commandBus') as CommandBus
-    const result = await executeReceivingAction(commandBus, commandAction, context.ctx)
+    const result = await executeReceivingAction(commandBus, commandAction, context.ctx, translate)
 
     await guarded.runAfterSuccess()
 
@@ -185,10 +187,10 @@ export async function POST(req: Request) {
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.receiving.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/registrations/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/registrations/route.ts
@@ -5,6 +5,7 @@ import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { E } from '#generated/entities.ids.generated'
 import * as F from '#generated/entities/warranty_claim_registration'
 import { WarrantyClaimRegistration } from '../../data/entities'
@@ -92,6 +93,7 @@ async function assertRegistrationSerialUnique(
   scope: { organizationId: string; tenantId: string },
   serialNumber: string | null | undefined,
   excludeId: string | null,
+  translate: (key: string, fallback?: string) => string,
 ): Promise<void> {
   if (!serialNumber) return
   const where: FilterQuery<WarrantyClaimRegistration> = {
@@ -103,7 +105,9 @@ async function assertRegistrationSerialUnique(
   if (excludeId) where.id = { $ne: excludeId }
   const existing = await em.count(WarrantyClaimRegistration, where)
   if (existing > 0) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.duplicateSerial' })
+    throw new CrudHttpError(400, {
+      error: translate('warranty_claims.errors.duplicateSerial', 'A registration with this serial number already exists.'),
+    })
   }
 }
 
@@ -320,8 +324,9 @@ const crud = makeCrudRoute<RawRegistrationInput, RawRegistrationInput, Registrat
       const result = registrationCreateSchema.safeParse({ ...input, ...scope })
       if (!result.success) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
+      const { translate } = await resolveTranslations()
       await assertOrderBelongsToCustomer(em, scope, result.data.orderId ?? null, result.data.customerId ?? null)
-      await assertRegistrationSerialUnique(em, scope, result.data.serialNumber ?? null, null)
+      await assertRegistrationSerialUnique(em, scope, result.data.serialNumber ?? null, null, translate)
     },
     beforeUpdate: async (input, ctx) => {
       const scope = scopeFromContext(ctx)
@@ -346,7 +351,8 @@ const crud = makeCrudRoute<RawRegistrationInput, RawRegistrationInput, Registrat
       const effectiveOrderId = hasOwn(parsed, 'orderId') ? (parsed.orderId ?? null) : (existing.orderId ?? null)
       await assertOrderBelongsToCustomer(em, scope, effectiveOrderId, effectiveCustomerId)
       if (hasOwn(parsed, 'serialNumber') && (parsed.serialNumber ?? null) !== (existing.serialNumber ?? null)) {
-        await assertRegistrationSerialUnique(em, scope, parsed.serialNumber ?? null, existing.id)
+        const { translate } = await resolveTranslations()
+        await assertRegistrationSerialUnique(em, scope, parsed.serialNumber ?? null, existing.id, translate)
       }
     },
     afterCreate: async (entity) => {

--- a/packages/core/src/modules/warranty_claims/api/replacement-order/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/replacement-order/route.ts
@@ -6,6 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -56,24 +57,23 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['warranty_claims.claim.manage', 'sales.orders.manage'] },
 }
 
-function translateKey(key: string): string {
-  return key
-}
-
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
+async function resolveActionContext(
+  req: Request,
+  translate: ActionRouteContext['translate'],
+): Promise<ActionRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -86,7 +86,7 @@ async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
     },
     tenantId: auth.tenantId,
     organizationId,
-    translate: translateKey,
+    translate,
   }
 }
 
@@ -113,7 +113,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -133,8 +133,9 @@ async function runGuard(
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveActionContext(req)
+    const context = await resolveActionContext(req, translate)
     const requestInput = toReplacementOrderRequest(toRecord(await readJsonSafe(req, {})))
     const guarded = await runGuard(req, context, requestInput)
     if (!guarded.ok) {
@@ -148,7 +149,7 @@ export async function POST(req: Request) {
       'warranty_claims.claim.create_replacement_order',
       { input: toCommandInput(guardedInput, context), ctx: context.ctx },
     )
-    if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+    if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
     await guarded.runAfterSuccess()
     return NextResponse.json({
       replacementOrderId: result.replacementOrderId,
@@ -157,10 +158,10 @@ export async function POST(req: Request) {
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.replacement-order.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/return-label/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/return-label/route.ts
@@ -167,7 +167,7 @@ async function loadClaimAndLines(
 ): Promise<{ claim: WarrantyClaim; lines: WarrantyClaimLine[] }> {
   const scope = { tenantId: context.tenantId, organizationId: context.organizationId }
   const em = (context.ctx.container.resolve('em') as EntityManager).fork()
-  const claim = await requireScopedClaim(em, claimId, scope)
+  const claim = await requireScopedClaim(em, claimId, scope, {}, context.translate('warranty_claims.errors.notFound', 'Claim not found.'))
   const lines = await findWithDecryption(
     em,
     WarrantyClaimLine,

--- a/packages/core/src/modules/warranty_claims/api/return-label/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/return-label/route.ts
@@ -7,6 +7,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -69,24 +70,23 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['warranty_claims.claim.manage'] },
 }
 
-function translateKey(key: string): string {
-  return key
-}
-
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
+async function resolveActionContext(
+  req: Request,
+  translate: ActionRouteContext['translate'],
+): Promise<ActionRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -99,7 +99,7 @@ async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
     },
     tenantId: auth.tenantId,
     organizationId,
-    translate: translateKey,
+    translate,
   }
 }
 
@@ -142,7 +142,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -178,9 +178,9 @@ async function loadClaimAndLines(
   return { claim, lines }
 }
 
-function assertGeneratableStatus(claim: WarrantyClaim): void {
+function assertGeneratableStatus(claim: WarrantyClaim, translate: ActionRouteContext['translate']): void {
   if (claim.status !== 'approved' && claim.status !== 'awaiting_return') {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.returnLabelInvalidStatus' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.returnLabelInvalidStatus', 'Return labels can only be created for approved claims that are awaiting return.') })
   }
 }
 
@@ -188,12 +188,13 @@ async function executeSetReturnLabel(
   commandBus: CommandBus,
   input: ClaimSetReturnLabelInput,
   ctx: CommandRuntimeContext,
+  translate: ActionRouteContext['translate'],
 ): Promise<ReturnLabelCreatedResponse> {
   const { result } = await commandBus.execute<ClaimSetReturnLabelInput, ReturnLabelCommandResult>(
     'warranty_claims.claim.set_return_label',
     { input, ctx },
   )
-  if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+  if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
   return {
     status: 'created',
     labelUrl: result.labelUrl,
@@ -210,8 +211,9 @@ export function firstTranslatableIssueKey(err: z.ZodError): string {
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveActionContext(req)
+    const context = await resolveActionContext(req, translate)
     const requestInput = toReturnLabelRequest(toRecord(await readJsonSafe(req, {})))
     const guarded = await runGuard(req, context, requestInput)
     if (!guarded.ok) {
@@ -225,13 +227,14 @@ export async function POST(req: Request) {
         commandBus,
         toSetReturnLabelInput(guardedInput, context),
         context.ctx,
+        translate,
       )
       await guarded.runAfterSuccess()
       return NextResponse.json(response)
     }
 
     const { claim, lines } = await loadClaimAndLines(context, guardedInput.claimId)
-    assertGeneratableStatus(claim)
+    assertGeneratableStatus(claim, translate)
     await enforceWarrantyClaimOptimisticLock(
       context.ctx,
       claim,
@@ -259,16 +262,17 @@ export async function POST(req: Request) {
         carrier: result.carrier,
       }, context),
       context.ctx,
+      translate,
     )
     await guarded.runAfterSuccess()
     return NextResponse.json(response)
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: firstTranslatableIssueKey(err) }, { status: 400 })
+      return NextResponse.json({ error: translate(firstTranslatableIssueKey(err), 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.return-label.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/risk/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/risk/route.ts
@@ -39,6 +39,7 @@ type RiskRouteContext = {
   tenantId: string
   organizationId: string
   scope: WarrantyClaimScope
+  translate: (key: string, fallback?: string) => string
   em: EntityManager
 }
 
@@ -63,6 +64,7 @@ async function resolveRiskContext(req: Request): Promise<RiskRouteContext> {
     tenantId: auth.tenantId,
     organizationId,
     scope: { tenantId: auth.tenantId, organizationId },
+    translate,
     em,
   }
 }
@@ -72,7 +74,7 @@ export async function GET(req: Request) {
     const context = await resolveRiskContext(req)
     const url = new URL(req.url)
     const query = querySchema.parse(Object.fromEntries(url.searchParams))
-    const claim = await requireScopedClaim(context.em, query.claimId, context.scope)
+    const claim = await requireScopedClaim(context.em, query.claimId, context.scope, {}, context.translate('warranty_claims.errors.notFound', 'Claim not found.'))
     const lines = await findWithDecryption(
       context.em,
       WarrantyClaimLine,

--- a/packages/core/src/modules/warranty_claims/api/sales-return/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/sales-return/route.ts
@@ -6,6 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runRouteMutationGuards, type RouteMutationGuardResult } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { withScopedPayload } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -54,24 +55,23 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['warranty_claims.claim.manage', 'sales.returns.create'] },
 }
 
-function translateKey(key: string): string {
-  return key
-}
-
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
-async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
+async function resolveActionContext(
+  req: Request,
+  translate: ActionRouteContext['translate'],
+): Promise<ActionRouteContext> {
   const container = await createRequestContainer()
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
   const organizationId = scope?.selectedId ?? auth.orgId ?? null
   if (!organizationId) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.organization_required' })
+    throw new CrudHttpError(400, { error: translate('warranty_claims.errors.organization_required', 'Organization context is required.') })
   }
   return {
     ctx: {
@@ -84,7 +84,7 @@ async function resolveActionContext(req: Request): Promise<ActionRouteContext> {
     },
     tenantId: auth.tenantId,
     organizationId,
-    translate: translateKey,
+    translate,
   }
 }
 
@@ -110,7 +110,7 @@ async function runGuard(
 ): Promise<RouteMutationGuardResult> {
   const userId = context.ctx.auth?.sub
   if (!userId) {
-    throw new CrudHttpError(401, { error: 'warranty_claims.errors.unauthorized' })
+    throw new CrudHttpError(401, { error: context.translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
   }
   return runRouteMutationGuards({
     container: context.ctx.container,
@@ -130,8 +130,9 @@ async function runGuard(
 }
 
 export async function POST(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
-    const context = await resolveActionContext(req)
+    const context = await resolveActionContext(req, translate)
     const requestInput = toSalesReturnRequest(toRecord(await readJsonSafe(req, {})))
     const guarded = await runGuard(req, context, requestInput)
     if (!guarded.ok) {
@@ -143,16 +144,16 @@ export async function POST(req: Request) {
       'warranty_claims.claim.create_sales_return',
       { input: toCommandInput(guardedInput, context), ctx: context.ctx },
     )
-    if (!result) throw new CrudHttpError(400, { error: 'warranty_claims.errors.save_failed' })
+    if (!result) throw new CrudHttpError(400, { error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') })
     await guarded.runAfterSuccess()
     return NextResponse.json({ salesReturnId: result.salesReturnId, skippedLineIds: result.skippedLineIds })
   } catch (err) {
     if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     if (err instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('warranty_claims.sales-return.post failed', { err })
-    return NextResponse.json({ error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/troubleshooting-guides/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/troubleshooting-guides/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseBooleanFromUnknown } from '@open-mercato/shared/lib/boolean'
 import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { applyIdsFilter } from '../../lib/apiIdsFilter'
@@ -122,9 +123,22 @@ function toEntitySteps(value: unknown): Record<string, unknown> | null {
   if (value === undefined || value === null) return null
   const parsed = parseGuideSteps(value)
   if (!parsed) {
-    throw new CrudHttpError(400, { error: 'warranty_claims.errors.invalidTroubleshootingSteps' })
+    throw new CrudHttpError(400, { error: '[internal] troubleshooting steps reached the entity mapper unvalidated' })
   }
   return { prompt: parsed.prompt, options: parsed.options }
+}
+
+async function assertParsableGuideSteps(input: object): Promise<void> {
+  if (!hasOwn(input, 'steps')) return
+  const value = (input as { steps?: unknown }).steps
+  if (value === undefined || value === null || parseGuideSteps(value)) return
+  const { translate } = await resolveTranslations()
+  throw new CrudHttpError(400, {
+    error: translate(
+      'warranty_claims.errors.invalidTroubleshootingSteps',
+      'Troubleshooting steps must include a prompt and valid option branches.',
+    ),
+  })
 }
 
 function toTroubleshootingGuideEntityData(input: TroubleshootingGuideCreateInput): Record<string, unknown> {
@@ -237,6 +251,14 @@ const crud = makeCrudRoute<RawTroubleshootingGuideInput, RawTroubleshootingGuide
   create: {
     schema: rawBodySchema,
     mapToEntity: (input, ctx) => toTroubleshootingGuideEntityData(parseCreateInput(input, ctx)),
+  },
+  hooks: {
+    beforeCreate: async (input) => {
+      await assertParsableGuideSteps(input)
+    },
+    beforeUpdate: async (input) => {
+      await assertParsableGuideSteps(input)
+    },
   },
   update: {
     schema: rawBodySchema,

--- a/packages/core/src/modules/warranty_claims/api/vendor-recovery-suggestions/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/vendor-recovery-suggestions/route.ts
@@ -43,6 +43,7 @@ type SuggestionsRouteContext = {
   tenantId: string
   organizationId: string
   scope: WarrantyClaimScope
+  translate: (key: string, fallback?: string) => string
   em: EntityManager
 }
 
@@ -79,6 +80,7 @@ async function resolveSuggestionsContext(req: Request): Promise<SuggestionsRoute
     tenantId: auth.tenantId,
     organizationId,
     scope: { tenantId: auth.tenantId, organizationId },
+    translate,
     em,
   }
 }
@@ -88,7 +90,7 @@ export async function GET(req: Request) {
     const context = await resolveSuggestionsContext(req)
     const url = new URL(req.url)
     const query = querySchema.parse(Object.fromEntries(url.searchParams))
-    const claim = await requireScopedClaim(context.em, query.claimId, context.scope)
+    const claim = await requireScopedClaim(context.em, query.claimId, context.scope, {}, context.translate('warranty_claims.errors.notFound', 'Claim not found.'))
     if (claim.claimType !== 'warranty' || (claim.status !== 'resolved' && claim.status !== 'closed')) {
       return NextResponse.json({ ok: true, result: { claimId: claim.id, suggestions: [] } })
     }

--- a/packages/core/src/modules/warranty_claims/commands/shared.ts
+++ b/packages/core/src/modules/warranty_claims/commands/shared.ts
@@ -80,14 +80,20 @@ export async function loadScopedClaim(
   )
 }
 
+/**
+ * `notFoundMessage` is passed to `assertFound` verbatim, so request-scoped callers
+ * must hand in an already-translated sentence; the key default only suits the
+ * command surface, which runs without a request locale.
+ */
 export async function requireScopedClaim(
   em: EntityManager,
   id: string,
   scope: WarrantyClaimScope,
   options: FindOneOptions<WarrantyClaim> = {},
+  notFoundMessage = 'warranty_claims.errors.notFound',
 ): Promise<WarrantyClaim> {
   const claim = await loadScopedClaim(em, id, scope, options)
-  return assertFound(claim, 'warranty_claims.errors.notFound')
+  return assertFound(claim, notFoundMessage)
 }
 
 export function appendClaimEvent(

--- a/packages/core/src/modules/warranty_claims/lib/portalAuthGuard.ts
+++ b/packages/core/src/modules/warranty_claims/lib/portalAuthGuard.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { getCustomerAuthFromRequest, type CustomerAuthContext } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+
+export type LinkedCustomerAuthContext = CustomerAuthContext & { customerEntityId: string }
+
+export async function resolveLinkedCustomerAuth(req: Request): Promise<LinkedCustomerAuthContext | Response> {
+  const auth = await getCustomerAuthFromRequest(req)
+  if (!auth) {
+    const { translate } = await resolveTranslations()
+    return NextResponse.json(
+      { ok: false, error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') },
+      { status: 401 },
+    )
+  }
+  if (!auth.customerEntityId) {
+    const { translate } = await resolveTranslations()
+    return NextResponse.json(
+      {
+        ok: false,
+        error: translate(
+          'warranty_claims.errors.customerAccountNotLinked',
+          'Customer account is not linked to a customer record',
+        ),
+      },
+      { status: 403 },
+    )
+  }
+  return auth as LinkedCustomerAuthContext
+}


### PR DESCRIPTION
## Summary

Follow-up to #5512 / #5518. PR #5518 localized the `error` field on the two routes named in #5512;
this change finishes the job across the rest of the `warranty_claims` API surface — the 78 remaining
sites in 14 route files that returned the raw i18n **key** instead of a localized sentence.

Clients render the server's `error` string verbatim, so these keys reached users as-is; on the portal
endpoints they reached customers.

## What changed

- **One shared portal guard.** The `resolvePortalContext` 401/403 guard pair was copy-pasted in four
  places (`portal/attachments`, `portal/events`, `portal/claims/[id]/route.ts`,
  `portal/claims/[id]/shared.ts`) plus the copy #5518 localized in `portal/claims/route.ts`.
  All five now call `resolveLinkedCustomerAuth()` from `lib/portalAuthGuard.ts`, so the portal auth
  errors are localized in exactly one place. This is the optional dedup the issue suggests.
- **Staff action routes** (`receiving`, `credit-memo`, `sales-return`, `replacement-order`,
  `return-label`, `ai/assess`) resolve the translator once at the route boundary and pass it through
  the request context. This also removes the five `translateKey = (key) => key` identity stubs and the
  equivalent `translate: (key) => key` in `ai/assess`, which were silently leaking the
  `errors.tenant_required` / `errors.organization_required` messages raised inside `withScopedPayload`.
- **`return-label`** translates the keyed ZodError message that `firstTranslatableIssueKey` picks
  (#5287); the helper still returns the key, so its existing test is unchanged.
- **`registrations`** threads the translator into `assertRegistrationSerialUnique`.
- **`troubleshooting-guides`** validates the guide steps in `beforeCreate` / `beforeUpdate`, where
  `resolveTranslations()` is reachable — `mapToEntity` is synchronous by contract, so the customer-facing
  message cannot be produced there. `toEntitySteps` keeps an `[internal]`-prefixed invariant throw for
  the now-unreachable case, matching the idiom already used in that file.

- **The scoped-claim 404** (added after review). `requireScopedClaim` handed the raw
  `warranty_claims.errors.notFound` key to `assertFound`, whose contract requires an already-translated
  message, so every route loading a claim through it answered
  `404 {"error": "warranty_claims.errors.notFound"}` — the #5512 defect on routes this PR listed as
  fixed. It now takes an optional `notFoundMessage` (the key stays the default for the command surface,
  which runs without a request locale), and the five API call sites — `return-label`, `ai/assess`,
  `events`, `risk`, `vendor-recovery-suggestions` — pass the translated sentence.

No new i18n keys — every key already existed in all five locales (de/en/es/ko/pl).
No API shape, database or contract change: only the human-readable `error` string differs.

## Acceptance

```
grep -rn "error: 'warranty_claims\." packages/core/src/modules/warranty_claims/api/ | grep -v "translate("
```
returns nothing.

## Testing

- `packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts` extended from
  10 to 46 tests: the portal attachment / events / detail / submit / withdraw routes; 401,
  400-no-organization and 400-invalid-body for all six staff action routes; and the 404 claim-lookup path
  on `return-label`, `ai/assess`, `events`, `risk` and `vendor-recovery-suggestions`.
- Plus a source invariant test that walks `api/**/*.ts` and fails if any route file ever inlines a raw
  `warranty_claims.` key in an error payload again — this is what covers `registrations` and
  `troubleshooting-guides`, whose `makeCrudRoute` paths are not reachable without a database. It now
  asserts a floor on the number of files walked, so an empty walk cannot pass silently.
- `__integration__/TC-WC-021-return-label-seam.spec.ts` and `__integration__/TC-WC-024-ai-assess.spec.ts`
  still expected the two raw keys this PR replaced (the `ephemeral-integration` failure on `f78ebfb`);
  both now expect the localized sentence, byte-identical to its `en.json` value.
- `__tests__/ai-assess.test.ts` had one expectation asserting the old raw key; it now expects the
  localized sentence, with the translator mocked so the assertion no longer depends on real locale
  detection.
- `yarn typecheck` ✅, `yarn lint` ✅ (0 errors), `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅,
  and the full `@open-mercato/core` jest suite ✅ (11 825 passed, 589/589 in `warranty_claims`).
  Playwright is verified by CI. `@open-mercato/cli` had 2 pre-existing failures in
  `module-facts.bc-guard.test.ts` on the first pass, reproduced identically on a clean `develop`.

## Not in scope

Error payloads raised **outside** `api/**` are still raw keys — 70 sites, all of them reached from the
command surface as well as from HTTP:

```
grep -rn "error: 'warranty_claims\." packages/core/src/modules/warranty_claims/commands packages/core/src/modules/warranty_claims/lib
```

`commands/claims.ts` (50), `commands/claim-lines.ts` (9), `commands/settings.ts` (3), `lib/aiAssist.ts` (3),
and one each in `lib/triage.ts`, `lib/stateMachine.ts`, `lib/grading.ts`, `lib/claimTypeConfig.ts` and
`lib/orderOwnership.ts`.

Commands also run from subscribers, CLI and workers, where there is no request and therefore no locale to
resolve, so this needs a design decision rather than a mechanical pass — filed as #5727 with three options
and their trade-offs. That is why the invariant test here is scoped to, and named after, what it actually
checks: no route **file** inlines a raw key.

Fixes #5522

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790489848&installation_model_id=432243&pr_number=5724&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5724&signature=102a36e9cabef5768546f6d4469ec0c4faee9c5170659d40b3e76faa2854f19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
