### PR TITLE
fix(search): record the organization on the fulltext worker's indexer log

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/status-log-organization-scope.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/status-log-organization-scope.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Which `indexer_status_logs` / `indexer_error_logs` rows the indexer panel shows.
+ *
+ * Two cases, and only one of them was wrong.
+ *
+ * An org-SCOPED caller is filtered to `organization_id IN (...)` with no NULL branch. That
+ * is deliberate (#3887): a null-organization diagnostic row carries a stack and a payload
+ * from a platform-wide operation that may concern another organization.
+ * `status-coverage-waterfall.test.ts` pins it and must keep passing.
+ *
+ * An UNRESTRICTED caller - `filterIds === null`, the all-organizations view - fell into an
+ * `else` that returned ONLY rows with `organization_id IS NULL`. No isolation argument
+ * applies there, so the effect was to make the panel's contents depend on whether a writer
+ * happened to record the organization: `worker:vector-indexing:*` and `cli:search.reindex`
+ * populate it and were invisible in that view, while the fulltext worker did not and was
+ * visible. Recording it on the fulltext worker - the point of this change - would have
+ * moved those rows from one blind spot into the other.
+ */
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockCreateRequestContainer = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+const mockGetEntityIds = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({
+  getEntityIds: (...args: unknown[]) => mockGetEntityIds(...args),
+}))
+
+const mockFlattenSystemEntityIds = jest.fn()
+jest.mock('@open-mercato/shared/lib/entities/system-entities', () => ({
+  flattenSystemEntityIds: (...args: unknown[]) => mockFlattenSystemEntityIds(...args),
+}))
+
+const mockResolveOrganizationScopeForRequest = jest.fn()
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) => mockResolveOrganizationScopeForRequest(...args),
+}))
+
+jest.mock('../lib/coverage', () => ({
+  readCoverageSnapshot: jest.fn(),
+  readCoverageSnapshots: jest.fn(async () => new Map()),
+  refreshCoverageSnapshot: jest.fn(),
+}))
+
+import { GET } from '../api/status'
+
+type FakeRow = Record<string, unknown>
+type FakePredicate = (row: FakeRow) => boolean
+
+function makeComparison(column: unknown, operator: unknown, value: unknown): FakePredicate {
+  const key = String(column)
+  if (operator === '=') return (row) => row[key] === value
+  if (operator === 'in') return (row) => Array.isArray(value) && value.includes(row[key])
+  if (operator === 'is') return (row) => (value == null ? row[key] == null : row[key] === value)
+  return () => true
+}
+
+function makeFakeDb(tableRows: Record<string, FakeRow[]>) {
+  const build = (table: string) => {
+    const rows = tableRows[String(table)] ?? []
+    const predicates: FakePredicate[] = []
+    const chain: Record<string, unknown> = {}
+    const passthrough = () => chain
+    for (const method of ['select', 'selectAll', 'distinct', 'orderBy', 'limit']) {
+      chain[method] = passthrough
+    }
+    chain.where = (...args: unknown[]) => {
+      if (typeof args[0] === 'function') {
+        const eb = ((column: unknown, operator: unknown, value: unknown) =>
+          makeComparison(column, operator, value)) as typeof makeComparison & { or: (items: FakePredicate[]) => FakePredicate }
+        eb.or = (items: FakePredicate[]) => (row: FakeRow) => items.some((item) => item(row))
+        const predicate = args[0](eb)
+        if (typeof predicate === 'function') predicates.push(predicate)
+      } else if (typeof args[0] === 'string') {
+        predicates.push(makeComparison(args[0], args[1], args[2]))
+      }
+      return chain
+    }
+    const execute = async () => rows.filter((row) => predicates.every((predicate) => predicate(row)))
+    chain.execute = execute
+    chain.executeTakeFirst = async () => (await execute())[0]
+    return chain
+  }
+  return { selectFrom: (table: string) => build(table) }
+}
+
+const TENANT = 'tenant-1'
+
+/** One row per (writer, organization) shape the two log tables really contain. */
+function logRow(handler: string, organizationId: string | null): FakeRow {
+  return {
+    id: `${handler}:${organizationId ?? 'null'}`,
+    source: 'fulltext',
+    handler,
+    message: 'indexed',
+    level: 'info',
+    tenant_id: TENANT,
+    organization_id: organizationId,
+    occurred_at: new Date(),
+    details: null,
+  }
+}
+
+function errorRow(handler: string, organizationId: string | null): FakeRow {
+  return { ...logRow(handler, organizationId), stack: null, payload: null }
+}
+
+const ROWS: Record<string, FakeRow[]> = {
+  custom_field_defs: [],
+  entity_index_jobs: [],
+  indexer_status_logs: [
+    logRow('worker:fulltext:index', 'org-1'),
+    logRow('worker:vector-indexing:index', 'org-2'),
+    logRow('cli:query_index.reindex', null),
+  ],
+  indexer_error_logs: [
+    errorRow('worker:fulltext:index', 'org-1'),
+    errorRow('worker:vector-indexing:index', 'org-2'),
+    errorRow('cli:query_index.reindex', null),
+  ],
+}
+
+function makeContainer() {
+  const db = makeFakeDb(ROWS)
+  const em = { getKysely: () => db }
+  return {
+    resolve: (name: string) => {
+      if (name === 'em') return em
+      if (name === 'eventBus') return { emitEvent: jest.fn(async () => undefined) }
+      if (name === 'searchModuleConfigs') return []
+      if (name === 'searchStrategies') return []
+      if (name === 'moduleConfigService') return { getValue: async () => true }
+      throw new Error(`Unexpected token: ${name}`)
+    },
+  }
+}
+
+async function readIds(res: Response) {
+  const body = await res.json()
+  return {
+    logs: (body.logs as Array<Record<string, any>>).map((row) => row.id),
+    errors: (body.errors as Array<Record<string, any>>).map((row) => row.id),
+  }
+}
+
+describe('query_index status route — which log rows each scope sees', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: TENANT, orgId: 'org-1', sub: 'user-1' })
+    mockGetEntityIds.mockReturnValue({})
+    mockFlattenSystemEntityIds.mockReturnValue([])
+    mockCreateRequestContainer.mockResolvedValue(makeContainer())
+  })
+
+  it('shows every organization to the unrestricted, all-organizations view', async () => {
+    // `filterIds: null` is the all-organizations view. It used to return ONLY the
+    // NULL-organization rows, so an operator asking "did indexing run?" across the
+    // installation saw the one writer that omits the organization and none of the ones
+    // that record it.
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: TENANT,
+    })
+
+    const { logs, errors } = await readIds(await GET(new Request('http://localhost/api/query_index/status')))
+
+    expect(logs).toEqual(expect.arrayContaining([
+      'worker:fulltext:index:org-1',
+      'worker:vector-indexing:index:org-2',
+      'cli:query_index.reindex:null',
+    ]))
+    expect(errors).toHaveLength(3)
+  })
+
+  it('keeps a scoped view to its own organizations only, null-organization rows included (#3887)', async () => {
+    // The half that must NOT change. A null-organization diagnostic carries a stack and a
+    // payload from a platform-wide operation, so it stays out of a scoped caller's view -
+    // stricter than `cfQuery` earlier in the same file, deliberately.
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: 'org-1',
+      filterIds: ['org-1'],
+      allowedIds: ['org-1'],
+      tenantId: TENANT,
+    })
+
+    const { logs, errors } = await readIds(await GET(new Request('http://localhost/api/query_index/status')))
+
+    expect(logs).toEqual(['worker:fulltext:index:org-1'])
+    expect(errors).toEqual(['worker:fulltext:index:org-1'])
+  })
+})

