### PR TITLE
fix(auth): make the per-principal ACL row unique and its read deterministic

### DIFF
--- a/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
@@ -278,10 +278,12 @@ describe('auth ACL audit commands', () => {
       await roleHandler().captureAfter!(roleInput, result, harness.ctx)
 
       // prepare + execute + captureAfter each look the row up; a handler that
-      // dropped the tenant predicate could cross tenants unnoticed.
+      // dropped the tenant predicate could cross tenants unnoticed. `deletedAt`
+      // is part of the same assertion: the editor must load the row
+      // `RbacService` reads, and that read is live-rows-only.
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ role: roleId, tenantId })
+        expect(filter).toEqual({ role: roleId, tenantId, deletedAt: null })
       }
     })
 
@@ -490,7 +492,7 @@ describe('auth ACL audit commands', () => {
 
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ user: userId, tenantId })
+        expect(filter).toEqual({ user: userId, tenantId, deletedAt: null })
       }
     })
 

--- a/packages/core/src/modules/auth/commands/acl.ts
+++ b/packages/core/src/modules/auth/commands/acl.ts
@@ -378,8 +378,12 @@ const updateRoleAclCommand = createAclUpdateCommand<RoleAclUpdateInput>({
   labelKey: 'auth.audit.roleAcl.update',
   labelFallback: 'Change role permissions',
   resourceId: (input) => input.roleId,
+  // `deletedAt: null` so the editor loads the row `RbacService` reads, never a
+  // superseded one. The two must agree: this read decides which row a save
+  // edits, and a partial unique index on the live rows
+  // (`role_acls_active_unique_idx`) guarantees there is at most one.
   loadAcl: (em, input) =>
-    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId }),
+    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     const acl =
       (existing as RoleAcl | null) ??
@@ -427,8 +431,9 @@ const updateUserAclCommand = createAclUpdateCommand<UserAclUpdateInput>({
   labelKey: 'auth.audit.userAcl.update',
   labelFallback: 'Change user permissions',
   resourceId: (input) => input.userId,
+  // Same reasoning as the role command above — see `user_acls_active_unique_idx`.
   loadAcl: (em, input) =>
-    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId }),
+    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     if (input.clear) {
       if (!existing) return

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -250,6 +250,11 @@ export class PasswordReset {
 
 // RBAC: Role-level ACL
 @Entity({ tableName: 'role_acls' })
+// Uniqueness is enforced by a partial unique index (`role_acls_active_unique_idx`)
+// on `(role_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth.
 export class RoleAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -288,6 +293,13 @@ export class RoleAcl {
 
 // RBAC: Per-user ACL override
 @Entity({ tableName: 'user_acls' })
+// Uniqueness is enforced by a partial unique index (`user_acls_active_unique_idx`)
+// on `(user_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth. This row REPLACES the user's role ACLs rather than
+// merging with them (see RbacService.loadAcl), so a second live row for the same
+// scope would silently decide the whole feature set.
 export class UserAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
@@ -1,0 +1,70 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// `user_acls` and `role_acls` decide what a principal may do, and neither had
+// any uniqueness beyond its primary key. `RbacService.loadAcl` resolves the
+// per-user row with a bare `findOne` and RETURNS EARLY on a hit — the per-user
+// ACL replaces the role ACLs rather than merging with them — so two rows for
+// the same `(user_id, tenant_id)` were schema-legal and resolved with no
+// `ORDER BY`: whichever row Postgres happened to return decided the user's
+// entire feature set, and could change between requests.
+//
+// The write path makes that reachable rather than theoretical:
+// `auth.user_acl.update` reads with `findOne` and creates when it misses, so
+// two concurrent saves for the same user both miss and both insert.
+//
+// Partial unique indexes scoped to live rows (`where deleted_at is null`),
+// matching the shape already used for the sidebar tables in
+// Migration20260427143311. A `@Unique` decorator cannot express a partial
+// index, so the entities carry a comment pointing here instead.
+//
+// Historical duplicates are collapsed first — most recently updated row wins,
+// the rest are soft-deleted, never dropped — so the indexes can be created on
+// a database that already carries some.
+export class Migration20260828120000_auth extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by user_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from user_acls
+        where deleted_at is null
+      )
+      update user_acls
+      set deleted_at = now()
+      from ranked
+      where user_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "user_acls_active_unique_idx" on "user_acls" ("user_id", "tenant_id") where "deleted_at" is null;`);
+
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by role_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from role_acls
+        where deleted_at is null
+      )
+      update role_acls
+      set deleted_at = now()
+      from ranked
+      where role_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "role_acls_active_unique_idx" on "role_acls" ("role_id", "tenant_id") where "deleted_at" is null;`);
+  }
+
+  override down(): void | Promise<void> {
+    // Only the indexes are reversible. The collapse soft-deleted rows rather
+    // than dropping them, so the data is still there to un-delete by hand if a
+    // deployment ever needs it; un-deleting automatically would recreate the
+    // ambiguity this migration exists to remove.
+    this.addSql(`drop index if exists "user_acls_active_unique_idx";`);
+    this.addSql(`drop index if exists "role_acls_active_unique_idx";`);
+  }
+
+}

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1562,4 +1562,153 @@ describe('RbacService', () => {
       expect(em.findOne).toHaveBeenCalledTimes(callsAfterFirst) // No new queries
     })
   })
