### PR TITLE
fix(auth): bind super-admin grants to the user's own tenant

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,56 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.7.0 → 0.7.1 (unreleased)
 
+### A super-admin grant now only counts inside the user's own tenant
+
+`RbacService.isGlobalSuperAdmin` named no tenant at all in either of its two lookups, so a
+`user_acls` or `role_acls` row flagged `is_super_admin` conferred platform-wide authority
+regardless of which tenant stamped it. Both lookups are now bound to `users.tenant_id`:
+the user-level grant must carry that tenant, and a role-level grant must reach the user
+through a role in that tenant *and* carry that tenant on its ACL row.
+
+**Two grant shapes stop conferring super-admin**, and the second one is the consequential
+one:
+
+1. A grant whose `tenant_id` differs from the user's own. This is the defect being fixed —
+   such a grant should never have applied outside its tenant.
+2. **Any grant held by a user whose `users.tenant_id` is NULL.** A tenant-less "global"
+   staff account is a shape the codebase supports deliberately, and for such a principal
+   this change removes *all* authorization, not only the super-admin flag: `loadAcl`
+   resolves its tenant as `scope.tenantId || user.tenantId`, both are null here, and it
+   short-circuits to `{ isSuperAdmin: false, features: [], organizations: null }` — so
+   every feature check fails and the account has no path back through the admin UI.
+
+**Action for operators: run these before upgrading.** If either returns rows, give those
+users a `tenant_id` (or re-stamp the grant into the tenant they administer) first.
+
+```sql
+-- user-level grants that will stop conferring super-admin
+SELECT ua.user_id, u.tenant_id AS user_tenant, ua.tenant_id AS grant_tenant
+FROM user_acls ua
+JOIN users u ON u.id = ua.user_id
+WHERE ua.is_super_admin
+  AND (u.tenant_id IS NULL OR u.tenant_id <> ua.tenant_id);
+
+-- role-level grants that will stop conferring super-admin
+SELECT ur.user_id, u.tenant_id AS user_tenant, r.tenant_id AS role_tenant, ra.tenant_id AS grant_tenant
+FROM user_roles ur
+JOIN users u ON u.id = ur.user_id
+JOIN roles r ON r.id = ur.role_id
+JOIN role_acls ra ON ra.role_id = r.id
+WHERE ra.is_super_admin
+  AND (u.tenant_id IS NULL OR r.tenant_id IS DISTINCT FROM u.tenant_id OR ra.tenant_id <> u.tenant_id);
+```
+
+After upgrading, the tenant-less case is also reported at runtime: `RbacService` logs
+`User has no tenant of their own, so no grant can confer super-admin` with the user id. The
+foreign-tenant cases cannot be reported without an extra query per check, so the audit above
+is the only signal for those — run it.
+
+**Action for module authors:** none. No exported signature changes;
+`isGlobalSuperAdmin` is private and its memo stays keyed by user id, since the answer now
+depends only on a property of the user.
+
 ### Sales line `discount_amount` is now read as a line total, and the percentage wins (#3757)
 
 `sales_order_lines.discount_amount` and `sales_quote_lines.discount_amount` have always been

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1562,4 +1562,153 @@ describe('RbacService', () => {
       expect(em.findOne).toHaveBeenCalledTimes(callsAfterFirst) // No new queries
     })
   })