--- a/packages/core/src/modules/query_index/api/status.ts
+++ b/packages/core/src/modules/query_index/api/status.ts
@@ -525,10 +525,21 @@ export async function GET(req: Request) {
   } else {
     errorQuery = errorQuery.where('tenant_id' as any, 'is', null as any)
   }
+  // An org-SCOPED caller keeps the strict `IN`, with no NULL branch: a null-organization
+  // diagnostic row carries a stack and a payload from a platform-wide operation that may
+  // concern another organization, and #3887 decided deliberately that those must not reach
+  // a scoped caller. That is stricter than `cfQuery` earlier in this file, on purpose.
+  //
+  // An UNRESTRICTED caller (`filterIds === null`, the all-organizations view) is a different
+  // question, and the `else` answered it wrongly: it returned ONLY the null-organization
+  // rows. There is no isolation argument there - the caller may see every organization in
+  // the tenant - so the effect was to make the panel's contents depend on whether a writer
+  // happened to record the organization. `worker:vector-indexing:*` and `cli:search.reindex`
+  // populate it and were invisible in that view; the fulltext worker did not and was
+  // visible. Recording it on the fulltext worker, which is what this change does, would
+  // have moved those rows from one blind spot into the other.
   if (Array.isArray(organizationScopeIds) && organizationScopeIds.length) {
     errorQuery = errorQuery.where('organization_id' as any, 'in', organizationScopeIds)
-  } else {
-    errorQuery = errorQuery.where('organization_id' as any, 'is', null as any)
   }
   const errorRows = await errorQuery
     .orderBy('occurred_at' as any, 'desc')
@@ -563,10 +574,10 @@ export async function GET(req: Request) {
   } else {
     logsQuery = logsQuery.where('tenant_id' as any, 'is', null as any)
   }
