### PR TITLE
fix(customer_accounts): show the organization on the customer users list (#5575)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
@@ -3,6 +3,7 @@ import {
   CustomerRole,
   CustomerUserRole,
 } from '@open-mercato/core/modules/customer_accounts/data/entities'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 
 const mockGetAuth = jest.fn()
 const mockRbac = { userHasAllFeatures: jest.fn() }
@@ -216,6 +217,75 @@ describe('admin /api/customer_accounts/admin/users — GET listing', () => {
     expect(body.total).toBe(1)
     const junctionCalls = mockEmFind.mock.calls.filter((call) => call[0] === CustomerUserRole)
     expect(junctionCalls.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('admin /api/customer_accounts/admin/users — GET organization column (#5575)', () => {
+  const orgAlpha = { id: '44444444-4444-4444-8444-444444444444', name: 'Alpha Org' }
+  const orgBeta = { id: '55555555-5555-4555-8555-555555555555', name: 'Beta Org' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuth.mockResolvedValue({ sub: adminId, tenantId, orgId })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+  })
+
+  it('returns organizationId and the resolved organizationName for every user in one batched query', async () => {
+    const users = [
+      makeUser('u1', { organizationId: orgAlpha.id }),
+      makeUser('u2', { organizationId: orgBeta.id }),
+      makeUser('u3', { organizationId: orgAlpha.id }),
+    ]
+    mockEmFindAndCount.mockResolvedValue([users, users.length])
+    mockEmFind.mockImplementation(async (entity: unknown) => {
+      if (entity === Organization) return [orgAlpha, orgBeta]
+      return []
+    })
+
+    const res = await GET(buildRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    const organizationByUser = Object.fromEntries(
+      body.items.map((item: any) => [item.id, { id: item.organizationId, name: item.organizationName }]),
+    )
+    expect(organizationByUser.u1).toEqual({ id: orgAlpha.id, name: 'Alpha Org' })
+    expect(organizationByUser.u2).toEqual({ id: orgBeta.id, name: 'Beta Org' })
+    expect(organizationByUser.u3).toEqual({ id: orgAlpha.id, name: 'Alpha Org' })
+
+    const organizationCalls = mockEmFind.mock.calls.filter((call) => call[0] === Organization)
+    expect(organizationCalls).toHaveLength(1)
+    expect(organizationCalls[0][1]).toMatchObject({
+      id: { $in: [orgAlpha.id, orgBeta.id] },
+      tenant: tenantId,
+      deletedAt: null,
+    })
+  })
+
+  it('falls back to a null organizationName when the organization cannot be resolved', async () => {
+    mockEmFindAndCount.mockResolvedValue([[makeUser('u1', { organizationId: orgAlpha.id })], 1])
+    mockEmFind.mockResolvedValue([])
+
+    const res = await GET(buildRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.items[0]).toMatchObject({
+      organizationId: orgAlpha.id,
+      organizationName: null,
+    })
+  })
+
+  it('never queries organizations when no user on the page carries one', async () => {
+    mockEmFindAndCount.mockResolvedValue([[makeUser('u1')], 1])
+    mockEmFind.mockResolvedValue([])
+
+    const res = await GET(buildRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.items[0]).toMatchObject({ organizationId: null, organizationName: null })
+    expect(mockEmFind.mock.calls.filter((call) => call[0] === Organization)).toHaveLength(0)
   })
 })
 

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -183,23 +183,15 @@ export async function GET(req: Request) {
   }
 
   const pageOrganizationIds = Array.from(new Set(
-    users
-      .map((user) => (user.organizationId ? String(user.organizationId) : null))
-      .filter((organizationId): organizationId is string => !!organizationId),
+    users.map((user) => user.organizationId).filter((organizationId): organizationId is string => !!organizationId),
   ))
   const organizations = pageOrganizationIds.length > 0
-    ? await em.find(Organization, { id: { $in: pageOrganizationIds as any }, tenant: auth.tenantId as any, deletedAt: null } as any)
+    ? await em.find(Organization, { id: { $in: pageOrganizationIds }, tenant: auth.tenantId, deletedAt: null })
     : []
-  const organizationNameById = new Map<string, string>()
-  for (const organization of organizations) {
-    const organizationId = organization?.id ? String(organization.id) : null
-    if (!organizationId) continue
-    const name = (organization as any)?.name
-    if (typeof name === 'string' && name.length > 0) organizationNameById.set(organizationId, name)
-  }
+  const organizationNameById = new Map(organizations.map((organization) => [organization.id, organization.name]))
 
   const items = users.map((user) => {
-    const organizationId = user.organizationId ? String(user.organizationId) : null
+    const organizationId = user.organizationId ?? null
     return {
       id: user.id,
       email: user.email,

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -6,6 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerUserService } from '@open-mercato/core/modules/customer_accounts/services/customerUserService'
 import { CustomerUser, CustomerUserRole, CustomerRole } from '@open-mercato/core/modules/customer_accounts/data/entities'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { adminCreateUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
@@ -181,20 +182,41 @@ export async function GET(req: Request) {
     else rolesByUserId.set(linkUserId, [entry])
   }
 
-  const items = users.map((user) => ({
-    id: user.id,
-    email: user.email,
-    displayName: user.displayName,
-    emailVerified: !!user.emailVerifiedAt,
-    isActive: user.isActive,
-    lockedUntil: user.lockedUntil || null,
-    lastLoginAt: user.lastLoginAt || null,
-    customerEntityId: user.customerEntityId || null,
-    personEntityId: user.personEntityId || null,
-    createdAt: user.createdAt,
-    updatedAt: user.updatedAt || null,
-    roles: rolesByUserId.get(user.id) ?? [],
-  }))
+  const pageOrganizationIds = Array.from(new Set(
+    users
+      .map((user) => (user.organizationId ? String(user.organizationId) : null))
+      .filter((organizationId): organizationId is string => !!organizationId),
+  ))
+  const organizations = pageOrganizationIds.length > 0
+    ? await em.find(Organization, { id: { $in: pageOrganizationIds as any }, tenant: auth.tenantId as any, deletedAt: null } as any)
+    : []
+  const organizationNameById = new Map<string, string>()
+  for (const organization of organizations) {
+    const organizationId = organization?.id ? String(organization.id) : null
+    if (!organizationId) continue
+    const name = (organization as any)?.name
+    if (typeof name === 'string' && name.length > 0) organizationNameById.set(organizationId, name)
+  }
+
+  const items = users.map((user) => {
+    const organizationId = user.organizationId ? String(user.organizationId) : null
+    return {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      emailVerified: !!user.emailVerifiedAt,
+      isActive: user.isActive,
+      lockedUntil: user.lockedUntil || null,
+      lastLoginAt: user.lastLoginAt || null,
+      customerEntityId: user.customerEntityId || null,
+      personEntityId: user.personEntityId || null,
+      organizationId,
+      organizationName: organizationId ? organizationNameById.get(organizationId) ?? null : null,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt || null,
+      roles: rolesByUserId.get(user.id) ?? [],
+    }
+  })
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
@@ -335,6 +357,8 @@ const userSchema = z.object({
   lastLoginAt: z.string().datetime().nullable(),
   customerEntityId: z.string().uuid().nullable(),
   personEntityId: z.string().uuid().nullable(),
+  organizationId: z.string().uuid().nullable().describe('Organization the customer user belongs to'),
+  organizationName: z.string().nullable().describe('Resolved organization display name'),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime().nullable(),
   roles: z.array(roleSchema),

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/PortalUsersPageClient.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/PortalUsersPageClient.tsx
@@ -35,6 +35,8 @@ type UserRow = {
   updatedAt?: string | null
   personEntityId: string | null
   customerEntityId: string | null
+  organizationId: string | null
+  organizationName: string | null
 }
 
 type UsersResponse = {
@@ -437,6 +439,15 @@ export function PortalUsersPageClient({ portalOrigin, portalOrgSlug = null }: Po
       {
         accessorKey: 'email',
         header: t('customer_accounts.admin.columns.email', 'Email'),
+      },
+      {
+        accessorKey: 'organizationName',
+        header: t('customer_accounts.admin.columns.organization', 'Organization'),
+        cell: ({ row }) => {
+          const label = row.original.organizationName || row.original.organizationId
+          if (!label) return noValue
+          return <span className="text-sm">{label}</span>
+        },
       },
       {
         accessorKey: 'emailVerified',

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/__tests__/PortalUsersPageClient.test.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/__tests__/PortalUsersPageClient.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import { PortalUsersPageClient } from '../PortalUsersPageClient'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
+
+jest.mock('lucide-react', () => ({
+  Globe: () => null,
+  Settings: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: ({ columns, data }: any) => (
+    <table>
+      <thead>
+        <tr>
+          {columns.map((column: any, index: number) => (
+            <th key={column.accessorKey ?? index} data-testid={`header-${column.accessorKey}`}>
+              {typeof column.header === 'string' ? column.header : null}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row: any) => (
+          <tr key={row.id}>
+            {columns.map((column: any, index: number) => (
+              <td key={column.accessorKey ?? index} data-testid={`cell-${column.accessorKey}-${row.id}`}>
+                {column.cell ? column.cell({ row: { original: row } }) : String(row[column.accessorKey] ?? '')}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/filters/ListEmptyState', () => ({
+  ListEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(async () => ({ ok: true, result: { items: [] } })),
+  readApiResultOrThrow: jest.fn(),
+  withScopedApiRequestHeaders: (_headers: Record<string, string>, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({ confirm: jest.fn(async () => false), ConfirmDialogElement: null }),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: jest.fn(({ operation }: { operation: () => unknown }) => operation()),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+const readApiResultOrThrowMock = readApiResultOrThrow as jest.MockedFunction<typeof readApiResultOrThrow>
+
+function makeRow(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    displayName: `User ${id}`,
+    email: `${id}@example.com`,
+    emailVerified: true,
+    isActive: true,
+    lastLoginAt: null,
+    roles: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: null,
+    personEntityId: null,
+    customerEntityId: null,
+    organizationId: null,
+    organizationName: null,
+    ...overrides,
+  }
+}
+
+describe('PortalUsersPageClient — organization column (#5575)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders an Organization column with each user organization name', async () => {
+    readApiResultOrThrowMock.mockResolvedValue({
+      items: [
+        makeRow('u1', { organizationId: 'org-1', organizationName: 'Alpha Org' }),
+        makeRow('u2', { organizationId: 'org-2', organizationName: 'Beta Org' }),
+      ],
+      total: 2,
+      totalPages: 1,
+    } as never)
+
+    render(<PortalUsersPageClient portalOrigin="https://shop.example.com" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-organizationName-u1')).toHaveTextContent('Alpha Org')
+    })
+    expect(screen.getByTestId('header-organizationName')).toHaveTextContent('Organization')
+    expect(screen.getByTestId('cell-organizationName-u2')).toHaveTextContent('Beta Org')
+  })
+
+  it('falls back to the organization id, then to a placeholder, when the name is missing', async () => {
+    readApiResultOrThrowMock.mockResolvedValue({
+      items: [
+        makeRow('u1', { organizationId: 'org-1', organizationName: null }),
+        makeRow('u2'),
+      ],
+      total: 2,
+      totalPages: 1,
+    } as never)
+
+    render(<PortalUsersPageClient portalOrigin="https://shop.example.com" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cell-organizationName-u1')).toHaveTextContent('org-1')
+    })
+    expect(screen.getByTestId('cell-organizationName-u2')).toHaveTextContent('-')
+  })
+})

--- a/packages/core/src/modules/customer_accounts/i18n/de.json
+++ b/packages/core/src/modules/customer_accounts/i18n/de.json
@@ -10,6 +10,7 @@
   "customer_accounts.admin.columns.email": "Email",
   "customer_accounts.admin.columns.emailVerified": "Verified",
   "customer_accounts.admin.columns.lastLogin": "Last Login",
+  "customer_accounts.admin.columns.organization": "Organization",
   "customer_accounts.admin.columns.roles": "Roles",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Delete user \"{{name}}\"?",

--- a/packages/core/src/modules/customer_accounts/i18n/de.json
+++ b/packages/core/src/modules/customer_accounts/i18n/de.json
@@ -10,7 +10,7 @@
   "customer_accounts.admin.columns.email": "Email",
   "customer_accounts.admin.columns.emailVerified": "Verified",
   "customer_accounts.admin.columns.lastLogin": "Last Login",
-  "customer_accounts.admin.columns.organization": "Organization",
+  "customer_accounts.admin.columns.organization": "Organisation",
   "customer_accounts.admin.columns.roles": "Roles",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Delete user \"{{name}}\"?",

--- a/packages/core/src/modules/customer_accounts/i18n/en.json
+++ b/packages/core/src/modules/customer_accounts/i18n/en.json
@@ -10,6 +10,7 @@
   "customer_accounts.admin.columns.email": "Email",
   "customer_accounts.admin.columns.emailVerified": "Verified",
   "customer_accounts.admin.columns.lastLogin": "Last Login",
+  "customer_accounts.admin.columns.organization": "Organization",
   "customer_accounts.admin.columns.roles": "Roles",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Delete user \"{{name}}\"?",

--- a/packages/core/src/modules/customer_accounts/i18n/es.json
+++ b/packages/core/src/modules/customer_accounts/i18n/es.json
@@ -10,6 +10,7 @@
   "customer_accounts.admin.columns.email": "Email",
   "customer_accounts.admin.columns.emailVerified": "Verified",
   "customer_accounts.admin.columns.lastLogin": "Last Login",
+  "customer_accounts.admin.columns.organization": "Organization",
   "customer_accounts.admin.columns.roles": "Roles",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Delete user \"{{name}}\"?",

--- a/packages/core/src/modules/customer_accounts/i18n/es.json
+++ b/packages/core/src/modules/customer_accounts/i18n/es.json
@@ -10,7 +10,7 @@
   "customer_accounts.admin.columns.email": "Email",
   "customer_accounts.admin.columns.emailVerified": "Verified",
   "customer_accounts.admin.columns.lastLogin": "Last Login",
-  "customer_accounts.admin.columns.organization": "Organization",
+  "customer_accounts.admin.columns.organization": "Organización",
   "customer_accounts.admin.columns.roles": "Roles",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Delete user \"{{name}}\"?",

--- a/packages/core/src/modules/customer_accounts/i18n/ko.json
+++ b/packages/core/src/modules/customer_accounts/i18n/ko.json
@@ -10,6 +10,7 @@
   "customer_accounts.admin.columns.email": "이메일",
   "customer_accounts.admin.columns.emailVerified": "확인됨",
   "customer_accounts.admin.columns.lastLogin": "마지막 로그인",
+  "customer_accounts.admin.columns.organization": "조직",
   "customer_accounts.admin.columns.roles": "역할",
   "customer_accounts.admin.columns.status": "상태",
   "customer_accounts.admin.confirm.delete": "사용자 \"{{name}}\"을(를) 삭제하시겠습니까?",

--- a/packages/core/src/modules/customer_accounts/i18n/pl.json
+++ b/packages/core/src/modules/customer_accounts/i18n/pl.json
@@ -10,6 +10,7 @@
   "customer_accounts.admin.columns.email": "E-mail",
   "customer_accounts.admin.columns.emailVerified": "Zweryfikowany",
   "customer_accounts.admin.columns.lastLogin": "Ostatnie logowanie",
+  "customer_accounts.admin.columns.organization": "Organizacja",
   "customer_accounts.admin.columns.roles": "Role",
   "customer_accounts.admin.columns.status": "Status",
   "customer_accounts.admin.confirm.delete": "Usunąć użytkownika \"{{name}}\"?",


### PR DESCRIPTION
Closes #5575

## 🎯 Goal
- The admin customer users list at `/backend/customer_accounts/users` gains an **Organization** column, so staff can tell which organization each customer user belongs to instead of guessing from name and email.

## 🔍 Problem
The table rendered seven columns — Name, Email, Verified, Status, Last Login, Roles, Created — and none of them showed the organization. As the issue notes, this matters most when reviewing users across organizations, where nothing on screen distinguishes one organization's users from another's. The issue also observed that the underlying API response carried neither `organizationId` nor an organization name.

## 🔍 Root Cause
A missing projection, not a query or scoping error. `GET /api/customer_accounts/admin/users` built its `items` payload directly from the `CustomerUser` rows and never projected `organizationId`, and it never resolved the organization's display name. Both sibling admin lists already do exactly that — `packages/core/src/modules/auth/api/users/route.ts` and `packages/core/src/modules/api_keys/api/keys/route.ts` each emit `organizationId` plus an `organizationName` resolved through one batched id→name map. Because the payload lacked the data, `PortalUsersPageClient.tsx` typed its `UserRow` without an organization field and had nothing to render even if a column had existed.

## What Changed
- **`packages/core/src/modules/customer_accounts/api/admin/users.ts`** — after the page of users is fetched, the handler collects their distinct non-null organization ids and resolves display names in a single batched `em.find(Organization, { id: { $in: … }, tenant: auth.tenantId, deletedAt: null })`, then adds `organizationId` and `organizationName` to every item. One extra query per page, never per row. The lookup is tenant-scoped as `customer_accounts/AGENTS.md` requires, and the ids it resolves come only from rows the caller is already scoped to, so no new data is exposed. `userSchema` gained both fields so the generated OpenAPI response document stays truthful.
- **`packages/core/src/modules/customer_accounts/backend/customer_accounts/users/PortalUsersPageClient.tsx`** — `UserRow` carries the two new fields, and an `organizationName` column is inserted after Email (mirroring `auth/backend/users/page.tsx`). It renders the resolved name, falls back to the raw organization id when the name cannot be resolved, and falls back to the existing dash placeholder when there is no organization at all.
- **`packages/core/src/modules/customer_accounts/i18n/{en,de,es,ko,pl}.json`** — new `customer_accounts.admin.columns.organization` key in every locale, so the header is translated rather than hardcoded.

## 🧪 Tests
- `packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts` — three new cases: every item carries `organizationId` and the resolved `organizationName` from exactly **one** tenant-scoped `Organization` query (guarding against an N+1 regression); an unresolvable organization yields `organizationName: null` rather than throwing; and no `Organization` query is issued at all when no user on the page carries one.
- `packages/core/src/modules/customer_accounts/backend/customer_accounts/users/__tests__/PortalUsersPageClient.test.tsx` (new) — renders the list client through a DataTable stub and asserts the Organization header is present with the per-row names, plus the id and dash fallbacks.
- Verified these are genuine regression tests, not tautologies: with the two production files stashed, 5 of the 17 tests fail; restored, all 17 pass.
- Gate: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck` and `build:app` all green. `yarn test --continue` ran 31 of 34 packages green including `@open-mercato/core`. The three reds are pre-existing and cannot be reached by a `packages/core` change — `@open-mercato/shared` and `@open-mercato/cli` fail only under turbo (worker death, zero jest output) and pass standalone at 2071 and 1806 tests respectively, and `create-mercato-app` fails in `writable-ast-oracles.test.ts`, its harness suite that requires locally installed agent CLIs.

## 💥 Breaking Changes
- None. The API change is purely additive to the response payload; no existing field, filter, route, schema or DB structure changed.

## Related issues — deliberately out of scope
`#5574` (the list ignores the "All organizations" selection) lives in the same handler's `where` clause, which pins `organizationId` to `auth.orgId`. Until that is fixed, the new column will show one repeated value rather than a mix. The two fixes are independent — this one changes the **response projection**, that one changes the **filter** — so they do not need to ship together, and no API contract is shared between them. `#5576` (cannot pick an organization when creating a user) touches the same screen's create dialog and is likewise untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790615788&installation_model_id=432243&pr_number=5775&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5775&signature=2b10a98f6eceded0b8d2996d0194e92225ea6f28f2714e8cc07301464bebf6cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->