### PR TITLE
fix(auth): canonicalize live ACL grants and targets

### DIFF
--- a/.ai/specs/2026-08-29-auth-acl-live-row-canonicalization.md
+++ b/.ai/specs/2026-08-29-auth-acl-live-row-canonicalization.md
@@ -1,0 +1,197 @@
+# Auth ACL Live-Row Canonicalization
+
+## TLDR
+
+Auth ACL resolution must treat exactly one non-deleted `user_acls` row per `(user_id, tenant_id)` and one non-deleted `role_acls` row per `(role_id, tenant_id)` as current. The change repairs historical duplicates, enforces that invariant with PostgreSQL partial unique indexes, and makes every authorization, target-protection, setup, API, and undo reader ignore revoked rows.
+
+## Problem Statement
+
+The ACL tables historically allowed duplicate live rows for the same principal and tenant. Reads were consequently order-dependent, and adding soft-delete-based uniqueness without updating every consumer would leave remediated duplicates behaviorally active in some paths.
+
+## Proposed Solution
+
+Choose the most recently changed row in each duplicate live group, soft-delete the rest, then create partial unique indexes over live rows only. Apply the same `deleted_at IS NULL` and live-role-membership semantics to every current-state reader while preserving historical rows for auditability.
+
+## Overview
+
+This is one coupled auth integrity capability: canonical live ACL resolution. The migration is unsafe without the reader changes, and the reader changes cannot prevent future ambiguity without the indexes, so they ship together.
+
+PostgreSQL is the relevant reference implementation. Its official documentation supports partial unique indexes as the native way to enforce uniqueness over only rows satisfying a predicate. The design adopts that mechanism and rejects application-only deduplication because concurrent writers could still create multiple live rows. See [PostgreSQL partial indexes](https://www.postgresql.org/docs/current/indexes-partial.html) and [unique indexes](https://www.postgresql.org/docs/current/indexes-unique.html).
+
+## Architecture
+
+### Migration
+
+`Migration20260828120000_auth.ts` performs the following operations for both ACL tables inside the migration transaction:
+
+1. Partition live rows by principal ID and tenant ID.
+2. Rank each partition by `coalesce(updated_at, created_at) DESC`, then `created_at DESC`, then `id DESC`.
+3. Set `deleted_at` on every row ranked after the winner.
+4. Create a partial unique index on the principal/tenant pair with `WHERE deleted_at IS NULL`.
+
+The deterministic tie-breaker makes reruns select the same winner. Soft deletion preserves the superseded records for audit and diagnosis.
+
+### Runtime reads
+
+Every path that asks for current ACL state includes `deletedAt: null`:
+
+- human and API-key grant resolution in `RbacService`;
+- super-admin target protection and exclusion lists in `grantChecks.ts`;
+- role/user ACL GET and PUT routes;
+- protected role filtering in the roles list;
+- setup reconciliation;
+- command snapshots used by delete/update undo.
+- notification role/feature recipient resolution.
+
+Role-derived grants additionally require a live `user_roles` link and a live `roles` row. This matches the canonical session-integrity resolver.
+
+Entity loads in target guards continue to omit a target `deletedAt` predicate intentionally so a deleted privileged target remains protected from non-super-admin mutation, but the loads use `findOneWithDecryption` as required by the auth data policy.
+
+### Cache behavior
+
+No cache key or TTL changes. Existing ACL write commands invalidate user or tenant RBAC tags. Migration deployment requires application instances to restart or begin with empty process-local ACL caches, which is the standard deployment behavior.
+
+## Data Models
+
+No columns or relationships change.
+
+| Table | Live-row invariant | Historical rows |
+|---|---|---|
+| `user_acls` | At most one row per `(user_id, tenant_id)` where `deleted_at IS NULL` | Preserved with non-null `deleted_at` |
+| `role_acls` | At most one row per `(role_id, tenant_id)` where `deleted_at IS NULL` | Preserved with non-null `deleted_at` |
+
+The partial indexes are raw SQL migration artifacts because MikroORM metadata does not express the required soft-delete predicate. Entity comments point maintainers to the migration as the source of truth; generated snapshots intentionally remain unchanged.
+
+No new sensitive fields are introduced. Reads of `User`, `Role`, `UserRole`, `UserAcl`, and `RoleAcl` continue through the module's decryption-aware helpers where required.
+
+## API Contracts
+
+No route, request, response, status-code, OpenAPI, event, ACL feature, or import-path contract changes.
+
+- `GET /api/auth/users/acl` returns the one live ACL row or the existing empty response.
+- `PUT /api/auth/users/acl` updates the one live row or creates one when only revoked history exists.
+- `GET /api/auth/roles/acl` returns the one live ACL row or the existing empty response.
+- `PUT /api/auth/roles/acl` updates the one live row or creates one when only revoked history exists.
+- User and role list responses retain their current shapes; only revoked grants and memberships stop affecting protection filters.
+
+Optimistic-lock versions continue to come from the selected live ACL row.
+
+## UI/UX and Internationalization
+
+No UI or user-facing string changes. Existing forms and conflict handling continue unchanged.
+
+## Migration & Backward Compatibility
+
+The change is additive under `BACKWARD_COMPATIBILITY.md`: it adds indexes and narrows current-state reads to rows already defined as live. No public surface is removed or renamed.
+
+The migration `up()` remediation is intentionally not data-reversible: `down()` drops the partial indexes but does not clear `deleted_at`, because doing so would reactivate ambiguous and potentially privileged rows. The historical payload remains stored, so an operator can inspect or explicitly restore a chosen row after rollback.
+
+Rolling deployments must ship migration and reader changes as one release. An old process running briefly after remediation may still read a newly revoked duplicate; deployment orchestration must drain/restart old instances and clear process-local RBAC caches. The new application code remains compatible before and after the migration because explicit live-row predicates work without the indexes.
+
+Standard `CREATE UNIQUE INDEX` is used because project migrations run transactionally and PostgreSQL does not permit `CREATE INDEX CONCURRENTLY` inside a transaction. Operators should schedule the migration with awareness that writes to the two ACL tables may briefly block while each index builds.
+
+## Implementation Plan
+
+### Phase 1: Canonical live ACL state
+
+1. Add deterministic duplicate remediation and partial unique indexes for both ACL tables.
+2. Audit every live ACL, role-membership, setup, API, and snapshot consumer and add explicit lifecycle predicates.
+3. Align grant, session, and target-protection semantics for revoked links and roles.
+4. Add focused unit and route tests, then run auth integration coverage and the package validation gate.
+
+All four steps ship together; no intermediate phase is independently deployable without weakening the invariant.
+
+### Testing Strategy
+
+- Migration SQL: verify deterministic ranking, live-row predicates, index names, and rollback statements.
+- Unit: direct/role super-admin grants, foreign-tenant grants, soft-deleted ACLs, soft-deleted assignments, soft-deleted roles, API-key ACLs, deterministic selection, and target protection.
+- Route: user/role ACL GET and PUT queries must carry `deletedAt: null`; role list protection must do the same.
+- Command: user and role snapshots must exclude revoked ACL history so undo cannot reactivate it or violate the new indexes.
+- Setup: reconciliation must ignore revoked ACL history and create/update the one live row.
+- Integration: existing `TC-AUTH-051`, `TC-AUTH-043`, `TC-AUTH-049`, `TC-AUTH-058`, `TC-LOCK-OSS-031`, and `TC-LOCK-OSS-032` cover the affected user/role ACL writes, reads, audit trail, and optimistic locking. These routes remain the manual QA surface after deployment.
+
+## Risks & Impact Review
+
+#### Stale duplicate remains authoritative in an unreviewed consumer
+- **Scenario**: A reader omits `deleted_at IS NULL` and returns or grants from a row remediated by the migration.
+- **Severity**: High
+- **Affected area**: Auth grants, API keys, ACL forms, setup, commands, and protected-target filters
+- **Mitigation**: Complete consumer audit plus query-shape and behavior regression tests for every consumer class.
+- **Residual risk**: Future raw ACL queries can regress; entity comments and partial-index names make the live-row contract discoverable in review.
+
+#### Revoked membership still confers super-admin
+- **Scenario**: A soft-deleted `user_roles` link or `roles` row is populated and used to derive a live role ACL grant.
+- **Severity**: High
+- **Affected area**: Session authorization, RBAC service, super-admin target protection, and list exclusions
+- **Mitigation**: Require both link and role `deletedAt: null` in every role-derived resolver and test each revoked state.
+- **Residual risk**: None known within the auth module; cross-module consumers remain covered by the module-decoupling and security review gates.
+
+#### Index creation blocks ACL writes
+- **Scenario**: A large ACL table makes transactional index creation hold a write-conflicting lock longer than the deployment window allows.
+- **Severity**: Medium
+- **Affected area**: Role and user permission administration during deployment
+- **Mitigation**: Inspect table cardinality before production rollout, schedule the migration appropriately, and monitor migration duration and blocked sessions.
+- **Residual risk**: Brief write unavailability is accepted because concurrent index creation is incompatible with the transactional migration runner.
+
+#### Rolling instances retain old semantics
+- **Scenario**: An old application instance reads a migration-soft-deleted duplicate or serves a cached grant during a rolling deployment.
+- **Severity**: High
+- **Affected area**: Authorization during the rollout window
+- **Mitigation**: Drain/restart old instances as part of the release and start new instances with empty local RBAC caches.
+- **Residual risk**: A short orchestration-dependent window remains; deployments must not leave mixed application versions running indefinitely.
+
+#### Rollback reactivates ambiguous privileges
+- **Scenario**: A rollback drops indexes and automatically restores all remediated rows as live.
+- **Severity**: Critical
+- **Affected area**: Tenant authorization and administrative access
+- **Mitigation**: `down()` drops only indexes and deliberately leaves remediated rows soft-deleted. Restoration requires an explicit operator choice.
+- **Residual risk**: Rolling back application code to readers that ignore `deleted_at` is unsafe; rollback uses a fixed release or an operator-reviewed data repair.
+
+## Final Compliance Report — 2026-08-29
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/auth/AGENTS.md`
+- `packages/core/src/modules/notifications/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|---|---|---|---|
+| Root `AGENTS.md` | Preserve tenant isolation and mutation guards | Compliant | Existing route guards remain; ACL reads bind principal and tenant and ignore revoked state. |
+| Root `AGENTS.md` | Use decryption-aware entity reads | Compliant | New target loads use `findOneWithDecryption`; ACL and membership reads use the shared helpers where applicable. |
+| Root `AGENTS.md` | Never edit generated files manually | Compliant | Partial indexes live only in the handwritten migration; generated snapshots are unchanged. |
+| `packages/core/AGENTS.md` | Keep auth behavior scoped and command side effects intact | Compliant | Commands retain atomic writes, audit logging, invalidation, and optimistic locking. |
+| Auth `AGENTS.md` | Canonical session/RBAC semantics must agree | Compliant | Grant and target readers require live ACLs, assignments, and roles. |
+| Notifications `AGENTS.md` | Preserve tenant-scoped notification delivery | Compliant | Role/feature recipients require live tenant roles, links, ACLs, and users. |
+| `BACKWARD_COMPATIBILITY.md` | Database schema changes are additive-only and documented | Compliant | Adds partial indexes, preserves rows, and documents rollback/deployment compatibility. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Data models match API contracts | Pass | No response or entity-field shape changes. |
+| API contracts match UI/UX section | Pass | UI behavior and response shapes are unchanged. |
+| Risks cover all write operations | Pass | Migration, ACL writes, setup, undo, cache, and rollback are covered. |
+| Commands defined for all mutations | Pass | Existing ACL/user/role commands remain authoritative. |
+| Cache strategy covers all read APIs | Pass | Existing user/tenant invalidation remains unchanged. |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+**Fully compliant: Approved — ready for implementation.**
+
+## Changelog
+
+### 2026-08-29
+
+- Added the live ACL canonicalization, migration, compatibility, consumer-audit, and validation contract.
+- **Scope-cohesion review — Fresh-context agent**: Passed; remediation, uniqueness enforcement, and lifecycle-aware consumers are mutually necessary layers of one canonical live ACL capability.
+- **Review — Agent**: Security passed; performance passed with deployment monitoring; cache passed; commands passed; risks passed; verdict approved.

--- a/packages/core/src/helpers/integration/dbFixtures.ts
+++ b/packages/core/src/helpers/integration/dbFixtures.ts
@@ -99,7 +99,7 @@ export async function setUserAclInDb(input: {
 }): Promise<void> {
   await withClient(async (client) => {
     const existing = await client.query<{ id: string }>(
-      'select id from user_acls where user_id = $1 and tenant_id = $2 limit 1',
+      'select id from user_acls where user_id = $1 and tenant_id = $2 and deleted_at is null limit 1',
       [input.userId, input.tenantId],
     );
     const featuresJson = JSON.stringify(input.features);

--- a/packages/core/src/modules/auth/__tests__/cli-setup-acl.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-setup-acl.test.ts
@@ -3,6 +3,7 @@ import { registerModules } from '@open-mercato/shared/lib/modules/registry'
 import { registerCliModules } from '@open-mercato/shared/modules/registry'
 import type { Module } from '@open-mercato/shared/modules/registry'
 import cli from '@open-mercato/core/modules/auth/cli'
+import { RoleAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 // Register modules so that ensureDefaultRoleAcls can read defaultRoleFeatures
 const testModules: Module[] = [
@@ -152,5 +153,11 @@ describe('auth CLI setup seeds ACLs', () => {
       'translations.view',
       'translations.manage',
     ]))
+    const roleAclLookups = findOne.mock.calls.filter(([entity]) => entity === RoleAcl)
+    expect(roleAclLookups.length).toBeGreaterThan(0)
+    expect(roleAclLookups.every(([, where]) => where.deletedAt === null)).toBe(true)
+    const userRoleLookups = findOne.mock.calls.filter(([entity]) => entity === UserRole)
+    expect(userRoleLookups.length).toBeGreaterThan(0)
+    expect(userRoleLookups.every(([, where]) => where.deletedAt === null)).toBe(true)
   }, 20000)
 })

--- a/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
@@ -136,6 +136,12 @@ describe('GET /api/auth/roles', () => {
       { name: { $ne: 'superadmin' } },
       { id: { $nin: ['323e4567-e89b-12d3-a456-426614174050'] } },
     ]))
