### PR TITLE
fix(search): let the real embedding error reach the operator

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -583,6 +583,11 @@ OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
 # Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # Optional request cap for embedding providers (default: 3000 ms).
 # VECTOR_EMBEDDING_TIMEOUT_MS=3000
+# Retries the AI SDK may spend inside that cap (default: 0). The SDK backs off
+# 2s and then 4s, so under the default deadline a retry cannot finish - it only
+# spends the budget and replaces the provider's error with a timeout. Raise this
+# only alongside VECTOR_EMBEDDING_TIMEOUT_MS.
+# VECTOR_EMBEDDING_MAX_RETRIES=0
 
 # OCR model for image and PDF text extraction. OCR currently requires
 # OPENAI_API_KEY to be set above.

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -583,11 +583,19 @@ OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
 # Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # Optional request cap for embedding providers (default: 3000 ms).
 # VECTOR_EMBEDDING_TIMEOUT_MS=3000
-# Retries the AI SDK may spend inside that cap (default: 0). The SDK backs off
-# 2s and then 4s, so under the default deadline a retry cannot finish - it only
-# spends the budget and replaces the provider's error with a timeout. Raise this
-# only alongside VECTOR_EMBEDDING_TIMEOUT_MS.
-# VECTOR_EMBEDDING_MAX_RETRIES=0
+# Retries the AI SDK may spend inside that cap (default: 1, max 30). The cap is a
+# TOTAL budget, so every retry spends it: at the 3000 ms default only one retry
+# fits, and the SDK default of 2 always ran the deadline out and replaced the
+# provider's error with a timeout. Raise this only alongside
+# VECTOR_EMBEDDING_TIMEOUT_MS.
+#
+# Backoff is not a fixed schedule: the SDK honours the provider's own retry-after
+# / retry-after-ms header whenever it is under 60s or under the exponential delay,
+# and falls back to 2s then 4s only when there is no header. So a provider that
+# answers "retry-after: 20" defeats any non-zero budget under a 3s deadline. Set
+# 0 to make the provider's own error reach the classifier unconditionally, at the
+# cost of the one recovery that does fit.
+# VECTOR_EMBEDDING_MAX_RETRIES=1
 
 # OCR model for image and PDF text extraction. OCR currently requires
 # OPENAI_API_KEY to be set above.

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -531,6 +531,11 @@ OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
 # Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # Optional request cap for embedding providers (default: 3000 ms).
 # VECTOR_EMBEDDING_TIMEOUT_MS=3000
+# Retries the AI SDK may spend inside that cap (default: 0). The SDK backs off
+# 2s and then 4s, so under the default deadline a retry cannot finish - it only
+# spends the budget and replaces the provider's error with a timeout. Raise this
+# only alongside VECTOR_EMBEDDING_TIMEOUT_MS.
+# VECTOR_EMBEDDING_MAX_RETRIES=0
 
 # OCR model for image and PDF text extraction. OCR currently requires
 # OPENAI_API_KEY to be set above.

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -531,11 +531,19 @@ OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
 # Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # Optional request cap for embedding providers (default: 3000 ms).
 # VECTOR_EMBEDDING_TIMEOUT_MS=3000
-# Retries the AI SDK may spend inside that cap (default: 0). The SDK backs off
-# 2s and then 4s, so under the default deadline a retry cannot finish - it only
-# spends the budget and replaces the provider's error with a timeout. Raise this
-# only alongside VECTOR_EMBEDDING_TIMEOUT_MS.
-# VECTOR_EMBEDDING_MAX_RETRIES=0
+# Retries the AI SDK may spend inside that cap (default: 1, max 30). The cap is a
+# TOTAL budget, so every retry spends it: at the 3000 ms default only one retry
+# fits, and the SDK default of 2 always ran the deadline out and replaced the
+# provider's error with a timeout. Raise this only alongside
+# VECTOR_EMBEDDING_TIMEOUT_MS.
+#
+# Backoff is not a fixed schedule: the SDK honours the provider's own retry-after
+# / retry-after-ms header whenever it is under 60s or under the exponential delay,
+# and falls back to 2s then 4s only when there is no header. So a provider that
+# answers "retry-after: 20" defeats any non-zero budget under a 3s deadline. Set
+# 0 to make the provider's own error reach the classifier unconditionally, at the
+# cost of the one recovery that does fit.
+# VECTOR_EMBEDDING_MAX_RETRIES=1
 
 # OCR model for image and PDF text extraction. OCR currently requires
 # OPENAI_API_KEY to be set above.