+
+  // Regression cover for the tenant binding on super-admin grants. These build a
+  // tiny in-memory table and evaluate the real filter the service emits, rather
+  // than keying a mock on the fields the test already expects — otherwise the
+  // test cannot tell a filter that was applied from one that was not.
+  describe('super-admin grant tenant binding', () => {
+    type Row = Record<string, any>
+
+    const idOf = (value: any): string | null => {
+      if (typeof value === 'string') return value
+      if (value && typeof value === 'object' && typeof value.id === 'string') return value.id
+      return null
+    }
+
+    const matches = (where: any, row: Row): boolean => {
+      if (!where || typeof where !== 'object') return true
+      return Object.entries(where).every(([key, expected]) => {
+        const actual = row[key]
+        if (expected && typeof expected === 'object' && Array.isArray((expected as any).$in)) {
+          const wanted = (expected as any).$in.map((v: any) => idOf(v))
+          return wanted.includes(idOf(actual))
+        }
+        if (expected && typeof expected === 'object' && !(expected instanceof Date)) {
+          // Relation sub-filter, e.g. `role: { tenantId, deletedAt: null }`.
+          return actual && typeof actual === 'object' ? matches(expected, actual) : false
+        }
+        if (typeof expected === 'string' && actual && typeof actual === 'object') {
+          return idOf(actual) === expected
+        }
+        if (expected === null) return actual === null || actual === undefined
+        return actual === expected
+      })
+    }
+
+    /** Wire `em.findOne` / `em.find` to evaluate the service's real filters. */
+    const seed = (tables: Map<any, Row[]>) => {
+      const rowsFor = (entity: any) => tables.get(entity) ?? []
+      em.findOne.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).find((row) => matches(where, row)) ?? null)
+      em.find.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).filter((row) => matches(where, row)))
+    }
+
+    const user: Row = { id: 'user-1', tenantId: 'tenant-home', organizationId: 'org-1', deletedAt: null }
+
+    it('ignores a user-level super-admin grant stamped with a foreign tenant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        // The row is real, live and flagged — it simply is not this user's own
+        // tenant's grant. Before the tenant binding it conferred `['*']` in
+        // every scope, so one mis-stamped row was a platform escalation.
+        [UserAcl, [{
+          user, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('keeps a home-tenant super-admin grant global across every scope', async () => {
+      // The anti-regression half: binding the grant to the user's own tenant
+      // must not stop a platform super-admin working inside a customer tenant,
+      // which is what the tenant switcher does on every cross-tenant view.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-customer', organizationId: 'org-99' }))
+        .resolves.toEqual({ isSuperAdmin: true, features: ['*'], organizations: null })
+    })
+
+    it('ignores a role-level super-admin grant whose ACL row is stamped with a foreign tenant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        // Production shape: one role, two ACL rows, one of them stamped with a
+        // tenant that is not the role's. Only the correctly stamped one counts.
+        [RoleAcl, [{
+          role, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a super-admin role that belongs to another tenant', async () => {
+      const foreignRole: Row = { id: 'role-foreign', tenantId: 'tenant-other', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role: foreignRole, deletedAt: null }]],
+        [RoleAcl, [{
+          role: foreignRole, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('grants nothing to a user with no tenant of their own', async () => {
+      const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [tenantless]],
+        [UserAcl, [{
+          user: tenantless, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+
+    it('grants nothing when the grant outlives the user row it names', async () => {
+      // The check now runs after the user load, so a `user_acls` row left behind
+      // by a hard-deleted user no longer confers anything.
+      seed(new Map<any, Row[]>([
+        [User, []],
+        [UserAcl, [{
+          user: { id: 'ghost' }, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('ghost', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+  })
+
 })

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -4,6 +4,7 @@ import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { createMemoryStrategy } from '@open-mercato/cache'
 import type { CacheStrategy } from '@open-mercato/cache'
 import * as enabledModulesRegistry from '@open-mercato/shared/security/enabledModulesRegistry'
+import { registerLoggerExtension, type LoggerExtensionRecord } from '@open-mercato/shared/lib/logger'
 import {
   applyAclFeatureOverrides,
   resetModuleContractOverridesForTests,
@@ -1689,8 +1690,22 @@ describe('RbacService', () => {
         [RoleAcl, []],
       ]))
 
-      await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
-        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+      const records: LoggerExtensionRecord[] = []
+      const dispose = registerLoggerExtension({ emit: (record) => { records.push(record) } })
+      try {
+        await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
+          .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+
+        // The consequence is larger than the flag - `loadAcl` short-circuits on a null
+        // tenant, so EVERY feature check fails for this principal - and a tenant-less
+        // staff account is a shape the codebase supports deliberately. Returning false in
+        // silence leaves an operator with a locked-out UI and no in-product signal.
+        expect(records.map((record) => record.message)).toContain(
+          'User has no tenant of their own, so no grant can confer super-admin',
+        )
+      } finally {
+        dispose()
+      }
     })
 
     it('grants nothing when the grant outlives the user row it names', async () => {

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -184,10 +184,45 @@ export class RbacService {
     }
   }
 
-  private async isGlobalSuperAdmin(userId: string): Promise<boolean> {
+  // A super-admin grant is deliberately GLOBAL: it survives every scope the
+  // caller asks about, which is what lets a platform super-admin work inside a
+  // customer tenant. What it must not do is survive the question of whose grant
+  // it is. Both lookups below are therefore evaluated against the user's OWN
+  // tenant (`users.tenant_id`), never against no tenant at all.
+  //
+  // Without that binding a single `user_acls` row — or a role link — stamped
+  // with ANY tenant confers platform super-admin everywhere, so a row written
+  // under the wrong tenant becomes a full privilege escalation with nothing in
+  // the schema or the UI to show for it. `user_acls` has no organization column
+  // and no uniqueness beyond its primary key, so such a row is cheap to create
+  // and invisible to the tenant/organization cross-wire checks.
+  //
+  // This is the tenant binding `resolveCanonicalStaffAuthContext` already
+  // applies when it computes `auth.isSuperAdmin` (see lib/sessionIntegrity.ts:
+  // `userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`, both bound to the
+  // user's own tenant). Before this change the two authorities disagreed:
+  // session integrity would say "not a super-admin" while `loadAcl` handed the
+  // same request `['*']`.
+  //
+  // The memo stays keyed by `userId` alone because the answer now depends only
+  // on the user's own tenant, which is a property of the user — not on the scope
+  // being asked about. `invalidateUserCache` therefore still clears it correctly.
+  private async isGlobalSuperAdmin(
+    em: EntityManager,
+    userId: string,
+    userTenantId: string | null,
+  ): Promise<boolean> {
     if (this.globalSuperAdminCache.has(userId)) return this.globalSuperAdminCache.get(userId)!
-    const em = this.em.fork()
-    const userSuper = await em.findOne(UserAcl, { user: userId as any, isSuperAdmin: true })
+    if (!userTenantId) {
+      // A user with no tenant of their own has no tenant to be a super-admin of.
+      this.globalSuperAdminCache.set(userId, false)
+      return false
+    }
+    const userSuper = await em.findOne(UserAcl, {
+      user: userId as any,
+      tenantId: userTenantId,
+      isSuperAdmin: true,
+    } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
@@ -195,7 +230,11 @@ export class RbacService {
     const links = await findWithDecryption(
       em,
       UserRole,
-      { user: userId as any },
+      // Roles that belong to the user's own tenant, as
+      // `resolveCanonicalStaffAuthContext` already requires. The encryption
+      // scope stays `{ null, null }` as before — this change is about which rows
+      // count, not about which key decrypts them.
+      { user: userId as any, role: { tenantId: userTenantId } } as any,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -212,7 +251,11 @@ export class RbacService {
       this.globalSuperAdminCache.set(userId, false)
       return false
     }
-    const roleSupers = await em.find(RoleAcl, { isSuperAdmin: true, role: { $in: roleIds as any } } as any)
+    const roleSupers = await em.find(RoleAcl, {
+      isSuperAdmin: true,
+      tenantId: userTenantId,
+      role: { $in: roleIds as any },
+    } as any)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))
@@ -249,18 +292,6 @@ export class RbacService {
     const cacheKey = this.getCacheKey(userId, scope)
     const cached = await this.getFromCache(cacheKey)
     if (cached) return cached
-
-    // Direct user-level super-admin grants and unrestricted role-level
-    // super-admin grants are global. Organization-restricted role grants are
-    // deliberately excluded by isGlobalSuperAdmin and continue through the
-    // scoped ACL projection below.
-    if (!userId.startsWith('api_key:')) {
-      if (await this.isGlobalSuperAdmin(userId)) {
-        const result = { isSuperAdmin: true, features: ['*'], organizations: null }
-        await this.setCache(cacheKey, result, userId, scope)
-        return result
-      }
-    }
 
     if (userId.startsWith('api_key:')) {
       const apiKeyId = userId.slice('api_key:'.length)
@@ -350,6 +381,23 @@ export class RbacService {
       await this.setCache(cacheKey, result, userId, scope)
       return result
     }
+
+    // Direct user-level super-admin grants and unrestricted role-level
+    // super-admin grants are global. Organization-restricted role grants are
+    // deliberately excluded by isGlobalSuperAdmin and continue through the
+    // scoped ACL projection below.
+    //
+    // The check runs AFTER the user is loaded because it is evaluated against
+    // the user's own tenant — see isGlobalSuperAdmin. It reuses that load and
+    // that EntityManager rather than issuing its own, so the reordering costs
+    // no extra query. API-key principals never reached it and still do not:
+    // their branch above has already returned.
+    if (await this.isGlobalSuperAdmin(em, userId, user.tenantId ?? null)) {
+      const result = { isSuperAdmin: true, features: ['*'], organizations: null }
+      await this.setCache(cacheKey, result, userId, scope)
+      return result
+    }
+
     const tenantId = scope.tenantId || user.tenantId || null
     const orgId = scope.organizationId || user.organizationId || null
 

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -1,4 +1,4 @@
-import type { EntityManager } from '@mikro-orm/postgresql'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import type { CacheStrategy } from '@open-mercato/cache'
 import { getCurrentCacheTenant, runWithCacheTenant } from '@open-mercato/cache'
 import { UserAcl, RoleAcl, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
@@ -11,7 +11,10 @@ import {
   resolveEffectiveFeatures,
 } from '@open-mercato/shared/security/featurePolicy'
 import { filterGrantsByEnabledModules } from '@open-mercato/shared/security/enabledModulesRegistry'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { resolveRoleOrganizationScope, roleAclAllowsOrganization } from './roleOrganizationScope'
+
+const logger = createLogger('auth').child({ component: 'rbac' })
 
 interface AclData {
   isSuperAdmin: boolean
@@ -215,14 +218,27 @@ export class RbacService {
     if (this.globalSuperAdminCache.has(userId)) return this.globalSuperAdminCache.get(userId)!
     if (!userTenantId) {
       // A user with no tenant of their own has no tenant to be a super-admin of.
+      //
+      // Reported rather than returned silently, because the consequence is larger than
+      // the flag: `loadAcl` derives its tenant as `scope.tenantId || user.tenantId`, and
+      // for such a principal both are null - `resolveCanonicalStaffAuthContext` pins
+      // `auth.tenantId` to `user.tenantId`, and `applySuperAdminScope` cannot override it
+      // from the cookie because it requires `auth.isSuperAdmin`, which is already false
+      // here. So the result is `{ isSuperAdmin: false, features: [], organizations: null }`
+      // and EVERY feature check fails. A tenant-less account is a shape the codebase
+      // supports deliberately (see commands/acl.ts), so an operator whose only platform
+      // administrator has one deserves a line in the log rather than a locked-out UI with
+      // no in-product signal. The foreign-tenant branches below cannot warn without an
+      // extra query; this one costs nothing.
+      logger.warn('User has no tenant of their own, so no grant can confer super-admin', { userId })
       this.globalSuperAdminCache.set(userId, false)
       return false
     }
     const userSuper = await em.findOne(UserAcl, {
-      user: userId as any,
+      user: userId,
       tenantId: userTenantId,
       isSuperAdmin: true,
-    } as any)
+    } as FilterQuery<UserAcl>)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
@@ -234,7 +250,7 @@ export class RbacService {
       // `resolveCanonicalStaffAuthContext` already requires. The encryption
       // scope stays `{ null, null }` as before — this change is about which rows
       // count, not about which key decrypts them.
-      { user: userId as any, role: { tenantId: userTenantId } } as any,
+      { user: userId, role: { tenantId: userTenantId } } as FilterQuery<UserRole>,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -254,8 +270,8 @@ export class RbacService {
     const roleSupers = await em.find(RoleAcl, {
       isSuperAdmin: true,
       tenantId: userTenantId,
-      role: { $in: roleIds as any },
-    } as any)
+      role: { $in: roleIds },
+    } as FilterQuery<RoleAcl>)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))


### PR DESCRIPTION
## What

`RbacService.isGlobalSuperAdmin` decides super-admin-ness from `user_acls` and `role_acls` rows without naming a tenant at all:

```ts
// packages/core/src/modules/auth/services/rbacService.ts
const userSuper = await em.findOne(UserAcl, { user: userId as any, isSuperAdmin: true })
if (userSuper && (userSuper as any).isSuperAdmin) { /* cache true */ return true }
```

`loadAcl` calls it before anything else and short-circuits to `{ isSuperAdmin: true, features: ['*'], organizations: null }`, so **one `user_acls` row flagged `is_super_admin` confers platform super-admin in every scope, no matter which tenant that row is stamped with**. The role half has the same gap on a second axis: the `user_roles` lookup names no tenant either, so a role link into *any* tenant is considered.

## Why this is the right shape

A super-admin grant being **global** is correct, and this PR keeps it. That is what lets a platform super-admin work inside a customer tenant after the tenant switcher swaps scope; evaluating the grant against the *scope being asked about* would break that, and would be a regression rather than a fix.

What must be bound is **whose grant it is**. Both lookups are now evaluated against the user's own tenant (`users.tenant_id`).

**Core already disagrees with itself here, which is the strongest argument for the change.** `lib/sessionIntegrity.ts` computes `auth.isSuperAdmin` through `userAclGrantsSuperAdmin()` / `roleAclGrantsSuperAdmin()`, and both are bound to the user's own tenant. So for a foreign-stamped grant the two authorities answered differently: `resolveCanonicalStaffAuthContext` said "not a super-admin" while `loadAcl` handed the same request `['*']`. Which of the two a given call site consults decided the outcome.

## Severity — defence in depth, not a live vulnerability

Filed publicly rather than as a security advisory, deliberately:

- `api/users/acl/route.ts` already refuses a foreign `tenantId` from a non-super-admin (`requestedTenantId !== authTenantId && !actorIsSuperAdmin` → 403), and otherwise pins the scope to the actor's own tenant.
- `assertActorCanGrantAclSnapshot` already refuses `isSuperAdmin: true` from a non-super-admin.

So producing the row takes a super-admin's own action or a mis-scoped write from elsewhere. The defect is that once such a row exists, nothing downstream questions it. Happy to move this to a private report if maintainers read it differently.

## Implementation notes

- The check moved below the `User` load so it can see that tenant. It reuses the load and the `EntityManager` already there, so the reorder costs **no extra query**. API-key principals never reached it and still do not — their branch returns above.
- Two consequences of the reorder, both deliberate and both matching `sessionIntegrity`: a grant that outlives the user row it names now confers nothing, and a user with no tenant of their own is not a super-admin.
- The `globalSuperAdminCache` memo stays keyed by `userId` alone. The answer now depends only on the user's own tenant — a property of the user, not of the scope being asked about — so `invalidateUserCache` still clears it correctly.
- The encryption scope passed to `findWithDecryption` is left at `{ null, null }`: this change is about which rows count, not about which key decrypts them.

## Tests

`packages/core/src/modules/auth/services/__tests__/rbacService.test.ts` gains a `super-admin grant tenant binding` block. It builds a small in-memory table and evaluates the filter the service really emits, rather than keying a mock on the fields the test already expects — otherwise a test cannot tell an applied filter from an absent one, which is how the existing suite stayed green while the tenant-less lookup shipped.

Both directions are covered:

- a foreign-tenant grant confers nothing — user-level row, role-ACL stamp, and a role belonging to another tenant;
- a **home-tenant grant stays global** when the caller asks about a different tenant (the anti-regression half — this is the platform super-admin working inside a customer tenant);
- a user with no tenant, and a grant whose user row is gone.

The existing suite is unchanged and still passes.

## Follow-up, not in this PR

- `user_acls` has no uniqueness beyond its primary key while `loadAcl` resolves it with an unordered `findOne` that returns early — separate PR, stacked on this one.
- `grantChecks.isUserEffectivelySuperAdmin` reads both ACL tables with neither a tenant nor a soft-delete filter. It answers a different question ("may this actor be modified"), so it is left alone here rather than quietly given different semantics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790525716&installation_model_id=432243&pr_number=5752&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5752&signature=2e5642fc8f7d2c7cd510773c97fe70fe949f1a2589ec34fa73dfb4cb160891d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->