### PR TITLE
fix(query_index): keep credential-bearing entity types out of the search index

### DIFF
--- a/.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md
+++ b/.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md
@@ -1,0 +1,204 @@
+# Credential-bearing entity types in the search index
+
+## TL;DR
+
+Nothing stops a credential table being written into `entity_indexes` and
+`search_tokens`. `mercato query_index reindex` with no `--entity` sweeps every
+generated entity id, so a stock deployment indexes `auth:session`,
+`auth:password_reset`, the four `customer_accounts` token tables,
+`communication_channels:channel_thread_token`, `messages:message_access_token`
+and the `security` module's MFA and sudo tables. `buildIndexDocument()` copies
+the base row into `doc` verbatim, so the credential is stored whatever the field
+blocklist says, and the row's non-blocklisted columns — a session's `ip_address`
+and `user_agent`, a sudo session's `target_identifier` — are tokenised and become
+searchable. A shared `isIndexableEntityType()` now refuses those entity types at
+the four places that write, and `registerNonIndexableEntityTypes()` lets code
+this package cannot name add its own.
+
+## Overview
+
+- **Changed**: `packages/shared/src/lib/entities/system-entities.ts` — the
+  refusal list, `isIndexableEntityType()`, `registerNonIndexableEntityTypes()`,
+  `listNonIndexableEntityTypes()`, `resetNonIndexableEntityTypes()`
+- **Changed**: `packages/core/src/modules/query_index/lib/indexer.ts`,
+  `.../batch.ts`, `.../search-tokens.ts`, `.../reindexer.ts` — one guard each
+- **Not touched**: `isSearchFieldBlocklisted()` and the field-level blocklist
+  (#4624), `RESERVED_SYSTEM_ENTITY_TYPES` and the enumeration helpers built on
+  it, the custom-field-definition API, the readers in `@open-mercato/search`,
+  the `entity_indexes` schema. No migration.
+
+## Problem statement
+
+Three separate facts combine.
+
+**1. Nothing gates which entity types may be indexed.** The
+`query_index.upsert_one` subscriber indexes whatever entity type the event
+names. `reindexEntity()` refuses an entity type that does not resolve to
+registered ORM metadata (#2705) and refuses `query_index:search_token` by name,
+and that is the whole of it. `mercato query_index reindex` and
+`mercato query_index rebuild-all`, invoked without `--entity`, iterate
+`flattenSystemEntityIds(getEntityIds())` — every generated entity id, minus the
+seven in `RESERVED_SYSTEM_ENTITY_TYPES` — and reindex each in turn. Credential
+tables are in that set.
+
+**2. The field blocklist governs the tokens, not the stored document.**
+`buildIndexDocument()` opens with
+
+```ts
+for (const [key, value] of Object.entries(baseRow)) {
+  doc[key] = value
+}
+```
+
+and `isSearchFieldBlocklisted()` is consulted afterwards, by
+`collectAggregateSearchValues()` for the `search_text` aggregate and by
+`shouldIndexField()` for the token rows. So #4624 stopped a blocklisted column's
+text coming back into `search_tokens` under the aggregate's name — it did not
+stop the column being copied into `entity_indexes.doc`. Unless the entity
+declares payload encryption, `doc->>'token'` on an indexed `auth:session` row is
+the session token, and `doc->>'secret'` on an indexed MFA row is the shared
+secret.
+
+**3. The columns that are not blocklisted are tokenised.** The blocklist matches
+field names against `password`, `token`, `secret`, `hash`. A credential table's
+*other* columns do not match:
+`customer_accounts:customer_user_session` contributes `ip_address` and
+`user_agent`; `security:sudo_session` contributes `target_identifier`;
+`customer_accounts:customer_user_invitation` contributes `email` and
+`display_name`. Those become searchable rows in `search_tokens` — a membership
+and session-metadata oracle for anyone who can reach global search.
+
+Compounding all three: several of these tables have no `tenant_id` column, so
+their index rows are filed under whichever tenant last ran a reindex. That is a
+separate defect with a separate fix (`reindexEntity()`'s tenant-scope guard);
+neither subsumes the other, and this one holds for the credential tables that
+*do* have a tenant column.
+
+**How it was found.** Auditing a production deployment's `entity_indexes` and
+`search_tokens` after a support question about odd global-search results. Every
+indexed session row carried its token in the stored document; on that
+deployment — which predates #4624 — the aggregate had copied it into
+`search_text` as well, and `search_text` was the only field producing tokens for
+those entity types, so the tokens were of the credential itself. #4624 closes
+that last part. It does not close the other two.
+
+## The fix
+
+`isIndexableEntityType(entityType)` in
+`packages/shared/src/lib/entities/system-entities.ts`, enforced at four write
+chokepoints:
+
+| Chokepoint | Behaviour | Why there |
+|---|---|---|
+| `buildIndexDoc()` | returns `null` | `upsertIndexRow()`'s null branch already deletes the projection row **and** its search tokens, so an index polluted by an earlier release cleans itself up as records are touched, rather than merely stopping the bleeding |
+| `upsertIndexBatch()` | returns an empty batch result | the batch path never goes through `buildIndexDoc`; `rebuild-all` calls it directly. Empty rather than a throw, so the CLI's `assertIndexBatchWritesLanded()` reads 0 written of 0 attempted and the sweep continues |
+| `buildSearchTokenRows()` | returns `[]` | an empty row set rather than a short-circuit in the callers, so `replaceSearchTokensForRecord` / `...ForBatch` still run their `DELETE` and stale tokens are removed |
+| `reindexEntity()` | empty result + warning | a reindex that got past this point would prepare a job, reset coverage and purge rows for an entity type that must not be in the index at all. Subsumes the `query_index:search_token` literal that was there |
+
+The four are belt and braces on purpose: `reindexEntity` covers the sweep,
+`buildIndexDoc` the event path, and the other two are for callers that batch or
+tokenise directly.
+
+## Why a list, and why also a registration seam
+
+The two shapes fail in opposite directions, and that decides the design.
+
+`registerTenantGlobalEntityTypes()` is an **allowlist**: an entity type nobody
+declares fails closed, and the cost of forgetting is a search result that does
+not appear plus a warning naming the entity type. Registration can therefore be
+the whole mechanism.
+
+This is a **denylist**: an entity type nobody declares fails open, and the cost
+of forgetting is a credential in a searchable table, silently. So registration
+cannot be the whole mechanism. Three consequences:
+
+1. The built-in list is authoritative and names every credential entity type in
+   this repository, including those in packages `shared` does not depend on.
+   Bare strings need no import, and `RESERVED_SYSTEM_ENTITY_TYPES` in the same
+   file already names entity types from `core` on the same basis.
+2. `registerNonIndexableEntityTypes()` is an escape hatch for applications and
+   out-of-tree packages, additive only — it can widen the refusal, never narrow
+   it.
+3. A registration that lands after the first index write has already lost, so
+   the seam is documented as a module-load-time call. An allowlist has no such
+   ordering hazard; this one does.
+
+A per-entity declaration (`@Entity({ indexable: false })`, or a flag in a
+module's `search.ts`) was considered and rejected for the same asymmetry: it
+puts the decision where it is easiest to forget, and a credential table added
+without the flag is indistinguishable from one that was reviewed.
+
+## Where the list came from
+
+Every `@Entity` class in this repository was enumerated from its module's
+`data/entities.ts` (262 of them) and its property names matched against
+`token|secret|password|hash|code|key|credential|otp|nonce|signature`, then again
+by class name. The admission test is **"is holding a bearer credential, or the
+verifier for one, the row's reason to exist?"** — not "does it contain a
+secret". Twelve entity types clear it:
+
+| entity type | package | the credential |
+|---|---|---|
+| `auth:session` | core | `token` |
+| `auth:password_reset` | core | `token` |
+| `customer_accounts:customer_user_session` | core | `token_hash` |
+| `customer_accounts:customer_user_password_reset` | core | `token` |
+| `customer_accounts:customer_user_email_verification` | core | `token` |
+| `customer_accounts:customer_user_invitation` | core | `token` |
+| `communication_channels:channel_thread_token` | core | `token` |
+| `messages:message_access_token` | core | `token` |
+| `query_index:search_token` | core | the index's own token table; indexing it is a feedback loop |
+| `security:sudo_session` | enterprise | `session_token` |
+| `security:mfa_challenge` | enterprise | `otp_code_hash` |
+| `security:mfa_recovery_code` | enterprise | `code_hash` |
+
+Deliberately **not** on it, because each holds a secret column *and* backs a
+list screen with fields a person searches for — removing them from the index
+breaks their own screens, and the field-level blocklist is what protects them:
+`api_keys:api_key`, `integrations:integration_credentials`, `sso:sso_config`,
+`sso:scim_token`, `security:user_mfa_method`, `inbox_ops:inbox_settings`,
+`webhooks:webhook_entity`, `checkout:checkout_link_template`,
+`payment_gateways:gateway_transaction`, `onboarding:onboarding_request`,
+`devices:user_device`. Also excluded, on the same test applied to closer calls:
+`record_locks:record_lock`, `attachments:attachment_quota_reservation`,
+`payment_gateways:gateway_session_initialization`,
+`payment_gateways:gateway_payment_operation`,
+`warranty_claims:warranty_claim_sla_signal` — operational records whose token is
+a coordination claim rather than the row's reason to exist.
+
+`customer_accounts:customer_user_invitation` is the closest call on the other
+side. It carries `email` and `display_name`, which an admin might reasonably
+want to search. It is refused anyway: its `token` grants an account to whoever
+presents it, and no first-party screen lists invitations through the query
+index — the module manages them through `customerInvitationService`.
+
+## What this does not fix
+
+- **The stored document still carries blocklisted fields for every entity type
+  that stays indexed.** `api_keys:api_key`'s `key_hash` and
+  `security:user_mfa_method`'s `secret` are in `entity_indexes.doc` after this
+  change exactly as before it. Stripping blocklisted fields from the document,
+  rather than only from the aggregate and the tokens, is the separate and larger
+  change; this one removes the entity types for which the document has no
+  legitimate content at all.
+- **Rows written by earlier releases are not migrated.** They are removed
+  opportunistically: `buildIndexDoc()` returning null makes `upsertIndexRow()`
+  delete the projection row and its tokens the next time the record is touched,
+  and `mercato query_index reindex` purges each entity type before refusing it.
+  Operators who want them gone now should run that command; see
+  `UPGRADE_NOTES.md`.
+- **The AI assistant's in-process search** resolves `searchService` from DI and
+  never reaches these writers; it reads whatever is in the index. It is
+  unaffected because the rows stop existing, not because it was gated.
+
+## Tests
+
+`packages/core/src/modules/query_index/__tests__/credential-entity-denylist.test.ts`
+— 37 cases: the policy itself (each refused type, each deliberate exclusion,
+normalisation, the registration seam and its reset), and one case per chokepoint
+with a matching negative control proving an ordinary entity type still gets
+indexed, still produces tokens, and still reaches its source table.
+
+Non-vacuity was measured, not assumed. With the policy module present but the
+four guards reverted, exactly four cases fail — one per chokepoint — and the
+other 33, the negative controls included, pass.

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -395,3 +395,41 @@ Issue #3852 removed the non-cryptographic passkey verification shape from `Passk
 **Why the deprecation protocol does not apply.** The protocol exists to give downstream authors a bridge release. Here the request shape being removed *is* the vulnerability: both values it compared are disclosed by the server, so a bridge would keep the passkey second factor bypassable for a minor version in both login MFA and sudo step-up. A security fix that leaves the hole open is not a fix.
 
 **Migration path.** Send `startAuthentication()` output as `payload.response`. The first-party `PasskeyChallengeVerify` component already does, so shipped UIs are unaffected. Credentials enrolled through the setup path's client-supplied `publicKey` shortcut are **not** reliably rendered unusable by this change — depending on what the client supplied, such a row holds either a key nobody can sign with or a keypair the enroller controls, and the second kind produces assertions this change accepts. That shortcut is a separate open surface (#5296); operator-facing remediation is in [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md).
+
+## Credential-Bearing Entity Types in the Search Index (2026-08-28)
+
+[`.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md`](.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md)
+stops entity types whose reason to exist is a bearer credential from being written to
+`entity_indexes` and `search_tokens`.
+
+| Surface | Change | Classification |
+|---------|--------|----------------|
+| Function signatures | New exports `isIndexableEntityType`, `registerNonIndexableEntityTypes`, `listNonIndexableEntityTypes`, `resetNonIndexableEntityTypes` from `@open-mercato/shared/lib/entities/system-entities` | ✓ ADDITIVE (new functions in an existing module) |
+| Function signatures | `buildIndexDoc`, `upsertIndexBatch`, `buildSearchTokenRows`, `reindexEntity` — signatures and return types unchanged | ✓ No change |
+| `buildIndexDoc` behaviour | Returns `null` for a refused entity type, which makes `upsertIndexRow()` delete the projection row and its search tokens | ⚠ Deliberate behaviour narrowing |
+| `upsertIndexBatch` behaviour | Returns an empty result (0 written of 0 attempted) for a refused entity type instead of writing rows | ⚠ Deliberate behaviour narrowing |
+| `buildSearchTokenRows` behaviour | Returns `[]` for a refused entity type; the callers' `DELETE` still runs | ⚠ Deliberate behaviour narrowing |
+| `reindexEntity` behaviour | Returns an empty result and logs a warning for a refused entity type, before any job, coverage or purge write. Subsumes the `query_index:search_token` special case | ⚠ Deliberate behaviour narrowing |
+| `RESERVED_SYSTEM_ENTITY_TYPES`, `isSystemEntitySelectable`, `flattenSystemEntityIds` | No change — a refused entity type is still enumerable and still accepts custom-field definitions | ✓ No change |
+| Import paths, type definitions, event IDs, API routes, DB schema, DI names, ACL features, notification IDs, CLI commands, generated files | No change | ✓ n/a |
+
+**The Emergency Security Exception is not invoked, and does not need to be.** Nothing is
+removed or renamed, so steps 1-3 have nothing to stage; every caller compiles unchanged.
+What narrows is which entity types these four functions will act on, and for the refused
+ones the only possible outcome was a credential in a table built to be searched. A flag
+restoring the old behaviour was considered and rejected for the reason the exception
+itself gives: a retained vulnerable branch is the bridge that must not be built.
+
+**Contract commitments**: the built-in list MAY grow as credential tables are added to
+this repository, and MUST NOT come to refuse an entity type that has legitimate display
+content. `registerNonIndexableEntityTypes()` is additive only — it widens the refusal and
+can never narrow it, and `resetNonIndexableEntityTypes()` restores exactly the built-in
+entries, never fewer. Note the asymmetry with `registerTenantGlobalEntityTypes()`, which
+is an allowlist: there an undeclared entity type fails closed, here it fails open, which
+is why the built-in list rather than the seam is the mechanism.
+
+**Migration path for existing modules**: none required unless a module owns a table whose
+rows are a bearer credential, which declares itself with
+`registerNonIndexableEntityTypes()` at module load. See
+[`UPGRADE_NOTES.md`](UPGRADE_NOTES.md) `0.7.0 → 0.7.1` for both the module-author and the
+operator action, including the index residue this change does not migrate.

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -42,6 +42,66 @@ yarn mercato query_index rebuild-all # equivalent when driving query_index direc
 Records whose indexed text contains none of these characters produce byte-identical hashes before and after, so a reindex is only required where the bug actually applied — but reindexing everything is harmless and is the simpler operational choice. Installations running Meilisearch may not have noticed the bug in global search (its own normalizer handles `ł` correctly), yet the backend users-list filter routes through the token path regardless, so the reindex still applies.
 
 **Action for module authors:** none, unless you persisted `tokenizeText` output outside `search_tokens`. If you did, recompute it; comparing a stored pre-fix token against a freshly computed one will not match for affected text.
+### Credential-bearing entity types are no longer written to the search index
+
+Nothing gated which entity types the query index would accept. `mercato query_index
+reindex` and `mercato query_index rebuild-all`, invoked without `--entity`, sweep every
+generated entity id, so a stock deployment indexed `auth:session`, `auth:password_reset`,
+the `customer_accounts` session/reset/verification/invitation tables,
+`communication_channels:channel_thread_token`, `messages:message_access_token` and — where
+the `security` module is enabled — `security:sudo_session`, `security:mfa_challenge` and
+`security:mfa_recovery_code`.
+
+The field blocklist did not cover this. `buildIndexDocument()` copies the base row into
+`doc` before any blocklist runs, so the credential was stored in `entity_indexes.doc`
+whatever the blocklist said, and the row's *other* columns — a session's `ip_address` and
+`user_agent`, a sudo session's `target_identifier`, an invitation's `email` — were
+tokenised into `search_tokens` and became searchable.
+
+Those twelve entity types are now refused at every point that writes:
+`buildIndexDoc()` returns null, `upsertIndexBatch()` returns an empty result,
+`buildSearchTokenRows()` returns no rows, and `reindexEntity()` returns an empty result
+and logs *"Refusing to reindex credential-bearing entity type"*.
+
+**Action for module authors.** If your module owns a table whose rows are a bearer
+credential or the verifier for one — a session, a one-time token, a reset or invitation
+code — declare it at module load, before any index write:
+
+```ts
+import { registerNonIndexableEntityTypes } from '@open-mercato/shared/lib/entities/system-entities'
+
+registerNonIndexableEntityTypes('billing:portal_magic_link')
+```
+
+Unlike `registerTenantGlobalEntityTypes()`, forgetting this is **not** safe: an
+undeclared entity type keeps being indexed. Tables that hold a secret column but also
+back a list screen — an API-key list, an integration's credentials, an SSO config — should
+**not** be declared; removing them from the index breaks their own screens, and the field
+blocklist (`OM_SEARCH_FIELD_BLOCKLIST`) is what protects them.
+
+**Action for operators.** Rows written by earlier releases are not migrated. They are
+removed opportunistically — the next `query_index.upsert_one` for such a record deletes
+its projection row and its tokens — so an idle credential row can persist. To clear them
+now, run a full reindex, which purges each entity type before refusing it:
+
+```bash
+mercato query_index reindex
+```
+
+Expect one warning line per refused entity type. If you would rather confirm the residue
+first, count it before and after:
+
+```sql
+SELECT entity_type, count(*) FROM entity_indexes
+ WHERE entity_type IN ('auth:session', 'auth:password_reset', 'security:sudo_session')
+ GROUP BY 1;
+```
+
+**What this does not change.** The stored document still carries blocklisted fields for
+entity types that remain indexed; `isSearchFieldBlocklisted()` governs the `search_text`
+aggregate and the token rows, not `entity_indexes.doc`. Custom-field definitions and the
+entity pickers are untouched — a refused entity type is still enumerable, it is only not
+indexed.
 
 ### `AlertDescription` renders a `<div>` instead of a `<p>` (#5487)
 

--- a/packages/core/src/modules/query_index/__tests__/credential-entity-denylist.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/credential-entity-denylist.test.ts
@@ -1,0 +1,249 @@
+import {
+  isIndexableEntityType,
+  listNonIndexableEntityTypes,
+  registerNonIndexableEntityTypes,
+  resetNonIndexableEntityTypes,
+} from '@open-mercato/shared/lib/entities/system-entities'
+import { buildIndexDoc } from '../lib/indexer'
+import { buildSearchTokenRows } from '../lib/search-tokens'
+import { upsertIndexBatch, createEmptyUpsertIndexBatchResult } from '../lib/batch'
+import { reindexEntity } from '../lib/reindexer'
+
+const SESSION = 'auth:session'
+const ORDINARY = 'customers:customer_person_profile'
+
+/**
+ * A session row as the reindexer would read it. `token` is blocklisted by field
+ * name, so it produces no tokens of its own; `ip_address` and `user_agent` are
+ * not, which is why a token-level fix alone would still make the row findable.
+ */
+const sessionRow = () => ({
+  id: 'a1b2c3d4-0000-0000-0000-000000000001',
+  token: 'bf712cbb88ee4b2c9f1d0e5a77c3b8e1aa04d6f39c2e15b7d8409ca6371e2f5d',
+  user_id: '8d2f1a90-0000-0000-0000-0000000000ff',
+  ip_address: '203.0.113.42',
+  user_agent: 'Mozilla/5.0 Cartography',
+  expires_at: '2026-09-27T10:00:00.000Z',
+})
+
+function createTrackingKysely() {
+  const reads: string[] = []
+  const writes: string[] = []
+  const chain: any = {
+    select: () => chain,
+    selectAll: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: () => chain,
+    offset: () => chain,
+    groupBy: () => chain,
+    values: () => chain,
+    set: () => chain,
+    onConflict: () => chain,
+    returning: () => chain,
+    execute: async () => [],
+    executeTakeFirst: async () => undefined,
+  }
+  const db: any = {
+    selectFrom: (table: any) => { reads.push(String(table)); return chain },
+    insertInto: (table: any) => { writes.push(String(table)); return chain },
+    updateTable: (table: any) => { writes.push(String(table)); return chain },
+    deleteFrom: (table: any) => { writes.push(String(table)); return chain },
+    transaction: () => ({ execute: async (fn: any) => fn(db) }),
+  }
+  return { db, reads, writes }
+}
+
+function makeEm(metaByClass: Record<string, string>) {
+  const { db, reads, writes } = createTrackingKysely()
+  const all = Object.entries(metaByClass).map(([className, tableName]) => ({ className, tableName }))
+  let kyselyCalls = 0
+  const em: any = {
+    getKysely: () => { kyselyCalls += 1; return db },
+    getMetadata: () => ({
+      find: (className: string) => {
+        const tableName = metaByClass[className]
+        return tableName ? { tableName } : undefined
+      },
+      getAll: () => all,
+    }),
+  }
+  return { em, reads, writes, kyselyCalls: () => kyselyCalls }
+}
+
+afterEach(() => {
+  resetNonIndexableEntityTypes()
+})
+
+describe('the non-indexable entity-type policy', () => {
+  it.each([
+    'auth:session',
+    'auth:password_reset',
+    'customer_accounts:customer_user_session',
+    'customer_accounts:customer_user_password_reset',
+    'customer_accounts:customer_user_email_verification',
+    'customer_accounts:customer_user_invitation',
+    'communication_channels:channel_thread_token',
+    'messages:message_access_token',
+    'query_index:search_token',
+    'security:sudo_session',
+    'security:mfa_challenge',
+    'security:mfa_recovery_code',
+  ])('refuses %s', (entityType) => {
+    expect(isIndexableEntityType(entityType)).toBe(false)
+  })
+
+  it.each([
+    // Ordinary entities. If the list ever swallows one of these, search silently
+    // loses a whole entity type.
+    'auth:user',
+    'customers:customer_person_profile',
+    'directory:organization',
+    // Deliberate exclusions: each holds a secret column but also backs a list
+    // screen with display-worthy fields, so the field-level blocklist is what
+    // protects them. Flipping one of these to `false` breaks its list view, not
+    // just its search.
+    'api_keys:api_key',
+    'integrations:integration_credentials',
+    'sso:sso_config',
+    'sso:scim_token',
+    'security:user_mfa_method',
+    'inbox_ops:inbox_settings',
+    'webhooks:webhook_entity',
+    'onboarding:onboarding_request',
+    'devices:user_device',
+  ])('keeps %s indexable', (entityType) => {
+    expect(isIndexableEntityType(entityType)).toBe(true)
+  })
+
+  it('treats an empty or whitespace-only entity type as indexable', () => {
+    // Not a security decision: an unnamed entity type never reaches a write with
+    // a table behind it, and failing closed here would refuse every caller that
+    // passes an id it has not resolved yet.
+    expect(isIndexableEntityType('')).toBe(true)
+    expect(isIndexableEntityType(undefined as unknown as string)).toBe(true)
+  })
+
+  it('matches a padded entity type, so a stray space cannot re-open the hole', () => {
+    expect(isIndexableEntityType('  auth:session  ')).toBe(false)
+  })
+
+  it('lets a module widen the refusal, and reports it', () => {
+    expect(isIndexableEntityType('billing:portal_magic_link')).toBe(true)
+    registerNonIndexableEntityTypes('billing:portal_magic_link')
+    expect(isIndexableEntityType('billing:portal_magic_link')).toBe(false)
+    expect(listNonIndexableEntityTypes()).toContain('billing:portal_magic_link')
+  })
+
+  it('restores the built-in entries on reset and drops registrations', () => {
+    registerNonIndexableEntityTypes('billing:portal_magic_link')
+    resetNonIndexableEntityTypes()
+    expect(isIndexableEntityType('billing:portal_magic_link')).toBe(true)
+    expect(isIndexableEntityType('auth:session')).toBe(false)
+  })
+
+  it('ignores a blank registration rather than refusing every entity type', () => {
+    registerNonIndexableEntityTypes('', '   ')
+    expect(isIndexableEntityType('customers:customer_person_profile')).toBe(true)
+  })
+})
+
+describe('buildIndexDoc refuses a credential-bearing entity type', () => {
+  it('returns null without reading the source table', async () => {
+    const { em, kyselyCalls } = makeEm({ Session: 'sessions' })
+
+    const doc = await buildIndexDoc(em, { entityType: SESSION, recordId: 'a1', tenantId: 't1', organizationId: 'o1' })
+
+    // Null rather than a throw: `upsertIndexRow` deletes the projection row and
+    // its tokens on a null document, so an index polluted before this release
+    // cleans itself up as records are touched.
+    expect(doc).toBeNull()
+    expect(kyselyCalls()).toBe(0)
+  })
+})
+
+describe('buildSearchTokenRows refuses a credential-bearing entity type', () => {
+  it('produces no tokens for a session row', () => {
+    const rows = buildSearchTokenRows({
+      entityType: SESSION,
+      recordId: 'a1',
+      organizationId: 'o1',
+      tenantId: 't1',
+      doc: sessionRow(),
+    })
+    expect(rows).toEqual([])
+  })
+
+  it('still tokenises the same fields on an ordinary entity type', () => {
+    // Negative control. Without it the suite would pass just as happily against
+    // a change that disabled token indexing outright.
+    const rows = buildSearchTokenRows({
+      entityType: ORDINARY,
+      recordId: 'a1',
+      organizationId: 'o1',
+      tenantId: 't1',
+      doc: sessionRow(),
+    })
+    expect(rows.length).toBeGreaterThan(0)
+    // And it shows what a token-level fix alone would leave behind: the session's
+    // IP and user agent are not blocklisted by field name.
+    expect(rows.map((row) => row.field)).toEqual(expect.arrayContaining(['ip_address', 'user_agent']))
+  })
+})
+
+describe('upsertIndexBatch refuses a credential-bearing entity type', () => {
+  it('writes nothing and reports an empty batch', async () => {
+    const { db, writes } = createTrackingKysely()
+
+    const result = await upsertIndexBatch(db, SESSION, [sessionRow()], { tenantId: 't1', orgId: 'o1' })
+
+    // Empty rather than a throw: `mercato query_index rebuild-all` calls this
+    // directly for every generated entity id and asserts the writes landed, so a
+    // refused entity type must read as 0 of 0 rather than as a lost batch.
+    expect(result).toEqual(createEmptyUpsertIndexBatchResult())
+    expect(writes).toEqual([])
+  })
+
+  it('attempts the write for an ordinary entity type', async () => {
+    const { db, writes } = createTrackingKysely()
+
+    const result = await upsertIndexBatch(db, ORDINARY, [sessionRow()], { tenantId: 't1', orgId: 'o1' })
+
+    expect(result.attempted).toBe(1)
+    expect(writes.length).toBeGreaterThan(0)
+  })
+})
+
+describe('reindexEntity refuses a credential-bearing entity type', () => {
+  it('returns an empty result before touching the table', async () => {
+    const { em, reads, writes } = makeEm({ Session: 'sessions' })
+
+    const result = await reindexEntity(em, { entityType: SESSION, tenantId: 't1', organizationId: 'o1' })
+
+    expect(result).toEqual({ processed: 0, total: 0, tenantScopes: [], scopes: [] })
+    // The refusal has to land here as well as in `upsertIndexBatch`: getting past
+    // this point prepares a job, resets coverage and purges rows for an entity
+    // type that must not be in the index at all.
+    expect(reads).toEqual([])
+    expect(writes).toEqual([])
+  })
+
+  it('keeps refusing the search-token table it refused by name before', async () => {
+    const { em, reads } = makeEm({ SearchToken: 'search_tokens' })
+
+    const result = await reindexEntity(em, { entityType: 'query_index:search_token', tenantId: 't1', organizationId: 'o1' })
+
+    expect(result).toEqual({ processed: 0, total: 0, tenantScopes: [], scopes: [] })
+    expect(reads).toEqual([])
+  })
+
+  it('reads the source table for an entity type that is still indexable', async () => {
+    // Negative control for the guard's placement: an ordinary entity type must
+    // get past it and reach the table.
+    const { em, reads } = makeEm({ CustomerPersonProfile: 'customer_person_profiles' })
+
+    await reindexEntity(em, { entityType: ORDINARY, tenantId: 't1', organizationId: 'o1' })
+
+    expect(reads.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/src/modules/query_index/lib/batch.ts
+++ b/packages/core/src/modules/query_index/lib/batch.ts
@@ -5,6 +5,7 @@ import { buildIndexDocument, type IndexCustomFieldValue } from './document'
 import { replaceSearchTokensForBatch, isSearchDebugEnabled } from './search-tokens'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
+import { isIndexableEntityType } from '@open-mercato/shared/lib/entities/system-entities'
 
 const logger = createLogger('query_index').child({ component: 'reindex-batch' })
 
@@ -149,6 +150,12 @@ export async function upsertIndexBatch(
   options: IndexBatchOptions = {},
 ): Promise<UpsertIndexBatchResult> {
   if (!rows.length) return createEmptyUpsertIndexBatchResult()
+  // The batch path never goes through `buildIndexDoc`, so it needs its own guard:
+  // `mercato query_index rebuild-all` sweeps every generated entity id and calls
+  // this directly. An empty result rather than a throw, so the CLI's
+  // `assertIndexBatchWritesLanded()` sees 0 written of 0 attempted and the sweep
+  // continues past a refused entity type.
+  if (!isIndexableEntityType(entityType)) return createEmptyUpsertIndexBatchResult()
   const recordIds = rows.map((row) => normalizeId(row.id))
 
   const failedRecordIds: string[] = []

--- a/packages/core/src/modules/query_index/lib/indexer.ts
+++ b/packages/core/src/modules/query_index/lib/indexer.ts
@@ -12,6 +12,7 @@ import { type Kysely, type Transaction, sql } from 'kysely'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { replaceSearchTokensForRecord, deleteSearchTokensForRecord } from './search-tokens'
 import { attachAggregateSearchField } from './document'
+import { isIndexableEntityType } from '@open-mercato/shared/lib/entities/system-entities'
 
 const logger = createLogger('query_index').child({ component: 'indexer' })
 
@@ -25,6 +26,10 @@ type BuildDocParams = {
 }
 
 export async function buildIndexDoc(em: EntityManager, params: BuildDocParams): Promise<Record<string, any> | null> {
+  // Null rather than an early return from `upsertIndexRow`: its null branch already
+  // deletes the projection row AND its search tokens, so an index polluted by an
+  // earlier release cleans itself up the next time the record is touched.
+  if (!isIndexableEntityType(params.entityType)) return null
   const db = (em as any).getKysely()
   const baseTable = resolveEntityTableName(em, params.entityType)
 

--- a/packages/core/src/modules/query_index/lib/reindexer.ts
+++ b/packages/core/src/modules/query_index/lib/reindexer.ts
@@ -16,6 +16,7 @@ import { prepareJob, updateJobProgress, finalizeJob, type JobScope } from './job
 import { purgeOrphans } from './stale'
 import type { VectorIndexService } from '@open-mercato/search/vector'
 import { isSearchDebugEnabled } from './search-tokens'
+import { isIndexableEntityType } from '@open-mercato/shared/lib/entities/system-entities'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('query_index').child({ component: 'reindexer' })
@@ -167,9 +168,19 @@ export async function reindexEntity(
   // reindexer at arbitrary tables (e.g. `auth_users`, `users`) and read their
   // rows into the index, bypassing tenant scoping and entity-level encryption.
   const table = resolveRegisteredEntityTableName(em, entityType)
-  if (!table || entityType === 'query_index:search_token' || table === 'search_tokens') {
+  // `isIndexableEntityType` subsumes the `query_index:search_token` literal this
+  // condition used to carry and extends the same refusal to every entity type
+  // whose whole purpose is to hold a credential. It has to be checked here as
+  // well as in `upsertIndexBatch`, because a reindex that got past this point
+  // would prepare a job, reset coverage and purge rows for an entity type that
+  // must not be in the index at all.
+  if (!table || !isIndexableEntityType(entityType) || table === 'search_tokens') {
     if (!table) {
       logger.warn('Refusing to reindex unregistered entity type', {
+        entityType,
+      })
+    } else if (!isIndexableEntityType(entityType)) {
+      logger.warn('Refusing to reindex credential-bearing entity type', {
         entityType,
       })
     }

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -7,6 +7,7 @@ import {
 } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { isIndexableEntityType } from '@open-mercato/shared/lib/entities/system-entities'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('query_index').child({ component: 'search-tokens' })
@@ -86,6 +87,10 @@ function shouldIndexField(
 export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[] {
   const config = params.config ?? resolveSearchConfig()
   if (!config.enabled) return []
+  // An empty row set rather than a short-circuit in the callers, so
+  // `replaceSearchTokensForRecord` / `...ForBatch` still run their DELETE and
+  // tokens written by an earlier release are removed as records are touched.
+  if (!isIndexableEntityType(params.entityType)) return []
   if (!params.doc) return []
   const tokens: SearchTokenRow[] = []
   const capturePairs = isSearchDebugEnabled() && params.entityType === 'customers:customer_deal'

--- a/packages/shared/src/lib/entities/system-entities.ts
+++ b/packages/shared/src/lib/entities/system-entities.ts
@@ -41,3 +41,117 @@ export function filterSelectableSystemEntityIds(entityIds: Iterable<string>): st
 export function isReservedSystemEntityType(entityId: string): boolean {
   return RESERVED_SYSTEM_ENTITY_TYPES.has(entityId)
 }
+
+/**
+ * Entity types that must never reach `entity_indexes` or `search_tokens`.
+ *
+ * Distinct from {@link RESERVED_SYSTEM_ENTITY_TYPES} above, which answers a
+ * different question — "may a custom field be attached to this, and should it be
+ * offered in an entity picker?" — and is consulted only where entity types are
+ * *enumerated*: `flattenSystemEntityIds()`, and the custom-field-definition API.
+ * Enumeration is not a chokepoint. `mercato query_index reindex --entity <id>`,
+ * `mercato query_index rebuild --entity <id>` and a `query_index.upsert_one`
+ * event all name their entity type directly and never pass through it, which is
+ * why `reindexEntity()` carried a second, one-entry copy of the idea as a bare
+ * `entityType === 'query_index:search_token'` literal. This list is that idea
+ * expressed once, enforced where the writes happen.
+ *
+ * The members are entity types whose whole purpose is to hold a bearer
+ * credential or the verifier for one. They carry nothing a person would search
+ * for, no screen renders them, and nothing reads them through the query engine —
+ * so the index row is pure exposure with no counterpart in value:
+ *
+ *  - `buildIndexDocument()` copies the base row into `doc` verbatim. Field-level
+ *    blocklisting (`isSearchFieldBlocklisted`, #4624) governs the `search_text`
+ *    aggregate and the token rows; it does not govern the stored document. The
+ *    credential therefore lands in `entity_indexes.doc` regardless, unless the
+ *    entity happens to declare payload encryption.
+ *  - The fields that are *not* blocklisted get tokenised and become searchable:
+ *    `customer_accounts:customer_user_session` contributes `ip_address` and
+ *    `user_agent`, `security:sudo_session` contributes `target_identifier`.
+ *  - Several of these tables have no `tenant_id` column at all, so the rows are
+ *    filed under whichever tenant last ran a reindex.
+ *
+ * A row already written by an earlier release is cleaned up rather than merely
+ * frozen: `buildIndexDoc()` returns null for these types, and `upsertIndexRow()`
+ * already deletes the projection row and its tokens on a null document, so the
+ * next event touching the record removes it. A full
+ * `mercato query_index reindex` purges each entity type before refusing it.
+ *
+ * Deliberately NOT here: entity types that hold a secret column *and* back a
+ * management list with display-worthy fields — `api_keys:api_key`,
+ * `integrations:integration_credentials`, `sso:sso_config`,
+ * `inbox_ops:inbox_settings`, `webhooks:webhook_entity`,
+ * `checkout:checkout_link_template`, `payment_gateways:gateway_transaction`.
+ * Removing those from the index would break their own list screens, so the
+ * field-level blocklist is what protects them. Also excluded, on the same test
+ * applied to closer calls: `security:user_mfa_method` and `sso:scim_token`
+ * (a `label`/`name` a user picks from), `onboarding:onboarding_request`
+ * (an admin queue keyed on the applicant's email), `devices:user_device`,
+ * `record_locks:record_lock`, `attachments:attachment_quota_reservation` and
+ * `payment_gateways:gateway_session_initialization` (operational records whose
+ * token is a coordination claim rather than the row's reason to exist).
+ */
+const CREDENTIAL_BEARING_ENTITY_TYPES: readonly string[] = [
+  // @open-mercato/core
+  'auth:session',
+  'auth:password_reset',
+  'customer_accounts:customer_user_session',
+  'customer_accounts:customer_user_password_reset',
+  'customer_accounts:customer_user_email_verification',
+  'customer_accounts:customer_user_invitation',
+  'communication_channels:channel_thread_token',
+  'messages:message_access_token',
+  // Indexing the token table into itself is a feedback loop. `reindexEntity()`
+  // refused this one by name; the refusal now lives here with the rest.
+  'query_index:search_token',
+  // @open-mercato/enterprise — `security`
+  'security:sudo_session',
+  'security:mfa_challenge',
+  'security:mfa_recovery_code',
+]
+
+const nonIndexableEntityTypes = new Set<string>(CREDENTIAL_BEARING_ENTITY_TYPES)
+
+function normalizeEntityType(entityType: string): string {
+  return String(entityType || '').trim()
+}
+
+/**
+ * Declare that an entity type must never be written to the query index.
+ *
+ * For credential tables owned by an application or by a package this one cannot
+ * name. Additive only: it can widen the refusal, never narrow it.
+ *
+ * Read the asymmetry with `registerTenantGlobalEntityTypes()` before treating
+ * the two as the same pattern. There, an entity type nobody declares fails
+ * *closed*, so registration is the whole mechanism and forgetting it costs a
+ * search result. Here, an entity type nobody declares fails *open*, and
+ * forgetting it costs a credential in a searchable table — so the built-in list
+ * above is the mechanism, and this is an escape hatch for code that cannot be on
+ * it. For the same reason the call must happen at module load, before any index
+ * write: a registration that lands after the first `query_index.upsert_one` has
+ * already lost.
+ */
+export function registerNonIndexableEntityTypes(...entityTypes: string[]): void {
+  for (const entityType of entityTypes) {
+    const normalized = normalizeEntityType(entityType)
+    if (normalized) nonIndexableEntityTypes.add(normalized)
+  }
+}
+
+/** False when the entity type must never reach `entity_indexes` or `search_tokens`. */
+export function isIndexableEntityType(entityType: string): boolean {
+  return !nonIndexableEntityTypes.has(normalizeEntityType(entityType))
+}
+
+/** The current refusal list, for diagnostics and tests. */
+export function listNonIndexableEntityTypes(): string[] {
+  return Array.from(nonIndexableEntityTypes)
+}
+
+/** Test-only: drop every registration and restore the built-in entries. */
+export function resetNonIndexableEntityTypes(): void {
+  nonIndexableEntityTypes.clear()
+  for (const entityType of CREDENTIAL_BEARING_ENTITY_TYPES) nonIndexableEntityTypes.add(entityType)
+}


### PR DESCRIPTION
## Summary

Nothing gates which entity types the query index will accept. `mercato query_index reindex` and `mercato query_index rebuild-all`, invoked without `--entity`, iterate `flattenSystemEntityIds(getEntityIds())` — every generated entity id — and reindex each in turn, so a stock deployment writes `auth:session`, `auth:password_reset`, the four `customer_accounts` token tables, `communication_channels:channel_thread_token`, `messages:message_access_token` and, where the `security` module is enabled, `security:sudo_session`, `security:mfa_challenge` and `security:mfa_recovery_code` into `entity_indexes` and `search_tokens`.

The field-level blocklist does not cover this, in two separate ways.

**1. It governs the tokens, not the stored document.** `buildIndexDocument()` opens with

```ts
for (const [key, value] of Object.entries(baseRow)) {
  doc[key] = value
}
```

and `isSearchFieldBlocklisted()` is consulted afterwards — by `collectAggregateSearchValues()` for the `search_text` aggregate and by `shouldIndexField()` for the token rows. #4624 stopped a blocklisted column's text coming back into `search_tokens` under the aggregate's name; it did not stop the column being copied into `entity_indexes.doc`. Unless the entity declares payload encryption, `doc->>'token'` on an indexed `auth:session` row is the session token.

**2. The columns that are *not* blocklisted are tokenised.** The blocklist matches field names against `password`, `token`, `secret`, `hash`. A credential table's other columns do not match: `customer_accounts:customer_user_session` contributes `ip_address` and `user_agent`, `security:sudo_session` contributes `target_identifier`, `customer_accounts:customer_user_invitation` contributes `email`. Those become searchable rows — a session-metadata and membership oracle for anyone who can reach global search.

Compounding both: several of these tables have no `tenant_id` column, so their rows are filed under whichever tenant last reindexed.

This was found by auditing a production deployment's `entity_indexes` and `search_tokens` after a support question about odd global-search results. Every indexed session row carried its token in the stored document; on that deployment, which predates #4624, the aggregate had copied it into `search_text` as well, and `search_text` was the only field producing tokens for those entity types — so the tokens were of the credential itself. #4624 closes that last part. It does not close the other two.

## Changes

- **`packages/shared/src/lib/entities/system-entities.ts`** — the refusal list, `isIndexableEntityType()`, `registerNonIndexableEntityTypes()`, `listNonIndexableEntityTypes()`, `resetNonIndexableEntityTypes()`.
- **Four guards in `packages/core/src/modules/query_index/lib/`**:

| chokepoint | behaviour | why there |
|---|---|---|
| `buildIndexDoc()` | returns `null` | `upsertIndexRow()`'s null branch already deletes the projection row **and** its search tokens, so an index polluted by an earlier release cleans itself up as records are touched, rather than merely stopping the bleeding |
| `upsertIndexBatch()` | returns an empty batch result | the batch path never goes through `buildIndexDoc`; `rebuild-all` calls it directly. Empty rather than a throw, so `assertIndexBatchWritesLanded()` reads 0 written of 0 attempted and the sweep continues |
| `buildSearchTokenRows()` | returns `[]` | an empty row set rather than a short-circuit in the callers, so `replaceSearchTokensForRecord` / `...ForBatch` still run their `DELETE` and stale tokens are removed |
| `reindexEntity()` | empty result + warning | a reindex that got past this point would prepare a job, reset coverage and purge rows for an entity type that must not be in the index at all. **Subsumes the `entityType === 'query_index:search_token'` literal** this condition already carried |

- `.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md`, plus `UPGRADE_NOTES.md` and `BACKWARD_COMPATIBILITY.md` entries (behaviour narrowing on a contract surface).
- No migration, no schema change.

### Why `shared`, and why this is not a new idea

This repository already has a fixed denylist of exactly this shape — `RESERVED_SYSTEM_ENTITY_TYPES` in the same file — which already names entity types belonging to `core` and already contains `query_index:search_token`. But it is consulted only where entity types are **enumerated** (`flattenSystemEntityIds()`, the custom-field-definition API), and enumeration is not a chokepoint: `--entity <id>` and a `query_index.upsert_one` event both name their entity type directly and bypass it. That is why `reindexEntity` carried a second, one-entry copy of the same idea as a string literal. This PR expresses the idea once and enforces it where the writes happen.

`shared` rather than `core` also avoids a layering problem: three of the twelve entity types live in `packages/enterprise`.

`RESERVED_SYSTEM_ENTITY_TYPES` and `isSystemEntitySelectable()` are deliberately **not** coupled to the new list. They answer a different question — may a custom field be attached, should this appear in an entity picker — and coupling them would change the custom-field-definition contract, which this PR does not touch.

### Why a built-in list *and* a registration seam

This is the design question I would most like a second opinion on, and the answer is the opposite of the one in #5722.

`registerTenantGlobalEntityTypes()` there is an **allowlist**: an entity type nobody declares fails closed, and the cost of forgetting is a search result that does not appear, plus a warning naming it. Registration can be the whole mechanism.

This is a **denylist**: an entity type nobody declares fails **open**, and silently. So:

1. the built-in list is authoritative and names every credential entity type in this repository, `packages/enterprise` included — bare strings need no import, and the neighbouring list already works that way;
2. `registerNonIndexableEntityTypes()` is an escape hatch for applications and out-of-tree packages, additive only;
3. it must be called at module load. A registration landing after the first index write has already lost — an ordering hazard the allowlist does not have, and it is documented as such rather than left implicit.

A per-entity declaration (`@Entity({ indexable: false })`, or a flag in a module's `search.ts`) was considered and rejected for the same asymmetry: it puts the decision where it is easiest to forget, and a credential table added without the flag is indistinguishable from one that was reviewed. Happy to do it that way instead if you would prefer the declarative shape.

### How the list was derived

Every `@Entity` class in this repository was enumerated from its module's `data/entities.ts` (262 of them) and matched on property names (`token|secret|password|hash|code|key|credential|otp|nonce|signature`), then again on class name. The admission test is **"is holding a bearer credential, or the verifier for one, the row's reason to exist?"** — not "does it contain a secret". Twelve clear it (listed in the spec with the column that makes each one qualify).

Deliberately **not** on the list, because each holds a secret column *and* backs a list screen with fields a person searches for — removing them would break their own screens, and the field blocklist is what protects them: `api_keys:api_key`, `integrations:integration_credentials`, `sso:sso_config`, `sso:scim_token`, `security:user_mfa_method`, `inbox_ops:inbox_settings`, `webhooks:webhook_entity`, `checkout:checkout_link_template`, `payment_gateways:gateway_transaction`, `onboarding:onboarding_request`, `devices:user_device`. Also excluded, on the same test applied to closer calls: `record_locks:record_lock`, `attachments:attachment_quota_reservation`, `payment_gateways:gateway_session_initialization`, `payment_gateways:gateway_payment_operation`, `warranty_claims:warranty_claim_sla_signal` — operational records whose token is a coordination claim rather than the row's reason to exist.

`customer_accounts:customer_user_invitation` is the closest call on the other side: it carries `email` and `display_name`, which an admin might want to search. It is refused anyway, because its `token` grants an account to whoever presents it and no first-party screen lists invitations through the query index. **Say so if you disagree** — it is one line.

### What this deliberately does not fix

The stored document still carries blocklisted fields for every entity type that stays indexed — `api_keys:api_key`'s `key_hash`, `security:user_mfa_method`'s `secret` — because `isSearchFieldBlocklisted()` governs the aggregate and the tokens, not `entity_indexes.doc`. Stripping blocklisted fields from the stored document is a separate and larger change with its own read-path consequences; this PR removes the entity types for which the document has no legitimate content at all. I am glad to open that as an issue if it is not already tracked.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/2026-08-28-credential-bearing-entity-types-in-the-search-index.md`

## Testing

`packages/core/src/modules/query_index/__tests__/credential-entity-denylist.test.ts` — 37 cases: the policy itself (each refused type, each deliberate exclusion, normalisation, the registration seam and its reset), and one case per chokepoint, each with a negative control proving an ordinary entity type still gets indexed, still produces tokens, and still reaches its source table.

**Non-vacuity was measured, not assumed.** With the policy module present but the four guards reverted, exactly four cases fail — one per chokepoint — and the other 33 pass, negative controls included.

- New suite: 37/37 pass.
- `query_index` module: 33 suites pass (1 skipped), 306 tests pass (2 skipped).
- `packages/core` full suite: 1442 suites / 11746 tests pass, against 1441 / 11709 measured on pristine `develop` in the same clone immediately before, rather than read off the after-run — exactly +1 suite and +37 tests. The 17 failing suites and 4 failing tests (`catalog`, `translations`, `workflows`) are identical in both runs: `#generated` imports absent in a clone that has never been built.
- `packages/shared` full suite: identical to pristine (174 suites / 1996 tests pass).
- `tsc --noEmit -p packages/shared`: 0 errors. `tsc --noEmit -p packages/core`: 265 errors, every one a `Cannot find module '#generated/...'` from the unbuilt clone; none outside that class, and none in the files this PR touches.
- eslint could not be run in my clone (`eslint-config-next` is absent from `node_modules`, so the flat config fails to load); please flag anything CI catches.

CI on a fork PR sits at `action_required` until a maintainer approves the workflow runs, so the above is local.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- left for the account owner to tick; the `license/cla` check reports SUCCESS on its own -->
- [x] I updated documentation, locales, or generators if the change requires it. <!-- UPGRADE_NOTES.md, BACKWARD_COMPATIBILITY.md, .ai/specs -->
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not added: the change has no UI surface and the behaviour is fully exercised by the unit suite at all four write chokepoints.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set — **I have no `triage` permission; suggesting `priority-high`.**
- [ ] Risk set — **suggesting `risk-medium`**: no schema or API change and no UI surface, but it narrows behaviour on a contract surface and stops rows being written that some deployment may have come to rely on being present.
- [ ] QA routing set — **suggesting `skip-qa`**: no manually exercisable UI surface, database structure and API surface unchanged, `BACKWARD_COMPATIBILITY.md` updated with the narrowing recorded, and automated tests ship with the change.

### Design System Compliance

N/A — no UI in this change.

## Linked issues

None that I could find; happy to link one if this is already tracked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790497182&installation_model_id=432243&pr_number=5728&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5728&signature=b6f82ee47dc80eef2f1073e35c3520afe437d3dec4aaac2ac266bf67c83ed281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->