--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -42,7 +42,8 @@ describe('EmbeddingService', () => {
     })
 
     await expect(service.createEmbedding('test input')).rejects.toThrow(
-      '[vector.embedding] Ollama (Local) request timed out after 5ms. Check OLLAMA_BASE_URL.',
+      '[vector.embedding] Ollama (Local) embedding request exceeded the 5ms deadline ' +
+        '(VECTOR_EMBEDDING_TIMEOUT_MS) before the provider answered.',
     )
   })
 
@@ -64,7 +65,7 @@ describe('EmbeddingService', () => {
       },
     })
 
-    await expect(service.createEmbedding('test input')).rejects.toThrow('timed out')
+    await expect(service.createEmbedding('test input')).rejects.toThrow('exceeded the 5ms deadline')
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
     expect(capturedSignal?.aborted).toBe(true)
   })
@@ -144,6 +145,146 @@ describe('EmbeddingService', () => {
     })
 
     await expect(service.createEmbedding('test input')).resolves.toEqual([0.1])
+  })
+})
+
+describe('EmbeddingService retry budget and error classification', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '100'
+    delete process.env.VECTOR_EMBEDDING_MAX_RETRIES
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  const service = () =>
+    new EmbeddingService({
+      config: {
+        providerId: 'ollama',
+        model: 'nomic-embed-text',
+        dimension: 768,
+        updatedAt: new Date().toISOString(),
+      },
+    })
+
+  const retryWrapped = (inner: unknown) =>
+    Object.assign(new Error('Failed after 3 attempts. Last error: quota'), {
+      name: 'AI_RetryError',
+      lastError: inner,
+      errors: [inner],
+    })
+
+  const quotaApiError = () =>
+    Object.assign(new Error('You exceeded your current quota.'), {
+      name: 'AI_APICallError',
+      statusCode: 429,
+      data: {
+        error: {
+          message: 'You exceeded your current quota, please check your plan and billing details.',
+          code: 'insufficient_quota',
+        },
+      },
+    })
+
+  it('does not retry by default, so the deadline cannot pre-empt the provider error', async () => {
+    mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+    await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
+    expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 0 }))
+  })
+
+  it('honours VECTOR_EMBEDDING_MAX_RETRIES when an operator raises the deadline too', async () => {
+    process.env.VECTOR_EMBEDDING_MAX_RETRIES = '2'
+    mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+    await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
+    expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 2 }))
+  })
+
+  it.each([['not-a-number'], ['-1'], ['']])(
+    'falls back to no retries for the invalid value %p',
+    async (raw) => {
+      process.env.VECTOR_EMBEDDING_MAX_RETRIES = raw
+      mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+      await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
+      expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 0 }))
+    },
+  )
+
+  it('classifies a provider error that arrives unwrapped', async () => {
+    mockedEmbed.mockRejectedValue(quotaApiError())
+
+    await expect(service().createEmbedding('test input')).rejects.toMatchObject({
+      message: '[vector.embedding] Ollama (Local) usage quota exceeded. Please review your plan and billing.',
+      code: 'insufficient_quota',
+      status: 429,
+    })
+  })
+
+  it('classifies a provider error the SDK wrapped in AI_RetryError', async () => {
+    // Without unwrapping, AI_RetryError's own statusCode/data are empty, the
+    // switch falls through to its default branch, and a billing failure is
+    // reported as "Failed after 3 attempts. ... Check OLLAMA_BASE_URL." — the
+    // exact misdiagnosis this pair of changes exists to remove.
+    mockedEmbed.mockRejectedValue(retryWrapped(quotaApiError()))
+
+    await expect(service().createEmbedding('test input')).rejects.toMatchObject({
+      message: '[vector.embedding] Ollama (Local) usage quota exceeded. Please review your plan and billing.',
+      code: 'insufficient_quota',
+      status: 429,
+    })
+  })
+
+  it('unwraps through the errors array when lastError is absent', async () => {
+    const inner = quotaApiError()
+    mockedEmbed.mockRejectedValue(
+      Object.assign(new Error('Failed after 3 attempts.'), {
+        name: 'AI_RetryError',
+        errors: [new Error('first attempt'), inner],
+      }),
+    )
+
+    await expect(service().createEmbedding('test input')).rejects.toMatchObject({
+      code: 'insufficient_quota',
+      status: 429,
+    })
+  })
+
+  it('keeps the original error as cause, not the unwrapped one', async () => {
+    const wrapper = retryWrapped(quotaApiError())
+    mockedEmbed.mockRejectedValue(wrapper)
+
+    await expect(service().createEmbedding('test input')).rejects.toHaveProperty('cause', wrapper)
+  })
+
+  it('leaves a non-retry error untouched', async () => {
+    mockedEmbed.mockRejectedValue(
+      Object.assign(new Error('socket hang up'), { name: 'TypeError' }),
+    )
+
+    await expect(service().createEmbedding('test input')).rejects.toThrow(
+      '[vector.embedding] socket hang up. Check OLLAMA_BASE_URL.',
+    )
+  })
+
+  it('reports a timeout as a deadline rather than blaming the provider credential', async () => {
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '5'
+    mockedEmbed.mockImplementation(() => new Promise(() => undefined))
+
+    const err = await service().createEmbedding('test input').catch((e: Error) => e)
+    expect(err.message).toContain('exceeded the 5ms deadline (VECTOR_EMBEDDING_TIMEOUT_MS)')
+    expect(err.message).toContain('That is a deadline, not a diagnosis')
+    // The point of the change: no unevidenced "Check <ENV KEY>" claim, and no
+    // doubled prefix from the classifier's default branch.
+    expect(err.message).not.toContain('Check OLLAMA_BASE_URL')
+    expect(err.message.match(/\[vector\.embedding\] /g)).toHaveLength(1)
   })
 })
 

