### PR TITLE
fix(customers): advance the deal lock token when its links change

### DIFF
--- a/.ai/specs/2026-08-27-deal-people-tab-linked-people-parity.md
+++ b/.ai/specs/2026-08-27-deal-people-tab-linked-people-parity.md
@@ -17,7 +17,9 @@
 | 1.3 | 2026-08-28 | Spec review round 2: set-diffing collides with the `is_primary` partial unique index that delete-and-recreate currently makes unreachable, so the set-diff must clear displaced flags and flush first; the lock stamp is keyed to membership **or** the primary flag and stated as a property of the whole deal write path rather than the people half; corrected the `CustomerDeal.updatedAt` citation. |
 | 1.4 | 2026-08-28 | Round-3 inline review: the `is_primary` rule was incomplete (covered a displaced row that stays, not one that is removed — inserts commit before deletes); named the `updated_at` touch mechanism and undo-path semantics; the write-path fix now ships as its own issue and PR; enumerated the real prop surface and flagged the extraction as the risky step. |
 | 2026-08-28 | Restructured delivery into three independently revertable PRs (stamp → UI → set-diff), sequencing the `linkedAt`-dependent surfaces behind the correction that makes them trustworthy. |
+| 2026-08-31 | Corrected § Data Models: PR 1 makes no-op link writes non-destructive as a side effect of the change-detection the lock stamp requires. Noted that `DealForm` submits both link lists on every Details save, which is why that side effect is user-visible rather than theoretical. |
 | 1.5 | 2026-08-28 | Split delivery into three PRs on maintainer direction: the `updated_at` stamp ships first and alone (PR 1), the UI parity work second (PR 2), and set-diffing last (PR 3). PR 2 deliberately omits the linked date and the "recently linked" sort — both depend on a durable `linkedAt` that only PR 3 delivers — so no wrong value is ever displayed. Added `availableSorts` and `PersonCard.showLinkedDate` as the switches that complete parity in PR 3. |
+| 1.6 | 2026-08-31 | Implementation feedback from PR 1 (#5757): the no-op early return the lock stamp needs also makes unchanged writes non-destructive, so `customer_deal_people` write semantics change in PR 1 as well as PR 3 — § Data Models now says so instead of claiming PR 1 leaves them untouched. |
 
 ## TLDR
 
@@ -199,9 +201,14 @@ The people CRUD route has no `dealEntityId` equivalent, so the deal link is a **
 
 No entity, migration or snapshot change. `CustomerDealPersonLink`, `CustomerPersonCompanyLink`, `CustomerEntity` and `CustomerPersonProfile` are read as they are today.
 
-**PR 3 only** changes the write semantics of `customer_deal_people`: rows survive an unrelated people update instead of being recreated, so `created_at` becomes a durable "linked at" value rather than a per-write timestamp. No backfill — existing rows keep whatever date the last write gave them, and the value only becomes meaningful going forward. Say so in the PR 3 body so the first post-deploy "recently linked" ordering is not read as a bug.
+Write semantics change across **two** of the three PRs, not one. The split follows from what each correction needs:
 
-PR 1 and PR 2 leave the table's write semantics exactly as they are today.
+- **PR 1** — deciding whether to stamp the lock token requires knowing whether the links actually changed, and once that is known, a write that changes nothing has no reason to delete and recreate every row. So a *no-op* write becomes non-destructive as of PR 1. This matters more than it sounds: `DealForm` puts `personIds` **and** `companyIds` into its payload on every Details save regardless of which groups are shown, so before PR 1 an ordinary Details save re-dated every link row on the deal.
+- **PR 3** — a *genuine* change stops deleting and recreating the untouched rows, which is what finally makes `created_at` durable in every case.
+
+No backfill in either. Existing rows keep whatever date the last write gave them, so "recently linked" only becomes meaningful going forward — increasingly so from PR 1 and fully from PR 3. Say so in the PR 3 body rather than letting the first post-deploy ordering read as a bug.
+
+PR 2 leaves the table's write semantics exactly as PR 1 left them.
 
 ## API Contracts
 

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
@@ -575,7 +575,7 @@ describe('DealDetailPage', () => {
     })
   })
 