+  // Same two cases as the error query above, for the same reasons: #3887's strict `IN` for
+  // a scoped caller, no organization filter at all for the unrestricted one.
   if (Array.isArray(organizationScopeIds) && organizationScopeIds.length) {
     logsQuery = logsQuery.where('organization_id' as any, 'in', organizationScopeIds)
-  } else {
-    logsQuery = logsQuery.where('organization_id' as any, 'is', null as any)
   }
   const logRows = await logsQuery
     .orderBy('occurred_at' as any, 'desc')

--- a/packages/search/src/__tests__/workers.test.ts
+++ b/packages/search/src/__tests__/workers.test.ts
@@ -57,6 +57,8 @@ jest.mock('../modules/search/lib/reindex-progress', () => ({
 
 import { handleVectorIndexJob } from '../modules/search/workers/vector-index.worker'
 import { handleFulltextIndexJob } from '../modules/search/workers/fulltext-index.worker'
+import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
+import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { updateReindexProgress, clearReindexLock } from '../modules/search/lib/reindex-lock'
 import { hasActiveReindexProgress, incrementReindexProgress } from '../modules/search/lib/reindex-progress'
 import { refreshCoverageSnapshot } from '@open-mercato/core/modules/query_index/lib/coverage'
@@ -676,4 +678,92 @@ describe('Fulltext Index Worker', () => {
       'Fulltext search is not available'
     )
   })
+
+  // The organization is the only axis that correlates a fulltext index write with
+  // the record it wrote. Dropping it from the audit trail makes every row's
+  // organization_id NULL regardless of the record's real organization, which is
+  // indistinguishable from a genuinely organization-less write. The vector worker
+  // has always logged it; these pin the fulltext worker to the same contract.
+  it('records the organization on the status log for a single index', async () => {
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      entityType: 'test:entity',
+      recordId: 'rec-1',
+    })
+
+    await handleFulltextIndexJob(job, createMockJobContext(), mockContainer)
+
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        handler: 'worker:fulltext:index',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+  })
+
+  it('records the organization on the status log for a batch index', async () => {
+    mockSearchIndexer.indexRecordsById.mockResolvedValueOnce({ indexed: 1, skipped: 0 })
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'batch-index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      records: [{ entityId: 'test:entity', recordId: 'rec-1' }],
+    })
+
+    await handleFulltextIndexJob(job, createMockJobContext(), mockContainer)
+
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        handler: 'worker:fulltext:batch-index',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+  })
+
+  it('records the organization on the error log when indexing throws', async () => {
+    mockSearchIndexer.indexRecordById.mockRejectedValueOnce(new Error('boom'))
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'index',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      entityType: 'test:entity',
+      recordId: 'rec-1',
+    })
+
+    await expect(handleFulltextIndexJob(job, createMockJobContext(), mockContainer)).rejects.toThrow('boom')
+
+    expect(recordIndexerError).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        handler: 'worker:fulltext:index',
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+  })
+
+  // `delete` and `purge` payloads carry no organization at all, so null here is
+  // the honest value rather than a dropped field. Pinned so a later payload
+  // change is a deliberate decision, not a silent one.
+  it('logs a null organization for a purge, whose payload carries none', async () => {
+    const job = createMockJob<FulltextIndexJobPayload>({
+      jobType: 'purge',
+      tenantId: 'tenant-123',
+      entityId: 'test:entity',
+    })
+
+    await handleFulltextIndexJob(job, createMockJobContext(), mockContainer)
+
+    expect(recordIndexerLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ handler: 'worker:fulltext:purge', tenantId: 'tenant-123' }),
+    )
+  })
+
 })

--- a/packages/search/src/modules/search/workers/fulltext-index.worker.ts
+++ b/packages/search/src/modules/search/workers/fulltext-index.worker.ts
@@ -197,6 +197,7 @@ export async function handleFulltextIndexJob(
           entityType,
           recordId,
           tenantId,
+          organizationId: organizationId ?? null,
           details: { jobId: jobCtx.jobId },
         },
       )
@@ -249,6 +250,7 @@ export async function handleFulltextIndexJob(
           handler: 'worker:fulltext:batch-index',
           message: `Indexed ${successCount}/${records.length} records to fulltext`,
           tenantId,
+          organizationId: organizationId ?? null,
           details: { jobId: jobCtx.jobId, requestedCount: records.length, successCount, skippedCount },
         },
       )