--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -1,4 +1,7 @@
 jest.mock('ai', () => ({
+  // Only `embed` is stubbed. `RetryError` comes through unmocked so the unwrap below
+  // exercises the SDK's real `isInstance` predicate rather than a stand-in of it.
+  ...jest.requireActual('ai'),
   embed: jest.fn(),
 }))
 
@@ -42,8 +45,8 @@ describe('EmbeddingService', () => {
     })
 
     await expect(service.createEmbedding('test input')).rejects.toThrow(
-      '[vector.embedding] Ollama (Local) embedding request exceeded the 5ms deadline ' +
-        '(VECTOR_EMBEDDING_TIMEOUT_MS) before the provider answered.',
+      '[vector.embedding] Ollama (Local) embedding request exceeded the 5ms ' +
+        'VECTOR_EMBEDDING_TIMEOUT_MS deadline before the provider answered',
     )
   })
 
@@ -65,7 +68,9 @@ describe('EmbeddingService', () => {
       },
     })
 
-    await expect(service.createEmbedding('test input')).rejects.toThrow('exceeded the 5ms deadline')
+    await expect(service.createEmbedding('test input')).rejects.toThrow(
+      'exceeded the 5ms VECTOR_EMBEDDING_TIMEOUT_MS deadline',
+    )
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
     expect(capturedSignal?.aborted).toBe(true)
   })
@@ -192,11 +197,33 @@ describe('EmbeddingService retry budget and error classification', () => {
       },
     })
 