-  it('updates linked people inline without reloading the full deal detail payload', async () => {
+  it('refreshes the deal after a people change so its lock token stays current', async () => {
     activeTabParam = 'people'
 
     renderWithProviders(<DealDetailPage params={{ id: 'deal-123' }} />)
@@ -593,13 +593,16 @@ describe('DealDetailPage', () => {
       })
     })
 
+    // The deal is re-read after the save: `updated_at` is the optimistic-lock token this
+    // write sends, and the server now advances it whenever the links change. Without the
+    // refresh the next save in this tab would 409 against the version it just superseded.
+    // That reload also carries the refreshed people list, so no separate lookup is issued.
     await waitFor(() => {
-      expect(readApiResultOrThrowMock).toHaveBeenCalledWith(
-        '/api/customers/people?ids=person-2&pageSize=1',
-      )
+      expect(detailRequestCount).toBe(2)
     })
-
-    expect(detailRequestCount).toBe(1)
+    expect(readApiResultOrThrowMock).not.toHaveBeenCalledWith(
+      '/api/customers/people?ids=person-2&pageSize=1',
+    )
   })
 
   it('defaults the activity target to the primary linked person when one is flagged (#4376)', async () => {

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/types.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/types.ts
@@ -6,29 +6,6 @@ export type DealAssociation = {
   isPrimary?: boolean
 }
 
-export type PersonAssociationApiRecord = {
-  id?: string
-  displayName?: string | null
-  display_name?: string | null
-  primaryEmail?: string | null
-  primary_email?: string | null
-  primaryPhone?: string | null
-  primary_phone?: string | null
-  personProfile?: { jobTitle?: string | null } | null
-  person_profile?: { jobTitle?: string | null } | null
-}
-
-export type CompanyAssociationApiRecord = {
-  id?: string
-  displayName?: string | null
-  display_name?: string | null
-  domain?: string | null
-  websiteUrl?: string | null
-  website_url?: string | null
-  companyProfile?: { domain?: string | null; websiteUrl?: string | null } | null
-  company_profile?: { domain?: string | null; websiteUrl?: string | null } | null
-}
-
 export type PipelineStageInfo = {
   id: string
   label: string

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/useDealAssociations.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/useDealAssociations.ts
@@ -6,80 +6,10 @@ import { readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type {
-  CompanyAssociationApiRecord,
   DealAssociation,
   DealDetailPayload,
   GuardedMutationRunner,
-  PersonAssociationApiRecord,
 } from './types'
-
-export function normalizePersonAssociationRecord(
-  record: PersonAssociationApiRecord,
-  fallbackId: string,
-): DealAssociation {
-  const displayName =
-    typeof record.displayName === 'string' && record.displayName.trim().length
-      ? record.displayName.trim()
-      : typeof record.display_name === 'string' && record.display_name.trim().length
-        ? record.display_name.trim()
-        : null
-  const email =
-    typeof record.primaryEmail === 'string' && record.primaryEmail.trim().length
-      ? record.primaryEmail.trim()
-      : typeof record.primary_email === 'string' && record.primary_email.trim().length
-        ? record.primary_email.trim()
-        : null
-  const phone =
-    typeof record.primaryPhone === 'string' && record.primaryPhone.trim().length
-      ? record.primaryPhone.trim()
-      : typeof record.primary_phone === 'string' && record.primary_phone.trim().length
-        ? record.primary_phone.trim()
-        : null
-  const profile = record.personProfile ?? record.person_profile ?? null
-  const jobTitle =
-    profile && typeof profile.jobTitle === 'string' && profile.jobTitle.trim().length
-      ? profile.jobTitle.trim()
-      : null
-  return {
-    id: typeof record.id === 'string' ? record.id : fallbackId,
-    label: displayName ?? email ?? phone ?? fallbackId,
-    subtitle: jobTitle ?? email ?? phone ?? null,
-    kind: 'person',
-  }
-}
-
-export function normalizeCompanyAssociationRecord(
-  record: CompanyAssociationApiRecord,
-  fallbackId: string,
-): DealAssociation {
-  const displayName =
-    typeof record.displayName === 'string' && record.displayName.trim().length
-      ? record.displayName.trim()
-      : typeof record.display_name === 'string' && record.display_name.trim().length
-        ? record.display_name.trim()
-        : null
-  const profile = record.companyProfile ?? record.company_profile ?? null
-  const domain =
-    typeof record.domain === 'string' && record.domain.trim().length
-      ? record.domain.trim()
-      : profile && typeof profile.domain === 'string' && profile.domain.trim().length
-        ? profile.domain.trim()
-        : null
-  const website =
-    typeof record.websiteUrl === 'string' && record.websiteUrl.trim().length
-      ? record.websiteUrl.trim()
-      : typeof record.website_url === 'string' && record.website_url.trim().length
-        ? record.website_url.trim()
-        : profile && typeof profile.websiteUrl === 'string' && profile.websiteUrl.trim().length
-          ? profile.websiteUrl.trim()
-          : null
-  return {
-    id: typeof record.id === 'string' ? record.id : fallbackId,
-    label: displayName ?? domain ?? website ?? fallbackId,
-    subtitle: domain ?? website ?? null,
-    kind: 'company',
-  }
-}
 
 function sameIdList(left: string[], right: string[]): boolean {
   if (left.length !== right.length) return false
@@ -97,8 +27,13 @@ type UseDealAssociationsOptions = {
   data: DealDetailPayload | null
   setData: React.Dispatch<React.SetStateAction<DealDetailPayload | null>>
   runMutationWithContext: GuardedMutationRunner
-  /** Re-fetch the deal detail; wired into the conflict bar's refresh action on a 409. */
-  onRefresh?: (() => void) | null
+  /**
+   * Re-fetch the deal detail. Wired into the conflict bar's refresh action on a 409, and
+   * awaited after a successful link save: the deal's `updated_at` is the lock token these
+   * writes send, and the server now advances it whenever the links change, so a page that
+   * kept its old token would 409 against its own next write.
+   */
+  onRefresh?: (() => void | Promise<void>) | null
 }
 
 type UseDealAssociationsResult = {
@@ -129,80 +64,6 @@ export function useDealAssociations({
     setPeopleEditorIds(data?.linkedPersonIds ?? [])
     setCompaniesEditorIds(data?.linkedCompanyIds ?? [])
   }, [data?.linkedCompanyIds, data?.linkedPersonIds])
-
-  const loadPeopleAssociations = React.useCallback(async (ids: string[]): Promise<DealAssociation[]> => {
-    const uniqueIds = Array.from(new Set(ids.map((value) => value.trim()).filter(Boolean)))
-    if (!uniqueIds.length) return []
-    try {
-      const params = new URLSearchParams({
-        ids: uniqueIds.join(','),
-        pageSize: String(Math.max(uniqueIds.length, 1)),
-      })
-      const payload = await readApiResultOrThrow<{ items?: PersonAssociationApiRecord[] }>(
-        `/api/customers/people?${params.toString()}`,
-      )
-      const items = Array.isArray(payload.items) ? payload.items : []
-      const byId = new Map<string, PersonAssociationApiRecord>()
-      items.forEach((record) => {
-        if (record && typeof record.id === 'string') byId.set(record.id, record)
-      })
-      return uniqueIds.map((personId) => {
-        const record = byId.get(personId)
-        return record
-          ? normalizePersonAssociationRecord(record, personId)
-          : {
-              id: personId,
-              label: personId,
-              subtitle: null,
-              kind: 'person' as const,
-            }
-      })
-    } catch {
-      return uniqueIds.map((personId) => ({
-        id: personId,
-        label: personId,
-        subtitle: null,
-        kind: 'person' as const,
-      }))
-    }
-  }, [])
-
-  const loadCompanyAssociations = React.useCallback(async (ids: string[]): Promise<DealAssociation[]> => {
-    const uniqueIds = Array.from(new Set(ids.map((value) => value.trim()).filter(Boolean)))
-    if (!uniqueIds.length) return []
-    try {
-      const params = new URLSearchParams({
-        ids: uniqueIds.join(','),
-        pageSize: String(Math.max(uniqueIds.length, 1)),
-      })
-      const payload = await readApiResultOrThrow<{ items?: CompanyAssociationApiRecord[] }>(
-        `/api/customers/companies?${params.toString()}`,
-      )
-      const items = Array.isArray(payload.items) ? payload.items : []
-      const byId = new Map<string, CompanyAssociationApiRecord>()
-      items.forEach((record) => {
-        if (record && typeof record.id === 'string') byId.set(record.id, record)
-      })
-      return uniqueIds.map((companyId) => {
-        const record = byId.get(companyId)
-        return record
-          ? normalizeCompanyAssociationRecord(record, companyId)
-          : {
-              id: companyId,
-              label: companyId,
-              subtitle: null,
-              kind: 'company' as const,
-            }
-      })
-    } catch {
-      return uniqueIds.map((companyId) => ({
-        id: companyId,
-        label: companyId,
-        subtitle: null,
-        kind: 'company' as const,
-      }))
-    }
-  }, [])
 
   const loadLinkedPeoplePage = React.useCallback(
     async (page: number, query: string): Promise<LinkedPageResult> => {
@@ -274,17 +135,12 @@ export function useDealAssociations({
           ),
           { id: currentDealId, personIds: nextIds, operation: 'updateDealPeople' },
         )
-        const nextPeople = await loadPeopleAssociations(nextIds.slice(0, 3))
-        setData((prev) =>
-          prev
-            ? {
-                ...prev,
-                people: nextPeople,
-                linkedPersonIds: nextIds,
-                counts: { ...prev.counts, people: nextIds.length },
-              }
-            : prev,
-        )
+        // The deal has to be re-read: `updated_at` is the optimistic-lock token this save
+        // sends, and the server advances it whenever the links change, so a page holding the
+        // superseded version would 409 against its own next write. The reload carries the
+        // refreshed `people` / `linkedPersonIds` / `counts` with it, so patching them from a
+        // separate lookup first would only be overwritten one round trip later.
+        await onRefresh?.()
       } catch (error) {
         setPeopleEditorIds(previousIds)
         setData((prev) =>
@@ -306,7 +162,7 @@ export function useDealAssociations({
         setPeopleSaving(false)
       }
     },
-    [currentDealId, data?.deal.updatedAt, data?.people, loadPeopleAssociations, onRefresh, peopleEditorIds, runMutationWithContext, setData, t],
+    [currentDealId, data?.deal.updatedAt, data?.people, onRefresh, peopleEditorIds, runMutationWithContext, setData, t],
   )
 
   const handleCompaniesAssociationsChange = React.useCallback(
@@ -325,17 +181,8 @@ export function useDealAssociations({
           ),
           { id: currentDealId, companyIds: nextIds, operation: 'updateDealCompanies' },
         )
-        const nextCompanies = await loadCompanyAssociations(nextIds.slice(0, 3))
-        setData((prev) =>
-          prev
-            ? {
-                ...prev,
-                companies: nextCompanies,
-                linkedCompanyIds: nextIds,
-                counts: { ...prev.counts, companies: nextIds.length },
-              }
-            : prev,
-        )
+        // See the people handler above: the reload refreshes the lock token and the list.
+        await onRefresh?.()
       } catch (error) {
         setCompaniesEditorIds(previousIds)
         setData((prev) =>
@@ -362,7 +209,6 @@ export function useDealAssociations({
       currentDealId,
       data?.companies,
       data?.deal.updatedAt,
-      loadCompanyAssociations,
       onRefresh,
       runMutationWithContext,
       setData,

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/useDealAssociations.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/useDealAssociations.ts
@@ -28,12 +28,11 @@ type UseDealAssociationsOptions = {
   setData: React.Dispatch<React.SetStateAction<DealDetailPayload | null>>
   runMutationWithContext: GuardedMutationRunner
   /**
-   * Re-fetch the deal detail. Wired into the conflict bar's refresh action on a 409, and
-   * awaited after a successful link save: the deal's `updated_at` is the lock token these
-   * writes send, and the server now advances it whenever the links change, so a page that
-   * kept its old token would 409 against its own next write.
+   * Re-fetch the deal detail. Required, not optional: this hook no longer patches the list
+   * itself on success, so a caller without it would show a stale list *and* keep a superseded
+   * lock token that 409s on the next save. It also backs the conflict bar's refresh on a 409.
    */
-  onRefresh?: (() => void | Promise<void>) | null
+  onRefresh: () => void | Promise<void>
 }
 
 type UseDealAssociationsResult = {
@@ -135,12 +134,7 @@ export function useDealAssociations({
           ),
           { id: currentDealId, personIds: nextIds, operation: 'updateDealPeople' },
         )
-        // The deal has to be re-read: `updated_at` is the optimistic-lock token this save
-        // sends, and the server advances it whenever the links change, so a page holding the
-        // superseded version would 409 against its own next write. The reload carries the
-        // refreshed `people` / `linkedPersonIds` / `counts` with it, so patching them from a
-        // separate lookup first would only be overwritten one round trip later.
-        await onRefresh?.()
+        await onRefresh()
       } catch (error) {
         setPeopleEditorIds(previousIds)
         setData((prev) =>
@@ -155,7 +149,7 @@ export function useDealAssociations({
         )
         // runMutationWithContext already surfaces the conflict bar on a 409; only
         // fall back to the generic flash when this is not a record conflict.
-        if (!surfaceRecordConflict(error, t, { onRefresh: onRefresh ?? null })) {
+        if (!surfaceRecordConflict(error, t, { onRefresh })) {
           flash(t('customers.deals.detail.peopleUpdateError', 'Failed to update linked people.'), 'error')
         }
       } finally {
@@ -181,8 +175,7 @@ export function useDealAssociations({
           ),
           { id: currentDealId, companyIds: nextIds, operation: 'updateDealCompanies' },
         )
-        // See the people handler above: the reload refreshes the lock token and the list.
-        await onRefresh?.()
+        await onRefresh()
       } catch (error) {
         setCompaniesEditorIds(previousIds)
         setData((prev) =>
@@ -197,7 +190,7 @@ export function useDealAssociations({
         )
         // runMutationWithContext already surfaces the conflict bar on a 409; only
         // fall back to the generic flash when this is not a record conflict.
-        if (!surfaceRecordConflict(error, t, { onRefresh: onRefresh ?? null })) {
+        if (!surfaceRecordConflict(error, t, { onRefresh })) {
           flash(t('customers.deals.detail.companiesUpdateError', 'Failed to update linked companies.'), 'error')
         }
       } finally {

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
@@ -198,7 +198,7 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
     data,
     setData,
     runMutationWithContext,
-    onRefresh: () => { void loadData() },
+    onRefresh: () => loadData(),
   })
 
   const { isStageSaving, handleStageChange } = useDealPipeline({

--- a/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
@@ -66,6 +66,23 @@ type Probe = {
   readTicks: number[]
   /** Ticks at which `em.flush()` was called, in order. */
   flushTicks: number[]
+  /**
+   * How many times `isPrimary` was assigned on an ALREADY EXISTING link row. Rows the run
+   * creates itself are plain objects and never counted, so this isolates the churn the
+   * primary-only branch used to produce on a save that changes nothing.
+   */
+  primaryFlagWrites: number
+}
+
+function emptyProbe(): Probe {
+  return {
+    tick: 0,
+    lastQueryTick: 0,
+    touchTick: null,
+    readTicks: [],
+    flushTicks: [],
+    primaryFlagWrites: 0,
+  }
 }
 
 function makeDeal(probe: Probe): CustomerDeal {
@@ -120,14 +137,26 @@ function makeEm(
   probe: Probe,
   scope: { tenantId: string; organizationId: string } = { tenantId: 'tenant-1', organizationId: 'org-1' },
 ) {
-  const personLinks = (links.people ?? []).map((entry, index) => ({
-    id: `person-link-${index}`,
-    deal,
-    person: { id: entry.personId },
-    isPrimary: entry.isPrimary === true,
-    participantRole: 'stakeholder',
-    createdAt: BASE_UPDATED_AT,
-  }))
+  const personLinks = (links.people ?? []).map((entry, index) => {
+    const link: Record<string, unknown> = {
+      id: `person-link-${index}`,
+      deal,
+      person: { id: entry.personId },
+      participantRole: 'stakeholder',
+      createdAt: BASE_UPDATED_AT,
+    }
+    let isPrimary = entry.isPrimary === true
+    Object.defineProperty(link, 'isPrimary', {
+      get: () => isPrimary,
+      set: (next: boolean) => {
+        isPrimary = next
+        probe.primaryFlagWrites += 1
+      },
+      enumerable: true,
+      configurable: true,
+    })
+    return link
+  })
   const companyLinks = (links.companies ?? []).map((companyId, index) => ({
     id: `company-link-${index}`,
     deal,
@@ -226,11 +255,76 @@ function makeCtx(em: any, scope?: { tenantId: string; orgId: string }) {
 async function runUpdate(links: LinkFixtures, input: Record<string, unknown>) {
   const handler = commandRegistry.get('customers.deals.update') as CommandHandler
   expect(handler).toBeDefined()
-  const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null, readTicks: [], flushTicks: [] }
+  const probe = emptyProbe()
   const deal = makeDeal(probe)
   const em = makeEm(deal, links, probe)
   await handler.execute!({ id: DEAL_ID, ...input }, makeCtx(em))
   return { deal, em, probe }
+}
+
+/**
+ * A `DealSnapshot` as `loadDealSnapshot` would have produced it. Only the link fields vary
+ * per case; the scalars mirror the fixture deal so the undo's scalar-restore phase is a
+ * no-op and cannot be mistaken for the link work under test.
+ */
+function makeSnapshot(
+  people: string[],
+  companies: string[],
+  primaryPersonEntityId: string | null = null,
+): Record<string, unknown> {
+  return {
+    deal: {
+      id: DEAL_ID,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      title: 'Expansion renewal',
+      description: null,
+      status: 'open',
+      pipelineStage: 'Discovery',
+      pipelineId: null,
+      pipelineStageId: null,
+      valueAmount: '12000',
+      valueCurrency: 'USD',
+      probability: 65,
+      expectedCloseAt: null,
+      ownerUserId: null,
+      source: 'Referral',
+      closureOutcome: null,
+      lossReasonId: null,
+      lossNotes: null,
+    },
+    people,
+    primaryPersonEntityId,
+    companies,
+    transitions: [],
+  }
+}
+
+async function runRestoreDirection(
+  commandId: string,
+  direction: 'undo' | 'redo',
+  links: LinkFixtures,
+  snapshot: { before?: unknown; after?: unknown },
+) {
+  const handler = commandRegistry.get(commandId) as CommandHandler
+  expect(handler).toBeDefined()
+  const run = handler[direction]
+  expect(run).toBeDefined()
+  const probe = emptyProbe()
+  const deal = makeDeal(probe)
+  const em = makeEm(deal, links, probe)
+  await run!({
+    logEntry: { resourceId: DEAL_ID, commandPayload: { undo: snapshot } },
+    ctx: makeCtx(em),
+  } as any)
+  return { deal, em, probe }
+}
+
+/** The person ids the run actually recreated, in insertion order. */
+function recreatedPersonIds(em: any): string[] {
+  return em.create.mock.calls
+    .filter((call: unknown[]) => call[0] === CustomerDealPersonLink)
+    .map((call: any[]) => call[1].person.id as string)
 }
 
 /**
@@ -318,6 +412,22 @@ describe('customers.deals.update — deal lock token on link changes', () => {
     expectTokenUnchanged(deal, probe)
   })
 
+  // The primary-only branch (personIds omitted) reaches the same no-op guard by a different
+  // route. Without it the branch would clear the flag on every row and flush just to put it
+  // back on the row it was already on.
+  it('writes nothing at all on a primary-only payload that re-sends the current primary', async () => {
+    const { deal, em, probe } = await runUpdate(
+      { people: [{ personId: ADA, isPrimary: true }, { personId: BOB }] },
+      { primaryPersonEntityId: ADA },
+    )
+    expectTokenUnchanged(deal, probe)
+    // The branch used to clear the flag on every row, flush, and re-set it on the row it had
+    // just cleared. Nothing was lost — these are updates, not a delete-and-recreate — but the
+    // save wrote twice and passed through a transient state with no primary at all.
+    expect(probe.primaryFlagWrites).toBe(0)
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealPersonLink, expect.anything())
+  })
+
   it('advances the token on a primary-only payload that omits personIds', async () => {
     const { deal, probe } = await runUpdate(
       { people: [{ personId: ADA, isPrimary: true }, { personId: BOB }] },
@@ -376,7 +486,7 @@ describe('customers.deals.update — deal lock token on link changes', () => {
     const handler = commandRegistry.get('customers.deals.create') as CommandHandler
     expect(handler).toBeDefined()
 
-    const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null, readTicks: [], flushTicks: [] }
+    const probe = emptyProbe()
     const deal = makeDeal(probe)
     const em = makeEm(deal, {}, probe, {
       tenantId: SCOPE_TENANT_ID,
@@ -403,5 +513,74 @@ describe('customers.deals.update — deal lock token on link changes', () => {
     expect(em.persist).toHaveBeenCalledWith(
       expect.objectContaining({ __entity: CustomerDealPersonLink }),
     )
+  })
+})
+
+/**
+ * The three restore directions call the sync helpers WITHOUT `{ stampLockToken: false }`, so
+ * unlike create they inherit both halves of this change: they stamp the token when the
+ * replayed snapshot differs from what is on the deal now, and they take the new no-op early
+ * return when it does not. The second half is what makes the spec's "an undo should not
+ * re-date links it did not touch" executable rather than aspirational — before the early
+ * return, replaying an identical set still deleted and recreated every row.
+ *
+ * The set assertions are the other half of the spec's acceptance criterion: whatever the
+ * token does, a restore must still reproduce the snapshot's set exactly.
+ */
+describe('deal link restore directions — token and set fidelity', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('restores the snapshot set exactly and stamps the token when undoing an update', async () => {
+    const { deal, em, probe } = await runRestoreDirection(
+      'customers.deals.update',
+      'undo',
+      { people: [{ personId: BOB }], companies: [ACME] },
+      { before: makeSnapshot([ADA], [ACME]), after: makeSnapshot([BOB], [ACME]) },
+    )
+    expect(recreatedPersonIds(em)).toEqual([ADA])
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('restores the snapshot set exactly when redoing a create', async () => {
+    const { deal, em, probe } = await runRestoreDirection(
+      'customers.deals.create',
+      'redo',
+      { people: [{ personId: BOB }] },
+      { after: makeSnapshot([ADA, BOB], []) },
+    )
+    expect(recreatedPersonIds(em)).toEqual([ADA, BOB])
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('restores the snapshot set exactly when undoing a delete', async () => {
+    const { em } = await runRestoreDirection(
+      'customers.deals.delete',
+      'undo',
+      {},
+      { before: makeSnapshot([ADA, BOB], [ACME], ADA) },
+    )
+    expect(recreatedPersonIds(em)).toEqual([ADA, BOB])
+  })
+
+  // The point of the early return, stated as a test: a restore whose snapshot already matches
+  // the live rows must leave them alone. Deleting and recreating them would re-date every
+  // surviving link and discard its participant_role — an undo of a change that never touched
+  // those rows silently rewriting them.
+  it('touches nothing when the replayed snapshot already matches the current links', async () => {
+    const { deal, em, probe } = await runRestoreDirection(
+      'customers.deals.update',
+      'undo',
+      { people: [{ personId: ADA }, { personId: BOB }], companies: [ACME] },
+      {
+        before: makeSnapshot([BOB, ADA], [ACME]),
+        after: makeSnapshot([BOB, ADA], [ACME]),
+      },
+    )
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealPersonLink, expect.anything())
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealCompanyLink, expect.anything())
+    expect(recreatedPersonIds(em)).toEqual([])
+    expectTokenUnchanged(deal, probe)
   })
 })

--- a/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
@@ -1,0 +1,308 @@
+/**
+ * The deal's optimistic-lock token is `customer_deals.updated_at`, and `CustomerDeal.updatedAt`
+ * is `onUpdate`-only, so it advances only when the deal entity itself enters the change set.
+ * A `{ id, personIds }` or `{ id, companyIds }` payload mutates link rows exclusively, so
+ * without an explicit touch the token never moved and two clients editing the same deal's links
+ * from the same base version both passed the version check — the later stale whole-set payload
+ * silently reinstating what the earlier one removed.
+ *
+ * Three properties are pinned here, and the third is the one that is easy to get wrong:
+ *
+ *  1. a real link change advances the token;
+ *  2. a write that changes nothing does not (an idle save must not invalidate other sessions),
+ *     and does not delete/recreate the rows either;
+ *  3. the touch is the LAST thing each helper does. MikroORM v7 discards a pending scalar
+ *     change when a query runs on the same EntityManager before the flush (SPEC-018), and these
+ *     helpers query — `requireCustomerEntity` per linked id. Touching before those reads leaves
+ *     the assignment visible on the in-memory entity while no UPDATE is ever issued, so an
+ *     assertion on `deal.updatedAt` alone passes against a completely broken implementation.
+ *     The `queryOrder` instrumentation below is what makes that failure observable in a unit
+ *     test: it records when the touch happened relative to the last query on the same EM.
+ */
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (emInstance: any, entity: unknown, filters: unknown, opts?: unknown) =>
+    emInstance.find(entity, filters, opts),
+  findOneWithDecryption: (emInstance: any, entity: unknown, filters: unknown, opts?: unknown) =>
+    emInstance.findOne(entity, filters, opts),
+}))
+
+import '@open-mercato/core/modules/customers/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import {
+  CustomerDeal,
+  CustomerDealCompanyLink,
+  CustomerDealPersonLink,
+  CustomerDealStageTransition,
+  CustomerDictionaryEntry,
+  CustomerEntity,
+  CustomerPipelineStage,
+} from '../../data/entities'
+
+const DEAL_ID = '550e8400-e29b-41d4-a716-446655440000'
+const ADA = '550e8400-e29b-41d4-a716-4466554400a1'
+const BOB = '550e8400-e29b-41d4-a716-4466554400a2'
+const ACME = '550e8400-e29b-41d4-a716-4466554400c1'
+const GLOBEX = '550e8400-e29b-41d4-a716-4466554400c2'
+
+const BASE_UPDATED_AT = new Date('2026-04-10T08:00:00.000Z')
+
+type Probe = {
+  /** Monotonic tick, bumped on every EM read. */
+  tick: number
+  /** Tick at which the last read happened. */
+  lastQueryTick: number
+  /** Tick at which `updatedAt` was assigned, or null if it never was. */
+  touchTick: number | null
+}
+
+function makeDeal(probe: Probe): CustomerDeal {
+  const deal: Record<string, unknown> = {
+    id: DEAL_ID,
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+    title: 'Expansion renewal',
+    description: null,
+    status: 'open',
+    pipelineStage: 'Discovery',
+    pipelineId: null,
+    pipelineStageId: null,
+    valueAmount: '12000',
+    valueCurrency: 'USD',
+    probability: 65,
+    expectedCloseAt: null,
+    ownerUserId: null,
+    source: 'Referral',
+    closureOutcome: null,
+    lossReasonId: null,
+    lossNotes: null,
+    createdAt: BASE_UPDATED_AT,
+    deletedAt: null,
+    people: [],
+    companies: [],
+    activities: [],
+    comments: [],
+    stageTransitions: [],
+  }
+  let updatedAt = BASE_UPDATED_AT
+  Object.defineProperty(deal, 'updatedAt', {
+    get: () => updatedAt,
+    set: (next: Date) => {
+      updatedAt = next
+      probe.touchTick = probe.tick
+    },
+    enumerable: true,
+    configurable: true,
+  })
+  return deal as unknown as CustomerDeal
+}
+
+type LinkFixtures = {
+  people?: Array<{ personId: string; isPrimary?: boolean }>
+  companies?: string[]
+}
+
+function makeEm(deal: CustomerDeal, links: LinkFixtures, probe: Probe) {
+  const personLinks = (links.people ?? []).map((entry, index) => ({
+    id: `person-link-${index}`,
+    deal,
+    person: { id: entry.personId },
+    isPrimary: entry.isPrimary === true,
+    participantRole: 'stakeholder',
+    createdAt: BASE_UPDATED_AT,
+  }))
+  const companyLinks = (links.companies ?? []).map((companyId, index) => ({
+    id: `company-link-${index}`,
+    deal,
+    company: { id: companyId },
+    createdAt: BASE_UPDATED_AT,
+  }))
+
+  const known = new Map<string, unknown>([
+    [ADA, { id: ADA, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'person', deletedAt: null }],
+    [BOB, { id: BOB, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'person', deletedAt: null }],
+    [ACME, { id: ACME, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'company', deletedAt: null }],
+    [GLOBEX, { id: GLOBEX, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'company', deletedAt: null }],
+  ])
+
+  const noteRead = () => {
+    probe.tick += 1
+    probe.lastQueryTick = probe.tick
+  }
+
+  const em: any = {
+    findOne: jest.fn(async (ctor: unknown, where: Record<string, unknown>) => {
+      noteRead()
+      if (ctor === CustomerDeal && where.id === deal.id) return deal
+      if (ctor === CustomerEntity) return known.get(where.id as string) ?? null
+      if (ctor === CustomerDealPersonLink) return personLinks.find((link) => link.isPrimary) ?? null
+      if (ctor === CustomerDealStageTransition) return null
+      if (ctor === CustomerDictionaryEntry) return null
+      if (ctor === CustomerPipelineStage) return null
+      return null
+    }),
+    find: jest.fn(async (ctor: unknown) => {
+      noteRead()
+      if (ctor === CustomerDealPersonLink) return personLinks
+      if (ctor === CustomerDealCompanyLink) return companyLinks
+      return []
+    }),
+    nativeDelete: jest.fn(async () => {}),
+    create: jest.fn((ctor: unknown, payload: Record<string, unknown>) => ({ __entity: ctor, ...payload })),
+    persist: jest.fn(() => {}),
+    flush: jest.fn(async () => {}),
+    transactional: jest.fn(async (fn: (inner: any) => Promise<unknown>) => fn(em)),
+    begin: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    getReference: jest.fn((_ctor: unknown, id: string) => ({ id })),
+    remove: jest.fn(),
+    getKysely: jest.fn(() => {
+      throw Object.assign(new Error('no kysely in this test'), { code: '42P01' })
+    }),
+  }
+  em.fork = jest.fn(() => em)
+  return em
+}
+
+function makeCtx(em: any) {
+  const engine: any = {
+    setCustomFields: jest.fn(async () => {}),
+    emitOrmEntityEvent: jest.fn(async () => {}),
+  }
+  const queue: any[] = []
+  engine.markOrmEntityChange = jest.fn((entry: any) => {
+    if (entry?.entity) queue.push(entry)
+  })
+  engine.flushOrmEntityChanges = jest.fn(async () => {
+    while (queue.length > 0) await engine.emitOrmEntityEvent(queue.shift())
+  })
+
+  return {
+    container: {
+      resolve: (token: string) => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return engine as unknown as DataEngine
+        if (token === 'eventBus') return undefined
+        throw new Error(`Unexpected dependency: ${token}`)
+      },
+    } as any,
+    auth: {
+      sub: '550e8400-e29b-41d4-a716-446655440099',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    } as any,
+    selectedOrganizationId: 'org-1',
+    organizationScope: null,
+    organizationIds: null,
+    request: undefined as any,
+  }
+}
+
+async function runUpdate(links: LinkFixtures, input: Record<string, unknown>) {
+  const handler = commandRegistry.get('customers.deals.update') as CommandHandler
+  expect(handler).toBeDefined()
+  const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null }
+  const deal = makeDeal(probe)
+  const em = makeEm(deal, links, probe)
+  await handler.execute!({ id: DEAL_ID, ...input }, makeCtx(em))
+  return { deal, em, probe }
+}
+
+/**
+ * The token moved AND the assignment was not stranded behind a later read on the same EM.
+ * Without the second half, an implementation that touches before `requireCustomerEntity`
+ * passes here while issuing no UPDATE at all.
+ */
+function expectTokenAdvanced(deal: CustomerDeal, probe: Probe) {
+  expect(deal.updatedAt.getTime()).toBeGreaterThan(BASE_UPDATED_AT.getTime())
+  expect(probe.touchTick).not.toBeNull()
+  expect(probe.touchTick).toBeGreaterThanOrEqual(probe.lastQueryTick)
+}
+
+function expectTokenUnchanged(deal: CustomerDeal, probe: Probe) {
+  expect(deal.updatedAt.getTime()).toBe(BASE_UPDATED_AT.getTime())
+  expect(probe.touchTick).toBeNull()
+}
+
+describe('customers.deals.update — deal lock token on link changes', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('advances the token when a person is added, after the last read', async () => {
+    const { deal, probe } = await runUpdate({ people: [{ personId: ADA }] }, { personIds: [ADA, BOB] })
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('advances the token when a person is removed', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA }, { personId: BOB }] },
+      { personIds: [BOB] },
+    )
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('advances the token when every person is unlinked', async () => {
+    const { deal, probe } = await runUpdate({ people: [{ personId: ADA }] }, { personIds: [] })
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('leaves the token and the rows alone when the people set is unchanged', async () => {
+    const { deal, em, probe } = await runUpdate(
+      { people: [{ personId: ADA }, { personId: BOB }] },
+      { personIds: [BOB, ADA] },
+    )
+    expectTokenUnchanged(deal, probe)
+    // A no-op must not delete and recreate the links either: that would silently discard
+    // participant_role, created_at and the link ids while reporting no change to other sessions.
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealPersonLink, expect.anything())
+    expect(em.create).not.toHaveBeenCalledWith(CustomerDealPersonLink, expect.anything())
+  })
+
+  it('advances the token when the primary flag moves within an unchanged set', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA, isPrimary: true }, { personId: BOB }] },
+      { personIds: [ADA, BOB], primaryPersonEntityId: BOB },
+    )
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('leaves the token alone when the primary is re-sent unchanged', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA, isPrimary: true }, { personId: BOB }] },
+      { personIds: [ADA, BOB], primaryPersonEntityId: ADA },
+    )
+    expectTokenUnchanged(deal, probe)
+  })
+
+  it('advances the token on a primary-only payload that omits personIds', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA, isPrimary: true }, { personId: BOB }] },
+      { primaryPersonEntityId: BOB },
+    )
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('advances the token when the company set changes, after the last read', async () => {
+    const { deal, probe } = await runUpdate({ companies: [ACME] }, { companyIds: [ACME, GLOBEX] })
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('leaves the token and the rows alone when the company set is unchanged', async () => {
+    const { deal, em, probe } = await runUpdate(
+      { companies: [ACME, GLOBEX] },
+      { companyIds: [GLOBEX, ACME] },
+    )
+    expectTokenUnchanged(deal, probe)
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealCompanyLink, expect.anything())
+  })
+})

--- a/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/deals.linkLockToken.test.ts
@@ -56,12 +56,16 @@ const GLOBEX = '550e8400-e29b-41d4-a716-4466554400c2'
 const BASE_UPDATED_AT = new Date('2026-04-10T08:00:00.000Z')
 
 type Probe = {
-  /** Monotonic tick, bumped on every EM read. */
+  /** Monotonic tick, bumped on every EM read and every flush. */
   tick: number
   /** Tick at which the last read happened. */
   lastQueryTick: number
-  /** Tick at which `updatedAt` was assigned, or null if it never was. */
+  /** Tick at which `updatedAt` was last assigned, or null if it never was. */
   touchTick: number | null
+  /** Ticks at which reads happened, in order. */
+  readTicks: number[]
+  /** Ticks at which `em.flush()` was called, in order. */
+  flushTicks: number[]
 }
 
 function makeDeal(probe: Probe): CustomerDeal {
@@ -110,7 +114,12 @@ type LinkFixtures = {
   companies?: string[]
 }
 
-function makeEm(deal: CustomerDeal, links: LinkFixtures, probe: Probe) {
+function makeEm(
+  deal: CustomerDeal,
+  links: LinkFixtures,
+  probe: Probe,
+  scope: { tenantId: string; organizationId: string } = { tenantId: 'tenant-1', organizationId: 'org-1' },
+) {
   const personLinks = (links.people ?? []).map((entry, index) => ({
     id: `person-link-${index}`,
     deal,
@@ -127,15 +136,16 @@ function makeEm(deal: CustomerDeal, links: LinkFixtures, probe: Probe) {
   }))
 
   const known = new Map<string, unknown>([
-    [ADA, { id: ADA, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'person', deletedAt: null }],
-    [BOB, { id: BOB, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'person', deletedAt: null }],
-    [ACME, { id: ACME, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'company', deletedAt: null }],
-    [GLOBEX, { id: GLOBEX, organizationId: 'org-1', tenantId: 'tenant-1', kind: 'company', deletedAt: null }],
+    [ADA, { id: ADA, ...scope, kind: 'person', deletedAt: null }],
+    [BOB, { id: BOB, ...scope, kind: 'person', deletedAt: null }],
+    [ACME, { id: ACME, ...scope, kind: 'company', deletedAt: null }],
+    [GLOBEX, { id: GLOBEX, ...scope, kind: 'company', deletedAt: null }],
   ])
 
   const noteRead = () => {
     probe.tick += 1
     probe.lastQueryTick = probe.tick
+    probe.readTicks.push(probe.tick)
   }
 
   const em: any = {
@@ -158,7 +168,10 @@ function makeEm(deal: CustomerDeal, links: LinkFixtures, probe: Probe) {
     nativeDelete: jest.fn(async () => {}),
     create: jest.fn((ctor: unknown, payload: Record<string, unknown>) => ({ __entity: ctor, ...payload })),
     persist: jest.fn(() => {}),
-    flush: jest.fn(async () => {}),
+    flush: jest.fn(async () => {
+      probe.tick += 1
+      probe.flushTicks.push(probe.tick)
+    }),
     transactional: jest.fn(async (fn: (inner: any) => Promise<unknown>) => fn(em)),
     begin: jest.fn().mockResolvedValue(undefined),
     commit: jest.fn().mockResolvedValue(undefined),
@@ -173,7 +186,10 @@ function makeEm(deal: CustomerDeal, links: LinkFixtures, probe: Probe) {
   return em
 }
 
-function makeCtx(em: any) {
+const SCOPE_TENANT_ID = '550e8400-e29b-41d4-a716-4466554400f1'
+const SCOPE_ORG_ID = '550e8400-e29b-41d4-a716-4466554400f2'
+
+function makeCtx(em: any, scope?: { tenantId: string; orgId: string }) {
   const engine: any = {
     setCustomFields: jest.fn(async () => {}),
     emitOrmEntityEvent: jest.fn(async () => {}),
@@ -197,10 +213,10 @@ function makeCtx(em: any) {
     } as any,
     auth: {
       sub: '550e8400-e29b-41d4-a716-446655440099',
-      tenantId: 'tenant-1',
-      orgId: 'org-1',
+      tenantId: scope?.tenantId ?? 'tenant-1',
+      orgId: scope?.orgId ?? 'org-1',
     } as any,
-    selectedOrganizationId: 'org-1',
+    selectedOrganizationId: scope?.orgId ?? 'org-1',
     organizationScope: null,
     organizationIds: null,
     request: undefined as any,
@@ -210,7 +226,7 @@ function makeCtx(em: any) {
 async function runUpdate(links: LinkFixtures, input: Record<string, unknown>) {
   const handler = commandRegistry.get('customers.deals.update') as CommandHandler
   expect(handler).toBeDefined()
-  const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null }
+  const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null, readTicks: [], flushTicks: [] }
   const deal = makeDeal(probe)
   const em = makeEm(deal, links, probe)
   await handler.execute!({ id: DEAL_ID, ...input }, makeCtx(em))
@@ -218,20 +234,38 @@ async function runUpdate(links: LinkFixtures, input: Record<string, unknown>) {
 }
 
 /**
- * The token moved AND the assignment was not stranded behind a later read on the same EM.
- * Without the second half, an implementation that touches before `requireCustomerEntity`
- * passes here while issuing no UPDATE at all.
+ * The token moved AND the assignment reached the database.
+ *
+ * The property that actually matters is *not* "the touch was the last event on the EM" —
+ * that only holds for a single-field payload, where the sibling helper returns at its
+ * `=== undefined` guard without querying. For the combined `{ personIds, companyIds }` shape
+ * the deal is touched by `syncDealPeople` and then `syncDealCompanies` issues its own read,
+ * which is still correct because `withAtomicFlush` flushes after **every** phase — an
+ * invariant that lives in another package and that nothing here would otherwise pin.
+ *
+ * So assert the real thing: a flush follows the touch with no read in between. MikroORM
+ * discards a pending scalar change when a query runs before the flush (SPEC-018), so a read
+ * landing in that window is exactly the failure mode, whatever the payload shape.
  */
 function expectTokenAdvanced(deal: CustomerDeal, probe: Probe) {
   expect(deal.updatedAt.getTime()).toBeGreaterThan(BASE_UPDATED_AT.getTime())
   expect(probe.touchTick).not.toBeNull()
-  expect(probe.touchTick).toBeGreaterThanOrEqual(probe.lastQueryTick)
+  const touchTick = probe.touchTick as number
+  const nextFlush = probe.flushTicks.find((tick) => tick > touchTick)
+  expect(nextFlush).toBeDefined()
+  const readsInWindow = probe.readTicks.filter(
+    (tick) => tick > touchTick && tick < (nextFlush as number),
+  )
+  expect(readsInWindow).toEqual([])
 }
 
 function expectTokenUnchanged(deal: CustomerDeal, probe: Probe) {
   expect(deal.updatedAt.getTime()).toBe(BASE_UPDATED_AT.getTime())
   expect(probe.touchTick).toBeNull()
 }
+
+const COMBINED_NOTE =
+  'the shape DealForm submits on every deal save — both lists, unconditionally'
 
 describe('customers.deals.update — deal lock token on link changes', () => {
   afterEach(() => {
@@ -297,6 +331,34 @@ describe('customers.deals.update — deal lock token on link changes', () => {
     expectTokenAdvanced(deal, probe)
   })
 
+  // `DealForm` puts personIds AND companyIds into its payload on every save, so this is the
+  // dominant shape in production — and the only one where the people-side touch is followed by
+  // another helper's read. It passes because withAtomicFlush flushes per phase; these cases are
+  // what would catch that guarantee being removed.
+  it(`advances the token when only the people set changes in a combined payload (${COMBINED_NOTE})`, async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA }], companies: [ACME] },
+      { personIds: [ADA, BOB], companyIds: [ACME] },
+    )
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('advances the token when both sets change in a combined payload', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA }], companies: [ACME] },
+      { personIds: [ADA, BOB], companyIds: [ACME, GLOBEX] },
+    )
+    expectTokenAdvanced(deal, probe)
+  })
+
+  it('leaves the token alone when a combined payload changes neither set', async () => {
+    const { deal, probe } = await runUpdate(
+      { people: [{ personId: ADA }], companies: [ACME] },
+      { personIds: [ADA], companyIds: [ACME] },
+    )
+    expectTokenUnchanged(deal, probe)
+  })
+
   it('leaves the token and the rows alone when the company set is unchanged', async () => {
     const { deal, em, probe } = await runUpdate(
       { companies: [ACME, GLOBEX] },
@@ -304,5 +366,42 @@ describe('customers.deals.update — deal lock token on link changes', () => {
     )
     expectTokenUnchanged(deal, probe)
     expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerDealCompanyLink, expect.anything())
+  })
+
+  // The spec's blast-radius section asks that create and the undo directions keep producing the
+  // exact sets they produce today. Create additionally opts out of the stamp: a brand-new deal
+  // has no other session holding a token, and stamping there would only push `updated_at` past
+  // `created_at` on every deal created with links.
+  it('does not stamp the token on create, while still linking the requested people', async () => {
+    const handler = commandRegistry.get('customers.deals.create') as CommandHandler
+    expect(handler).toBeDefined()
+
+    const probe: Probe = { tick: 0, lastQueryTick: 0, touchTick: null, readTicks: [], flushTicks: [] }
+    const deal = makeDeal(probe)
+    const em = makeEm(deal, {}, probe, {
+      tenantId: SCOPE_TENANT_ID,
+      organizationId: SCOPE_ORG_ID,
+    })
+    // The create path builds its own entity; hand back the fixture so the helpers operate on a
+    // deal whose `updatedAt` is instrumented.
+    em.create = jest.fn((ctor: unknown, payload: Record<string, unknown>) =>
+      ctor === CustomerDeal ? Object.assign(deal, payload) : { __entity: ctor, ...payload },
+    )
+
+    await handler.execute!(
+      {
+        title: 'New expansion',
+        organizationId: SCOPE_ORG_ID,
+        tenantId: SCOPE_TENANT_ID,
+        personIds: [ADA, BOB],
+      },
+      makeCtx(em, { tenantId: SCOPE_TENANT_ID, orgId: SCOPE_ORG_ID }),
+    )
+
+    expect(probe.touchTick).toBeNull()
+    expect(deal.updatedAt.getTime()).toBe(BASE_UPDATED_AT.getTime())
+    expect(em.persist).toHaveBeenCalledWith(
+      expect.objectContaining({ __entity: CustomerDealPersonLink }),
+    )
   })
 })

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -383,12 +383,49 @@ function toNumericString(value: number | null | undefined): string | null {
   return value.toString()
 }
 
+function sameLinkIdSet(next: Set<string>, current: Set<string>): boolean {
+  if (next.size !== current.size) return false
+  for (const id of next) {
+    if (!current.has(id)) return false
+  }
+  return true
+}
+
+/**
+ * The deal's optimistic-lock token is `customer_deals.updated_at`, and `CustomerDeal.updatedAt`
+ * is declared `onUpdate`-only — it advances only when the deal entity itself enters the change
+ * set. A `{ id, personIds }` or `{ id, companyIds }` payload mutates link rows exclusively, so
+ * without this explicit touch the token never moves: two clients editing the same deal's links
+ * from the same base version both pass the version check and the later stale whole-set payload
+ * silently reinstates what the earlier one removed.
+ *
+ * Assigning the property is what dirties the entity; the `onUpdate` hook then supplies the
+ * committed value, so the two do not fight. Same pattern as the profile-only branch in
+ * `people.ts`, which touches its parent for exactly this reason.
+ *
+ * Callers MUST only invoke this when the links actually changed — stamping on a no-op write
+ * would invalidate every other session's token on an idle save.
+ *
+ * ORDERING: this MUST be the last thing a sync helper does. MikroORM v7 discards a pending
+ * scalar change on a managed entity when a query runs on the same EntityManager before the
+ * flush (SPEC-018) — the same footgun the CRITICAL comment in `updateDealCommand` guards
+ * against, and these helpers are exactly the queries it names. Touching before
+ * `requireCustomerEntity` runs would silently drop the UPDATE and leave the token frozen.
+ */
+function touchDealLockToken(deal: CustomerDeal): void {
+  deal.updatedAt = new Date()
+}
+
 async function syncDealPeople(
   em: EntityManager,
   deal: CustomerDeal,
   personIds: string[] | undefined | null,
-  primaryPersonEntityId?: string | null
+  primaryPersonEntityId?: string | null,
+  options?: { stampLockToken?: boolean }
 ): Promise<void> {
+  // A freshly created deal has no other session holding a token to invalidate, and stamping
+  // there would only make `updated_at` overtake `created_at` on every new deal with links.
+  const stampLockToken = options?.stampLockToken !== false
   if (personIds === undefined) {
     if (primaryPersonEntityId === undefined) return
     const links = await em.find(CustomerDealPersonLink, { deal })
@@ -400,6 +437,12 @@ async function syncDealPeople(
           'Primary person must be linked to the deal',
         ),
       })
+    }
+    const currentPrimaryId = links.find((link) => link.isPrimary)?.person?.id ?? null
+    // Safe here: only assignments and the explicit flush below follow — no query runs
+    // between this touch and the flush that persists it.
+    if (stampLockToken && currentPrimaryId !== primaryPersonEntityId) {
+      touchDealLockToken(deal)
     }
     for (const link of links) {
       link.isPrimary = false
@@ -421,13 +464,30 @@ async function syncDealPeople(
       ),
     })
   }
+  // Read the current links once: this both resolves the inherited primary (as the previous
+  // `findOne(..., { isPrimary: true })` did) and lets us tell a real change from a no-op save,
+  // which the lock stamp below depends on.
+  const existingLinks = await em.find(CustomerDealPersonLink, { deal })
+  const currentPersonIds = new Set(existingLinks.map((link) => link.person.id))
+  const currentPrimaryId = existingLinks.find((link) => link.isPrimary)?.person?.id ?? null
+
   let effectivePrimaryId = primaryPersonEntityId
   if (effectivePrimaryId === undefined) {
-    const existingPrimary = await em.findOne(CustomerDealPersonLink, { deal, isPrimary: true })
-    effectivePrimaryId = existingPrimary?.person?.id ?? null
+    effectivePrimaryId = currentPrimaryId
   }
+  const linksChanged =
+    !sameLinkIdSet(new Set(unique), currentPersonIds) || effectivePrimaryId !== currentPrimaryId
+  // Nothing to do. Returning here also stops a no-op save from deleting and recreating every
+  // row, which would otherwise discard `participant_role`, `created_at` and the link ids while
+  // this function reports the write as a no-op to every other session.
+  //
+  // NOTE: this only covers the pure no-op. A genuine change below still deletes and recreates
+  // every row, so surviving participants do lose those columns — pre-existing behaviour that
+  // the set-diff in PR 3 of the linked-people parity spec removes. It is out of scope here
+  // because the linked date it corrupts is not rendered until that PR.
+  if (!linksChanged) return
+
   await em.nativeDelete(CustomerDealPersonLink, { deal })
-  if (!unique.length) return
   for (const personId of unique) {
     const person = await requireCustomerEntity(em, personId, { tenantId: deal.tenantId, organizationId: deal.organizationId }, 'person', 'Person not found')
     ensureSameScope(person, deal.organizationId, deal.tenantId)
@@ -438,17 +498,24 @@ async function syncDealPeople(
     })
     em.persist(link)
   }
+  // Last statement on purpose — see the ORDERING note on `touchDealLockToken`.
+  if (stampLockToken) touchDealLockToken(deal)
 }
 
 async function syncDealCompanies(
   em: EntityManager,
   deal: CustomerDeal,
-  companyIds: string[] | undefined | null
+  companyIds: string[] | undefined | null,
+  options?: { stampLockToken?: boolean }
 ): Promise<void> {
   if (companyIds === undefined) return
+  const stampLockToken = options?.stampLockToken !== false
+  const unique = Array.from(new Set(companyIds ?? []))
+  const existingLinks = await em.find(CustomerDealCompanyLink, { deal })
+  const currentCompanyIds = new Set(existingLinks.map((link) => link.company.id))
+  if (sameLinkIdSet(new Set(unique), currentCompanyIds)) return
+
   await em.nativeDelete(CustomerDealCompanyLink, { deal })
-  if (!companyIds || !companyIds.length) return
-  const unique = Array.from(new Set(companyIds))
   for (const companyId of unique) {
     const company = await requireCustomerEntity(em, companyId, { tenantId: deal.tenantId, organizationId: deal.organizationId }, 'company', 'Company not found')
     ensureSameScope(company, deal.organizationId, deal.tenantId)
@@ -458,6 +525,8 @@ async function syncDealCompanies(
     })
     em.persist(link)
   }
+  // Last statement on purpose — see the ORDERING note on `touchDealLockToken`.
+  if (stampLockToken) touchDealLockToken(deal)
 }
 
 const createDealCommand: CommandHandler<DealCreateInput, { dealId: string }> = {
@@ -530,8 +599,8 @@ const createDealCommand: CommandHandler<DealCreateInput, { dealId: string }> = {
           transitionedByUserId: normalizedTransitionAuthorUserId,
         })
       },
-      () => syncDealPeople(em, deal, parsed.personIds ?? [], parsed.primaryPersonEntityId),
-      () => syncDealCompanies(em, deal, parsed.companyIds ?? []),
+      () => syncDealPeople(em, deal, parsed.personIds ?? [], parsed.primaryPersonEntityId, { stampLockToken: false }),
+      () => syncDealCompanies(em, deal, parsed.companyIds ?? [], { stampLockToken: false }),
     ], { transaction: true })
 
     const de = (ctx.container.resolve('dataEngine') as DataEngine)

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -439,9 +439,15 @@ async function syncDealPeople(
       })
     }
     const currentPrimaryId = links.find((link) => link.isPrimary)?.person?.id ?? null
+    // Nothing changed — same invariant the whole-set branch below enforces. Without this the
+    // clear loop and its flush would rewrite every link row just to put the flag back on the
+    // row it was already on, and would briefly leave the deal with no primary at all inside
+    // the transaction. Only one row can carry the flag (partial unique index on
+    // `deal_id where is_primary`), so there is no second stale flag left to clean up here.
+    if (currentPrimaryId === primaryPersonEntityId) return
     // Safe here: only assignments and the explicit flush below follow — no query runs
     // between this touch and the flush that persists it.
-    if (stampLockToken && currentPrimaryId !== primaryPersonEntityId) {
+    if (stampLockToken) {
       touchDealLockToken(deal)
     }
     for (const link of links) {

--- a/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import MyTimesheetsPage from '../page'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 
@@ -219,12 +219,18 @@ describe('MyTimesheetsPage — duration entry (#4846)', () => {
 
   it('stops counting a cell in the totals once its pending value becomes invalid', async () => {
     const inputs = await renderGrid()
+    // Scope to the totals row. An unscoped `getAllByText('2')` also matches the grid's
+    // day-of-month labels (`<div className="text-xs">{date.getDate()}</div>`), so it passed
+    // for the wrong reason whenever the rendered week excluded the 2nd — and failed outright
+    // whenever it included it, which is roughly one week in four.
+    const totalsRow = () => screen.getByText('Daily Total').closest('tr') as HTMLElement
+
     typeAndBlur(inputs[0], '2')
-    await waitFor(() => expect(screen.getAllByText('2').length).toBeGreaterThan(0))
+    await waitFor(() => expect(within(totalsRow()).getAllByText('2').length).toBeGreaterThan(0))
 
     typeAndBlur(inputs[0], 'abc')
     await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
-    expect(screen.queryAllByText('2')).toHaveLength(0)
+    expect(within(totalsRow()).queryAllByText('2')).toHaveLength(0)
   })
 
   it('names every duration cell after its own project and date', async () => {


### PR DESCRIPTION
## Summary

`customer_deals.updated_at` is the deal's optimistic-lock token, and `CustomerDeal.updatedAt` is declared `onUpdate`-only — it advances only when the deal entity itself enters the change set.

A `{ id, personIds }` or `{ id, companyIds }` payload never does that: `updateDealCommand`'s scalar phase assigns only the fields the payload carries, and `syncDealPeople` / `syncDealCompanies` touch link rows exclusively. So the token did not move on a link-only write — even though the Deal detail page already sends `buildOptimisticLockHeader(deal.updatedAt)` on that save (`useDealAssociations.ts`). The lock read as working while being decorative.

**Failure scenario.** A and B both open a deal holding `{Ada, Bob, Cid}` at version `T`. A unlinks Ada; the write succeeds and `updated_at` is still `T`. B unlinks Bob, and B's whole-set payload — computed from B's stale view, which still contains Ada — passes the version check and **reinstates Ada**. Neither user is told.

This is PR 1 of 3 from the merged [Deal People tab parity spec](https://github.com/open-mercato/open-mercato/blob/421cefe668c119236437c90807f6deb174bf6136/.ai/specs/2026-08-27-deal-people-tab-linked-people-parity.md) (§ Deal Write Path, correction 2). It ships on its own because it is a live data-loss bug on an aggregate with undo semantics, unrelated to the UI parity work and independently revertable.

> **One caveat on "independently revertable":** this PR also carries `test(staff): scope the timesheet totals assertion to the totals row` (`0eb7546f`), an unrelated repair in the `staff` module. It is here because it is what makes this PR's own `test` job capable of going green — the assertion was a calendar time bomb that fails in any week containing the 2nd of the month, pre-existing on `develop`. So reverting the customers fix would now also revert that repair. Flagged explicitly so a future bisect does not read the pairing as accidental; happy to split it into its own PR if a reviewer prefers.

## Changes

- **`commands/deals.ts`** — both sync helpers touch `deal.updatedAt` when the links actually change: membership in either direction, or the primary flag moving. A write that changes neither deliberately does not stamp, so an idle save cannot invalidate other sessions.
- **The touch is the last statement in each helper.** MikroORM v7 discards a pending scalar change when a query runs on the same `EntityManager` before the flush (SPEC-018), and these helpers query — once per linked id via `requireCustomerEntity`. Touching earlier leaves the assignment visible in memory while no `UPDATE` is ever issued. This is the exact footgun the `CRITICAL` comment in `updateDealCommand` already guards against, and that comment names these two helpers.
- **No-op writes now return before the delete-and-recreate.** Previously a write that reported no change to other sessions still discarded `participant_role`, `created_at` and the link ids of every row.
- **The create path opts out** (`stampLockToken: false`): a new deal has no other session holding a token to invalidate, and stamping there would only make `updated_at` overtake `created_at`.
- **`useDealAssociations.ts`** — the page re-reads the deal after a successful link save. Without it, once the token actually advances, the next save in the same tab would 409 against the version it had just superseded. The reload carries the refreshed list, so the separate three-record lookup it used to issue is gone, along with the two normalizers that were its only callers (net −186 lines in that file).

Undo paths need no special handling: nothing in `deals.ts` reads a snapshot's `updated_at`, so a restore that changes the link set stamps forward on its own rather than reinstating a version other sessions may already hold.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-08-27-deal-people-tab-linked-people-parity.md` — merged in #5700, [permalink at the merge commit](https://github.com/open-mercato/open-mercato/blob/421cefe668c119236437c90807f6deb174bf6136/.ai/specs/2026-08-27-deal-people-tab-linked-people-parity.md).

## Testing

New `commands/__tests__/deals.linkLockToken.test.ts` (9 cases). It asserts **both** that the token moves and that the assignment is not stranded behind a later read on the same `EntityManager` — an assertion on `updatedAt` alone passes against an implementation that never issues the `UPDATE`, which is exactly the bug an earlier revision of this branch had. Reintroducing the wrong ordering fails 3 of the 9 cases; that was verified rather than assumed.

Covered: add / remove / unlink-everything, no-op leaves both the token and the rows alone, primary flag moving within an unchanged set, primary re-sent unchanged, the primary-only payload that omits `personIds`, and both company cases.

Full configured gate (`.ai/agentic.config.json` → `validation.commands`): `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app` — **33 of 34 turbo tasks green**.

The one failure is `create-mercato-app#test` → `src/lib/design-system-inventory.test.ts` ("gallery and foundation baselines must be ancestors of the generated inventory"). It is **pre-existing on `develop`**: verified by removing this branch's changes entirely and re-running that package, where it fails identically.

`packages/core` customers suite: 251 suites / 1611 tests pass.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — no locale or generator surface touched.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests — N/A. This is a server-side write-path fix with no manually exercisable UI surface of its own; the spec places the Playwright case with the UI work in PR 2.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — merged separately in #5700.
- [ ] Priority set / [ ] Risk set / [ ] QA routing set.

> Label note: opened from a fork by a `read`-permission contributor, so the author cannot self-label. Suggested: `bug`, `priority-medium`, `risk-medium`, `needs-qa`. Risk is medium rather than low because the change makes a previously permissive write path strict — its realistic failure mode is a false 409, not data loss. QA routing is `needs-qa` rather than `skip-qa` because the deal detail page's save behaviour changes observably, even though no component markup does.

### Design System Compliance

Not applicable — no UI markup in this PR.

## Known, deliberately out of scope

Two points raised in review that are **pre-existing page-wide behaviour**, not introduced here, evidenced by `useDealFormHandlers.ts:64` already doing `await loadData()` after a successful save:

1. A failed post-save reload sets the page-level `error` and renders the full-page `ErrorMessage`, which reads as if the save destroyed the record.
2. Between the save and the reload resolving, the Details form still holds the superseded token, so acting in that window can produce a self-inflicted conflict.

Fixing either properly means changing `useDealData`'s error handling and disabling controls during refresh — page-wide concerns that would leave the page inconsistent if applied only to link saves. Happy to file a follow-up issue if maintainers want them tracked.

Also out of scope by design: a genuine set change still deletes and recreates every link row, so surviving participants lose `participant_role` and `created_at`. That is the set-diff in **PR 3** of the spec; it is deferred because the linked date it corrupts is not rendered until that PR.

## Linked issues

Part of #5732.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790533544&installation_model_id=432243&pr_number=5757&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5757&signature=0edc4481380a9d57dc921bf48da29e6c13b5cab7a446300a7853e98d9e1189cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
