### PR TITLE
fix(auth): give the super-admin TARGET checks the same reading as the grant

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
 import { DELETE, GET } from '@open-mercato/core/modules/auth/api/roles/route'
-import { RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
 
 const mockGetAuthFromRequest = jest.fn()
 const mockLoadAcl = jest.fn()
@@ -158,6 +158,9 @@ describe('GET /api/auth/roles', () => {
     const superAdminRoleId = '323e4567-e89b-12d3-a456-426614174999'
     mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: false })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isRoleEffectivelySuperAdmin` resolves the role's own tenant first and
+      // matches the grant against it, so the role row has to exist here.
+      if (entity === Role) return { id: superAdminRoleId, tenantId: actorTenantId }
       if (entity === RoleAcl) return { isSuperAdmin: true }
       return null
     })

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1482,6 +1482,9 @@ describe('GET /api/auth/users', () => {
       organizations: null,
     })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
+      // matches the grant against it, so the target row has to exist here.
+      if (entity === User) return { id: superAdminUserId, tenantId }
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })
@@ -1508,6 +1511,9 @@ describe('GET /api/auth/users', () => {
       organizations: null,
     })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
+      // matches the grant against it, so the target row has to exist here.
+      if (entity === User) return { id: superAdminUserId, tenantId }
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })

--- a/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
@@ -278,10 +278,12 @@ describe('auth ACL audit commands', () => {
       await roleHandler().captureAfter!(roleInput, result, harness.ctx)
 
       // prepare + execute + captureAfter each look the row up; a handler that
-      // dropped the tenant predicate could cross tenants unnoticed.
+      // dropped the tenant predicate could cross tenants unnoticed. `deletedAt`
+      // is part of the same assertion: the editor must load the row
+      // `RbacService` reads, and that read is live-rows-only.
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ role: roleId, tenantId })
+        expect(filter).toEqual({ role: roleId, tenantId, deletedAt: null })
       }
     })
 
@@ -490,7 +492,7 @@ describe('auth ACL audit commands', () => {
 
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ user: userId, tenantId })
+        expect(filter).toEqual({ user: userId, tenantId, deletedAt: null })
       }
     })
 

--- a/packages/core/src/modules/auth/commands/acl.ts
+++ b/packages/core/src/modules/auth/commands/acl.ts
@@ -378,8 +378,12 @@ const updateRoleAclCommand = createAclUpdateCommand<RoleAclUpdateInput>({
   labelKey: 'auth.audit.roleAcl.update',
   labelFallback: 'Change role permissions',
   resourceId: (input) => input.roleId,
+  // `deletedAt: null` so the editor loads the row `RbacService` reads, never a
+  // superseded one. The two must agree: this read decides which row a save
+  // edits, and a partial unique index on the live rows
+  // (`role_acls_active_unique_idx`) guarantees there is at most one.
   loadAcl: (em, input) =>
-    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId }),
+    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     const acl =
       (existing as RoleAcl | null) ??
@@ -427,8 +431,9 @@ const updateUserAclCommand = createAclUpdateCommand<UserAclUpdateInput>({
   labelKey: 'auth.audit.userAcl.update',
   labelFallback: 'Change user permissions',
   resourceId: (input) => input.userId,
+  // Same reasoning as the role command above — see `user_acls_active_unique_idx`.
   loadAcl: (em, input) =>
-    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId }),
+    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     if (input.clear) {
       if (!existing) return

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -250,6 +250,11 @@ export class PasswordReset {
 
 // RBAC: Role-level ACL
 @Entity({ tableName: 'role_acls' })
+// Uniqueness is enforced by a partial unique index (`role_acls_active_unique_idx`)
+// on `(role_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth.
 export class RoleAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -288,6 +293,13 @@ export class RoleAcl {
 
 // RBAC: Per-user ACL override
 @Entity({ tableName: 'user_acls' })
+// Uniqueness is enforced by a partial unique index (`user_acls_active_unique_idx`)
+// on `(user_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth. This row REPLACES the user's role ACLs rather than
+// merging with them (see RbacService.loadAcl), so a second live row for the same
+// scope would silently decide the whole feature set.
 export class UserAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
@@ -7,7 +7,7 @@ import {
   isRoleEffectivelySuperAdmin,
   listSuperAdminUserIds,
 } from '@open-mercato/core/modules/auth/lib/grantChecks'
-import { RoleAcl, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl, User, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 const mockFindWithDecryption = jest.fn()
 
@@ -16,16 +16,111 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
 }))
 
-type MockEm = {
-  findOne: jest.Mock
-  find: jest.Mock
+const tenantId = '11111111-1111-1111-1111-111111111111'
+const otherTenantId = '99999999-9999-9999-9999-999999999999'
+const actorId = '22222222-2222-2222-2222-222222222222'
+const targetUserId = '33333333-3333-3333-3333-333333333333'
+const targetRoleId = '44444444-4444-4444-4444-444444444444'
+const superAdminRoleId = '55555555-5555-5555-5555-555555555555'
+const otherUserId = '66666666-6666-6666-6666-666666666666'
+
+// ---------------------------------------------------------------------------
+// A small in-memory table set, and an EntityManager double that EVALUATES the
+// filter the code really emits against it.
+//
+// This is deliberate rather than incidental: the previous doubles answered from
+// `mockResolvedValueOnce` queues keyed on call order, so a query that named no
+// tenant and a query that named the right one produced identical results and
+// the suite stayed green either way. The lookups under test differ from each
+// other only in their filters, so a double that ignores filters cannot see the
+// defect at all.
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>
+
+type Db = {
+  users: Row[]
+  roles: Row[]
+  userAcls: Row[]
+  roleAcls: Row[]
+  userRoles: Row[]
 }
 
-function makeEm(): MockEm {
-  return {
-    findOne: jest.fn(),
-    find: jest.fn(),
+function emptyDb(): Db {
+  return { users: [], roles: [], userAcls: [], roleAcls: [], userRoles: [] }
+}
+
+function refId(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object') {
+    const id = (value as { id?: unknown }).id
+    if (typeof id === 'string') return id
   }
+  return null
+}
+
+function tableFor(db: Db, entity: unknown): Row[] {
+  if (entity === User) return db.users
+  if (entity === Role) return db.roles
+  if (entity === UserAcl) return db.userAcls
+  if (entity === RoleAcl) return db.roleAcls
+  if (entity === UserRole) return db.userRoles
+  throw new Error(`unmapped entity in test double: ${String((entity as { name?: string })?.name)}`)
+}
+
+// Which table a relation column points at, so a nested filter such as
+// `{ role: { tenantId } }` can be resolved the way the ORM would.
+function relatedTable(db: Db, column: string): Row[] {
+  if (column === 'user') return db.users
+  if (column === 'role') return db.roles
+  throw new Error(`unmapped relation in test double: ${column}`)
+}
+
+function matchesValue(actual: unknown, expected: unknown): boolean {
+  if (expected === null) return actual === null || actual === undefined
+  return actual === expected
+}
+
+function matchesRow(db: Db, row: Row, where: Row): boolean {
+  for (const [key, condition] of Object.entries(where)) {
+    const actual = row[key]
+    if (condition && typeof condition === 'object' && !(condition instanceof Date)) {
+      const cond = condition as Row
+      if (Array.isArray(cond.$in)) {
+        const id = refId(actual)
+        if (!id || !(cond.$in as unknown[]).includes(id)) return false
+        continue
+      }
+      // Nested filter on a relation: resolve the referenced row and match there.
+      const id = refId(actual)
+      if (!id) return false
+      const related = relatedTable(db, key).find((candidate) => candidate.id === id)
+      if (!related) return false
+      if (!matchesRow(db, related, cond)) return false
+      continue
+    }
+    if (key === 'id' || key === 'user' || key === 'role') {
+      if (refId(actual) !== condition) return false
+      continue
+    }
+    if (!matchesValue(actual, condition)) return false
+  }
+  return true
+}
+
+function makeEm(db: Db) {
+  const findMany = jest.fn((entity: unknown, where: Row) =>
+    Promise.resolve(tableFor(db, entity).filter((row) => matchesRow(db, row, where ?? {}))))
+  const em = {
+    find: findMany,
+    findOne: jest.fn((entity: unknown, where: Row) =>
+      Promise.resolve(tableFor(db, entity).find((row) => matchesRow(db, row, where ?? {})) ?? null)),
+  }
+  // `findWithDecryption` is only ever used here to read `user_roles`; route it
+  // into the same tables so its filter is evaluated too.
+  mockFindWithDecryption.mockImplementation((_em: unknown, entity: unknown, where: Row) =>
+    Promise.resolve(tableFor(db, entity).filter((row) => matchesRow(db, row, where ?? {}))))
+  return em
 }
 
 function makeRbac(actorIsSuperAdmin: boolean) {
@@ -38,11 +133,30 @@ function makeRbac(actorIsSuperAdmin: boolean) {
   }
 }
 
-const tenantId = '11111111-1111-1111-1111-111111111111'
-const actorId = '22222222-2222-2222-2222-222222222222'
-const targetUserId = '33333333-3333-3333-3333-333333333333'
-const targetRoleId = '44444444-4444-4444-4444-444444444444'
-const superAdminRoleId = '55555555-5555-5555-5555-555555555555'
+/** A user in `tenantId` holding a live, own-tenant super-admin grant. */
+function dbWithDirectGrant(): Db {
+  const db = emptyDb()
+  db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+  db.userAcls.push({ id: 'acl-1', user: targetUserId, tenantId, isSuperAdmin: true, deletedAt: null })
+  return db
+}
+
+/** A user in `tenantId` whose super-admin comes from a role of that tenant. */
+function dbWithRoleGrant(): Db {
+  const db = emptyDb()
+  db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+  db.roles.push({ id: superAdminRoleId, tenantId, deletedAt: null })
+  db.userRoles.push({ id: 'link-1', user: targetUserId, role: superAdminRoleId, deletedAt: null })
+  db.roleAcls.push({
+    id: 'racl-1',
+    role: superAdminRoleId,
+    tenantId,
+    isSuperAdmin: true,
+    organizationsJson: null,
+    deletedAt: null,
+  })
+  return db
+}
 
 beforeEach(() => {
   mockFindWithDecryption.mockReset()
@@ -51,76 +165,150 @@ beforeEach(() => {
 
 describe('isUserEffectivelySuperAdmin', () => {
   test('returns true when the user has a direct UserAcl super admin grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(true)
-    expect(em.findOne).toHaveBeenCalledWith(UserAcl, expect.objectContaining({ isSuperAdmin: true }))
-    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    const em = makeEm(dbWithDirectGrant())
+    expect(await isUserEffectivelySuperAdmin(em as never, targetUserId)).toBe(true)
   })
 
   test('returns true when any assigned role grants super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([{ role: { id: superAdminRoleId } }])
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(true)
-    expect(em.findOne).toHaveBeenLastCalledWith(
-      RoleAcl,
-      expect.objectContaining({ isSuperAdmin: true }),
-    )
+    const em = makeEm(dbWithRoleGrant())
+    expect(await isUserEffectivelySuperAdmin(em as never, targetUserId)).toBe(true)
   })
 
   test('returns false when neither UserAcl nor any role grants super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([{ role: { id: targetRoleId } }])
-    em.findOne.mockResolvedValueOnce(null)
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.userRoles.push({ id: 'link-1', user: targetUserId, role: targetRoleId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: false, deletedAt: null })
 
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(false)
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
   })
 
   test('returns false when the user has no role assignments and no UserAcl grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([])
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
 
-    expect(result).toBe(false)
+  // --- the tenant binding ---------------------------------------------------
+
+  test('ignores a UserAcl grant stamped with a tenant other than the user own', async () => {
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a RoleAcl grant stamped with a tenant other than the user own', async () => {
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a role that belongs to another tenant', async () => {
+    const db = dbWithRoleGrant()
+    db.roles[0]!.tenantId = otherTenantId
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('returns false for a user with no tenant of their own', async () => {
+    const db = dbWithDirectGrant()
+    db.users[0]!.tenantId = null
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('returns false for a grant that outlives the user row it names', async () => {
+    const db = dbWithDirectGrant()
+    db.users = []
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  // --- revoked grants -------------------------------------------------------
+
+  test('ignores a soft-deleted UserAcl grant', async () => {
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a soft-deleted RoleAcl grant', async () => {
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  // --- deliberate over-inclusion --------------------------------------------
+
+  test('still protects a soft-deleted user holding a live grant', async () => {
+    const db = dbWithDirectGrant()
+    db.users[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(true)
+  })
+
+  test('still protects a holder of an organization-restricted super admin role', async () => {
+    // `RbacService.isGlobalSuperAdmin` drops these from the GLOBAL answer, but
+    // the scoped projection still reports isSuperAdmin inside those
+    // organizations, so the target stays privileged and must stay protected.
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.organizationsJson = ['77777777-7777-7777-7777-777777777777']
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(true)
   })
 })
 
 describe('isRoleEffectivelySuperAdmin', () => {
+  function dbWithRoleAcl(): Db {
+    const db = emptyDb()
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: true, deletedAt: null })
+    return db
+  }
+
   test('returns true when the role has a RoleAcl super admin grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isRoleEffectivelySuperAdmin(em as never, targetRoleId)
-
-    expect(result).toBe(true)
+    expect(await isRoleEffectivelySuperAdmin(makeEm(dbWithRoleAcl()) as never, targetRoleId)).toBe(true)
   })
 
   test('returns false when no RoleAcl grant flags the role as super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.isSuperAdmin = false
 
-    const result = await isRoleEffectivelySuperAdmin(em as never, targetRoleId)
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
 
-    expect(result).toBe(false)
+  test('ignores a grant stamped with a tenant other than the role own', async () => {
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
+
+  test('ignores a soft-deleted grant', async () => {
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
+
+  test('returns false for a grant that outlives the role row it names', async () => {
+    const db = dbWithRoleAcl()
+    db.roles = []
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
   })
 })
 
 describe('assertActorCanModifySuperAdminUserTarget', () => {
   test('always allows super admin actors', async () => {
-    const em = makeEm()
+    const em = makeEm(dbWithDirectGrant())
     const rbacService = makeRbac(true)
 
     await expect(
@@ -136,14 +324,10 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
   })
 
   test('forbids non-super admin actors when the target is a super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-    const rbacService = makeRbac(false)
-
     await expect(
       assertActorCanModifySuperAdminUserTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(dbWithDirectGrant()) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetUserId,
@@ -152,15 +336,31 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
   })
 
   test('allows non-super admin actors when the target is not a super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([])
-    const rbacService = makeRbac(false)
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
     await expect(
       assertActorCanModifySuperAdminUserTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
+        actorUserId: actorId,
+        tenantId,
+        targetUserId,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('allows a non-super admin actor to manage a user whose super admin was revoked', async () => {
+    // The trap this closes: an over-broad protection predicate never expires, so
+    // revoking a super-admin would leave the account unmanageable by the very
+    // tenant admins who revoked it.
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    await expect(
+      assertActorCanModifySuperAdminUserTarget({
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetUserId,
@@ -170,8 +370,15 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
 })
 
 describe('assertActorCanModifySuperAdminRoleTarget', () => {
+  function dbWithSuperAdminRole(): Db {
+    const db = emptyDb()
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: true, deletedAt: null })
+    return db
+  }
+
   test('always allows super admin actors', async () => {
-    const em = makeEm()
+    const em = makeEm(dbWithSuperAdminRole())
     const rbacService = makeRbac(true)
 
     await expect(
@@ -187,14 +394,10 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
   })
 
   test('forbids non-super admin actors when the target role is a super admin role', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-    const rbacService = makeRbac(false)
-
     await expect(
       assertActorCanModifySuperAdminRoleTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(dbWithSuperAdminRole()) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetRoleId,
@@ -203,14 +406,13 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
   })
 
   test('allows non-super admin actors when the role is not a super admin role', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    const rbacService = makeRbac(false)
+    const db = dbWithSuperAdminRole()
+    db.roleAcls[0]!.isSuperAdmin = false
 
     await expect(
       assertActorCanModifySuperAdminRoleTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetRoleId,
@@ -220,33 +422,77 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
 })
 
 describe('listSuperAdminUserIds', () => {
+  function dbWithBothHalves(): Db {
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+    db.users.push({ id: otherUserId, tenantId, deletedAt: null })
+    db.userAcls.push({ id: 'acl-1', user: targetUserId, tenantId, isSuperAdmin: true, deletedAt: null })
+    db.roles.push({ id: superAdminRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({
+      id: 'racl-1',
+      role: superAdminRoleId,
+      tenantId,
+      isSuperAdmin: true,
+      organizationsJson: null,
+      deletedAt: null,
+    })
+    db.userRoles.push({ id: 'link-1', user: otherUserId, role: superAdminRoleId, deletedAt: null })
+    return db
+  }
+
   test('returns the union of UserAcl and role-derived super admin user ids', async () => {
-    const em = makeEm()
-    em.find
-      .mockResolvedValueOnce([{ user: { id: targetUserId } }])
-      .mockResolvedValueOnce([{ role: { id: superAdminRoleId } }])
-    mockFindWithDecryption.mockResolvedValueOnce([{ user: { id: 'role-derived-user' } }])
+    const result = await listSuperAdminUserIds(makeEm(dbWithBothHalves()) as never, tenantId)
 
-    const result = await listSuperAdminUserIds(em as never, tenantId)
-
-    expect(result).toEqual(new Set([targetUserId, 'role-derived-user']))
-    expect(em.find).toHaveBeenNthCalledWith(1, UserAcl, expect.objectContaining({ tenantId, isSuperAdmin: true }))
-    expect(em.find).toHaveBeenNthCalledWith(2, RoleAcl, expect.objectContaining({ isSuperAdmin: true }))
-    expect(mockFindWithDecryption).toHaveBeenCalledWith(
-      expect.anything(),
-      UserRole,
-      expect.objectContaining({ role: expect.objectContaining({ $in: [superAdminRoleId] }) }),
-      {},
-      expect.objectContaining({ tenantId: null }),
-    )
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
   })
 
   test('returns an empty set when there are no super admin grants', async () => {
-    const em = makeEm()
-    em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([])
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
-    const result = await listSuperAdminUserIds(em as never, tenantId)
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
 
     expect(result.size).toBe(0)
+  })
+
+  test('applies the tenant filter to the RoleAcl half as well as the UserAcl half', async () => {
+    // The half that used to be unfiltered. A role ACL stamped elsewhere confers
+    // no super-admin (see `RbacService.isGlobalSuperAdmin`), so its members are
+    // ordinary users of this tenant and must not be hidden from it.
+    const db = dbWithBothHalves()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result).toEqual(new Set([targetUserId]))
+  })
+
+  test('ignores soft-deleted grants on both halves', async () => {
+    const db = dbWithBothHalves()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result.size).toBe(0)
+  })
+
+  test('keeps organization-restricted super admin roles in the exclusion list', async () => {
+    const db = dbWithBothHalves()
+    db.roleAcls[0]!.organizationsJson = ['77777777-7777-7777-7777-777777777777']
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
+  })
+
+  test('applies no tenant filter to either half when no tenant is given', async () => {
+    const db = dbWithBothHalves()
+    db.userAcls[0]!.tenantId = otherTenantId
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, null)
+
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
   })
 })

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -304,16 +304,58 @@ async function resolveActorIsSuperAdmin(input: GrantCheckContext & { actorIsSupe
   return acl.isSuperAdmin
 }
 
+/**
+ * Answers "is this user effectively a super-admin" about a TARGET — the input to
+ * `assertActorCanModifySuperAdminUserTarget`, not to any authorization decision
+ * about the caller.
+ *
+ * It is bound to the target's OWN tenant (`users.tenant_id`) and to live grant
+ * rows, because that is the reading the two authorities already share:
+ * `RbacService.isGlobalSuperAdmin` and `lib/sessionIntegrity.ts`
+ * (`userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`). A protection
+ * predicate that answered differently would protect people who hold nothing —
+ * a grant stamped a foreign tenant, or one that was revoked — while every
+ * authorization path treats them as ordinary users. That over-protection does
+ * not expire: nothing short of a super-admin could edit such an account again,
+ * and revoking someone's super-admin would leave them permanently unmanageable
+ * by their own tenant's admins.
+ *
+ * Two asymmetries with `isGlobalSuperAdmin` are deliberate:
+ *
+ * - Organization-restricted role grants are NOT excluded. That exclusion only
+ *   keeps them out of the GLOBAL answer; `loadAcl`'s scoped projection still
+ *   returns `isSuperAdmin: true` for such a role inside the organizations it
+ *   names, so its holder is a privileged target. A protection predicate may be
+ *   a superset of the authorization answer; it must never be a subset.
+ * - The `User` load carries no `deletedAt` filter, matching the load in
+ *   `assertActorCanAccessUserTarget` below. A soft-deleted super-admin stays
+ *   protected; it is the ACL rows that must be live.
+ *
+ * "No user row" and "no tenant of their own" both answer false, as
+ * `isGlobalSuperAdmin` does. Neither is exploitable, because every call site
+ * pairs this guard with `assertActorCanAccessUserTarget`: that one delegates a
+ * missing target to the caller's own tenant-scoped load, and 404s a target
+ * whose `tenantId` is absent, so no mutation reaches either case.
+ */
 export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: string): Promise<boolean> {
+  // Read without decryption on purpose: the only column consulted is
+  // `tenant_id`, which is not encrypted, so decrypting the row would be work
+  // thrown away on a guard that runs on every user write.
+  const target = await em.findOne(User, { id: userId } as FilterQuery<User>)
+  const tenantId = normalizeNullableString((target as { tenantId?: string | null } | null)?.tenantId)
+  if (!tenantId) return false
   const directGrant = await em.findOne(
     UserAcl,
-    { user: userId as unknown, isSuperAdmin: true } as FilterQuery<UserAcl>,
+    { user: userId as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<UserAcl>,
   )
   if (directGrant && (directGrant as { isSuperAdmin?: boolean }).isSuperAdmin === true) return true
   const links = await findWithDecryption(
     em,
     UserRole,
-    { user: userId as unknown } as FilterQuery<UserRole>,
+    // Roles of the user's own tenant, the same restriction `isGlobalSuperAdmin`
+    // applies. The encryption scope stays `{ null, null }`: this is about which
+    // rows count, not about which key decrypts them.
+    { user: userId as unknown, role: { tenantId } } as FilterQuery<UserRole>,
     { populate: ['role'] },
     { tenantId: null, organizationId: null },
   )
@@ -328,22 +370,69 @@ export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: str
   if (!roleIds.length) return false
   const roleGrant = await em.findOne(
     RoleAcl,
-    { role: { $in: roleIds } as unknown, isSuperAdmin: true } as FilterQuery<RoleAcl>,
+    { role: { $in: roleIds } as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<RoleAcl>,
   )
   return !!roleGrant && (roleGrant as { isSuperAdmin?: boolean }).isSuperAdmin === true
 }
 
+/**
+ * The role twin of `isUserEffectivelySuperAdmin`, and it carries the same
+ * reading for the same reasons: the grant must be live, and it must be stamped
+ * with the role's OWN tenant. A `role_acls` row stamped elsewhere confers
+ * nothing (`RbacService.loadAcl` reads role ACLs `{ tenantId, deletedAt: null }`),
+ * so protecting a role on the strength of one would refuse an edit that every
+ * authorization path considers ordinary.
+ *
+ * A role that does not exist answers false, which its paired guard
+ * `assertActorCanAccessRoleTarget` then delegates to the caller in the same way
+ * the user side does.
+ */
 export async function isRoleEffectivelySuperAdmin(em: EntityManager, roleId: string): Promise<boolean> {
+  const role = await em.findOne(Role, { id: roleId } as FilterQuery<Role>)
+  const tenantId = normalizeNullableString((role as { tenantId?: string | null } | null)?.tenantId)
+  if (!tenantId) return false
   const grant = await em.findOne(
     RoleAcl,
-    { role: roleId as unknown, isSuperAdmin: true } as FilterQuery<RoleAcl>,
+    { role: roleId as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<RoleAcl>,
   )
   return !!grant && (grant as { isSuperAdmin?: boolean }).isSuperAdmin === true
 }
 
+/**
+ * The super-admin user ids a non-super-admin must not be shown while looking at
+ * `tenantId` — an exclusion list, not an authorization answer.
+ *
+ * `tenantId` names the tenant whose users are being listed. Because a
+ * super-admin grant is bound to the holder's own tenant (see
+ * `isUserEffectivelySuperAdmin` above and `RbacService.isGlobalSuperAdmin`),
+ * that is also the tenant a grant must be stamped with in order to count here,
+ * so the filter is applied to BOTH ACL tables. It used to reach only
+ * `user_acls`, which made the two halves disagree about what a tenant-scoped
+ * answer meant.
+ *
+ * The narrowing on `role_acls` is only safe TOGETHER with that tenant binding:
+ * while a foreign-stamped row still conferred super-admin, dropping it from this
+ * list would have unhidden a real one.
+ *
+ * The caller owes the other half of the scoping. This returns ids; it is the
+ * caller's own subject query that must already be restricted to `tenantId`.
+ * Both wired call sites are — `auth/api/users/route.ts` filters the user query
+ * by the same tenant, and documents' principals route scopes to `ctx.tenantId`
+ * — so a role member living in another tenant is merely excluded from a list
+ * they were never in. That is not licence to pass a tenant unrelated to the
+ * subject set.
+ *
+ * Deliberately NOT narrowed further: organization-restricted role grants count
+ * (their holders are super-admins inside those organizations), and the
+ * `user_roles` expansion stays tenant-less. Over-inclusion there is bounded by
+ * the caller's subject scoping, and for an exclusion list hiding one user too
+ * many is the safe direction.
+ */
 export async function listSuperAdminUserIds(em: EntityManager, tenantId: string | null): Promise<Set<string>> {
   const ids = new Set<string>()
-  const userAclFilter: Record<string, unknown> = { isSuperAdmin: true }
+  // A revoked override must not keep answering — the same rule the ACL reads in
+  // `RbacService` follow.
+  const userAclFilter: Record<string, unknown> = { isSuperAdmin: true, deletedAt: null }
   if (tenantId) userAclFilter.tenantId = tenantId
   const userAcls = await em.find(UserAcl, userAclFilter as FilterQuery<UserAcl>)
   for (const acl of userAcls) {
@@ -353,10 +442,9 @@ export async function listSuperAdminUserIds(em: EntityManager, tenantId: string 
       : userRef
     if (userId) ids.add(String(userId))
   }
-  const roleAcls = await em.find(
-    RoleAcl,
-    { isSuperAdmin: true } as FilterQuery<RoleAcl>,
-  )
+  const roleAclFilter: Record<string, unknown> = { isSuperAdmin: true, deletedAt: null }
+  if (tenantId) roleAclFilter.tenantId = tenantId
+  const roleAcls = await em.find(RoleAcl, roleAclFilter as FilterQuery<RoleAcl>)
   const roleIds = roleAcls
     .map((acl) => {
       const roleRef = (acl as { role?: { id?: unknown } | string | null }).role

--- a/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
@@ -1,0 +1,70 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// `user_acls` and `role_acls` decide what a principal may do, and neither had
+// any uniqueness beyond its primary key. `RbacService.loadAcl` resolves the
+// per-user row with a bare `findOne` and RETURNS EARLY on a hit — the per-user
+// ACL replaces the role ACLs rather than merging with them — so two rows for
+// the same `(user_id, tenant_id)` were schema-legal and resolved with no
+// `ORDER BY`: whichever row Postgres happened to return decided the user's
+// entire feature set, and could change between requests.
+//
+// The write path makes that reachable rather than theoretical:
+// `auth.user_acl.update` reads with `findOne` and creates when it misses, so
+// two concurrent saves for the same user both miss and both insert.
+//
+// Partial unique indexes scoped to live rows (`where deleted_at is null`),
+// matching the shape already used for the sidebar tables in
+// Migration20260427143311. A `@Unique` decorator cannot express a partial
+// index, so the entities carry a comment pointing here instead.
+//
+// Historical duplicates are collapsed first — most recently updated row wins,
+// the rest are soft-deleted, never dropped — so the indexes can be created on
+// a database that already carries some.
+export class Migration20260828120000_auth extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by user_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from user_acls
+        where deleted_at is null
+      )
+      update user_acls
+      set deleted_at = now()
+      from ranked
+      where user_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "user_acls_active_unique_idx" on "user_acls" ("user_id", "tenant_id") where "deleted_at" is null;`);
+
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by role_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from role_acls
+        where deleted_at is null
+      )
+      update role_acls
+      set deleted_at = now()
+      from ranked
+      where role_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "role_acls_active_unique_idx" on "role_acls" ("role_id", "tenant_id") where "deleted_at" is null;`);
+  }
+
+  override down(): void | Promise<void> {
+    // Only the indexes are reversible. The collapse soft-deleted rows rather
+    // than dropping them, so the data is still there to un-delete by hand if a
+    // deployment ever needs it; un-deleting automatically would recreate the
+    // ambiguity this migration exists to remove.
+    this.addSql(`drop index if exists "user_acls_active_unique_idx";`);
+    this.addSql(`drop index if exists "role_acls_active_unique_idx";`);
+  }
+
+}

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1562,4 +1562,153 @@ describe('RbacService', () => {
       expect(em.findOne).toHaveBeenCalledTimes(callsAfterFirst) // No new queries
     })
   })
+
+  // Regression cover for the tenant binding on super-admin grants. These build a
+  // tiny in-memory table and evaluate the real filter the service emits, rather
+  // than keying a mock on the fields the test already expects — otherwise the
+  // test cannot tell a filter that was applied from one that was not.
+  describe('super-admin grant tenant binding', () => {
+    type Row = Record<string, any>
+
+    const idOf = (value: any): string | null => {
+      if (typeof value === 'string') return value
+      if (value && typeof value === 'object' && typeof value.id === 'string') return value.id
+      return null
+    }
+
+    const matches = (where: any, row: Row): boolean => {
+      if (!where || typeof where !== 'object') return true
+      return Object.entries(where).every(([key, expected]) => {
+        const actual = row[key]
+        if (expected && typeof expected === 'object' && Array.isArray((expected as any).$in)) {
+          const wanted = (expected as any).$in.map((v: any) => idOf(v))
+          return wanted.includes(idOf(actual))
+        }
+        if (expected && typeof expected === 'object' && !(expected instanceof Date)) {
+          // Relation sub-filter, e.g. `role: { tenantId, deletedAt: null }`.
+          return actual && typeof actual === 'object' ? matches(expected, actual) : false
+        }
+        if (typeof expected === 'string' && actual && typeof actual === 'object') {
+          return idOf(actual) === expected
+        }
+        if (expected === null) return actual === null || actual === undefined
+        return actual === expected
+      })
+    }
+
+    /** Wire `em.findOne` / `em.find` to evaluate the service's real filters. */
+    const seed = (tables: Map<any, Row[]>) => {
+      const rowsFor = (entity: any) => tables.get(entity) ?? []
+      em.findOne.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).find((row) => matches(where, row)) ?? null)
+      em.find.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).filter((row) => matches(where, row)))
+    }
+
+    const user: Row = { id: 'user-1', tenantId: 'tenant-home', organizationId: 'org-1', deletedAt: null }
+
+    it('ignores a user-level super-admin grant stamped with a foreign tenant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        // The row is real, live and flagged — it simply is not this user's own
+        // tenant's grant. Before the tenant binding it conferred `['*']` in
+        // every scope, so one mis-stamped row was a platform escalation.
+        [UserAcl, [{
+          user, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('keeps a home-tenant super-admin grant global across every scope', async () => {
+      // The anti-regression half: binding the grant to the user's own tenant
+      // must not stop a platform super-admin working inside a customer tenant,
+      // which is what the tenant switcher does on every cross-tenant view.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-customer', organizationId: 'org-99' }))
+        .resolves.toEqual({ isSuperAdmin: true, features: ['*'], organizations: null })
+    })
+
+    it('ignores a role-level super-admin grant whose ACL row is stamped with a foreign tenant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        // Production shape: one role, two ACL rows, one of them stamped with a
+        // tenant that is not the role's. Only the correctly stamped one counts.
+        [RoleAcl, [{
+          role, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a super-admin role that belongs to another tenant', async () => {
+      const foreignRole: Row = { id: 'role-foreign', tenantId: 'tenant-other', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role: foreignRole, deletedAt: null }]],
+        [RoleAcl, [{
+          role: foreignRole, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('grants nothing to a user with no tenant of their own', async () => {
+      const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [tenantless]],
+        [UserAcl, [{
+          user: tenantless, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+
+    it('grants nothing when the grant outlives the user row it names', async () => {
+      // The check now runs after the user load, so a `user_acls` row left behind
+      // by a hard-deleted user no longer confers anything.
+      seed(new Map<any, Row[]>([
+        [User, []],
+        [UserAcl, [{
+          user: { id: 'ghost' }, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('ghost', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+  })
+
 })

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1677,6 +1677,67 @@ describe('RbacService', () => {
         .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
     })
 
+    it('ignores a soft-deleted user-level super-admin grant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      // Neither the global path nor the scoped per-user read may answer from a
+      // revoked override, so the user falls through to their (empty) roles.
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a soft-deleted role-level super-admin grant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        [RoleAcl, [{
+          role, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('resolves the per-user ACL with an explicit ordering', async () => {
+      // A shape assertion, deliberately: the ordering is applied by Postgres, so
+      // a mocked EntityManager cannot demonstrate WHICH row wins. What it can
+      // demonstrate is that the service asks for an order at all — the absence
+      // of one is the defect, and it is invisible in any single-row fixture.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: false,
+          featuresJson: ['documents.view'], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' })
+
+      const scopedRead = em.findOne.mock.calls.find(([entity, where]: any[]) => (
+        entity === UserAcl && where && where.isSuperAdmin === undefined
+      ))
+      expect(scopedRead).toBeDefined()
+      expect(scopedRead![1]).toMatchObject({ tenantId: 'tenant-home', deletedAt: null })
+      expect(scopedRead![2]).toMatchObject({ orderBy: { createdAt: 'desc', id: 'desc' } })
+    })
+
     it('grants nothing to a user with no tenant of their own', async () => {
       const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
       seed(new Map<any, Row[]>([

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -184,10 +184,45 @@ export class RbacService {
     }
   }
 
-  private async isGlobalSuperAdmin(userId: string): Promise<boolean> {
+  // A super-admin grant is deliberately GLOBAL: it survives every scope the
+  // caller asks about, which is what lets a platform super-admin work inside a
+  // customer tenant. What it must not do is survive the question of whose grant
+  // it is. Both lookups below are therefore evaluated against the user's OWN
+  // tenant (`users.tenant_id`), never against no tenant at all.
+  //
+  // Without that binding a single `user_acls` row — or a role link — stamped
+  // with ANY tenant confers platform super-admin everywhere, so a row written
+  // under the wrong tenant becomes a full privilege escalation with nothing in
+  // the schema or the UI to show for it. `user_acls` has no organization column
+  // and no uniqueness beyond its primary key, so such a row is cheap to create
+  // and invisible to the tenant/organization cross-wire checks.
+  //
+  // This is the tenant binding `resolveCanonicalStaffAuthContext` already
+  // applies when it computes `auth.isSuperAdmin` (see lib/sessionIntegrity.ts:
+  // `userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`, both bound to the
+  // user's own tenant). Before this change the two authorities disagreed:
+  // session integrity would say "not a super-admin" while `loadAcl` handed the
+  // same request `['*']`.
+  //
+  // The memo stays keyed by `userId` alone because the answer now depends only
+  // on the user's own tenant, which is a property of the user — not on the scope
+  // being asked about. `invalidateUserCache` therefore still clears it correctly.
+  private async isGlobalSuperAdmin(
+    em: EntityManager,
+    userId: string,
+    userTenantId: string | null,
+  ): Promise<boolean> {
     if (this.globalSuperAdminCache.has(userId)) return this.globalSuperAdminCache.get(userId)!
-    const em = this.em.fork()
-    const userSuper = await em.findOne(UserAcl, { user: userId as any, isSuperAdmin: true })
+    if (!userTenantId) {
+      // A user with no tenant of their own has no tenant to be a super-admin of.
+      this.globalSuperAdminCache.set(userId, false)
+      return false
+    }
+    const userSuper = await em.findOne(UserAcl, {
+      user: userId as any,
+      tenantId: userTenantId,
+      isSuperAdmin: true,
+    } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
@@ -195,7 +230,11 @@ export class RbacService {
     const links = await findWithDecryption(
       em,
       UserRole,
-      { user: userId as any },
+      // Roles that belong to the user's own tenant, as
+      // `resolveCanonicalStaffAuthContext` already requires. The encryption
+      // scope stays `{ null, null }` as before — this change is about which rows
+      // count, not about which key decrypts them.
+      { user: userId as any, role: { tenantId: userTenantId } } as any,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -212,7 +251,11 @@ export class RbacService {
       this.globalSuperAdminCache.set(userId, false)
       return false
     }
-    const roleSupers = await em.find(RoleAcl, { isSuperAdmin: true, role: { $in: roleIds as any } } as any)
+    const roleSupers = await em.find(RoleAcl, {
+      isSuperAdmin: true,
+      tenantId: userTenantId,
+      role: { $in: roleIds as any },
+    } as any)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))
@@ -249,18 +292,6 @@ export class RbacService {
     const cacheKey = this.getCacheKey(userId, scope)
     const cached = await this.getFromCache(cacheKey)
     if (cached) return cached
-
-    // Direct user-level super-admin grants and unrestricted role-level
-    // super-admin grants are global. Organization-restricted role grants are
-    // deliberately excluded by isGlobalSuperAdmin and continue through the
-    // scoped ACL projection below.
-    if (!userId.startsWith('api_key:')) {
-      if (await this.isGlobalSuperAdmin(userId)) {
-        const result = { isSuperAdmin: true, features: ['*'], organizations: null }
-        await this.setCache(cacheKey, result, userId, scope)
-        return result
-      }
-    }
 
     if (userId.startsWith('api_key:')) {
       const apiKeyId = userId.slice('api_key:'.length)
@@ -350,6 +381,23 @@ export class RbacService {
       await this.setCache(cacheKey, result, userId, scope)
       return result
     }
+
+    // Direct user-level super-admin grants and unrestricted role-level
+    // super-admin grants are global. Organization-restricted role grants are
+    // deliberately excluded by isGlobalSuperAdmin and continue through the
+    // scoped ACL projection below.
+    //
+    // The check runs AFTER the user is loaded because it is evaluated against
+    // the user's own tenant — see isGlobalSuperAdmin. It reuses that load and
+    // that EntityManager rather than issuing its own, so the reordering costs
+    // no extra query. API-key principals never reached it and still do not:
+    // their branch above has already returned.
+    if (await this.isGlobalSuperAdmin(em, userId, user.tenantId ?? null)) {
+      const result = { isSuperAdmin: true, features: ['*'], organizations: null }
+      await this.setCache(cacheKey, result, userId, scope)
+      return result
+    }
+
     const tenantId = scope.tenantId || user.tenantId || null
     const orgId = scope.organizationId || user.organizationId || null
 

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -222,6 +222,7 @@ export class RbacService {
       user: userId as any,
       tenantId: userTenantId,
       isSuperAdmin: true,
+      deletedAt: null,
     } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
@@ -254,6 +255,7 @@ export class RbacService {
     const roleSupers = await em.find(RoleAcl, {
       isSuperAdmin: true,
       tenantId: userTenantId,
+      deletedAt: null,
       role: { $in: roleIds as any },
     } as any)
     const result = roleSupers.some((roleAcl) => (
@@ -407,8 +409,25 @@ export class RbacService {
       return result
     }
 
-    // Per-user ACL first
-    const uacl = await em.findOne(UserAcl, { user: userId as any, tenantId })
+    // Per-user ACL first. This row REPLACES the role ACLs rather than merging
+    // with them, so which row is returned decides the whole feature set. A
+    // partial unique index now makes a second live row impossible
+    // (`user_acls_active_unique_idx`, Migration20260828120000_auth), but the
+    // ordering is stated anyway: an index can be dropped by an operator, and an
+    // unordered `findOne` over a table that used to allow duplicates is exactly
+    // the read this pairs with. Soft-deleted rows are excluded — a revoked
+    // override must not keep answering.
+    const uacl = await em.findOne(
+      UserAcl,
+      { user: userId as any, tenantId, deletedAt: null } as any,
+      // `createdAt`/`id`, not `updatedAt`: `updated_at` is nullable and Postgres
+      // sorts NULLs FIRST under DESC, so ordering by it would prefer a row that
+      // was never updated. The migration's one-time collapse uses
+      // `coalesce(updated_at, created_at)` because there it is picking the row
+      // an operator would call current; here the only requirement is that the
+      // answer not vary between requests.
+      { orderBy: { createdAt: 'desc', id: 'desc' } } as any,
+    )
     if (uacl) {
       const result = {
         isSuperAdmin: !!uacl.isSuperAdmin,
@@ -439,7 +458,7 @@ export class RbacService {
         tenantId,
         scope.organizationId,
       )
-      const racls = await em.find(RoleAcl, { tenantId, role: { $in: roleIds as any } } as any, {})
+      const racls = await em.find(RoleAcl, { tenantId, deletedAt: null, role: { $in: roleIds as any } } as any, {})
       const roleAcls = Array.isArray(racls) ? racls : []
       for (const r of roleAcls) {
         if (roleAclAllowsOrganization(r, roleOrganizationScope)) {


### PR DESCRIPTION
## Summary

Stacked on #5753 (which is stacked on #5752). `packages/core/src/modules/auth/lib/grantChecks.ts` has three super-admin **TARGET** lookups — `isUserEffectivelySuperAdmin`, `isRoleEffectivelySuperAdmin`, and `listSuperAdminUserIds` — used to decide whether an actor is allowed to modify another user/role. They read the ACL tables with neither a tenant nor a soft-delete filter, and `listSuperAdminUserIds` applied its `tenantId` argument to `user_acls` only, leaving the `role_acls` half of the same lookup untenanted.

This PR gives all three the same reading `RbacService.loadAcl` now uses for the grant itself (#5752, #5753): scoped to the user's/role's own tenant (`users.tenant_id` / `roles.tenant_id`), live rows only, and the tenant filter applied to both the `user_acls` and `role_acls` halves of `listSuperAdminUserIds`.

**Important dependency on #5752:** the `role_acls` narrowing in `listSuperAdminUserIds` is only safe stacked on #5752. Before #5752, a foreign-tenant-stamped ACL row still conferred super-admin (the grant check itself was untenanted), so a naive tenant-scoping of this TARGET list on its own would have hidden a real super-admin from the list while the grant check still honored that row elsewhere — i.e. it would have unhidden a real one rather than closing anything. With #5752 landed first, the grant and the target-protection check now agree on whose tenant a row belongs to, so narrowing this list is consistent rather than a new gap.

Deliberately kept broad, and now documented in the file:
- Organization-restricted role grants still count toward super-admin target protection.
- The `User`/`Role` loads carry no `deletedAt` filter.
- The `user_roles` expansion inside `listSuperAdminUserIds` stays tenant-less.

## Test plan

- Test suite for this area was rewritten off `mockResolvedValueOnce` call-order queues onto a small in-memory table set that evaluates the filter the code actually emits, rather than asserting on mock call order.
- 13 of its 31 cases fail against the unfixed (pre-this-PR) lookups, confirming they exercise the fixed behavior.
- `cd packages/core && npx jest --config jest.config.cjs src/modules/auth` — 91 suites / 793 tests, all passing (Node 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790577552&installation_model_id=432243&pr_number=5764&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5764&signature=3a25e1c71ee4ac1c796e5f0e33c02999cc02b089de011965b503f7f8d6c03863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->