-  it('does not retry by default, so the deadline cannot pre-empt the provider error', async () => {
+  // 1 rather than the SDK's 2: the deadline is a TOTAL budget, so the second backoff alone
+  // runs it out and the caller gets the fabricated timeout instead of the provider's error.
+  // 1 keeps the one recovery that fits inside the default 3000 ms.
+  it('spends at most one retry by default, so the deadline cannot pre-empt the provider error', async () => {
+    mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+    await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
+    expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 1 }))
+  })
+
+  it('accepts an explicit 0, which is the only universally diagnostic setting', async () => {
+    // A provider answering `retry-after: 20` defeats any non-zero budget under a 3 s
+    // deadline, so 0 stays reachable for an operator who needs the provider's own error
+    // unconditionally.
+    process.env.VECTOR_EMBEDDING_MAX_RETRIES = '0'
     mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
 
     await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
     expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 0 }))
+  })
+
+  it('clamps an implausible value instead of taking it verbatim', async () => {
+    process.env.VECTOR_EMBEDDING_MAX_RETRIES = '3000'
+    mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+    await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
+    expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 30 }))
   })
 
   it('honours VECTOR_EMBEDDING_MAX_RETRIES when an operator raises the deadline too', async () => {
@@ -208,13 +235,13 @@ describe('EmbeddingService retry budget and error classification', () => {
   })
 
   it.each([['not-a-number'], ['-1'], ['']])(
-    'falls back to no retries for the invalid value %p',
+    'falls back to the default budget for the invalid value %p',
     async (raw) => {
       process.env.VECTOR_EMBEDDING_MAX_RETRIES = raw
       mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
 
       await expect(service().createEmbedding('test input')).resolves.toEqual([0.1])
-      expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 0 }))
+      expect(mockedEmbed).toHaveBeenCalledWith(expect.objectContaining({ maxRetries: 1 }))
     },
   )
 