+    expect(mockEm.find).toHaveBeenNthCalledWith(
+      1,
+      RoleAcl,
+      { tenantId: actorTenantId, isSuperAdmin: true, deletedAt: null },
+      {},
+    )
   })
 
   test('applies requested tenant scope for superadmin actor', async () => {

--- a/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
 import { DELETE, GET } from '@open-mercato/core/modules/auth/api/roles/route'
-import { RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
 
 const mockGetAuthFromRequest = jest.fn()
 const mockLoadAcl = jest.fn()
@@ -158,6 +158,9 @@ describe('GET /api/auth/roles', () => {
     const superAdminRoleId = '323e4567-e89b-12d3-a456-426614174999'
     mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: false })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isRoleEffectivelySuperAdmin` resolves the role's own tenant first and
+      // matches the grant against it, so the role row has to exist here.
+      if (entity === Role) return { id: superAdminRoleId, tenantId: actorTenantId }
       if (entity === RoleAcl) return { isSuperAdmin: true }
       return null
     })

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1481,10 +1481,11 @@ describe('GET /api/auth/users', () => {
       features: ['auth.users.edit'],
       organizations: null,
     })
-    mockEm.findOne.mockImplementation(async (entity: unknown) => {
-      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
-      // matches the grant against it, so the target row has to exist here.
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
       if (entity === User) return { id: superAdminUserId, tenantId }
+      return null
+    })
+    mockEm.findOne.mockImplementation(async (entity: unknown) => {
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })
@@ -1510,10 +1511,11 @@ describe('GET /api/auth/users', () => {
       features: ['auth.users.delete'],
       organizations: null,
     })
-    mockEm.findOne.mockImplementation(async (entity: unknown) => {
-      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
-      // matches the grant against it, so the target row has to exist here.
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
       if (entity === User) return { id: superAdminUserId, tenantId }
+      return null
+    })
+    mockEm.findOne.mockImplementation(async (entity: unknown) => {
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1482,6 +1482,9 @@ describe('GET /api/auth/users', () => {
       organizations: null,
     })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
+      // matches the grant against it, so the target row has to exist here.
+      if (entity === User) return { id: superAdminUserId, tenantId }
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })
@@ -1508,6 +1511,9 @@ describe('GET /api/auth/users', () => {
       organizations: null,
     })
     mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      // `isUserEffectivelySuperAdmin` resolves the target's own tenant first and
+      // matches the grant against it, so the target row has to exist here.
+      if (entity === User) return { id: superAdminUserId, tenantId }
       if (entity === UserAcl) return { isSuperAdmin: true }
       return null
     })

--- a/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
+++ b/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
@@ -175,6 +175,17 @@ describe('role ACL tenant scoping — existence oracle prevention', () => {
     expect(res.status).toBe(200)
   })
 
+  it('reads only the live role ACL row', async () => {
+    const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
+    mockEm.findOne.mockImplementation(async (entity: unknown) => entity === Role ? role : null)
+
+    const res = await GET(new Request(`http://localhost/api/auth/roles/acl?roleId=${ROLE_ID}`))
+
+    expect(res.status).toBe(200)
+    const aclLookup = mockEm.findOne.mock.calls.find(([entity]) => entity === RoleAcl)
+    expect(aclLookup?.[1]).toMatchObject({ tenantId: ACTOR_TENANT_ID, deletedAt: null })
+  })
+
   it('PUT rejects feature grants outside the actor effective ACL', async () => {
     const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
     mockRbacService.loadAcl.mockResolvedValueOnce({
@@ -213,6 +224,8 @@ describe('role ACL tenant scoping — existence oracle prevention', () => {
     expect(res.status).toBe(403)
     expect(body.error).toContain('Cannot grant feature api_keys.create')
     expect(mockEm.persist).not.toHaveBeenCalled()
+    const aclLookup = mockEm.findOne.mock.calls.find(([entity]) => entity === RoleAcl)
+    expect(aclLookup?.[1]).toMatchObject({ tenantId: ACTOR_TENANT_ID, deletedAt: null })
   })
 
   it('PUT rejects superadmin grants from non-superadmin actors', async () => {

--- a/packages/core/src/modules/auth/api/roles/acl/route.ts
+++ b/packages/core/src/modules/auth/api/roles/acl/route.ts
@@ -99,7 +99,7 @@ export async function GET(req: Request) {
   }
 
   const acl = tenantScope
-    ? await em.findOne(RoleAcl, { role, tenantId: tenantScope })
+    ? await em.findOne(RoleAcl, { role, tenantId: tenantScope, deletedAt: null })
     : null
   const response = acl
     ? {
@@ -178,7 +178,7 @@ export async function PUT(req: Request) {
     }
   }
 
-  const acl = await em.findOne(RoleAcl, { role, tenantId: targetTenantId })
+  const acl = await em.findOne(RoleAcl, { role, tenantId: targetTenantId, deletedAt: null })
   // Optimistic lock: refuse a stale ACL overwrite so two admins editing the same
   // role's features in parallel cannot silently clobber each other (#2055). The
   // check is strictly additive — when the client sends no expected-version header

--- a/packages/core/src/modules/auth/api/roles/route.ts
+++ b/packages/core/src/modules/auth/api/roles/route.ts
@@ -201,7 +201,7 @@ export async function GET(req: Request) {
   }
   let superAdminRoleIds: Set<string> | null = null
   if (!isSuperAdmin && actorTenantId) {
-    const superAdminAcls = await findWithDecryption(em, RoleAcl, { tenantId: actorTenantId, isSuperAdmin: true }, {}, { tenantId: actorTenantId, organizationId: null })
+    const superAdminAcls = await findWithDecryption(em, RoleAcl, { tenantId: actorTenantId, isSuperAdmin: true, deletedAt: null }, {}, { tenantId: actorTenantId, organizationId: null })
     if (superAdminAcls.length) {
       superAdminRoleIds = new Set(
         superAdminAcls

--- a/packages/core/src/modules/auth/api/users/acl/__tests__/tenant-resolution.test.ts
+++ b/packages/core/src/modules/auth/api/users/acl/__tests__/tenant-resolution.test.ts
@@ -148,7 +148,7 @@ describe('user ACL tenant resolution', () => {
 
     // The ACL lookup must carry a concrete tenant, never an undefined predicate.
     const aclLookup = mockEm.findOne.mock.calls.find(([ctor]) => ctor === UserAcl)
-    expect(aclLookup?.[1]).toMatchObject({ tenantId: TARGET_TENANT_ID })
+    expect(aclLookup?.[1]).toMatchObject({ tenantId: TARGET_TENANT_ID, deletedAt: null })
   })
 
   it('does not read the target user when the actor has a tenant', async () => {
@@ -219,7 +219,7 @@ describe('user ACL tenant resolution', () => {
     expect(body.updatedAt).toBe('2026-08-07T10:00:00.000Z')
 
     const aclLookup = mockEm.findOne.mock.calls.find(([ctor]) => ctor === UserAcl)
-    expect(aclLookup?.[1]).toMatchObject({ tenantId: TARGET_TENANT_ID })
+    expect(aclLookup?.[1]).toMatchObject({ tenantId: TARGET_TENANT_ID, deletedAt: null })
   })
 
   it('honours an explicit tenant for a super admin on both verbs', async () => {

--- a/packages/core/src/modules/auth/api/users/acl/route.ts
+++ b/packages/core/src/modules/auth/api/users/acl/route.ts
@@ -171,7 +171,11 @@ export async function GET(req: Request) {
     }
   }
   const acl = tenantId
-    ? await em.findOne(UserAcl, { user: parsed.data.userId as any, tenantId })
+    ? await em.findOne(UserAcl, {
+        user: parsed.data.userId as unknown as User,
+        tenantId,
+        deletedAt: null,
+      } as FilterQuery<UserAcl>)
     : null
   const response = acl
     ? {
@@ -268,7 +272,11 @@ export async function PUT(req: Request) {
     }
   }
 
-  const acl = await em.findOne(UserAcl, { user: parsed.data.userId as any, tenantId })
+  const acl = await em.findOne(UserAcl, {
+    user: parsed.data.userId as unknown as User,
+    tenantId,
+    deletedAt: null,
+  } as FilterQuery<UserAcl>)
   // Optimistic lock: refuse a stale per-user ACL overwrite so concurrent edits
   // cannot silently clobber each other (#2055). Strictly additive — a no-op when
   // the client sends no expected-version header; skipped when no ACL row exists.

--- a/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/acl.test.ts
@@ -278,10 +278,12 @@ describe('auth ACL audit commands', () => {
       await roleHandler().captureAfter!(roleInput, result, harness.ctx)
 
       // prepare + execute + captureAfter each look the row up; a handler that
-      // dropped the tenant predicate could cross tenants unnoticed.
+      // dropped the tenant predicate could cross tenants unnoticed. `deletedAt`
+      // is part of the same assertion: the editor must load the row
+      // `RbacService` reads, and that read is live-rows-only.
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ role: roleId, tenantId })
+        expect(filter).toEqual({ role: roleId, tenantId, deletedAt: null })
       }
     })
 
@@ -490,7 +492,7 @@ describe('auth ACL audit commands', () => {
 
       expect(harness.findOneFilters).toHaveLength(3)
       for (const filter of harness.findOneFilters) {
-        expect(filter).toEqual({ user: userId, tenantId })
+        expect(filter).toEqual({ user: userId, tenantId, deletedAt: null })
       }
     })
 

--- a/packages/core/src/modules/auth/commands/__tests__/roles.custom-fields.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/roles.custom-fields.test.ts
@@ -16,10 +16,15 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   }),
 }))
 
+jest.mock('@open-mercato/shared/lib/commands/customFieldSnapshots', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/customFieldSnapshots')
+  return { ...actual, loadCustomFieldSnapshot: jest.fn(async () => ({})) }
+})
+
 import '@open-mercato/core/modules/auth/commands/roles'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import type { Role } from '../../data/entities'
+import { RoleAcl, type Role } from '../../data/entities'
 import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -50,15 +55,18 @@ describe('auth.roles.update', () => {
     }
     const em = {
       findOne: jest.fn(async () => existingRole),
+      find: jest.fn(async () => []),
       count: jest.fn(async () => 0),
     }
     const ctx = makeExecuteCtx(dataEngine, em)
 
+    await handler.prepare!({ id: roleId, name: 'admin' }, ctx)
     const result = await handler.execute({ id: roleId, name: 'admin' }, ctx)
 
     expect(result).toMatchObject({ id: roleId, name: 'admin', tenantId })
     expect(em.count).not.toHaveBeenCalled()
     expect(updateOrmEntity).toHaveBeenCalled()
+    expect(em.find.mock.calls.find(([entity]) => entity === RoleAcl)?.[1]).toMatchObject({ deletedAt: null })
     expect(markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
       action: 'updated',
       identifiers: expect.objectContaining({ id: roleId, tenantId }),
@@ -202,6 +210,8 @@ function makeExecuteCtx(dataEngine: object, em: object): CommandRuntimeContext {
           return dataEngine
         case 'em':
           return em
+        case 'rbacService':
+          return { loadAcl: async () => ({ isSuperAdmin: true, features: ['*'], organizations: null }) }
         default:
           throw new Error(`Unexpected dependency: ${token}`)
       }

--- a/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
@@ -25,11 +25,16 @@ jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
   }
 })
 
+jest.mock('@open-mercato/shared/lib/commands/customFieldSnapshots', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/customFieldSnapshots')
+  return { ...actual, loadCustomFieldSnapshot: jest.fn(async () => ({})) }
+})
+
 import '@open-mercato/core/modules/auth/commands/users'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { User } from '../../data/entities'
+import { User, UserAcl, UserRole } from '../../data/entities'
 
 /**
  * Regression coverage for issue #2339 — the auth.users.delete cascade deleted
@@ -46,6 +51,7 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     rollback: number
     flush: number
     nativeDelete: number
+    find: Array<{ entity: unknown; where: unknown }>
   }
 
   function makeEm(calls: TxnCalls): EntityManager {
@@ -67,7 +73,10 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
         calls.nativeDelete += 1
         return 0
       },
-      find: async () => [],
+      find: async (entity: unknown, where: unknown) => {
+        calls.find.push({ entity, where })
+        return []
+      },
       findOne: async (entity: unknown) => (entity === User
         ? { id: userId, organizationId: 'org-1', tenantId: 'tenant-1', deletedAt: null }
         : null),
@@ -101,24 +110,31 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
 
   it('commits after every cascade delete succeeds', async () => {
     const handler = commandRegistry.get('auth.users.delete') as CommandHandler<{ query?: Record<string, unknown> }, unknown>
-    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0 }
+    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0, find: [] }
     const em = makeEm(calls)
     const dataEngine = {
       deleteOrmEntity: jest.fn(async () => ({ id: userId, organizationId: 'org-1', tenantId: 'tenant-1' })),
     }
+    const ctx = makeCtx(em, dataEngine)
 
-    await handler.execute({ query: { id: userId } }, makeCtx(em, dataEngine))
+    await handler.prepare!({ query: { id: userId } }, ctx)
+    await handler.execute({ query: { id: userId } }, ctx)
 
     expect(calls.begin).toBe(1)
     expect(calls.commit).toBe(1)
     expect(calls.rollback).toBe(0)
     expect(calls.nativeDelete).toBe(4)
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
+    expect(calls.find.find(({ entity }) => entity === UserAcl)?.where).toMatchObject({ deletedAt: null })
+    expect(calls.find.find(({ entity }) => entity === UserRole)?.where).toMatchObject({
+      deletedAt: null,
+      role: { deletedAt: null },
+    })
   })
 
   it('rolls back the whole cascade when the user delete fails', async () => {
     const handler = commandRegistry.get('auth.users.delete') as CommandHandler<{ query?: Record<string, unknown> }, unknown>
-    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0 }
+    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0, find: [] }
     const em = makeEm(calls)
     const dataEngine = {
       deleteOrmEntity: jest.fn(async () => {

--- a/packages/core/src/modules/auth/commands/__tests__/users.update-destination-scope.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.update-destination-scope.test.ts
@@ -302,5 +302,7 @@ describe('auth.users.update destination scope defense', () => {
     expect(em.begin).toHaveBeenCalledTimes(1)
     expect(em.rollback).toHaveBeenCalledTimes(1)
     expect(em.commit).not.toHaveBeenCalled()
+    const currentLinkRead = mockFindWithDecryption.mock.calls.find(([, entity]) => entity === UserRole)
+    expect(currentLinkRead?.[2]).toMatchObject({ deletedAt: null, role: { deletedAt: null } })
   })
 })

--- a/packages/core/src/modules/auth/commands/acl.ts
+++ b/packages/core/src/modules/auth/commands/acl.ts
@@ -378,8 +378,12 @@ const updateRoleAclCommand = createAclUpdateCommand<RoleAclUpdateInput>({
   labelKey: 'auth.audit.roleAcl.update',
   labelFallback: 'Change role permissions',
   resourceId: (input) => input.roleId,
+  // `deletedAt: null` so the editor loads the row `RbacService` reads, never a
+  // superseded one. The two must agree: this read decides which row a save
+  // edits, and a partial unique index on the live rows
+  // (`role_acls_active_unique_idx`) guarantees there is at most one.
   loadAcl: (em, input) =>
-    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId }),
+    em.findOne(RoleAcl, { role: input.roleId as unknown as Role, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     const acl =
       (existing as RoleAcl | null) ??
@@ -427,8 +431,9 @@ const updateUserAclCommand = createAclUpdateCommand<UserAclUpdateInput>({
   labelKey: 'auth.audit.userAcl.update',
   labelFallback: 'Change user permissions',
   resourceId: (input) => input.userId,
+  // Same reasoning as the role command above — see `user_acls_active_unique_idx`.
   loadAcl: (em, input) =>
-    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId }),
+    em.findOne(UserAcl, { user: input.userId as unknown as User, tenantId: input.tenantId, deletedAt: null }),
   persist: async ({ em, input, existing }) => {
     if (input.clear) {
       if (!existing) return

--- a/packages/core/src/modules/auth/commands/roles.ts
+++ b/packages/core/src/modules/auth/commands/roles.ts
@@ -622,7 +622,7 @@ function captureRoleSnapshots(
 }
 
 async function loadRoleAclSnapshots(em: EntityManager, roleId: string): Promise<RoleAclSnapshot[]> {
-  const entries = await findWithDecryption(em, RoleAcl, { role: roleId as unknown as Role }, {}, { tenantId: null, organizationId: null })
+  const entries = await findWithDecryption(em, RoleAcl, { role: roleId as unknown as Role, deletedAt: null }, {}, { tenantId: null, organizationId: null })
   return entries.map((entry) => ({
     id: entry.id ? String(entry.id) : null,
     tenantId: String(entry.tenantId),

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -1082,7 +1082,13 @@ async function syncUserRoles(em: EntityManager, user: User, desiredRoles: string
   }
 
   const desiredIds = new Set(resolvedRoles.map((r) => String(r.id)))
-  const currentLinks = await findWithDecryption(em, UserRole, { user }, {}, { tenantId: null, organizationId: null })
+  const currentLinks = await findWithDecryption(
+    em,
+    UserRole,
+    { user, deletedAt: null, role: { deletedAt: null } } as FilterQuery<UserRole>,
+    {},
+    { tenantId: null, organizationId: null },
+  )
   const currentRoleIds = new Map(
     currentLinks.map((link) => {
       const roleId = String(link.role?.id ?? (link.role as unknown as string) ?? '')
@@ -1109,7 +1115,11 @@ async function loadUserRoleNames(em: EntityManager, userId: string): Promise<str
   const links = await findWithDecryption(
     em,
     UserRole,
-    { user: userId as unknown as User },
+    {
+      user: userId as unknown as User,
+      deletedAt: null,
+      role: { deletedAt: null },
+    } as FilterQuery<UserRole>,
     { populate: ['role'] },
     { tenantId: null, organizationId: null },
   )
@@ -1156,7 +1166,7 @@ function captureUserSnapshots(
 }
 
 async function loadUserAclSnapshots(em: EntityManager, userId: string): Promise<UserAclSnapshot[]> {
-  const list = await findWithDecryption(em, UserAcl, { user: userId as unknown as User }, {}, { tenantId: null, organizationId: null })
+  const list = await findWithDecryption(em, UserAcl, { user: userId as unknown as User, deletedAt: null }, {}, { tenantId: null, organizationId: null })
   return list.map((acl) => ({
     tenantId: String(acl.tenantId),
     features: Array.isArray(acl.featuresJson) ? [...acl.featuresJson] : null,

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -250,6 +250,11 @@ export class PasswordReset {
 
 // RBAC: Role-level ACL
 @Entity({ tableName: 'role_acls' })
+// Uniqueness is enforced by a partial unique index (`role_acls_active_unique_idx`)
+// on `(role_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth.
 export class RoleAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -288,6 +293,13 @@ export class RoleAcl {
 
 // RBAC: Per-user ACL override
 @Entity({ tableName: 'user_acls' })
+// Uniqueness is enforced by a partial unique index (`user_acls_active_unique_idx`)
+// on `(user_id, tenant_id)` scoped to live rows (`WHERE deleted_at IS NULL`) and
+// owned by raw SQL in Migration20260828120000_auth. A `@Unique` decorator can't
+// express a partial index, so the entity intentionally omits it — the migration
+// is the source of truth. This row REPLACES the user's role ACLs rather than
+// merging with them (see RbacService.loadAcl), so a second live row for the same
+// scope would silently decide the whole feature set.
 export class UserAcl {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
@@ -7,7 +7,7 @@ import {
   isRoleEffectivelySuperAdmin,
   listSuperAdminUserIds,
 } from '@open-mercato/core/modules/auth/lib/grantChecks'
-import { RoleAcl, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl, User, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 const mockFindWithDecryption = jest.fn()
 
@@ -16,16 +16,111 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
 }))
 
-type MockEm = {
-  findOne: jest.Mock
-  find: jest.Mock
+const tenantId = '11111111-1111-1111-1111-111111111111'
+const otherTenantId = '99999999-9999-9999-9999-999999999999'
+const actorId = '22222222-2222-2222-2222-222222222222'
+const targetUserId = '33333333-3333-3333-3333-333333333333'
+const targetRoleId = '44444444-4444-4444-4444-444444444444'
+const superAdminRoleId = '55555555-5555-5555-5555-555555555555'
+const otherUserId = '66666666-6666-6666-6666-666666666666'
+
+// ---------------------------------------------------------------------------
+// A small in-memory table set, and an EntityManager double that EVALUATES the
+// filter the code really emits against it.
+//
+// This is deliberate rather than incidental: the previous doubles answered from
+// `mockResolvedValueOnce` queues keyed on call order, so a query that named no
+// tenant and a query that named the right one produced identical results and
+// the suite stayed green either way. The lookups under test differ from each
+// other only in their filters, so a double that ignores filters cannot see the
+// defect at all.
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>
+
+type Db = {
+  users: Row[]
+  roles: Row[]
+  userAcls: Row[]
+  roleAcls: Row[]
+  userRoles: Row[]
 }
 
-function makeEm(): MockEm {
-  return {
-    findOne: jest.fn(),
-    find: jest.fn(),
+function emptyDb(): Db {
+  return { users: [], roles: [], userAcls: [], roleAcls: [], userRoles: [] }
+}
+
+function refId(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object') {
+    const id = (value as { id?: unknown }).id
+    if (typeof id === 'string') return id
   }
+  return null
+}
+
+function tableFor(db: Db, entity: unknown): Row[] {
+  if (entity === User) return db.users
+  if (entity === Role) return db.roles
+  if (entity === UserAcl) return db.userAcls
+  if (entity === RoleAcl) return db.roleAcls
+  if (entity === UserRole) return db.userRoles
+  throw new Error(`unmapped entity in test double: ${String((entity as { name?: string })?.name)}`)
+}
+
+// Which table a relation column points at, so a nested filter such as
+// `{ role: { tenantId } }` can be resolved the way the ORM would.
+function relatedTable(db: Db, column: string): Row[] {
+  if (column === 'user') return db.users
+  if (column === 'role') return db.roles
+  throw new Error(`unmapped relation in test double: ${column}`)
+}
+
+function matchesValue(actual: unknown, expected: unknown): boolean {
+  if (expected === null) return actual === null || actual === undefined
+  return actual === expected
+}
+
+function matchesRow(db: Db, row: Row, where: Row): boolean {
+  for (const [key, condition] of Object.entries(where)) {
+    const actual = row[key]
+    if (condition && typeof condition === 'object' && !(condition instanceof Date)) {
+      const cond = condition as Row
+      if (Array.isArray(cond.$in)) {
+        const id = refId(actual)
+        if (!id || !(cond.$in as unknown[]).includes(id)) return false
+        continue
+      }
+      // Nested filter on a relation: resolve the referenced row and match there.
+      const id = refId(actual)
+      if (!id) return false
+      const related = relatedTable(db, key).find((candidate) => candidate.id === id)
+      if (!related) return false
+      if (!matchesRow(db, related, cond)) return false
+      continue
+    }
+    if (key === 'id' || key === 'user' || key === 'role') {
+      if (refId(actual) !== condition) return false
+      continue
+    }
+    if (!matchesValue(actual, condition)) return false
+  }
+  return true
+}
+
+function makeEm(db: Db) {
+  const findMany = jest.fn((entity: unknown, where: Row) =>
+    Promise.resolve(tableFor(db, entity).filter((row) => matchesRow(db, row, where ?? {}))))
+  const em = {
+    find: findMany,
+    findOne: jest.fn((entity: unknown, where: Row) =>
+      Promise.resolve(tableFor(db, entity).find((row) => matchesRow(db, row, where ?? {})) ?? null)),
+  }
+  // `findWithDecryption` is only ever used here to read `user_roles`; route it
+  // into the same tables so its filter is evaluated too.
+  mockFindWithDecryption.mockImplementation((_em: unknown, entity: unknown, where: Row) =>
+    Promise.resolve(tableFor(db, entity).filter((row) => matchesRow(db, row, where ?? {}))))
+  return em
 }
 
 function makeRbac(actorIsSuperAdmin: boolean) {
@@ -38,11 +133,30 @@ function makeRbac(actorIsSuperAdmin: boolean) {
   }
 }
 
-const tenantId = '11111111-1111-1111-1111-111111111111'
-const actorId = '22222222-2222-2222-2222-222222222222'
-const targetUserId = '33333333-3333-3333-3333-333333333333'
-const targetRoleId = '44444444-4444-4444-4444-444444444444'
-const superAdminRoleId = '55555555-5555-5555-5555-555555555555'
+/** A user in `tenantId` holding a live, own-tenant super-admin grant. */
+function dbWithDirectGrant(): Db {
+  const db = emptyDb()
+  db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+  db.userAcls.push({ id: 'acl-1', user: targetUserId, tenantId, isSuperAdmin: true, deletedAt: null })
+  return db
+}
+
+/** A user in `tenantId` whose super-admin comes from a role of that tenant. */
+function dbWithRoleGrant(): Db {
+  const db = emptyDb()
+  db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+  db.roles.push({ id: superAdminRoleId, tenantId, deletedAt: null })
+  db.userRoles.push({ id: 'link-1', user: targetUserId, role: superAdminRoleId, deletedAt: null })
+  db.roleAcls.push({
+    id: 'racl-1',
+    role: superAdminRoleId,
+    tenantId,
+    isSuperAdmin: true,
+    organizationsJson: null,
+    deletedAt: null,
+  })
+  return db
+}
 
 beforeEach(() => {
   mockFindWithDecryption.mockReset()
@@ -51,76 +165,150 @@ beforeEach(() => {
 
 describe('isUserEffectivelySuperAdmin', () => {
   test('returns true when the user has a direct UserAcl super admin grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(true)
-    expect(em.findOne).toHaveBeenCalledWith(UserAcl, expect.objectContaining({ isSuperAdmin: true }))
-    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    const em = makeEm(dbWithDirectGrant())
+    expect(await isUserEffectivelySuperAdmin(em as never, targetUserId)).toBe(true)
   })
 
   test('returns true when any assigned role grants super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([{ role: { id: superAdminRoleId } }])
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(true)
-    expect(em.findOne).toHaveBeenLastCalledWith(
-      RoleAcl,
-      expect.objectContaining({ isSuperAdmin: true }),
-    )
+    const em = makeEm(dbWithRoleGrant())
+    expect(await isUserEffectivelySuperAdmin(em as never, targetUserId)).toBe(true)
   })
 
   test('returns false when neither UserAcl nor any role grants super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([{ role: { id: targetRoleId } }])
-    em.findOne.mockResolvedValueOnce(null)
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.userRoles.push({ id: 'link-1', user: targetUserId, role: targetRoleId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: false, deletedAt: null })
 
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
-
-    expect(result).toBe(false)
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
   })
 
   test('returns false when the user has no role assignments and no UserAcl grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([])
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
-    const result = await isUserEffectivelySuperAdmin(em as never, targetUserId)
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
 
-    expect(result).toBe(false)
+  // --- the tenant binding ---------------------------------------------------
+
+  test('ignores a UserAcl grant stamped with a tenant other than the user own', async () => {
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a RoleAcl grant stamped with a tenant other than the user own', async () => {
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a role that belongs to another tenant', async () => {
+    const db = dbWithRoleGrant()
+    db.roles[0]!.tenantId = otherTenantId
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('returns false for a user with no tenant of their own', async () => {
+    const db = dbWithDirectGrant()
+    db.users[0]!.tenantId = null
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('returns false for a grant that outlives the user row it names', async () => {
+    const db = dbWithDirectGrant()
+    db.users = []
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  // --- revoked grants -------------------------------------------------------
+
+  test('ignores a soft-deleted UserAcl grant', async () => {
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a soft-deleted RoleAcl grant', async () => {
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  // --- deliberate over-inclusion --------------------------------------------
+
+  test('still protects a soft-deleted user holding a live grant', async () => {
+    const db = dbWithDirectGrant()
+    db.users[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(true)
+  })
+
+  test('still protects a holder of an organization-restricted super admin role', async () => {
+    // `RbacService.isGlobalSuperAdmin` drops these from the GLOBAL answer, but
+    // the scoped projection still reports isSuperAdmin inside those
+    // organizations, so the target stays privileged and must stay protected.
+    const db = dbWithRoleGrant()
+    db.roleAcls[0]!.organizationsJson = ['77777777-7777-7777-7777-777777777777']
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(true)
   })
 })
 
 describe('isRoleEffectivelySuperAdmin', () => {
+  function dbWithRoleAcl(): Db {
+    const db = emptyDb()
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: true, deletedAt: null })
+    return db
+  }
+
   test('returns true when the role has a RoleAcl super admin grant', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-
-    const result = await isRoleEffectivelySuperAdmin(em as never, targetRoleId)
-
-    expect(result).toBe(true)
+    expect(await isRoleEffectivelySuperAdmin(makeEm(dbWithRoleAcl()) as never, targetRoleId)).toBe(true)
   })
 
   test('returns false when no RoleAcl grant flags the role as super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.isSuperAdmin = false
 
-    const result = await isRoleEffectivelySuperAdmin(em as never, targetRoleId)
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
 
-    expect(result).toBe(false)
+  test('ignores a grant stamped with a tenant other than the role own', async () => {
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
+
+  test('ignores a soft-deleted grant', async () => {
+    const db = dbWithRoleAcl()
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
+  })
+
+  test('returns false for a grant that outlives the role row it names', async () => {
+    const db = dbWithRoleAcl()
+    db.roles = []
+
+    expect(await isRoleEffectivelySuperAdmin(makeEm(db) as never, targetRoleId)).toBe(false)
   })
 })
 
 describe('assertActorCanModifySuperAdminUserTarget', () => {
   test('always allows super admin actors', async () => {
-    const em = makeEm()
+    const em = makeEm(dbWithDirectGrant())
     const rbacService = makeRbac(true)
 
     await expect(
@@ -136,14 +324,10 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
   })
 
   test('forbids non-super admin actors when the target is a super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-    const rbacService = makeRbac(false)
-
     await expect(
       assertActorCanModifySuperAdminUserTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(dbWithDirectGrant()) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetUserId,
@@ -152,15 +336,31 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
   })
 
   test('allows non-super admin actors when the target is not a super admin', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    mockFindWithDecryption.mockResolvedValueOnce([])
-    const rbacService = makeRbac(false)
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
     await expect(
       assertActorCanModifySuperAdminUserTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
+        actorUserId: actorId,
+        tenantId,
+        targetUserId,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('allows a non-super admin actor to manage a user whose super admin was revoked', async () => {
+    // The trap this closes: an over-broad protection predicate never expires, so
+    // revoking a super-admin would leave the account unmanageable by the very
+    // tenant admins who revoked it.
+    const db = dbWithDirectGrant()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    await expect(
+      assertActorCanModifySuperAdminUserTarget({
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetUserId,
@@ -170,8 +370,15 @@ describe('assertActorCanModifySuperAdminUserTarget', () => {
 })
 
 describe('assertActorCanModifySuperAdminRoleTarget', () => {
+  function dbWithSuperAdminRole(): Db {
+    const db = emptyDb()
+    db.roles.push({ id: targetRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({ id: 'racl-1', role: targetRoleId, tenantId, isSuperAdmin: true, deletedAt: null })
+    return db
+  }
+
   test('always allows super admin actors', async () => {
-    const em = makeEm()
+    const em = makeEm(dbWithSuperAdminRole())
     const rbacService = makeRbac(true)
 
     await expect(
@@ -187,14 +394,10 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
   })
 
   test('forbids non-super admin actors when the target role is a super admin role', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce({ isSuperAdmin: true })
-    const rbacService = makeRbac(false)
-
     await expect(
       assertActorCanModifySuperAdminRoleTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(dbWithSuperAdminRole()) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetRoleId,
@@ -203,14 +406,13 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
   })
 
   test('allows non-super admin actors when the role is not a super admin role', async () => {
-    const em = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
-    const rbacService = makeRbac(false)
+    const db = dbWithSuperAdminRole()
+    db.roleAcls[0]!.isSuperAdmin = false
 
     await expect(
       assertActorCanModifySuperAdminRoleTarget({
-        em: em as never,
-        rbacService: rbacService as never,
+        em: makeEm(db) as never,
+        rbacService: makeRbac(false) as never,
         actorUserId: actorId,
         tenantId,
         targetRoleId,
@@ -220,33 +422,77 @@ describe('assertActorCanModifySuperAdminRoleTarget', () => {
 })
 
 describe('listSuperAdminUserIds', () => {
+  function dbWithBothHalves(): Db {
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
+    db.users.push({ id: otherUserId, tenantId, deletedAt: null })
+    db.userAcls.push({ id: 'acl-1', user: targetUserId, tenantId, isSuperAdmin: true, deletedAt: null })
+    db.roles.push({ id: superAdminRoleId, tenantId, deletedAt: null })
+    db.roleAcls.push({
+      id: 'racl-1',
+      role: superAdminRoleId,
+      tenantId,
+      isSuperAdmin: true,
+      organizationsJson: null,
+      deletedAt: null,
+    })
+    db.userRoles.push({ id: 'link-1', user: otherUserId, role: superAdminRoleId, deletedAt: null })
+    return db
+  }
+
   test('returns the union of UserAcl and role-derived super admin user ids', async () => {
-    const em = makeEm()
-    em.find
-      .mockResolvedValueOnce([{ user: { id: targetUserId } }])
-      .mockResolvedValueOnce([{ role: { id: superAdminRoleId } }])
-    mockFindWithDecryption.mockResolvedValueOnce([{ user: { id: 'role-derived-user' } }])
+    const result = await listSuperAdminUserIds(makeEm(dbWithBothHalves()) as never, tenantId)
 
-    const result = await listSuperAdminUserIds(em as never, tenantId)
-
-    expect(result).toEqual(new Set([targetUserId, 'role-derived-user']))
-    expect(em.find).toHaveBeenNthCalledWith(1, UserAcl, expect.objectContaining({ tenantId, isSuperAdmin: true }))
-    expect(em.find).toHaveBeenNthCalledWith(2, RoleAcl, expect.objectContaining({ isSuperAdmin: true }))
-    expect(mockFindWithDecryption).toHaveBeenCalledWith(
-      expect.anything(),
-      UserRole,
-      expect.objectContaining({ role: expect.objectContaining({ $in: [superAdminRoleId] }) }),
-      {},
-      expect.objectContaining({ tenantId: null }),
-    )
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
   })
 
   test('returns an empty set when there are no super admin grants', async () => {
-    const em = makeEm()
-    em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([])
+    const db = emptyDb()
+    db.users.push({ id: targetUserId, tenantId, deletedAt: null })
 
-    const result = await listSuperAdminUserIds(em as never, tenantId)
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
 
     expect(result.size).toBe(0)
+  })
+
+  test('applies the tenant filter to the RoleAcl half as well as the UserAcl half', async () => {
+    // The half that used to be unfiltered. A role ACL stamped elsewhere confers
+    // no super-admin (see `RbacService.isGlobalSuperAdmin`), so its members are
+    // ordinary users of this tenant and must not be hidden from it.
+    const db = dbWithBothHalves()
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result).toEqual(new Set([targetUserId]))
+  })
+
+  test('ignores soft-deleted grants on both halves', async () => {
+    const db = dbWithBothHalves()
+    db.userAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+    db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result.size).toBe(0)
+  })
+
+  test('keeps organization-restricted super admin roles in the exclusion list', async () => {
+    const db = dbWithBothHalves()
+    db.roleAcls[0]!.organizationsJson = ['77777777-7777-7777-7777-777777777777']
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
+
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
+  })
+
+  test('applies no tenant filter to either half when no tenant is given', async () => {
+    const db = dbWithBothHalves()
+    db.userAcls[0]!.tenantId = otherTenantId
+    db.roleAcls[0]!.tenantId = otherTenantId
+
+    const result = await listSuperAdminUserIds(makeEm(db) as never, null)
+
+    expect(result).toEqual(new Set([targetUserId, otherUserId]))
   })
 })

--- a/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/grantChecks.test.ts
@@ -10,9 +10,10 @@ import {
 import { Role, RoleAcl, User, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
-  findOneWithDecryption: jest.fn(),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
   findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
 }))
 
@@ -89,6 +90,13 @@ function matchesRow(db: Db, row: Row, where: Row): boolean {
       if (Array.isArray(cond.$in)) {
         const id = refId(actual)
         if (!id || !(cond.$in as unknown[]).includes(id)) return false
+        const relationConditions = Object.fromEntries(
+          Object.entries(cond).filter(([conditionKey]) => conditionKey !== '$in'),
+        )
+        if (Object.keys(relationConditions).length > 0) {
+          const related = relatedTable(db, key).find((candidate) => candidate.id === id)
+          if (!related || !matchesRow(db, related, relationConditions)) return false
+        }
         continue
       }
       // Nested filter on a relation: resolve the referenced row and match there.
@@ -120,6 +128,8 @@ function makeEm(db: Db) {
   // into the same tables so its filter is evaluated too.
   mockFindWithDecryption.mockImplementation((_em: unknown, entity: unknown, where: Row) =>
     Promise.resolve(tableFor(db, entity).filter((row) => matchesRow(db, row, where ?? {}))))
+  mockFindOneWithDecryption.mockImplementation((_em: unknown, entity: unknown, where: Row) =>
+    Promise.resolve(tableFor(db, entity).find((row) => matchesRow(db, row, where ?? {})) ?? null))
   return em
 }
 
@@ -161,6 +171,8 @@ function dbWithRoleGrant(): Db {
 beforeEach(() => {
   mockFindWithDecryption.mockReset()
   mockFindWithDecryption.mockResolvedValue([])
+  mockFindOneWithDecryption.mockReset()
+  mockFindOneWithDecryption.mockResolvedValue(null)
 })
 
 describe('isUserEffectivelySuperAdmin', () => {
@@ -241,6 +253,20 @@ describe('isUserEffectivelySuperAdmin', () => {
   test('ignores a soft-deleted RoleAcl grant', async () => {
     const db = dbWithRoleGrant()
     db.roleAcls[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a super-admin role reached through a soft-deleted assignment', async () => {
+    const db = dbWithRoleGrant()
+    db.userRoles[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
+  })
+
+  test('ignores a soft-deleted super-admin role', async () => {
+    const db = dbWithRoleGrant()
+    db.roles[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
 
     expect(await isUserEffectivelySuperAdmin(makeEm(db) as never, targetUserId)).toBe(false)
   })
@@ -475,6 +501,19 @@ describe('listSuperAdminUserIds', () => {
     const result = await listSuperAdminUserIds(makeEm(db) as never, tenantId)
 
     expect(result.size).toBe(0)
+  })
+
+  test('ignores role-derived users reached through soft-deleted assignments or roles', async () => {
+    const db = dbWithBothHalves()
+    db.userAcls = []
+    db.userRoles[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await listSuperAdminUserIds(makeEm(db) as never, tenantId)).toEqual(new Set())
+
+    db.userRoles[0]!.deletedAt = null
+    db.roles[0]!.deletedAt = new Date('2026-08-01T00:00:00Z')
+
+    expect(await listSuperAdminUserIds(makeEm(db) as never, tenantId)).toEqual(new Set())
   })
 
   test('keeps organization-restricted super admin roles in the exclusion list', async () => {

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -338,10 +338,13 @@ async function resolveActorIsSuperAdmin(input: GrantCheckContext & { actorIsSupe
  * whose `tenantId` is absent, so no mutation reaches either case.
  */
 export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: string): Promise<boolean> {
-  // Read without decryption on purpose: the only column consulted is
-  // `tenant_id`, which is not encrypted, so decrypting the row would be work
-  // thrown away on a guard that runs on every user write.
-  const target = await em.findOne(User, { id: userId } as FilterQuery<User>)
+  const target = await findOneWithDecryption(
+    em,
+    User,
+    { id: userId } as FilterQuery<User>,
+    {},
+    { tenantId: null, organizationId: null },
+  )
   const tenantId = normalizeNullableString((target as { tenantId?: string | null } | null)?.tenantId)
   if (!tenantId) return false
   const directGrant = await em.findOne(
@@ -355,7 +358,11 @@ export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: str
     // Roles of the user's own tenant, the same restriction `isGlobalSuperAdmin`
     // applies. The encryption scope stays `{ null, null }`: this is about which
     // rows count, not about which key decrypts them.
-    { user: userId as unknown, role: { tenantId } } as FilterQuery<UserRole>,
+    {
+      user: userId as unknown,
+      deletedAt: null,
+      role: { tenantId, deletedAt: null },
+    } as FilterQuery<UserRole>,
     { populate: ['role'] },
     { tenantId: null, organizationId: null },
   )
@@ -388,7 +395,13 @@ export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: str
  * the user side does.
  */
 export async function isRoleEffectivelySuperAdmin(em: EntityManager, roleId: string): Promise<boolean> {
-  const role = await em.findOne(Role, { id: roleId } as FilterQuery<Role>)
+  const role = await findOneWithDecryption(
+    em,
+    Role,
+    { id: roleId } as FilterQuery<Role>,
+    {},
+    { tenantId: null, organizationId: null },
+  )
   const tenantId = normalizeNullableString((role as { tenantId?: string | null } | null)?.tenantId)
   if (!tenantId) return false
   const grant = await em.findOne(
@@ -457,7 +470,10 @@ export async function listSuperAdminUserIds(em: EntityManager, tenantId: string 
     const links = await findWithDecryption(
       em,
       UserRole,
-      { role: { $in: roleIds } as unknown } as FilterQuery<UserRole>,
+      {
+        deletedAt: null,
+        role: { id: { $in: roleIds }, deletedAt: null },
+      } as FilterQuery<UserRole>,
       {},
       { tenantId: null, organizationId: null },
     )

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -304,16 +304,58 @@ async function resolveActorIsSuperAdmin(input: GrantCheckContext & { actorIsSupe
   return acl.isSuperAdmin
 }
 
+/**
+ * Answers "is this user effectively a super-admin" about a TARGET — the input to
+ * `assertActorCanModifySuperAdminUserTarget`, not to any authorization decision
+ * about the caller.
+ *
+ * It is bound to the target's OWN tenant (`users.tenant_id`) and to live grant
+ * rows, because that is the reading the two authorities already share:
+ * `RbacService.isGlobalSuperAdmin` and `lib/sessionIntegrity.ts`
+ * (`userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`). A protection
+ * predicate that answered differently would protect people who hold nothing —
+ * a grant stamped a foreign tenant, or one that was revoked — while every
+ * authorization path treats them as ordinary users. That over-protection does
+ * not expire: nothing short of a super-admin could edit such an account again,
+ * and revoking someone's super-admin would leave them permanently unmanageable
+ * by their own tenant's admins.
+ *
+ * Two asymmetries with `isGlobalSuperAdmin` are deliberate:
+ *
+ * - Organization-restricted role grants are NOT excluded. That exclusion only
+ *   keeps them out of the GLOBAL answer; `loadAcl`'s scoped projection still
+ *   returns `isSuperAdmin: true` for such a role inside the organizations it
+ *   names, so its holder is a privileged target. A protection predicate may be
+ *   a superset of the authorization answer; it must never be a subset.
+ * - The `User` load carries no `deletedAt` filter, matching the load in
+ *   `assertActorCanAccessUserTarget` below. A soft-deleted super-admin stays
+ *   protected; it is the ACL rows that must be live.
+ *
+ * "No user row" and "no tenant of their own" both answer false, as
+ * `isGlobalSuperAdmin` does. Neither is exploitable, because every call site
+ * pairs this guard with `assertActorCanAccessUserTarget`: that one delegates a
+ * missing target to the caller's own tenant-scoped load, and 404s a target
+ * whose `tenantId` is absent, so no mutation reaches either case.
+ */
 export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: string): Promise<boolean> {
+  // Read without decryption on purpose: the only column consulted is
+  // `tenant_id`, which is not encrypted, so decrypting the row would be work
+  // thrown away on a guard that runs on every user write.
+  const target = await em.findOne(User, { id: userId } as FilterQuery<User>)
+  const tenantId = normalizeNullableString((target as { tenantId?: string | null } | null)?.tenantId)
+  if (!tenantId) return false
   const directGrant = await em.findOne(
     UserAcl,
-    { user: userId as unknown, isSuperAdmin: true } as FilterQuery<UserAcl>,
+    { user: userId as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<UserAcl>,
   )
   if (directGrant && (directGrant as { isSuperAdmin?: boolean }).isSuperAdmin === true) return true
   const links = await findWithDecryption(
     em,
     UserRole,
-    { user: userId as unknown } as FilterQuery<UserRole>,
+    // Roles of the user's own tenant, the same restriction `isGlobalSuperAdmin`
+    // applies. The encryption scope stays `{ null, null }`: this is about which
+    // rows count, not about which key decrypts them.
+    { user: userId as unknown, role: { tenantId } } as FilterQuery<UserRole>,
     { populate: ['role'] },
     { tenantId: null, organizationId: null },
   )
@@ -328,22 +370,69 @@ export async function isUserEffectivelySuperAdmin(em: EntityManager, userId: str
   if (!roleIds.length) return false
   const roleGrant = await em.findOne(
     RoleAcl,
-    { role: { $in: roleIds } as unknown, isSuperAdmin: true } as FilterQuery<RoleAcl>,
+    { role: { $in: roleIds } as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<RoleAcl>,
   )
   return !!roleGrant && (roleGrant as { isSuperAdmin?: boolean }).isSuperAdmin === true
 }
 
+/**
+ * The role twin of `isUserEffectivelySuperAdmin`, and it carries the same
+ * reading for the same reasons: the grant must be live, and it must be stamped
+ * with the role's OWN tenant. A `role_acls` row stamped elsewhere confers
+ * nothing (`RbacService.loadAcl` reads role ACLs `{ tenantId, deletedAt: null }`),
+ * so protecting a role on the strength of one would refuse an edit that every
+ * authorization path considers ordinary.
+ *
+ * A role that does not exist answers false, which its paired guard
+ * `assertActorCanAccessRoleTarget` then delegates to the caller in the same way
+ * the user side does.
+ */
 export async function isRoleEffectivelySuperAdmin(em: EntityManager, roleId: string): Promise<boolean> {
+  const role = await em.findOne(Role, { id: roleId } as FilterQuery<Role>)
+  const tenantId = normalizeNullableString((role as { tenantId?: string | null } | null)?.tenantId)
+  if (!tenantId) return false
   const grant = await em.findOne(
     RoleAcl,
-    { role: roleId as unknown, isSuperAdmin: true } as FilterQuery<RoleAcl>,
+    { role: roleId as unknown, tenantId, isSuperAdmin: true, deletedAt: null } as FilterQuery<RoleAcl>,
   )
   return !!grant && (grant as { isSuperAdmin?: boolean }).isSuperAdmin === true
 }
 
+/**
+ * The super-admin user ids a non-super-admin must not be shown while looking at
+ * `tenantId` — an exclusion list, not an authorization answer.
+ *
+ * `tenantId` names the tenant whose users are being listed. Because a
+ * super-admin grant is bound to the holder's own tenant (see
+ * `isUserEffectivelySuperAdmin` above and `RbacService.isGlobalSuperAdmin`),
+ * that is also the tenant a grant must be stamped with in order to count here,
+ * so the filter is applied to BOTH ACL tables. It used to reach only
+ * `user_acls`, which made the two halves disagree about what a tenant-scoped
+ * answer meant.
+ *
+ * The narrowing on `role_acls` is only safe TOGETHER with that tenant binding:
+ * while a foreign-stamped row still conferred super-admin, dropping it from this
+ * list would have unhidden a real one.
+ *
+ * The caller owes the other half of the scoping. This returns ids; it is the
+ * caller's own subject query that must already be restricted to `tenantId`.
+ * Both wired call sites are — `auth/api/users/route.ts` filters the user query
+ * by the same tenant, and documents' principals route scopes to `ctx.tenantId`
+ * — so a role member living in another tenant is merely excluded from a list
+ * they were never in. That is not licence to pass a tenant unrelated to the
+ * subject set.
+ *
+ * Deliberately NOT narrowed further: organization-restricted role grants count
+ * (their holders are super-admins inside those organizations), and the
+ * `user_roles` expansion stays tenant-less. Over-inclusion there is bounded by
+ * the caller's subject scoping, and for an exclusion list hiding one user too
+ * many is the safe direction.
+ */
 export async function listSuperAdminUserIds(em: EntityManager, tenantId: string | null): Promise<Set<string>> {
   const ids = new Set<string>()
-  const userAclFilter: Record<string, unknown> = { isSuperAdmin: true }
+  // A revoked override must not keep answering — the same rule the ACL reads in
+  // `RbacService` follow.
+  const userAclFilter: Record<string, unknown> = { isSuperAdmin: true, deletedAt: null }
   if (tenantId) userAclFilter.tenantId = tenantId
   const userAcls = await em.find(UserAcl, userAclFilter as FilterQuery<UserAcl>)
   for (const acl of userAcls) {
@@ -353,10 +442,9 @@ export async function listSuperAdminUserIds(em: EntityManager, tenantId: string 
       : userRef
     if (userId) ids.add(String(userId))
   }
-  const roleAcls = await em.find(
-    RoleAcl,
-    { isSuperAdmin: true } as FilterQuery<RoleAcl>,
-  )
+  const roleAclFilter: Record<string, unknown> = { isSuperAdmin: true, deletedAt: null }
+  if (tenantId) roleAclFilter.tenantId = tenantId
+  const roleAcls = await em.find(RoleAcl, roleAclFilter as FilterQuery<RoleAcl>)
   const roleIds = roleAcls
     .map((acl) => {
       const roleRef = (acl as { role?: { id?: unknown } | string | null }).role

--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -444,7 +444,7 @@ export async function setupInitialTenant(
         await tem.flush()
         for (const roleName of base.roles) {
           const role = await findRoleByNameOrFail(tem, roleName, roleTenantId)
-          const existingLink = await findOneWithDecryption(tem, UserRole, { user, role }, {}, { tenantId: tenantId ?? null, organizationId: null })
+          const existingLink = await findOneWithDecryption(tem, UserRole, { user, role, deletedAt: null }, {}, { tenantId: tenantId ?? null, organizationId: null })
           if (!existingLink) tem.persist(tem.create(UserRole, { user, role, createdAt: new Date() }))
         }
         await tem.flush()
@@ -661,7 +661,7 @@ async function ensureRoleAclFor(
   // so a first init used to store the string twice while the second run silently collapsed it.
   // Same list, two shapes, depending only on how many times setup had run.
   const uniqueFeatures = Array.from(new Set(features))
-  const existing = await findOneWithDecryption(em, RoleAcl, { role, tenantId }, {}, { tenantId, organizationId: null })
+  const existing = await findOneWithDecryption(em, RoleAcl, { role, tenantId, deletedAt: null }, {}, { tenantId, organizationId: null })
   if (!existing) {
     const acl = em.create(RoleAcl, {
       role,

--- a/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260828120000_auth.ts
@@ -1,0 +1,70 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// `user_acls` and `role_acls` decide what a principal may do, and neither had
+// any uniqueness beyond its primary key. `RbacService.loadAcl` resolves the
+// per-user row with a bare `findOne` and RETURNS EARLY on a hit — the per-user
+// ACL replaces the role ACLs rather than merging with them — so two rows for
+// the same `(user_id, tenant_id)` were schema-legal and resolved with no
+// `ORDER BY`: whichever row Postgres happened to return decided the user's
+// entire feature set, and could change between requests.
+//
+// The write path makes that reachable rather than theoretical:
+// `auth.user_acl.update` reads with `findOne` and creates when it misses, so
+// two concurrent saves for the same user both miss and both insert.
+//
+// Partial unique indexes scoped to live rows (`where deleted_at is null`),
+// matching the shape already used for the sidebar tables in
+// Migration20260427143311. A `@Unique` decorator cannot express a partial
+// index, so the entities carry a comment pointing here instead.
+//
+// Historical duplicates are collapsed first — most recently updated row wins,
+// the rest are soft-deleted, never dropped — so the indexes can be created on
+// a database that already carries some.
+export class Migration20260828120000_auth extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by user_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from user_acls
+        where deleted_at is null
+      )
+      update user_acls
+      set deleted_at = now()
+      from ranked
+      where user_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "user_acls_active_unique_idx" on "user_acls" ("user_id", "tenant_id") where "deleted_at" is null;`);
+
+    this.addSql(`
+      with ranked as (
+        select id,
+               row_number() over (
+                 partition by role_id, tenant_id
+                 order by coalesce(updated_at, created_at) desc, created_at desc, id desc
+               ) as rn
+        from role_acls
+        where deleted_at is null
+      )
+      update role_acls
+      set deleted_at = now()
+      from ranked
+      where role_acls.id = ranked.id and ranked.rn > 1;
+    `);
+    this.addSql(`create unique index if not exists "role_acls_active_unique_idx" on "role_acls" ("role_id", "tenant_id") where "deleted_at" is null;`);
+  }
+
+  override down(): void | Promise<void> {
+    // Only the indexes are reversible. The collapse soft-deleted rows rather
+    // than dropping them, so the data is still there to un-delete by hand if a
+    // deployment ever needs it; un-deleting automatically would recreate the
+    // ambiguity this migration exists to remove.
+    this.addSql(`drop index if exists "user_acls_active_unique_idx";`);
+    this.addSql(`drop index if exists "role_acls_active_unique_idx";`);
+  }
+
+}

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -283,6 +283,34 @@ describe('RbacService', () => {
       })
     })
 
+    it('ignores soft-deleted role ACLs for API keys', async () => {
+      const key: Partial<ApiKey> = {
+        id: 'key-revoked-role',
+        tenantId: 'tenant-1',
+        organizationId: null,
+        rolesJson: ['role-a'],
+        deletedAt: null,
+      }
+      const revokedRoleAcl: Partial<RoleAcl> = {
+        role: { id: 'role-a' } as Role,
+        tenantId: 'tenant-1',
+        isSuperAdmin: true,
+        featuresJson: ['documents.manage'],
+        organizationsJson: null,
+        deletedAt: new Date('2026-08-01T00:00:00Z'),
+      }
+
+      em.findOne.mockImplementation(async (entity: unknown) => entity === ApiKey ? key : null)
+      em.find.mockImplementation(async (entity: unknown, where: Record<string, unknown>) => (
+        entity === RoleAcl && where.deletedAt !== null ? [revokedRoleAcl] : []
+      ))
+
+      await expect(service.loadAcl('api_key:key-revoked-role', {
+        tenantId: 'tenant-1',
+        organizationId: null,
+      })).resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
     it('preserves feature and organization correlation for tenant-scoped API-key roles', async () => {
       const key: Partial<ApiKey> = {
         id: 'key-disjoint-roles',
@@ -1568,20 +1596,23 @@ describe('RbacService', () => {
   // than keying a mock on the fields the test already expects — otherwise the
   // test cannot tell a filter that was applied from one that was not.
   describe('super-admin grant tenant binding', () => {
-    type Row = Record<string, any>
+    type Row = Record<string, unknown>
 
-    const idOf = (value: any): string | null => {
+    const idOf = (value: unknown): string | null => {
       if (typeof value === 'string') return value
-      if (value && typeof value === 'object' && typeof value.id === 'string') return value.id
+      if (value && typeof value === 'object') {
+        const id = (value as { id?: unknown }).id
+        if (typeof id === 'string') return id
+      }
       return null
     }
 
-    const matches = (where: any, row: Row): boolean => {
+    const matches = (where: unknown, row: Row): boolean => {
       if (!where || typeof where !== 'object') return true
-      return Object.entries(where).every(([key, expected]) => {
+      return Object.entries(where as Row).every(([key, expected]) => {
         const actual = row[key]
-        if (expected && typeof expected === 'object' && Array.isArray((expected as any).$in)) {
-          const wanted = (expected as any).$in.map((v: any) => idOf(v))
+        if (expected && typeof expected === 'object' && Array.isArray((expected as { $in?: unknown }).$in)) {
+          const wanted = (expected as { $in: unknown[] }).$in.map((value) => idOf(value))
           return wanted.includes(idOf(actual))
         }
         if (expected && typeof expected === 'object' && !(expected instanceof Date)) {
@@ -1597,18 +1628,18 @@ describe('RbacService', () => {
     }
 
     /** Wire `em.findOne` / `em.find` to evaluate the service's real filters. */
-    const seed = (tables: Map<any, Row[]>) => {
-      const rowsFor = (entity: any) => tables.get(entity) ?? []
-      em.findOne.mockImplementation(async (entity: any, where: any) =>
+    const seed = (tables: Map<unknown, Row[]>) => {
+      const rowsFor = (entity: unknown) => tables.get(entity) ?? []
+      em.findOne.mockImplementation(async (entity: unknown, where: unknown) =>
         rowsFor(entity).find((row) => matches(where, row)) ?? null)
-      em.find.mockImplementation(async (entity: any, where: any) =>
+      em.find.mockImplementation(async (entity: unknown, where: unknown) =>
         rowsFor(entity).filter((row) => matches(where, row)))
     }
 
     const user: Row = { id: 'user-1', tenantId: 'tenant-home', organizationId: 'org-1', deletedAt: null }
 
     it('ignores a user-level super-admin grant stamped with a foreign tenant', async () => {
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         // The row is real, live and flagged — it simply is not this user's own
         // tenant's grant. Before the tenant binding it conferred `['*']` in
@@ -1629,7 +1660,7 @@ describe('RbacService', () => {
       // The anti-regression half: binding the grant to the user's own tenant
       // must not stop a platform super-admin working inside a customer tenant,
       // which is what the tenant switcher does on every cross-tenant view.
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, [{
           user, tenantId: 'tenant-home', isSuperAdmin: true,
@@ -1645,7 +1676,7 @@ describe('RbacService', () => {
 
     it('ignores a role-level super-admin grant whose ACL row is stamped with a foreign tenant', async () => {
       const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, []],
         [UserRole, [{ user, role, deletedAt: null }]],
@@ -1663,7 +1694,7 @@ describe('RbacService', () => {
 
     it('ignores a super-admin role that belongs to another tenant', async () => {
       const foreignRole: Row = { id: 'role-foreign', tenantId: 'tenant-other', deletedAt: null }
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, []],
         [UserRole, [{ user, role: foreignRole, deletedAt: null }]],
@@ -1678,7 +1709,7 @@ describe('RbacService', () => {
     })
 
     it('ignores a soft-deleted user-level super-admin grant', async () => {
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, [{
           user, tenantId: 'tenant-home', isSuperAdmin: true,
@@ -1697,7 +1728,7 @@ describe('RbacService', () => {
 
     it('ignores a soft-deleted role-level super-admin grant', async () => {
       const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, []],
         [UserRole, [{ user, role, deletedAt: null }]],
@@ -1717,7 +1748,7 @@ describe('RbacService', () => {
       // a mocked EntityManager cannot demonstrate WHICH row wins. What it can
       // demonstrate is that the service asks for an order at all — the absence
       // of one is the defect, and it is invisible in any single-row fixture.
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [user]],
         [UserAcl, [{
           user, tenantId: 'tenant-home', isSuperAdmin: false,
@@ -1730,9 +1761,13 @@ describe('RbacService', () => {
 
       await service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' })
 
-      const scopedRead = em.findOne.mock.calls.find(([entity, where]: any[]) => (
-        entity === UserAcl && where && where.isSuperAdmin === undefined
-      ))
+      const scopedRead = em.findOne.mock.calls.find((call) => {
+        const [entity, where] = call as unknown[]
+        return entity === UserAcl
+          && !!where
+          && typeof where === 'object'
+          && (where as { isSuperAdmin?: unknown }).isSuperAdmin === undefined
+      })
       expect(scopedRead).toBeDefined()
       expect(scopedRead![1]).toMatchObject({ tenantId: 'tenant-home', deletedAt: null })
       expect(scopedRead![2]).toMatchObject({ orderBy: { createdAt: 'desc', id: 'desc' } })
@@ -1740,7 +1775,7 @@ describe('RbacService', () => {
 
     it('grants nothing to a user with no tenant of their own', async () => {
       const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, [tenantless]],
         [UserAcl, [{
           user: tenantless, tenantId: 'tenant-other', isSuperAdmin: true,
@@ -1757,7 +1792,7 @@ describe('RbacService', () => {
     it('grants nothing when the grant outlives the user row it names', async () => {
       // The check now runs after the user load, so a `user_acls` row left behind
       // by a hard-deleted user no longer confers anything.
-      seed(new Map<any, Row[]>([
+      seed(new Map<unknown, Row[]>([
         [User, []],
         [UserAcl, [{
           user: { id: 'ghost' }, tenantId: 'tenant-home', isSuperAdmin: true,
@@ -1769,6 +1804,36 @@ describe('RbacService', () => {
 
       await expect(service.loadAcl('ghost', { tenantId: 'tenant-home', organizationId: 'org-1' }))
         .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+
+    it('ignores a super-admin role reached through a soft-deleted assignment', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<unknown, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: new Date('2026-08-01T00:00:00Z') }]],
+        [RoleAcl, [{ role, tenantId: 'tenant-home', isSuperAdmin: true, deletedAt: null }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a soft-deleted super-admin role', async () => {
+      const role: Row = {
+        id: 'role-a',
+        tenantId: 'tenant-home',
+        deletedAt: new Date('2026-08-01T00:00:00Z'),
+      }
+      seed(new Map<unknown, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        [RoleAcl, [{ role, tenantId: 'tenant-home', isSuperAdmin: true, deletedAt: null }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
     })
   })
 

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1562,4 +1562,153 @@ describe('RbacService', () => {
       expect(em.findOne).toHaveBeenCalledTimes(callsAfterFirst) // No new queries
     })
   })
+
+  // Regression cover for the tenant binding on super-admin grants. These build a
+  // tiny in-memory table and evaluate the real filter the service emits, rather
+  // than keying a mock on the fields the test already expects — otherwise the
+  // test cannot tell a filter that was applied from one that was not.
+  describe('super-admin grant tenant binding', () => {
+    type Row = Record<string, any>
+
+    const idOf = (value: any): string | null => {
+      if (typeof value === 'string') return value
+      if (value && typeof value === 'object' && typeof value.id === 'string') return value.id
+      return null
+    }
+
+    const matches = (where: any, row: Row): boolean => {
+      if (!where || typeof where !== 'object') return true
+      return Object.entries(where).every(([key, expected]) => {
+        const actual = row[key]
+        if (expected && typeof expected === 'object' && Array.isArray((expected as any).$in)) {
+          const wanted = (expected as any).$in.map((v: any) => idOf(v))
+          return wanted.includes(idOf(actual))
+        }
+        if (expected && typeof expected === 'object' && !(expected instanceof Date)) {
+          // Relation sub-filter, e.g. `role: { tenantId, deletedAt: null }`.
+          return actual && typeof actual === 'object' ? matches(expected, actual) : false
+        }
+        if (typeof expected === 'string' && actual && typeof actual === 'object') {
+          return idOf(actual) === expected
+        }
+        if (expected === null) return actual === null || actual === undefined
+        return actual === expected
+      })
+    }
+
+    /** Wire `em.findOne` / `em.find` to evaluate the service's real filters. */
+    const seed = (tables: Map<any, Row[]>) => {
+      const rowsFor = (entity: any) => tables.get(entity) ?? []
+      em.findOne.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).find((row) => matches(where, row)) ?? null)
+      em.find.mockImplementation(async (entity: any, where: any) =>
+        rowsFor(entity).filter((row) => matches(where, row)))
+    }
+
+    const user: Row = { id: 'user-1', tenantId: 'tenant-home', organizationId: 'org-1', deletedAt: null }
+
+    it('ignores a user-level super-admin grant stamped with a foreign tenant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        // The row is real, live and flagged — it simply is not this user's own
+        // tenant's grant. Before the tenant binding it conferred `['*']` in
+        // every scope, so one mis-stamped row was a platform escalation.
+        [UserAcl, [{
+          user, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('keeps a home-tenant super-admin grant global across every scope', async () => {
+      // The anti-regression half: binding the grant to the user's own tenant
+      // must not stop a platform super-admin working inside a customer tenant,
+      // which is what the tenant switcher does on every cross-tenant view.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-customer', organizationId: 'org-99' }))
+        .resolves.toEqual({ isSuperAdmin: true, features: ['*'], organizations: null })
+    })
+
+    it('ignores a role-level super-admin grant whose ACL row is stamped with a foreign tenant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        // Production shape: one role, two ACL rows, one of them stamped with a
+        // tenant that is not the role's. Only the correctly stamped one counts.
+        [RoleAcl, [{
+          role, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a super-admin role that belongs to another tenant', async () => {
+      const foreignRole: Row = { id: 'role-foreign', tenantId: 'tenant-other', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role: foreignRole, deletedAt: null }]],
+        [RoleAcl, [{
+          role: foreignRole, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('grants nothing to a user with no tenant of their own', async () => {
+      const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [tenantless]],
+        [UserAcl, [{
+          user: tenantless, tenantId: 'tenant-other', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('user-2', { tenantId: null, organizationId: null }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+
+    it('grants nothing when the grant outlives the user row it names', async () => {
+      // The check now runs after the user load, so a `user_acls` row left behind
+      // by a hard-deleted user no longer confers anything.
+      seed(new Map<any, Row[]>([
+        [User, []],
+        [UserAcl, [{
+          user: { id: 'ghost' }, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null, deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await expect(service.loadAcl('ghost', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: null })
+    })
+  })
+
 })

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -1677,6 +1677,67 @@ describe('RbacService', () => {
         .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
     })
 
+    it('ignores a soft-deleted user-level super-admin grant', async () => {
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      // Neither the global path nor the scoped per-user read may answer from a
+      // revoked override, so the user falls through to their (empty) roles.
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('ignores a soft-deleted role-level super-admin grant', async () => {
+      const role: Row = { id: 'role-a', tenantId: 'tenant-home', deletedAt: null }
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, []],
+        [UserRole, [{ user, role, deletedAt: null }]],
+        [RoleAcl, [{
+          role, tenantId: 'tenant-home', isSuperAdmin: true,
+          featuresJson: [], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: new Date('2026-02-01'),
+        }]],
+      ]))
+
+      await expect(service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' }))
+        .resolves.toEqual({ isSuperAdmin: false, features: [], organizations: [] })
+    })
+
+    it('resolves the per-user ACL with an explicit ordering', async () => {
+      // A shape assertion, deliberately: the ordering is applied by Postgres, so
+      // a mocked EntityManager cannot demonstrate WHICH row wins. What it can
+      // demonstrate is that the service asks for an order at all — the absence
+      // of one is the defect, and it is invisible in any single-row fixture.
+      seed(new Map<any, Row[]>([
+        [User, [user]],
+        [UserAcl, [{
+          user, tenantId: 'tenant-home', isSuperAdmin: false,
+          featuresJson: ['documents.view'], organizationsJson: null,
+          createdAt: new Date('2026-01-01'), deletedAt: null,
+        }]],
+        [UserRole, []],
+        [RoleAcl, []],
+      ]))
+
+      await service.loadAcl('user-1', { tenantId: 'tenant-home', organizationId: 'org-1' })
+
+      const scopedRead = em.findOne.mock.calls.find(([entity, where]: any[]) => (
+        entity === UserAcl && where && where.isSuperAdmin === undefined
+      ))
+      expect(scopedRead).toBeDefined()
+      expect(scopedRead![1]).toMatchObject({ tenantId: 'tenant-home', deletedAt: null })
+      expect(scopedRead![2]).toMatchObject({ orderBy: { createdAt: 'desc', id: 'desc' } })
+    })
+
     it('grants nothing to a user with no tenant of their own', async () => {
       const tenantless: Row = { id: 'user-2', tenantId: null, organizationId: null, deletedAt: null }
       seed(new Map<any, Row[]>([

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -184,10 +184,45 @@ export class RbacService {
     }
   }
 
-  private async isGlobalSuperAdmin(userId: string): Promise<boolean> {
+  // A super-admin grant is deliberately GLOBAL: it survives every scope the
+  // caller asks about, which is what lets a platform super-admin work inside a
+  // customer tenant. What it must not do is survive the question of whose grant
+  // it is. Both lookups below are therefore evaluated against the user's OWN
+  // tenant (`users.tenant_id`), never against no tenant at all.
+  //
+  // Without that binding a single `user_acls` row — or a role link — stamped
+  // with ANY tenant confers platform super-admin everywhere, so a row written
+  // under the wrong tenant becomes a full privilege escalation with nothing in
+  // the schema or the UI to show for it. `user_acls` has no organization column
+  // and no uniqueness beyond its primary key, so such a row is cheap to create
+  // and invisible to the tenant/organization cross-wire checks.
+  //
+  // This is the tenant binding `resolveCanonicalStaffAuthContext` already
+  // applies when it computes `auth.isSuperAdmin` (see lib/sessionIntegrity.ts:
+  // `userAclGrantsSuperAdmin` / `roleAclGrantsSuperAdmin`, both bound to the
+  // user's own tenant). Before this change the two authorities disagreed:
+  // session integrity would say "not a super-admin" while `loadAcl` handed the
+  // same request `['*']`.
+  //
+  // The memo stays keyed by `userId` alone because the answer now depends only
+  // on the user's own tenant, which is a property of the user — not on the scope
+  // being asked about. `invalidateUserCache` therefore still clears it correctly.
+  private async isGlobalSuperAdmin(
+    em: EntityManager,
+    userId: string,
+    userTenantId: string | null,
+  ): Promise<boolean> {
     if (this.globalSuperAdminCache.has(userId)) return this.globalSuperAdminCache.get(userId)!
-    const em = this.em.fork()
-    const userSuper = await em.findOne(UserAcl, { user: userId as any, isSuperAdmin: true })
+    if (!userTenantId) {
+      // A user with no tenant of their own has no tenant to be a super-admin of.
+      this.globalSuperAdminCache.set(userId, false)
+      return false
+    }
+    const userSuper = await em.findOne(UserAcl, {
+      user: userId as any,
+      tenantId: userTenantId,
+      isSuperAdmin: true,
+    } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
@@ -195,7 +230,11 @@ export class RbacService {
     const links = await findWithDecryption(
       em,
       UserRole,
-      { user: userId as any },
+      // Roles that belong to the user's own tenant, as
+      // `resolveCanonicalStaffAuthContext` already requires. The encryption
+      // scope stays `{ null, null }` as before — this change is about which rows
+      // count, not about which key decrypts them.
+      { user: userId as any, role: { tenantId: userTenantId } } as any,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -212,7 +251,11 @@ export class RbacService {
       this.globalSuperAdminCache.set(userId, false)
       return false
     }
-    const roleSupers = await em.find(RoleAcl, { isSuperAdmin: true, role: { $in: roleIds as any } } as any)
+    const roleSupers = await em.find(RoleAcl, {
+      isSuperAdmin: true,
+      tenantId: userTenantId,
+      role: { $in: roleIds as any },
+    } as any)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))
@@ -249,18 +292,6 @@ export class RbacService {
     const cacheKey = this.getCacheKey(userId, scope)
     const cached = await this.getFromCache(cacheKey)
     if (cached) return cached
-
-    // Direct user-level super-admin grants and unrestricted role-level
-    // super-admin grants are global. Organization-restricted role grants are
-    // deliberately excluded by isGlobalSuperAdmin and continue through the
-    // scoped ACL projection below.
-    if (!userId.startsWith('api_key:')) {
-      if (await this.isGlobalSuperAdmin(userId)) {
-        const result = { isSuperAdmin: true, features: ['*'], organizations: null }
-        await this.setCache(cacheKey, result, userId, scope)
-        return result
-      }
-    }
 
     if (userId.startsWith('api_key:')) {
       const apiKeyId = userId.slice('api_key:'.length)
@@ -350,6 +381,23 @@ export class RbacService {
       await this.setCache(cacheKey, result, userId, scope)
       return result
     }
+
+    // Direct user-level super-admin grants and unrestricted role-level
+    // super-admin grants are global. Organization-restricted role grants are
+    // deliberately excluded by isGlobalSuperAdmin and continue through the
+    // scoped ACL projection below.
+    //
+    // The check runs AFTER the user is loaded because it is evaluated against
+    // the user's own tenant — see isGlobalSuperAdmin. It reuses that load and
+    // that EntityManager rather than issuing its own, so the reordering costs
+    // no extra query. API-key principals never reached it and still do not:
+    // their branch above has already returned.
+    if (await this.isGlobalSuperAdmin(em, userId, user.tenantId ?? null)) {
+      const result = { isSuperAdmin: true, features: ['*'], organizations: null }
+      await this.setCache(cacheKey, result, userId, scope)
+      return result
+    }
+
     const tenantId = scope.tenantId || user.tenantId || null
     const orgId = scope.organizationId || user.organizationId || null
 

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -222,6 +222,7 @@ export class RbacService {
       user: userId as any,
       tenantId: userTenantId,
       isSuperAdmin: true,
+      deletedAt: null,
     } as any)
     if (userSuper && (userSuper as any).isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
@@ -254,6 +255,7 @@ export class RbacService {
     const roleSupers = await em.find(RoleAcl, {
       isSuperAdmin: true,
       tenantId: userTenantId,
+      deletedAt: null,
       role: { $in: roleIds as any },
     } as any)
     const result = roleSupers.some((roleAcl) => (
@@ -407,8 +409,25 @@ export class RbacService {
       return result
     }
 
-    // Per-user ACL first
-    const uacl = await em.findOne(UserAcl, { user: userId as any, tenantId })
+    // Per-user ACL first. This row REPLACES the role ACLs rather than merging
+    // with them, so which row is returned decides the whole feature set. A
+    // partial unique index now makes a second live row impossible
+    // (`user_acls_active_unique_idx`, Migration20260828120000_auth), but the
+    // ordering is stated anyway: an index can be dropped by an operator, and an
+    // unordered `findOne` over a table that used to allow duplicates is exactly
+    // the read this pairs with. Soft-deleted rows are excluded — a revoked
+    // override must not keep answering.
+    const uacl = await em.findOne(
+      UserAcl,
+      { user: userId as any, tenantId, deletedAt: null } as any,
+      // `createdAt`/`id`, not `updatedAt`: `updated_at` is nullable and Postgres
+      // sorts NULLs FIRST under DESC, so ordering by it would prefer a row that
+      // was never updated. The migration's one-time collapse uses
+      // `coalesce(updated_at, created_at)` because there it is picking the row
+      // an operator would call current; here the only requirement is that the
+      // answer not vary between requests.
+      { orderBy: { createdAt: 'desc', id: 'desc' } } as any,
+    )
     if (uacl) {
       const result = {
         isSuperAdmin: !!uacl.isSuperAdmin,
@@ -439,7 +458,7 @@ export class RbacService {
         tenantId,
         scope.organizationId,
       )
-      const racls = await em.find(RoleAcl, { tenantId, role: { $in: roleIds as any } } as any, {})
+      const racls = await em.find(RoleAcl, { tenantId, deletedAt: null, role: { $in: roleIds as any } } as any, {})
       const roleAcls = Array.isArray(racls) ? racls : []
       for (const r of roleAcls) {
         if (roleAclAllowsOrganization(r, roleOrganizationScope)) {

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -1,7 +1,7 @@
-import type { EntityManager } from '@mikro-orm/postgresql'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import type { CacheStrategy } from '@open-mercato/cache'
 import { getCurrentCacheTenant, runWithCacheTenant } from '@open-mercato/cache'
-import { UserAcl, RoleAcl, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { UserAcl, RoleAcl, Role, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { OrganizationHierarchyService } from '@open-mercato/shared/lib/auth/principal-service'
@@ -219,12 +219,12 @@ export class RbacService {
       return false
     }
     const userSuper = await em.findOne(UserAcl, {
-      user: userId as any,
+      user: userId as unknown as User,
       tenantId: userTenantId,
       isSuperAdmin: true,
       deletedAt: null,
-    } as any)
-    if (userSuper && (userSuper as any).isSuperAdmin) {
+    } as FilterQuery<UserAcl>)
+    if (userSuper?.isSuperAdmin) {
       this.globalSuperAdminCache.set(userId, true)
       return true
     }
@@ -235,7 +235,11 @@ export class RbacService {
       // `resolveCanonicalStaffAuthContext` already requires. The encryption
       // scope stays `{ null, null }` as before — this change is about which rows
       // count, not about which key decrypts them.
-      { user: userId as any, role: { tenantId: userTenantId } } as any,
+      {
+        user: userId as unknown as User,
+        deletedAt: null,
+        role: { tenantId: userTenantId, deletedAt: null },
+      } as FilterQuery<UserRole>,
       { populate: ['role'] },
       { tenantId: null, organizationId: null },
     )
@@ -245,7 +249,7 @@ export class RbacService {
       return false
     }
     const roleIds = Array.from(new Set(linkList.map((link) => {
-      const role = link.role as any
+      const role = link.role
       return role?.id ? String(role.id) : null
     }).filter((id): id is string => typeof id === 'string' && id.length > 0)))
     if (!roleIds.length) {
@@ -256,8 +260,8 @@ export class RbacService {
       isSuperAdmin: true,
       tenantId: userTenantId,
       deletedAt: null,
-      role: { $in: roleIds as any },
-    } as any)
+      role: { $in: roleIds as unknown as Role[] },
+    } as FilterQuery<RoleAcl>)
     const result = roleSupers.some((roleAcl) => (
       !!roleAcl.isSuperAdmin && !isRestrictedRoleAcl(roleAcl)
     ))
@@ -320,7 +324,11 @@ export class RbacService {
           tenantId,
           evaluatedOrganizationId,
         )
-        const racls = await em.find(RoleAcl, { tenantId, role: { $in: roleIds as any } } as any)
+        const racls = await em.find(RoleAcl, {
+          tenantId,
+          deletedAt: null,
+          role: { $in: roleIds as unknown as Role[] },
+        } as FilterQuery<RoleAcl>)
         for (const acl of racls) {
           if (roleAclAllowsOrganization(acl, roleOrganizationScope)) {
             isSuper = isSuper || !!acl.isSuperAdmin
@@ -419,14 +427,14 @@ export class RbacService {
     // override must not keep answering.
     const uacl = await em.findOne(
       UserAcl,
-      { user: userId as any, tenantId, deletedAt: null } as any,
+      { user: userId as unknown as User, tenantId, deletedAt: null } as FilterQuery<UserAcl>,
       // `createdAt`/`id`, not `updatedAt`: `updated_at` is nullable and Postgres
       // sorts NULLs FIRST under DESC, so ordering by it would prefer a row that
       // was never updated. The migration's one-time collapse uses
       // `coalesce(updated_at, created_at)` because there it is picking the row
       // an operator would call current; here the only requirement is that the
       // answer not vary between requests.
-      { orderBy: { createdAt: 'desc', id: 'desc' } } as any,
+      { orderBy: { createdAt: 'desc', id: 'desc' } } as const,
     )
     if (uacl) {
       const result = {
@@ -442,12 +450,18 @@ export class RbacService {
     const links = await findWithDecryption(
       em,
       UserRole,
-      { user: userId as any, role: { tenantId } } as any,
+      {
+        user: userId as unknown as User,
+        deletedAt: null,
+        role: { tenantId, deletedAt: null },
+      } as FilterQuery<UserRole>,
       { populate: ['role'] },
       { tenantId, organizationId: orgId },
     )
     const linkList = Array.isArray(links) ? links : []
-    const roleIds = linkList.map((l) => (l.role as any)?.id).filter(Boolean)
+    const roleIds = linkList
+      .map((link) => link.role?.id ? String(link.role.id) : null)
+      .filter((roleId): roleId is string => roleId !== null)
     let isSuper = false
     const features: string[] = []
     let organizations: string[] | null = []
@@ -458,7 +472,11 @@ export class RbacService {
         tenantId,
         scope.organizationId,
       )
-      const racls = await em.find(RoleAcl, { tenantId, deletedAt: null, role: { $in: roleIds as any } } as any, {})
+      const racls = await em.find(RoleAcl, {
+        tenantId,
+        deletedAt: null,
+        role: { $in: roleIds as unknown as Role[] },
+      } as FilterQuery<RoleAcl>, {})
       const roleAcls = Array.isArray(racls) ? racls : []
       for (const r of roleAcls) {
         if (roleAclAllowsOrganization(r, roleOrganizationScope)) {
@@ -515,7 +533,7 @@ export class RbacService {
       tenantId,
       opts?.organizationId,
     )
-    const roleAcls = await em.find(RoleAcl, { tenantId, deletedAt: null } as any, {})
+    const roleAcls = await em.find(RoleAcl, { tenantId, deletedAt: null } as FilterQuery<RoleAcl>, {})
     const list = Array.isArray(roleAcls) ? roleAcls : []
 
     for (const acl of list) {

--- a/packages/core/src/modules/notifications/__tests__/notificationRecipients.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationRecipients.test.ts
@@ -1,4 +1,17 @@
-import { getScopedNotificationRecipientUserIds } from '../lib/notificationRecipients'
+import {
+  getRecipientUserIdsForFeature,
+  getRecipientUserIdsForRole,
+  getScopedNotificationRecipientUserIds,
+} from '../lib/notificationRecipients'
+
+function createQuery(rows: unknown[] = []) {
+  const query: Record<string, jest.Mock> = {}
+  query.innerJoin = jest.fn(() => query)
+  query.where = jest.fn(() => query)
+  query.select = jest.fn(() => query)
+  query.execute = jest.fn().mockResolvedValue(rows)
+  return query
+}
 
 describe('getScopedNotificationRecipientUserIds', () => {
   it('filters recipients by id, live status, tenant, and organization', async () => {
@@ -38,5 +51,34 @@ describe('getScopedNotificationRecipientUserIds', () => {
     await getScopedNotificationRecipientUserIds(db as never, 'tenant-1', null, ['user-1'])
 
     expect(query.where).not.toHaveBeenCalledWith('users.organization_id', '=', expect.anything())
+  })
+
+  it('requires a live tenant role when resolving explicit role recipients', async () => {
+    const query = createQuery([{ user_id: 'user-1' }])
+    const db = { selectFrom: jest.fn(() => query) }
+
+    await expect(getRecipientUserIdsForRole(db as never, 'tenant-1', 'role-1'))
+      .resolves.toEqual(['user-1'])
+
+    expect(query.innerJoin).toHaveBeenCalledWith('roles', 'user_roles.role_id', 'roles.id')
+    expect(query.where).toHaveBeenCalledWith('roles.deleted_at', 'is', null)
+    expect(query.where).toHaveBeenCalledWith('roles.tenant_id', '=', 'tenant-1')
+  })
+
+  it('requires live roles and links when resolving feature recipients', async () => {
+    const userAclQuery = createQuery([])
+    const roleAclQuery = createQuery([{ user_id: 'user-1', features_json: ['documents.view'], is_super_admin: false }])
+    const db = {
+      selectFrom: jest.fn((table: string) => table === 'user_acls' ? userAclQuery : roleAclQuery),
+    }
+
+    await expect(getRecipientUserIdsForFeature(db as never, 'tenant-1', 'documents.view'))
+      .resolves.toEqual(['user-1'])
+
+    expect(roleAclQuery.innerJoin).toHaveBeenCalledWith('roles', 'role_acls.role_id', 'roles.id')
+    expect(roleAclQuery.where).toHaveBeenCalledWith('role_acls.deleted_at', 'is', null)
+    expect(roleAclQuery.where).toHaveBeenCalledWith('user_roles.deleted_at', 'is', null)
+    expect(roleAclQuery.where).toHaveBeenCalledWith('roles.deleted_at', 'is', null)
+    expect(roleAclQuery.where).toHaveBeenCalledWith('roles.tenant_id', '=', 'tenant-1')
   })
 })

--- a/packages/core/src/modules/notifications/lib/notificationRecipients.ts
+++ b/packages/core/src/modules/notifications/lib/notificationRecipients.ts
@@ -64,9 +64,12 @@ export async function getRecipientUserIdsForRole(
   const builder: any = db
   const userRoles = await builder
     .selectFrom('user_roles')
+    .innerJoin('roles', 'user_roles.role_id', 'roles.id')
     .innerJoin('users', 'user_roles.user_id', 'users.id')
     .where('user_roles.role_id', '=', roleId)
     .where('user_roles.deleted_at', 'is', null)
+    .where('roles.deleted_at', 'is', null)
+    .where('roles.tenant_id', '=', tenantId)
     .where('users.deleted_at', 'is', null)
     .where('users.tenant_id', '=', tenantId)
     .select('users.id as user_id')
@@ -101,10 +104,13 @@ export async function getRecipientUserIdsForFeature(
 
   const roleAcls = await builder
     .selectFrom('role_acls')
+    .innerJoin('roles', 'role_acls.role_id', 'roles.id')
     .innerJoin('user_roles', 'role_acls.role_id', 'user_roles.role_id')
     .innerJoin('users', 'user_roles.user_id', 'users.id')
     .where('role_acls.tenant_id', '=', tenantId)
     .where('role_acls.deleted_at', 'is', null)
+    .where('roles.deleted_at', 'is', null)
+    .where('roles.tenant_id', '=', tenantId)
     .where('user_roles.deleted_at', 'is', null)
     .where('users.deleted_at', 'is', null)
     .where('users.tenant_id', '=', tenantId)


### PR DESCRIPTION
Supersedes #5764

Credit: original implementation by @Geeknauts-company. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the fork branch.

Original PR: https://github.com/open-mercato/open-mercato/pull/5764

## Included work

- Original tenant-bound, live-row super-admin grant and TARGET-check changes from #5764 and its stacked commits
- Deterministic remediation plus partial unique indexes for live user/role ACL rows
- Complete live-row consumer audit across RBAC, API keys, ACL routes, setup, undo snapshots, role membership, and notification recipients
- Decryption-aware target entity reads
- Compatibility/migration specification with rollback and deployment risks
- Regression coverage for revoked ACLs, links, roles, route query shapes, setup, undo snapshots, and recipient resolution

## Validation

Validation source: GitHub checks plus local fallback. The original head exposed only CLA success and CodeSmith skipped, so the repo-local fallback was used.

- `yarn build:packages` (twice) — pass on the original reviewed head
- `yarn generate` — pass on the original reviewed head
- `yarn i18n:check-sync` — pass
- `yarn i18n:check-usage` — pass (advisory unused-key report only)
- `yarn workspace @open-mercato/core typecheck` — pass
- `yarn workspace @open-mercato/core build` — pass
- Full auth suite plus notification recipient regression — 92 suites / 804 tests pass
- `git diff --check` — pass

The carried-forward diff was re-reviewed after autofix and is intended to be merge-ready. Because it changes auth semantics and database indexes, manual QA remains required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790606967&installation_model_id=432243&pr_number=5770&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5770&signature=2dd0d64951821b226884c04a95a77dad0cac8a7d732f0dfa5459ea3d54a1e5af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->