@@ -333,6 +335,10 @@ export async function handleFulltextIndexJob(
     const entityId = 'entityId' in job.payload ? job.payload.entityId :
                      'entityType' in job.payload ? (job.payload as { entityType?: string }).entityType : undefined
     const recordId = 'recordId' in job.payload ? job.payload.recordId : undefined
+    // `delete` and `purge` payloads carry no organization, so this is null for them by construction.
+    const organizationId = 'organizationId' in job.payload
+      ? (job.payload as { organizationId?: string | null }).organizationId ?? null
+      : null
 
     await recordIndexerError(
       { em: em ?? undefined },
@@ -343,6 +349,7 @@ export async function handleFulltextIndexJob(
         entityType: entityId,
         recordId,
         tenantId,
+        organizationId,
         payload: job.payload,
       },
     )


### PR DESCRIPTION
## The problem

`handleFulltextIndexJob` destructures `organizationId` from the job payload and
passes it to `searchIndexer.indexRecordById()` / `indexRecordsById()` — and then
omits it from the `recordIndexerLog()` call immediately after, and from
`recordIndexerError()` in the `catch`. Both helpers accept the field
(`RecordIndexerLogInput.organizationId`, `RecordIndexerErrorInput.organizationId`).

So every `indexer_status_logs` and `indexer_error_logs` row that worker writes
has `organization_id = NULL` regardless of the record's real organization.

The vector worker logs it (`logVectorOperation`, and `recordIndexerError` in its
own `catch`), and `cli:query_index.reindex` logs it at all six of its call
sites. The fulltext worker is the outlier.

## Evidence

A long-lived development database, grouped by handler:

| handler | rows | with_org | with_tenant |
|---|---|---|---|
| `cli:query_index.reindex` | 354 | 0 | 352 |
| `cli:search.reindex` | 90 | 90 | 90 |
| **`worker:fulltext:batch-index`** | **35** | **0** | 35 |
| **`worker:fulltext:index`** | **3** | **0** | 3 |
| `worker:vector-indexing:delete` | 174 | 174 | 174 |
| `worker:vector-indexing:index` | 162 | 162 | 162 |

Fulltext is 38/38 NULL; vector is 336/336 populated. For one record indexed by
both workers 110 ms apart, the vector row names the organization and the
fulltext row does not:

```
worker:fulltext:index         cs_campaign#4e50d468…  org: (null)     14:22:04.075
worker:vector-indexing:index  cs_campaign#4e50d468…  org: f21494dd…  14:22:04.185
```

**Row 1 of that table is a different thing and I want to be explicit about it,
because it is easy to fold in and it would point a fix at the wrong file.**
`cli:query_index.reindex`'s 354 NULLs are runs invoked without
`--organization`; that command passes the field faithfully. Its NULL is a true
fact about the run. The fulltext worker's NULL is not a fact about anything.

## Why it is worth fixing

`indexer_status_logs` is the only per-write audit trail the search index has,
and the organization is the axis you need to correlate an index write with the
record it wrote — the tenant alone cannot, because a projection can carry a
correct tenant and a wrong organization.

There is also a direction in which a constant is worse than an absent column.
Investigating a set of organization-NULL projection rows, you find a fulltext
log row whose organization is also NULL and can read it as corroboration —
when the field is simply never written. That is what prompted this: an
investigation downstream that wanted exactly this axis and could not use it.

## The change

Four lines, at three of the file's five log call sites:

- `jobType === 'index'` → `organizationId: organizationId ?? null`
- `jobType === 'batch-index'` → same
- the `catch` → read it defensively off the payload, matching how `entityId` and
  `recordId` are already recovered there

**`delete` and `purge` are deliberately left alone.** `FulltextDeletePayload`
and `FulltextPurgePayload` carry no organization at all, and
`fulltextStrategy.delete()` / `purge()` are tenant-scoped — so `null` there is
honest rather than dropped, and the defensive read in the `catch` yields `null`
for them by construction. Widening those payloads would touch the enqueue sites
and the strategy signatures, and it turns on a question I would rather not
answer inside a logging fix: **is a purge meant to be per-organization at all?**
Happy to follow up separately if you have a view.

## Verification

- `packages/search` suite: **345 passed, 34/35 suites**. The one failing suite
  (`VectorSearchSection.test.tsx`, `@open-mercato/ui` absent from that package's
  `moduleNameMapper`) fails identically on a clean `develop` — confirmed by
  restoring both files to `origin/develop` and re-running (341 passed, same
  suite failing).
- **Three of the four new tests fail against the unpatched worker** and pass
  against the patched one, so the coverage is mutation-checked rather than
  merely green. The fourth is the `purge` case, which passes either way on
  purpose: it pins `null`-for-purge as a deliberate choice so a later payload
  change is a decision rather than a silent drift.
- `tsc --noEmit -p packages/search/tsconfig.json` adds no findings on either
  changed file.

No `.ai/specs/` entry: `CONTRIBUTING.md` asks for one for new features and
significant changes, and this is an ordinary bugfix. `CHANGELOG.md` left to
maintainers per the same document.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790507302&installation_model_id=432243&pr_number=5730&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5730&signature=55a8b7b1ae7dc13bf1a3977d476a949fef672911af5db95ac932ff3d81464522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->