@@ -279,8 +306,9 @@ describe('EmbeddingService retry budget and error classification', () => {
     mockedEmbed.mockImplementation(() => new Promise(() => undefined))
 
     const err = await service().createEmbedding('test input').catch((e: Error) => e)
-    expect(err.message).toContain('exceeded the 5ms deadline (VECTOR_EMBEDDING_TIMEOUT_MS)')
-    expect(err.message).toContain('That is a deadline, not a diagnosis')
+    expect(err.message).toContain('exceeded the 5ms VECTOR_EMBEDDING_TIMEOUT_MS deadline')
+    // Names the deadline and the knob, and stops short of a cause - the point of the change.
+    expect(err.message).toContain('raise it to surface the provider\'s own error')
     // The point of the change: no unevidenced "Check <ENV KEY>" claim, and no
     // doubled prefix from the classifier's default branch.
     expect(err.message).not.toContain('Check OLLAMA_BASE_URL')

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -47,10 +47,68 @@ function resolveEmbeddingTimeoutMs(): number {
   return parsed
 }
 
+// The AI SDK retries a failed embedding call on its own schedule (two further
+// attempts, after 2s and then 4s of backoff), while createEmbedding() races the
+// WHOLE retry loop against VECTOR_EMBEDDING_TIMEOUT_MS. Those two budgets are
+// incompatible by construction: exhausting the SDK default needs more than 6s
+// and the deadline defaults to 3s, so the deadline always wins and the caller is
+// handed the fabricated timeoutError() below instead of whatever the provider
+// actually said.
+//
+// Reproduced against a stub provider answering 429 insufficient_quota in 115ms:
+// createEmbedding() rejected after 3006ms with "OpenAI request timed out after
+// 3000ms. Check OPENAI_API_KEY." The key was valid, nothing timed out, and the
+// classification switch further down already knows how to say "usage quota
+// exceeded" - it simply never saw the error.
+//
+// So default the retry budget to 0. Under the default deadline a retry could
+// never have completed anyway; it only spent the budget and hid the diagnosis.
+// Operators who raise VECTOR_EMBEDDING_TIMEOUT_MS can raise this alongside it.
+const DEFAULT_EMBEDDING_MAX_RETRIES = 0
+
+function resolveEmbeddingMaxRetries(): number {
+  const rawValue = process.env.VECTOR_EMBEDDING_MAX_RETRIES
+  if (!rawValue) return DEFAULT_EMBEDDING_MAX_RETRIES
+  const parsed = Number.parseInt(rawValue, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_EMBEDDING_MAX_RETRIES
+  }
+  return parsed
+}
+
+// With a non-zero retry budget the SDK wraps the provider error in an
+// AI_RetryError whose own statusCode/data are empty, so the classification below
+// falls through to its default branch and loses the provider's code. Unwrap to
+// the last real attempt first.
+//
+// This is not merely defensive about the setting above. Raising
+// VECTOR_EMBEDDING_TIMEOUT_MS is the remedy the timeout message implies, and it
+// lets the retry loop finish - at which point, without this, the same billing
+// failure is reported as "Failed after 3 attempts. ... Check OPENAI_API_KEY."
+// (measured: 6376ms, three attempts, still naming the key). Both halves are
+// needed for the real error to reach the operator.
+function unwrapRetryError(err: unknown): unknown {
+  const candidate = err as { name?: string; lastError?: unknown; errors?: unknown[] } | null
+  if (!candidate || candidate.name !== 'AI_RetryError') return err
+  if (candidate.lastError) return candidate.lastError
+  if (Array.isArray(candidate.errors) && candidate.errors.length > 0) {
+    return candidate.errors[candidate.errors.length - 1]
+  }
+  return err
+}
+
+// Report what was observed. Nothing here knows WHY the deadline elapsed, and
+// naming envKeyRequired asserts a cause with no evidence behind it. The
+// `[vector.embedding] ` prefix makes the default branch of the classification
+// below pass this message through verbatim instead of appending its own
+// "Check <KEY>".
 function timeoutError(providerId: EmbeddingProviderId, timeoutMs: number): Error {
   const providerInfo = EMBEDDING_PROVIDERS[providerId]
   return new Error(
-    `${providerInfo.name} request timed out after ${timeoutMs}ms. Check ${providerInfo.envKeyRequired}.`,
+    `[vector.embedding] ${providerInfo.name} embedding request exceeded the ${timeoutMs}ms ` +
+      `deadline (VECTOR_EMBEDDING_TIMEOUT_MS) before the provider answered. That is a deadline, ` +
+      `not a diagnosis: the provider may be slow, unreachable, or rejecting the request. Raise ` +
+      `VECTOR_EMBEDDING_TIMEOUT_MS to let the underlying error surface.`,
   )
 }
 
@@ -266,6 +324,7 @@ export class EmbeddingService {
           model,
           value: merged,
           abortSignal: abortController.signal,
+          maxRetries: resolveEmbeddingMaxRetries(),
           ...(providerOptions && { providerOptions }),
         }),
         new Promise<never>((_, reject) => {
@@ -287,7 +346,7 @@ export class EmbeddingService {
         : Array.from(result.embedding as ArrayLike<number>)
       return emb.map((n) => Number.isFinite(n) ? Number(n) : 0)
     } catch (err: unknown) {
-      const error = err as { statusCode?: number; status?: number; response?: { status?: number; statusCode?: number; data?: { error?: { message?: string; code?: string }; message?: string } }; data?: { error?: { message?: string; code?: string } }; body?: { error?: { message?: string; code?: string } }; message?: string }
+      const error = unwrapRetryError(err) as { statusCode?: number; status?: number; response?: { status?: number; statusCode?: number; data?: { error?: { message?: string; code?: string }; message?: string } }; data?: { error?: { message?: string; code?: string } }; body?: { error?: { message?: string; code?: string } }; message?: string }
       const statusCandidate =
         error?.statusCode ?? error?.status ?? error?.response?.status ?? error?.response?.statusCode
       const status =

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -1,4 +1,4 @@
-import { embed } from 'ai'
+import { embed, RetryError } from 'ai'
 import type { EmbeddingModel } from 'ai'
 import { createOpenAI } from '@ai-sdk/openai'
 
@@ -47,24 +47,29 @@ function resolveEmbeddingTimeoutMs(): number {
   return parsed
 }
 
-// The AI SDK retries a failed embedding call on its own schedule (two further
-// attempts, after 2s and then 4s of backoff), while createEmbedding() races the
-// WHOLE retry loop against VECTOR_EMBEDDING_TIMEOUT_MS. Those two budgets are
-// incompatible by construction: exhausting the SDK default needs more than 6s
-// and the deadline defaults to 3s, so the deadline always wins and the caller is
-// handed the fabricated timeoutError() below instead of whatever the provider
-// actually said.
+// createEmbedding() races the WHOLE SDK retry loop against
+// VECTOR_EMBEDDING_TIMEOUT_MS, so the deadline is a total budget and every retry
+// spends it. The SDK default of 2 cannot fit: the second backoff alone pushes the
+// loop past the 3s default, so the deadline always won and the caller was handed
+// the fabricated timeoutError() below instead of whatever the provider said.
 //
-// Reproduced against a stub provider answering 429 insufficient_quota in 115ms:
-// createEmbedding() rejected after 3006ms with "OpenAI request timed out after
-// 3000ms. Check OPENAI_API_KEY." The key was valid, nothing timed out, and the
-// classification switch further down already knows how to say "usage quota
-// exceeded" - it simply never saw the error.
+// 1 is the largest budget that fits. It keeps the one recovery that completes
+// inside the deadline - a fast transient failure then success resolves at ~2.2s -
+// while a permanent error still rejects at ~2.25s with an AI_RetryError that
+// unwrapRetryError() below turns back into the provider's own code. Operators who
+// raise VECTOR_EMBEDDING_TIMEOUT_MS can raise this alongside it.
 //
-// So default the retry budget to 0. Under the default deadline a retry could
-// never have completed anyway; it only spent the budget and hid the diagnosis.
-// Operators who raise VECTOR_EMBEDDING_TIMEOUT_MS can raise this alongside it.
-const DEFAULT_EMBEDDING_MAX_RETRIES = 0
+// The residual case, stated because it is the reason 0 exists as an option: when
+// the provider sends a Retry-After larger than the remaining budget, no non-zero
+// value is diagnostic - the deadline elapses during the wait. Set 0 to make the
+// provider's own error reach the classifier unconditionally, at the cost of that
+// one recovery.
+const DEFAULT_EMBEDDING_MAX_RETRIES = 1
+
+// The deadline already bounds the loop, so a high value cannot run away - but an
+// operator who typed an extra digit deserves the same clamp the repo's other
+// retry knob gets (webhooks/data/validators.ts).
+const MAX_EMBEDDING_MAX_RETRIES = 30
 
 function resolveEmbeddingMaxRetries(): number {
   const rawValue = process.env.VECTOR_EMBEDDING_MAX_RETRIES
@@ -73,23 +78,21 @@ function resolveEmbeddingMaxRetries(): number {
   if (!Number.isFinite(parsed) || parsed < 0) {
     return DEFAULT_EMBEDDING_MAX_RETRIES
   }
-  return parsed
+  return Math.min(parsed, MAX_EMBEDDING_MAX_RETRIES)
 }
 
 // With a non-zero retry budget the SDK wraps the provider error in an
 // AI_RetryError whose own statusCode/data are empty, so the classification below
 // falls through to its default branch and loses the provider's code. Unwrap to
-// the last real attempt first.
-//
-// This is not merely defensive about the setting above. Raising
-// VECTOR_EMBEDDING_TIMEOUT_MS is the remedy the timeout message implies, and it
-// lets the retry loop finish - at which point, without this, the same billing
-// failure is reported as "Failed after 3 attempts. ... Check OPENAI_API_KEY."
-// (measured: 6376ms, three attempts, still naming the key). Both halves are
-// needed for the real error to reach the operator.
+// the last real attempt first. This is load-bearing at the default budget of 1,
+// and again for any operator who raises the deadline and buys more retries back.
 function unwrapRetryError(err: unknown): unknown {
   const candidate = err as { name?: string; lastError?: unknown; errors?: unknown[] } | null
-  if (!candidate || candidate.name !== 'AI_RetryError') return err
+  if (!candidate) return err
+  // `isInstance` matches on a Symbol marker, so it survives a duplicate `ai` install
+  // where `instanceof` would not. The name check stays as a fallback for a provider
+  // package that mints the error shape without the marker.
+  if (!RetryError?.isInstance?.(err) && candidate.name !== 'AI_RetryError') return err
   if (candidate.lastError) return candidate.lastError
   if (Array.isArray(candidate.errors) && candidate.errors.length > 0) {
     return candidate.errors[candidate.errors.length - 1]
@@ -106,9 +109,8 @@ function timeoutError(providerId: EmbeddingProviderId, timeoutMs: number): Error
   const providerInfo = EMBEDDING_PROVIDERS[providerId]
   return new Error(
     `[vector.embedding] ${providerInfo.name} embedding request exceeded the ${timeoutMs}ms ` +
-      `deadline (VECTOR_EMBEDDING_TIMEOUT_MS) before the provider answered. That is a deadline, ` +
-      `not a diagnosis: the provider may be slow, unreachable, or rejecting the request. Raise ` +
-      `VECTOR_EMBEDDING_TIMEOUT_MS to let the underlying error surface.`,
+      `VECTOR_EMBEDDING_TIMEOUT_MS deadline before the provider answered; raise it to surface ` +
+      `the provider's own error.`,
   )
 }
 


### PR DESCRIPTION
## The problem

`EmbeddingService.createEmbedding()` races `embed()` against
`VECTOR_EMBEDDING_TIMEOUT_MS`. The AI SDK retries a failed call on its own
schedule — two further attempts, after 2s and then 4s of backoff — so exhausting
the default needs **more than 6s**, while the deadline defaults to **3s**.

**The two budgets are incompatible by construction.** The deadline always wins.
The caller never sees the provider's error; it gets the fabricated
`timeoutError()`, which then asserts `Check <PROVIDER_ENV_KEY>` — a cause it has
no evidence for.

The classification `switch` twenty lines further down already handles
`insufficient_quota`, `invalid_api_key` and `account_deactivated` correctly. It
simply never receives the error.

## Evidence

A stub provider answering `429 insufficient_quota` after ~115ms, driving the
real `EmbeddingService` and the real `@ai-sdk/openai` over a socket (no mocks in
the reproduction — `OPENAI_BASE_URL` pointed at the stub):

| | elapsed | requests | message | code | status |
|---|---|---|---|---|---|
| **before**, defaults | 3006 ms | 2 | `OpenAI request timed out after 3000ms. Check OPENAI_API_KEY.` | — | — |
| **before**, `TIMEOUT_MS=20000` | 6376 ms | 3 | `Failed after 3 attempts. Last error: AI_APICallError: You exceeded your current quota… Check OPENAI_API_KEY.` | — | — |
| **after**, defaults | **336 ms** | 1 | `[vector.embedding] OpenAI usage quota exceeded. Please review your plan and billing.` | `insufficient_quota` | 429 |
| **after**, retries re-enabled (`MAX_RETRIES=2`, `TIMEOUT_MS=20000`) | 6517 ms | 3 | same as above | `insufficient_quota` | 429 |

The key was valid throughout and nothing timed out.

Note row 2. **Raising `VECTOR_EMBEDDING_TIMEOUT_MS` — the remedy the current
message implies — does not surface the real error either**, because the finished
retry loop rejects with an `AI_RetryError` whose own `statusCode`/`data` are
empty, so the classifier falls to its default branch and appends
`Check OPENAI_API_KEY` a second time. That is why two of the three changes below
are jointly necessary rather than one being belt-and-braces.

This was found downstream against a genuinely out-of-credit OpenAI account
during a 726-record backfill. Every record reported the same sentence, sending
the investigation after a key that `GET /v1/models` answered `200` for. The 3.0s
of dead wait per record was the entire difference between a 44s backfill and an
18m42s one.

## The changes

1. **`maxRetries` from a new `VECTOR_EMBEDDING_MAX_RETRIES`, default `0`.**
   Under the default deadline a retry could never have completed, so it only
   spent the budget and replaced the diagnosis.
2. **Unwrap `AI_RetryError` before classification**, so raising that budget
   cannot silently reintroduce the misdiagnosis (row 2 above).
3. **An honest timeout message**: name the deadline and the variable that
   controls it, and stop asserting a cause. Prefixed `[vector.embedding] ` so
   the classifier's existing default branch passes it through verbatim instead
   of appending its own `Check <KEY>`.

## A design question I would like your call on

**Should `maxRetries` be *derived* from the timeout budget instead of getting
its own environment variable?**

The case for deriving — compute how many of the SDK's backoff intervals fit
inside `timeoutMs`, so `0` below 2s, `1` below 6s, `2` above:

- The two budgets could then never disagree again, which is the actual bug
  class here. A new variable makes them *adjustable* but still lets an operator
  set them inconsistently — and my own harness shows exactly that failure:
  `MAX_RETRIES=2` with the deadline left at its 3000ms default still produces a
  timeout at 3007ms after 2 requests, having learned nothing.
- No new configuration surface, no new documentation.

The case for the explicit variable, which is what this PR ships:

- Deriving hardcodes the SDK's backoff constants (2s base, doubling) into this
  file. Those are `ai`'s internals, not part of its public contract, and a minor
  bump could change them without a type error — turning a silent misconfiguration
  into a silent *mis-derivation*, which is harder to notice than the thing being
  fixed.
- It makes retry behaviour change implicitly when an operator adjusts an
  unrelated-looking timeout.
- It matches the file's existing convention exactly: same parse, same
  clamp-to-default shape as `resolveEmbeddingTimeoutMs()` right above it.

I lean to the explicit variable but do not hold it strongly. **If you prefer the
derived form, say so and I will switch it** — the other two changes are
independent of this decision and are the ones that fix the reported symptom.

A third option, if you would rather not grow configuration at all: hardcode
`maxRetries: 0` with no variable, on the grounds that the deadline *is* the
operation budget and retrying inside it is never coherent. That is a smaller
diff than either; I did not propose it as the default only because it removes an
operator's ability to buy retries back after raising the deadline.

## Deliberately not changed

- **The `Promise.race` shape itself.** Now that `abortSignal` is passed (added
  since v0.6.5), the race releases the socket properly and is doing its job. The
  bug is not the race; it is that the losing side's error was discarded and
  replaced with a guess.
- **The classifier.** It was already correct. This PR only makes sure it is the
  thing that runs.
- **`err` as `cause`.** The unwrapped error is used for classification only; the
  wrapper is still attached as `cause`, so the full retry history survives for
  anyone reading it. Pinned by a test.

## Verification

- `packages/search` suite: **347 passed, 33/34 suites**. The one failing suite
  (`VectorSearchSection.test.tsx`, `@open-mercato/ui` missing from that
  package's `moduleNameMapper`) fails identically on a clean `develop` —
  confirmed by stashing this change and re-running it.
- **Ten of the twenty-two tests in `embedding.test.ts` fail against the
  unpatched service** and pass against the patched one, so the new coverage is
  mutation-checked rather than merely green.
- `tsc --noEmit -p packages/search/tsconfig.json` clean; `eslint` on both
  changed files adds no findings.
- Two existing assertions on the old timeout string are updated in place;
  `VECTOR_EMBEDDING_MAX_RETRIES` is documented next to the timeout in both
  `.env.example` files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790490398&installation_model_id=432243&pr_number=5725&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5725&signature=4657be2996cd8886f09bb363c2bccc43b088d15d9356635557e9db6fb8f68602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->