+
+  // Regression cover for the tenant binding on super-admin grants. These build a
+  // tiny in-memory table and evaluate the real filter the service emits, rather
+  // than keying a mock on the fields the test already expects — otherwise the
+  // test cannot tell a filter that was applied from one that was not.
+  describe('super-admin grant tenant binding', () => {
+    type Row = Record<string, any>
+
+    const idOf = (value: any): string | null => {
+      if (typeof value === 'string') return value
+      if (value && typeof value === 'object' && typeof value.id === 'string') return value.id
+      return null
+    }
+
+    const matches = (where: any, row: Row): boolean => {
+      if (!where || typeof where !== 'object') return true
+      return Object.entries(where).every(([key, expected]) => {
+        const actual = row[key]
+        if (expected && typeof expected === 'object' && Array.isArray((expected as any).$in)) {
+          const wanted = (expected as any).$in.map((v: any) => idOf(v))
+          return wanted.includes(idOf(actual))
+        }
+        if (expected && typeof expected === 'object' && !(expected instanceof Date)) {
+          // Relation sub-filter, e.g. `role: { tenantId, deletedAt: null }`.
+          return actual && typeof actual === 'object' ? matches(expected, actual) : false
+        }
+        if (typeof expected === 'string' && actual && typeof actual === 'object') {
+          return idOf(actual) === expected
+        }
+        if (expected === null) return actual === null || actual === undefined
+        return actual === expected
+      })
+    }
+
+    /** Wire `em.findOne` / `em.find` to evaluate the service's real filters. */
+    const seed = (tables: Map<any, Row[]>) => {
+      const rowsFor = (entity: any) => tables.get(entity) ?? []
+      em.findOne.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).find((row) => matches(where, row)) ?? null)
+      em.find.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).filter((row) => matches(where, row)))
+    }
+
+    const user: Row = { id: 'user-1', tenantId: 'tenant-home', organizationId: 'org-1', deletedAt: null }
+
+    it('ignores a user-level super-admin grant stamped with a foreign tenant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        // The row is real, live and flagged — it simply is not this user's own
+        // tenant's grant. Before the tenant binding it conferred `['*']` in
+        // every scope, so one mis-stamped row was a platform escalation.
+        [UserAcl, [{
+          user, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('keeps a home-tenant super-admin grant global across every scope', async () => {
+      // The anti-regression half: binding the grant to the user's own tenant
+      // must not stop a platform super-admin working inside a customer tenant,
+      // which is what the tenant switcher does on every cross-tenant view.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-customer', organizationId: 'org-99' }))
+        .resolves.toEqual({ isSuperAdmin: true, features: ['*'], organizations: null })
+    })
+
+    it('ignores a role-level super-admin grant whose ACL row is stamped with a foreign tenant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        // Production shape: one role, two ACL rows, one of them stamped with a
+        // tenant that is not the role's. Only the correctly stamped one counts.
+        [RoleAcl, [{
+          role, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a super-admin role that belongs to another tenant', async () => {
+      const foreignRole: Row = { id: 'role-foreign', tenantId: 'tenant-other', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role: foreignRole, deletedAt: null }]],
+        [RoleAcl, [{
+          role: foreignRole, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('grants nothing to a user with no tenant of their own', async () => {
+      const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [tenantless]],
+        [UserAcl, [{
+          user: tenantless, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+
+    it('grants nothing when the grant outlives the user row it names', async () => {
+      // The check now runs after the user load, so a `user_acls` row left behind
+      // by a hard-deleted user no longer confers anything.
+      seed(new Map<any, Row[]>([
+        [User, []],
+        [UserAcl, [{
+          user: { id: 'ghost' }, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('ghost', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+  })
+
 })

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1677,6 +1677,67 @@ describe('RbacService', () => {
         .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
     })
 
+    it('ignores a soft-deleted user-level super-admin grant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      // Neither the global path nor the scoped per-user read may answer from a
+      // revoked override, so the user falls through to their (empty) roles.
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a soft-deleted role-level super-admin grant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        [RoleAcl, [{
+          role, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('resolves the per-user ACL with an explicit ordering', async () => {
+      // A shape assertion, deliberately: the ordering is applied by Postgres, so
+      // a mocked EntityManager cannot demonstrate WHICH row wins. What it can
+      // demonstrate is that the service asks for an order at all — the absence
+      // of one is the defect, and it is invisible in any single-row fixture.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: false,
+          featuresJson: ['documents.view'], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' })
+
+      const scopedRead = em.findOne.mock.calls.find(([entity, where]: any[]) => (
+        entity === UserAcl && where && where.isSuperAdmin === undefined
+      ))
+      expect(scopedRead).toBeDefined()
+      expect(scopedRead![1]).toMatchObject({ tenantId: 'tenant-home', deletedAt: null })
+      expect(scopedRead![2]).toMatchObject({ orderBy: { createdAt: 'desc', id: 'desc' } })
+    })
+
     it('grants nothing to a user with no tenant of their own', async () => {
       const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
       seed(new Map<any, Row[]>([

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -184,10 +184,45 @@ export class RbacService {
     }
   }
 
-  private async isGlobalSuperAdmin(userId: string): Promise<boolean> {
+  // A super-admin grant is deliberately GLOBAL: it survives every scope the
+  // caller asks about, which is what lets a platform super-admin work inside a
+  // customer tenant. What it must not do is survive the question of whose grant
+  // it is. Both lookups below are therefore evaluated against the user's OWN
+  // tenant (`users.tenant_id`), never against no tenant at all.
+  //
+  // Without that binding a single `user_acls` row — or a role link — stamped
+  // with ANY tenant confers platform super-admin everywhere, so a row written
+  // under the wrong tenant becomes a full privilege escalation with nothing in
+  // the schema or the UI to show for it. `user_acls` has no organization column
+  // and no uniqueness beyond its primary key, so such a row is cheap to create
+  // and invisible to the tenant/organization cross-wire checks.
+  //
+  // This is the tenant binding `resolveCanonicalStaffAuthContext` already
+  // applies when it computes `auth.isSuperAdmin` (see lib/sessionIntegrity.ts:
+  // `userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`, both bound to the
+  // user's own tenant). Before this change the two authorities disagreed:
+  // session integrity would say "not a super-admin" while `loadAcl` handed the
+  // same request `['*']`.
+  //
+  // The memo stays keyed by `userId` alone because the answer now depends only
+  // on the user's own tenant, which is a property of the user — not on the scope
+  // being asked about. `invalidateUserCache` therefore still clears it correctly.
+  private async isGlobalSuperAdmin(
+    em: EntityManager,
+    userId: string,
+    userTenantId: string | null,
+  ): Promise<boolean> {
     if (this.globalSuperAdminCache.has(userId)) return this.globalSuperAdminCache.get(userId)!
-    const em = this.em.fork()
-    const userSuper = await em.findOne(UserAcl, { user: userId as any, isSuperAdmin: true })
+    if (!userTenantId) {
+      // A user with no tenant of their own has no tenant to be a super-admin of.
+      this.globalSuperAdminCache.set(userId, false)
+      return false
+    }
+    const userSuper = await em.findOne(UserAcl, {
+      user: userId as any,
+      tenantId: userTenantId,
+      isSuperAdmin: true,
+    } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
@@ -195,7 +230,11 @@ export class RbacService {
     const links = await findWithDecryption(
       em,
       UserRole,
-      { user: userId as any },
+      // Roles that belong to the user's own tenant, as
+      // `resolveCanonicalStaffAuthContext` already requires. The encryption
+      // scope stays `{ null, null }` as before — this change is about which rows
+      // count, not about which key decrypts them.
+      { user: userId as any, role: { tenantId: userTenantId } } as any,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -212,7 +251,11 @@ export class RbacService {
       this.globalSuperAdminCache.set(userId, false)
       return false
     }
-    const roleSupers = await em.find(RoleAcl, { isSuperAdmin: true, role: { $in: roleIds as any } } as any)
+    const roleSupers = await em.find(RoleAcl, {
+      isSuperAdmin: true,
+      tenantId: userTenantId,
+      role: { $in: roleIds as any },
+    } as any)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))
@@ -249,18 +292,6 @@ export class RbacService {
     const cacheKey = this.getCacheKey(userId, scope)
     const cached = await this.getFromCache(cacheKey)
     if (cached) return cached
-
-    // Direct user-level super-admin grants and unrestricted role-level
-    // super-admin grants are global. Organization-restricted role grants are
-    // deliberately excluded by isGlobalSuperAdmin and continue through the
-    // scoped ACL projection below.
-    if (!userId.startsWith('api_key:')) {
-      if (await this.isGlobalSuperAdmin(userId)) {
-        const result = { isSuperAdmin: true, features: ['*'], organizations: null }
-        await this.setCache(cacheKey, result, userId, scope)
-        return result
-      }
-    }
 
     if (userId.startsWith('api_key:')) {
       const apiKeyId = userId.slice('api_key:'.length)
@@ -350,6 +381,23 @@ export class RbacService {
       await this.setCache(cacheKey, result, userId, scope)
       return result
     }
+
+    // Direct user-level super-admin grants and unrestricted role-level
+    // super-admin grants are global. Organization-restricted role grants are
+    // deliberately excluded by isGlobalSuperAdmin and continue through the
+    // scoped ACL projection below.
+    //
+    // The check runs AFTER the user is loaded because it is evaluated against
+    // the user's own tenant — see isGlobalSuperAdmin. It reuses that load and
+    // that EntityManager rather than issuing its own, so the reordering costs
+    // no extra query. API-key principals never reached it and still do not:
+    // their branch above has already returned.
+    if (await this.isGlobalSuperAdmin(em, userId, user.tenantId ?? null)) {
+      const result = { isSuperAdmin: true, features: ['*'], organizations: null }
+      await this.setCache(cacheKey, result, userId, scope)
+      return result
+    }
+
     const tenantId = scope.tenantId || user.tenantId || null
     const orgId = scope.organizationId || user.organizationId || null
 

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -222,6 +222,7 @@ export class RbacService {
       user: userId as any,
       tenantId: userTenantId,
       isSuperAdmin: true,
+      deletedAt: null,
     } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
@@ -254,6 +255,7 @@ export class RbacService {
     const roleSupers = await em.find(RoleAcl, {
       isSuperAdmin: true,
       tenantId: userTenantId,
+      deletedAt: null,
       role: { $in: roleIds as any },
     } as any)
     const result = roleSupers.some((roleAcl) => (
@@ -407,8 +409,25 @@ export class RbacService {
       return result
     }
 
-    // Per-user ACL first
-    const uacl = await em.findOne(UserAcl, { user: userId as any, tenantId })
+    // Per-user ACL first. This row REPLACES the role ACLs rather than merging
+    // with them, so which row is returned decides the whole feature set. A
+    // partial unique index now makes a second live row impossible
+    // (`user_acls_active_unique_idx`, Migration20260828120000_auth), but the
+    // ordering is stated anyway: an index can be dropped by an operator, and an
+    // unordered `findOne` over a table that used to allow duplicates is exactly
+    // the read this pairs with. Soft-deleted rows are excluded — a revoked
+    // override must not keep answering.
+    const uacl = await em.findOne(
+      UserAcl,
+      { user: userId as any, tenantId, deletedAt: null } as any,
+      // `createdAt`/`id`, not `updatedAt`: `updated_at` is nullable and Postgres
+      // sorts NULLs FIRST under DESC, so ordering by it would prefer a row that
+      // was never updated. The migration's one-time collapse uses
+      // `coalesce(updated_at, created_at)` because there it is picking the row
+      // an operator would call current; here the only requirement is that the
+      // answer not vary between requests.
+      { orderBy: { createdAt: 'desc', id: 'desc' } } as any,
+    )
     if (uacl) {
       const result = {
         isSuperAdmin: !!uacl.isSuperAdmin,
@@ -439,7 +458,7 @@ export class RbacService {
         tenantId,
         scope.organizationId,
       )
-      const racls = await em.find(RoleAcl, { tenantId, role: { $in: roleIds as any } } as any, {})
+      const racls = await em.find(RoleAcl, { tenantId, deletedAt: null, role: { $in: roleIds as any } } as any, {})
       const roleAcls = Array.isArray(racls) ? racls : []
       for (const r of roleAcls) {
         if (roleAclAllowsOrganization(r, roleOrganizationScope)) {


### PR DESCRIPTION
> Stacked on #5752 (`fix/user-acl-tenant-scope`). Review that one first; this branch contains its commit, so the diff here is only the second commit.

## What

`user_acls` and `role_acls` decide what a principal may do, and neither carries any uniqueness beyond its primary key — no `@Unique`, no `@Index`, and no migration adding one.

That matters most on the user side, because `RbacService.loadAcl` resolves the per-user row with a bare `findOne` and **returns early**: the per-user ACL *replaces* the user's role ACLs rather than merging with them.

```ts
const uacl = await em.findOne(UserAcl, { user: userId as any, tenantId })
if (uacl) { /* returns; role ACLs are never consulted */ }
```

Two rows for the same `(user_id, tenant_id)` are therefore schema-legal and resolved with no `ORDER BY`, so whichever row Postgres happens to return decides the user's entire feature set — and can change between requests with nothing changing in the data.

The write path makes that reachable rather than theoretical: `auth.user_acl.update` reads with `findOne` and creates when it misses, so two concurrent saves for the same user both miss and both insert. After this change the losing insert fails the constraint, which is the right outcome — a visible error beats silently deciding someone's permissions at random.

## The migration

`Migration20260828120000_auth` adds partial unique indexes scoped to live rows — `(user_id, tenant_id)` and `(role_id, tenant_id)`, both `where deleted_at is null` — after collapsing any historical duplicates (most recently touched row wins, the rest are **soft-deleted, never dropped**).

This is the same shape as the sidebar tables in `Migration20260427143311`, which is also why the entities carry a comment rather than a decorator: a `@Unique` cannot express a partial index.

One thing a reviewer will reasonably ask about: the new indexes are **not** in
`migrations/.snapshot-*.json`, because no entity declares them. That is the same
property the precedent has — `user_sidebar_preferences_active_unique_idx` is
absent from the snapshots too, and has been since April — so this follows the
existing choice rather than introducing a new one. Say the word if you would
rather they were modelled some other way.

Dry-run against two real databases (one production, one dev) inside a transaction that was then rolled back: the collapse updated **0 rows** on each and both indexes created cleanly, so on those at least the migration has nothing to fail on.

## Reads made to agree with the constraint

- the per-user ACL read gets an explicit `orderBy` — `created_at`, then `id`. Not `updated_at`: it is nullable and Postgres sorts NULLs first under `DESC`, which would prefer a row that was never updated. An index can be dropped by an operator; stating the order costs nothing and removes the last way for the answer to vary.
- every ACL read now excludes soft-deleted rows: the two super-admin lookups, the scoped per-user read, and the scoped role aggregation. A revoked override must not keep answering. (`sessionIntegrity.ts` already filters both.)
- `auth.user_acl.update` / `auth.role_acl.update` load live rows only, so the editor edits the row `RbacService` reads.

## Scope

I swept every `packages/*/src/modules/*/data/entities.ts` for entities carrying a principal (`user_id`/`role_id`) plus `tenant_id`: 35 match and about half declare no uniqueness. Almost all are legitimately multi-row — events, deliveries, moderation flags, MFA challenges, devices, watchers, saved perspectives. What makes `user_acls` different is the reader: one row, found by an unordered `findOne`, that returns early and replaces everything else. No other table in that sweep is resolved that way for an authorization decision.

A few others look like they want a constraint on their own merits (`notification_preferences`, `role_perspectives`, `sso_identities`), but none is an authorization decision and none is measured here, so they are deliberately left out — speculative constraints on tables nobody has looked at is how a migration fails on somebody's data.

## Tests

Added to `rbacService.test.ts`, in the block introduced by the parent PR:

- a soft-deleted user-level and a soft-deleted role-level super-admin grant each confer nothing (real filter evaluation against an in-memory table);
- the per-user read asks for an explicit ordering. That one is a shape assertion and is labelled as such in the test: ordering is applied by Postgres, so a mocked `EntityManager` cannot demonstrate *which* row wins — but it can demonstrate that the service asks for an order at all, and the absence of one is invisible in any single-row fixture.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790525724&installation_model_id=432243&pr_number=5753&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5753&signature=7998e973b1e859cb4020e2575ab3deef5527c15b14645734188ceafd50826d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->