### PR TITLE
fix(security): enforce feature scope for all-organization requests

### DIFF
--- a/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
+++ b/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
@@ -1,0 +1,62 @@
+# Execution plan — finish all-organization feature-scope hardening (adopted from PR #5778)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-29 because PR #5778 carried no execution plan.
+**PR:** #5778 · **Branch:** `codex/fix-all-organization-feature-scope` · **Base:** `develop`
+**Author:** @haxiorz — this plan records the CI follow-up on the existing security-fix branch.
+
+## Goal
+
+Finish PR #5778 by preserving established empty-scope and non-enumerating route behavior while retaining the all-organization feature-scope restriction that closes the reported EUDR read bypass.
+
+## Scope
+
+- Diagnose the two failed ephemeral integration shards and classify whether each failure originates in this branch or its base.
+- Correct the dispatcher/RBAC interaction so a principal with the required feature but zero visible organizations passes the feature gate while downstream data access remains narrowed to an empty set.
+- Add focused regression coverage for the authorization decision and run the affected Docker integration tests plus the configured validation gate.
+- Push the verified correction to the existing PR and return it for review.
+
+## Non-goals
+
+- Do not weaken tenant or organization data scoping.
+- Do not change API response contracts, database structure, UI behavior, or ACL feature IDs.
+- Do not absorb unrelated changes from the fork's `develop` branch or address unrelated CI failures.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| The all-organization EUDR bypass is closed by deriving and binding the organizations where every required feature is granted | Security report, PR implementation, and EUDR integration regression | high |
+| CI shard 3 is branch-caused: an `api_keys.view` principal with an empty organization allowlist now receives an early 403 instead of the established empty 200 list | Run 33272290510 artifact `integration-test-results-3` and `TC-APIKEY-007` | high |
+| CI shard 7 is branch-caused: an empty-scope customer detail request now receives an early 403 instead of the established non-enumerating 404 | Run 33272290510 artifact `integration-test-results-7` and `TC-CRM-072` | high |
+| The base commit is not responsible for either failure | Both assertions passed before the PR's new empty-allowed-set authorization branch and all other integration shards passed | high |
+
+## Assumptions
+
+- Feature possession and data visibility are separate decisions: an empty feature-authorized organization set must bind downstream reads to no organizations, not fail the feature gate itself.
+- Existing list-empty and detail-not-found semantics are security-relevant because they prevent record enumeration and are part of the tested API behavior.
+- The minimal correction belongs in the shared dispatcher authorization decision and its generated-app template twin.
+
+## Risks
+
+- Allowing the feature gate to pass with an empty narrowed set would be unsafe if a downstream route ignored the request-bound organization scope; focused tests must prove the shared CRUD layer consumes the empty set fail-closed.
+- The API dispatcher and create-app template must remain byte-for-byte behaviorally aligned.
+- Authorization caching or wildcard grants could make a narrow unit test pass while integration behavior differs, so Docker integration coverage is required.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Implement organization-feature narrowing and add the EUDR all-organization regression — ee0a8f0ee4
+
+### Phase 2: Resolve CI regressions
+
+- [ ] 2.1 Diagnose failed CI shards and classify their attribution
+- [ ] 2.2 Preserve empty-scope feature authorization while retaining fail-closed query narrowing
+- [ ] 2.3 Add regression coverage for empty-list and non-enumerating detail behavior
+
+### Phase 3: Validate and return for review
+
+- [ ] 3.1 Run focused Docker integration tests and the configured validation gate
+- [ ] 3.2 Complete the authoritative review pass, update PR evidence, and release the continuation lock

--- a/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
+++ b/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
@@ -59,4 +59,4 @@ Finish PR #5778 by preserving established empty-scope and non-enumerating route 
 ### Phase 3: Validate and return for review
 
 - [x] 3.1 Run focused Docker integration tests and the configured validation gate — dc9d7cd541
-- [ ] 3.2 Complete the authoritative review pass, update PR evidence, and release the continuation lock
+- [x] 3.2 Complete the authoritative review pass, update PR evidence, and release the continuation lock — dc9d7cd541

--- a/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
+++ b/.ai/runs/2026-08-29-fix-all-organization-feature-scope.md
@@ -52,11 +52,11 @@ Finish PR #5778 by preserving established empty-scope and non-enumerating route 
 
 ### Phase 2: Resolve CI regressions
 
-- [ ] 2.1 Diagnose failed CI shards and classify their attribution
-- [ ] 2.2 Preserve empty-scope feature authorization while retaining fail-closed query narrowing
-- [ ] 2.3 Add regression coverage for empty-list and non-enumerating detail behavior
+- [x] 2.1 Diagnose failed CI shards and classify their attribution — dc9d7cd541
+- [x] 2.2 Preserve empty-scope feature authorization while retaining fail-closed query narrowing — dc9d7cd541
+- [x] 2.3 Add regression coverage for empty-list and non-enumerating detail behavior — dc9d7cd541
 
 ### Phase 3: Validate and return for review
 
-- [ ] 3.1 Run focused Docker integration tests and the configured validation gate
+- [x] 3.1 Run focused Docker integration tests and the configured validation gate — dc9d7cd541
 - [ ] 3.2 Complete the authoritative review pass, update PR evidence, and release the continuation lock

--- a/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
+++ b/apps/mercato/src/__tests__/extract-tenant-candidate.test.ts
@@ -23,15 +23,23 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => ({ resolve: jest.fn(() => ({})) })),
 }))
 
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveFeatureCheckContext: jest.fn(),
+}))
+
 jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => {
   const actual = jest.requireActual('@open-mercato/core/modules/auth/lib/tenantAccess')
   return { ...actual, enforceTenantSelection: jest.fn() }
 })
 
 import { enforceTenantSelection } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveFeatureCheckContext } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { checkAuthorization, extractTenantCandidate, extractTenantCandidates } from '@/app/api/[...slug]/route'
 
 const enforceTenantSelectionMock = enforceTenantSelection as jest.MockedFunction<typeof enforceTenantSelection>
+const createRequestContainerMock = createRequestContainer as jest.MockedFunction<typeof createRequestContainer>
+const resolveFeatureCheckContextMock = resolveFeatureCheckContext as jest.MockedFunction<typeof resolveFeatureCheckContext>
 
 function buildMultipartRequest(formData: FormData): NextRequest {
   return new NextRequest('http://localhost:3001/api/example/test', {
@@ -213,5 +221,78 @@ describe('checkAuthorization tenant pollution enforcement (issue #2665)', () => 
     expect(response).toBeNull()
     expect(enforceTenantSelectionMock).toHaveBeenCalledTimes(1)
     expect(enforceTenantSelectionMock).toHaveBeenCalledWith(expect.anything(), foreignTenant)
+  })
+})
+
+describe('checkAuthorization organization feature narrowing', () => {
+  const tenantId = '00000000-0000-0000-0000-0000000000dd'
+  const userHasAllFeaturesMock = jest.fn()
+  const loadAclMock = jest.fn()
+
+  beforeEach(() => {
+    userHasAllFeaturesMock.mockReset().mockResolvedValue(true)
+    loadAclMock.mockReset().mockResolvedValue({
+      features: [],
+      isSuperAdmin: false,
+      organizations: [],
+    })
+    createRequestContainerMock.mockReset()
+    createRequestContainerMock.mockResolvedValue({
+      resolve: jest.fn((name: string) => {
+        if (name === 'rbacService') {
+          return {
+            userHasAllFeatures: userHasAllFeaturesMock,
+            loadAcl: loadAclMock,
+          }
+        }
+        return {}
+      }),
+    } as Awaited<ReturnType<typeof createRequestContainer>>)
+    resolveFeatureCheckContextMock.mockResolvedValue({
+      organizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: [],
+        allowedIds: [],
+        tenantId,
+      },
+      allowedOrganizationIds: [],
+    })
+  })
+
+  it('passes the feature guard when an authorized principal is narrowed to zero visible organizations', async () => {
+    const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'GET' })
+
+    const response = await checkAuthorization(
+      { requireFeatures: ['api_keys.view'] },
+      buildAuth(tenantId),
+      request,
+    )
+
+    expect(response).toBeNull()
+    expect(userHasAllFeaturesMock).toHaveBeenCalledWith(
+      'user-1',
+      ['api_keys.view'],
+      { tenantId, organizationId: null },
+    )
+  })
+
+  it('still rejects a principal that does not hold the required feature', async () => {
+    userHasAllFeaturesMock.mockResolvedValue(false)
+    const warning = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const request = new NextRequest('http://localhost:3001/api/example/test', { method: 'GET' })
+
+    try {
+      const response = await checkAuthorization(
+        { requireFeatures: ['api_keys.view'] },
+        buildAuth(tenantId),
+        request,
+      )
+
+      expect(response?.status).toBe(403)
+      expect(loadAclMock).toHaveBeenCalled()
+    } finally {
+      warning.mockRestore()
+    }
   })
 })

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -211,12 +211,20 @@ export async function checkAuthorization(
     }
     const featureContainer = await ensureContainer()
     const rbac = featureContainer.resolve<RbacService>('rbacService')
-    const featureContext = await resolveFeatureCheckContext({ container: featureContainer, auth, request: req })
-    const { organizationId } = featureContext
-    const ok = await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
-      tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
-      organizationId,
+    const featureContext = await resolveFeatureCheckContext({
+      container: featureContainer,
+      auth,
+      request: req,
+      requiredFeatures,
     })
+    const { organizationId } = featureContext
+    const ok = Array.isArray(featureContext.allowedOrganizationIds)
+      && featureContext.allowedOrganizationIds.length === 0
+      ? false
+      : await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+          tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
+          organizationId,
+        })
     if (!ok) {
       try {
         const acl = await rbac.loadAcl(auth.sub, { tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null, organizationId })

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -218,13 +218,10 @@ export async function checkAuthorization(
       requiredFeatures,
     })
     const { organizationId } = featureContext
-    const ok = Array.isArray(featureContext.allowedOrganizationIds)
-      && featureContext.allowedOrganizationIds.length === 0
-      ? false
-      : await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
-          tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
-          organizationId,
-        })
+    const ok = await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+      tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
+      organizationId,
+    })
     if (!ok) {
       try {
         const acl = await rbac.loadAcl(auth.sub, { tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null, organizationId })

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -950,6 +950,237 @@ describe('RbacService', () => {
     })
   })
 
+  describe('resolveFeatureOrganizationAccess', () => {
+    const organizations = [
+      { id: 'org-1', ancestorIds: [] },
+      { id: 'org-2', ancestorIds: [] },
+    ]
+
+    it('keeps only organizations where the required feature is granted', async () => {
+      const unrestrictedRole: Partial<Role> = { id: 'role-unrestricted' }
+      const riskRole: Partial<Role> = { id: 'role-risk' }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return null
+        return null
+      })
+      em.find.mockImplementation(async (entity: any) => {
+        if (entity === UserRole) return [
+          { role: unrestrictedRole },
+          { role: riskRole },
+        ]
+        if (entity === RoleAcl) return [
+          {
+            role: unrestrictedRole,
+            featuresJson: ['eudr.statements.view'],
+            organizationsJson: null,
+          },
+          {
+            role: riskRole,
+            featuresJson: ['eudr.risk.view'],
+            organizationsJson: ['org-1'],
+          },
+        ]
+        return []
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        { tenantId: 'tenant-1' },
+      )
+      expect(access.unrestricted).toBe(false)
+      expect(access.filterOrganizationIds(organizations)).toEqual(['org-1'])
+    })
+
+    it('preserves unrestricted access when every required feature is globally granted', async () => {
+      const role: Partial<Role> = { id: 'role-global' }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return null
+        return null
+      })
+      em.find.mockImplementation(async (entity: any) => {
+        if (entity === UserRole) return [{ role }]
+        if (entity === RoleAcl) return [{
+          role,
+          featuresJson: ['eudr.risk.view'],
+          organizationsJson: null,
+        }]
+        return []
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        { tenantId: 'tenant-1' },
+      )
+      expect(access.unrestricted).toBe(true)
+      expect(access.filterOrganizationIds(organizations)).toEqual(['org-1', 'org-2'])
+    })
+
+    it('honors parent organization grants for descendant candidates', async () => {
+      const role: Partial<Role> = { id: 'role-parent' }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return null
+        return null
+      })
+      em.find.mockImplementation(async (entity: any) => {
+        if (entity === UserRole) return [{ role }]
+        if (entity === RoleAcl) return [{
+          role,
+          featuresJson: ['eudr.risk.view'],
+          organizationsJson: ['org-parent'],
+        }]
+        return []
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        {
+          tenantId: 'tenant-1',
+        },
+      )
+      expect(access.unrestricted).toBe(false)
+      expect(access.filterOrganizationIds([
+        { id: 'org-parent', ancestorIds: [] },
+        { id: 'org-child', ancestorIds: ['org-parent'] },
+        { id: 'org-sibling', ancestorIds: [] },
+      ])).toEqual(['org-parent', 'org-child'])
+    })
+
+    it('requires every feature to be granted in the same organization', async () => {
+      const roleA: Partial<Role> = { id: 'role-a' }
+      const roleB: Partial<Role> = { id: 'role-b' }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return null
+        return null
+      })
+      em.find.mockImplementation(async (entity: any) => {
+        if (entity === UserRole) return [{ role: roleA }, { role: roleB }]
+        if (entity === RoleAcl) return [
+          { role: roleA, featuresJson: ['feature.read'], organizationsJson: ['org-1'] },
+          { role: roleB, featuresJson: ['feature.export'], organizationsJson: ['org-2'] },
+        ]
+        return []
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['feature.read', 'feature.export'],
+        { tenantId: 'tenant-1' },
+      )
+
+      expect(access.unrestricted).toBe(false)
+      expect(access.filterOrganizationIds(organizations)).toEqual([])
+    })
+
+    it('keeps a per-user ACL exclusive and organization-scoped', async () => {
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return {
+          isSuperAdmin: false,
+          featuresJson: ['eudr.risk.view'],
+          organizationsJson: ['org-1'],
+        }
+        return null
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        { tenantId: 'tenant-1' },
+      )
+
+      expect(access.unrestricted).toBe(false)
+      expect(access.filterOrganizationIds(organizations)).toEqual(['org-1'])
+      expect(em.find).not.toHaveBeenCalledWith(
+        UserRole,
+        expect.objectContaining({ role: expect.anything() }),
+        expect.anything(),
+      )
+    })
+
+    it('keeps an empty-organization super-admin role globally authorized', async () => {
+      const role: Partial<Role> = { id: 'role-super' }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl) return null
+        return null
+      })
+      em.find.mockImplementation(async (entity: any) => {
+        if (entity === UserRole) return [{ role }]
+        if (entity === RoleAcl) return [{
+          role,
+          isSuperAdmin: true,
+          featuresJson: [],
+          organizationsJson: [],
+        }]
+        return []
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        { tenantId: 'tenant-1' },
+      )
+
+      expect(access.unrestricted).toBe(true)
+      expect(access.filterOrganizationIds(organizations)).toEqual(['org-1', 'org-2'])
+    })
+
+    it('preserves the existing cross-tenant global super-admin shortcut', async () => {
+      const globalSuperAcl = {
+        isSuperAdmin: true,
+        featuresJson: [],
+        organizationsJson: null,
+      }
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === UserAcl && where?.isSuperAdmin === true) return globalSuperAcl
+        return null
+      })
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        baseUser.id!,
+        ['eudr.risk.view'],
+        { tenantId: 'another-tenant' },
+      )
+
+      expect(access.unrestricted).toBe(true)
+      expect(access.filterOrganizationIds(organizations)).toEqual(['org-1', 'org-2'])
+    })
+
+    it('keeps an organization-bound API key inside its exact key scope', async () => {
+      const key: Partial<ApiKey> = {
+        id: 'key-org-bound',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        rolesJson: ['role-global'],
+        deletedAt: null,
+      }
+      em.findOne.mockImplementation(async (entity: any) => entity === ApiKey ? key : null)
+      em.find.mockImplementation(async (entity: any) => entity === RoleAcl ? [{
+        featuresJson: ['eudr.risk.view'],
+        organizationsJson: null,
+      }] : [])
+
+      const access = await service.resolveFeatureOrganizationAccess(
+        'api_key:key-org-bound',
+        ['eudr.risk.view'],
+        { tenantId: 'tenant-1' },
+      )
+
+      expect(access.unrestricted).toBe(false)
+      expect(access.filterOrganizationIds([
+        { id: 'org-1', ancestorIds: [] },
+        { id: 'org-1-child', ancestorIds: ['org-1'] },
+      ])).toEqual(['org-1'])
+    })
+  })
+
   describe('Cache behavior', () => {
     it('should cache ACL results and not query database on second call', async () => {
       em.findOne.mockImplementation(async (entity: any, where: any) => {

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -37,6 +37,120 @@ function isRestrictedRoleAcl(acl: Pick<RoleAcl, 'organizationsJson'>): boolean {
     && !acl.organizationsJson.includes('__all__')
 }
 
+type FeatureOrganizationCandidate = {
+  id: string
+  ancestorIds?: readonly string[] | null
+}
+
+type FeatureOrganizationAccess = {
+  unrestricted: boolean
+  filterOrganizationIds: (organizations: readonly FeatureOrganizationCandidate[]) => string[]
+}
+
+function normalizeFeatureOrganizationCandidates(
+  organizations: readonly FeatureOrganizationCandidate[],
+): FeatureOrganizationCandidate[] {
+  const normalized = new Map<string, FeatureOrganizationCandidate>()
+  for (const organization of organizations) {
+    const id = typeof organization.id === 'string' ? organization.id.trim() : ''
+    if (!id || normalized.has(id)) continue
+    const ancestorIds = Array.isArray(organization.ancestorIds)
+      ? Array.from(new Set(organization.ancestorIds
+        .map((ancestorId) => typeof ancestorId === 'string' ? ancestorId.trim() : '')
+        .filter(Boolean)))
+      : []
+    normalized.set(id, { id, ancestorIds })
+  }
+  return Array.from(normalized.values())
+}
+
+function buildFeatureOrganizationScope(
+  organization: FeatureOrganizationCandidate,
+): ReadonlySet<string> {
+  return new Set([organization.id, ...(organization.ancestorIds ?? [])])
+}
+
+function roleAclProvidesGlobalFeatureScope(acl: Pick<RoleAcl, 'organizationsJson'>): boolean {
+  const organizations = Array.isArray(acl.organizationsJson) ? acl.organizationsJson : null
+  return !organizations || organizations.length === 0 || organizations.includes('__all__')
+}
+
+function roleAclProvidesGlobalVisibility(
+  acl: Pick<RoleAcl, 'organizationsJson'>,
+  emptyOrganizationsAreUnrestricted: boolean,
+): boolean {
+  const organizations = Array.isArray(acl.organizationsJson) ? acl.organizationsJson : null
+  if (!organizations || organizations.includes('__all__')) return true
+  return emptyOrganizationsAreUnrestricted && organizations.length === 0
+}
+
+function roleAclProvidesOrganizationVisibility(
+  acl: Pick<RoleAcl, 'organizationsJson'>,
+  organizationScope: ReadonlySet<string>,
+  emptyOrganizationsAreUnrestricted: boolean,
+): boolean {
+  const organizations = Array.isArray(acl.organizationsJson) ? acl.organizationsJson : null
+  if (!organizations || organizations.includes('__all__')) return true
+  if (organizations.length === 0) return emptyOrganizationsAreUnrestricted
+  return organizations.some((organizationId) => organizationScope.has(organizationId))
+}
+
+function roleAclsAuthorizeFeatures(
+  roleAcls: readonly RoleAcl[],
+  required: readonly string[],
+  organization: FeatureOrganizationCandidate,
+  emptyOrganizationsAreUnrestricted: boolean,
+): boolean {
+  const organizationScope = buildFeatureOrganizationScope(organization)
+  const grantedFeatures = new Set<string>()
+  let unrestricted = false
+  let scopeAllowed = false
+
+  for (const acl of roleAcls) {
+    if (roleAclProvidesOrganizationVisibility(acl, organizationScope, emptyOrganizationsAreUnrestricted)) {
+      scopeAllowed = true
+    }
+    if (!roleAclAllowsOrganization(acl, organizationScope)) continue
+    unrestricted = unrestricted || acl.isSuperAdmin === true
+    for (const feature of Array.isArray(acl.featuresJson) ? acl.featuresJson : []) {
+      grantedFeatures.add(feature)
+    }
+  }
+
+  return authorizeFeatures([...required], {
+    grantedFeatures: Array.from(grantedFeatures),
+    unrestricted,
+    scopeAllowed: scopeAllowed || unrestricted,
+  })
+}
+
+function roleAclsAuthorizeFeaturesGlobally(
+  roleAcls: readonly RoleAcl[],
+  required: readonly string[],
+  emptyOrganizationsAreUnrestricted: boolean,
+): boolean {
+  const grantedFeatures = new Set<string>()
+  let unrestricted = false
+  let scopeAllowed = false
+
+  for (const acl of roleAcls) {
+    if (roleAclProvidesGlobalVisibility(acl, emptyOrganizationsAreUnrestricted)) {
+      scopeAllowed = true
+    }
+    if (!roleAclProvidesGlobalFeatureScope(acl)) continue
+    unrestricted = unrestricted || acl.isSuperAdmin === true
+    for (const feature of Array.isArray(acl.featuresJson) ? acl.featuresJson : []) {
+      grantedFeatures.add(feature)
+    }
+  }
+
+  return authorizeFeatures([...required], {
+    grantedFeatures: Array.from(grantedFeatures),
+    unrestricted,
+    scopeAllowed: scopeAllowed || unrestricted,
+  })
+}
+
 export class RbacService {
   private cacheTtlMs: number = 5 * 60 * 1000 // 5 minutes default
   private cache: CacheStrategy | null = null
@@ -513,6 +627,125 @@ export class RbacService {
       unrestricted: acl.isSuperAdmin,
       scopeAllowed: organizationAllowed,
     })
+  }
+
+  async resolveFeatureOrganizationAccess(
+    userId: string,
+    required: readonly string[],
+    input: { tenantId: string | null },
+  ): Promise<FeatureOrganizationAccess> {
+    const allowAll = (organizations: readonly FeatureOrganizationCandidate[]) =>
+      normalizeFeatureOrganizationCandidates(organizations).map((organization) => organization.id)
+    const denyAll = () => []
+    if (!required.length) return { unrestricted: true, filterOrganizationIds: allowAll }
+    if (!input.tenantId) return { unrestricted: false, filterOrganizationIds: denyAll }
+    if (
+      !userId.startsWith('api_key:')
+      && await this.isGlobalSuperAdmin(userId)
+      && authorizeFeatures(required, { grantedFeatures: ['*'], unrestricted: true })
+    ) {
+      return { unrestricted: true, filterOrganizationIds: allowAll }
+    }
+
+    const em = this.em.fork()
+    if (userId.startsWith('api_key:')) {
+      const apiKeyId = userId.slice('api_key:'.length)
+      const key = await em.findOne(ApiKey, { id: apiKeyId, deletedAt: null })
+      if (
+        !key
+        || (key.expiresAt && key.expiresAt.getTime() < Date.now())
+        || (key.tenantId && key.tenantId !== input.tenantId)
+      ) {
+        return { unrestricted: false, filterOrganizationIds: denyAll }
+      }
+
+      const roleIds = Array.isArray(key.rolesJson) ? key.rolesJson.filter(Boolean) : []
+      if (!roleIds.length) return { unrestricted: false, filterOrganizationIds: denyAll }
+      const roleAcls = await em.find(RoleAcl, {
+        tenantId: input.tenantId,
+        role: { $in: roleIds },
+      })
+      const keyOrganizationId = typeof key.organizationId === 'string' && key.organizationId.trim().length > 0
+        ? key.organizationId.trim()
+        : null
+      const unrestricted = keyOrganizationId === null
+        && roleAclsAuthorizeFeaturesGlobally(roleAcls, required, true)
+      if (unrestricted) return { unrestricted: true, filterOrganizationIds: allowAll }
+
+      return {
+        unrestricted: false,
+        filterOrganizationIds: (candidates) => normalizeFeatureOrganizationCandidates(candidates)
+          .filter((organization) => (
+            (!keyOrganizationId || organization.id === keyOrganizationId)
+            && roleAclsAuthorizeFeatures(roleAcls, required, organization, true)
+          ))
+          .map((organization) => organization.id),
+      }
+    }
+
+    const user = await em.findOne(User, { id: userId })
+    if (!user) return { unrestricted: false, filterOrganizationIds: denyAll }
+
+    const userAcl = await em.findOne(UserAcl, { user: userId, tenantId: input.tenantId })
+    if (userAcl) {
+      const grantedFeatures = Array.isArray(userAcl.featuresJson) ? userAcl.featuresJson : []
+      const allowedOrganizations = Array.isArray(userAcl.organizationsJson)
+        ? userAcl.organizationsJson
+        : null
+      const hasGlobalScope = userAcl.isSuperAdmin === true
+        || allowedOrganizations === null
+        || allowedOrganizations.includes('__all__')
+      const unrestricted = authorizeFeatures([...required], {
+        grantedFeatures,
+        unrestricted: userAcl.isSuperAdmin === true,
+        scopeAllowed: hasGlobalScope,
+      })
+      if (unrestricted) return { unrestricted: true, filterOrganizationIds: allowAll }
+
+      return {
+        unrestricted: false,
+        filterOrganizationIds: (candidates) => normalizeFeatureOrganizationCandidates(candidates)
+          .filter((organization) => {
+            const scopeAllowed = userAcl.isSuperAdmin === true
+              || allowedOrganizations === null
+              || allowedOrganizations.includes('__all__')
+              || allowedOrganizations.includes(organization.id)
+            return authorizeFeatures([...required], {
+              grantedFeatures,
+              unrestricted: userAcl.isSuperAdmin === true,
+              scopeAllowed,
+            })
+          })
+          .map((organization) => organization.id),
+      }
+    }
+
+    const links = await findWithDecryption(
+      em,
+      UserRole,
+      { user: userId, role: { tenantId: input.tenantId } },
+      { populate: ['role'] },
+      { tenantId: input.tenantId, organizationId: null },
+    )
+    const roleIds = Array.from(new Set(links
+      .map((link) => link.role?.id)
+      .filter((roleId): roleId is string => typeof roleId === 'string' && roleId.length > 0)))
+    if (!roleIds.length) return { unrestricted: false, filterOrganizationIds: denyAll }
+
+    const roleAcls = await em.find(RoleAcl, {
+      tenantId: input.tenantId,
+      role: { $in: roleIds },
+    })
+    if (roleAclsAuthorizeFeaturesGlobally(roleAcls, required, false)) {
+      return { unrestricted: true, filterOrganizationIds: allowAll }
+    }
+
+    return {
+      unrestricted: false,
+      filterOrganizationIds: (candidates) => normalizeFeatureOrganizationCandidates(candidates)
+        .filter((organization) => roleAclsAuthorizeFeatures(roleAcls, required, organization, false))
+        .map((organization) => organization.id),
+    }
   }
 
   /**

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -5,7 +5,11 @@ import type { AwilixContainer } from 'awilix'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import { ALL_ORGANIZATIONS_COOKIE_VALUE } from '@open-mercato/core/modules/directory/constants'
-import { resolveOrganizationScope, resolveOrganizationScopeForRequest } from '../organizationScope'
+import {
+  resolveFeatureCheckContext,
+  resolveOrganizationScope,
+  resolveOrganizationScopeForRequest,
+} from '../organizationScope'
 
 /**
  * Creates a mock EntityManager whose `find` returns Organization-like rows
@@ -14,9 +18,9 @@ import { resolveOrganizationScope, resolveOrganizationScopeForRequest } from '..
 function createMockEm(rows: Array<{ id: string; descendantIds: string[] }>) {
   return {
     find: jest.fn((_entity: unknown, filter: { id?: { $in: string[] }; tenant?: string }) => {
-      const requestedIds = filter?.id?.$in ?? []
+      const requestedIds = filter?.id?.$in
       return Promise.resolve(
-        rows.filter((row) => requestedIds.includes(row.id)),
+        requestedIds ? rows.filter((row) => requestedIds.includes(row.id)) : rows,
       )
     }),
   } as unknown as EntityManager
@@ -457,5 +461,154 @@ describe('resolveOrganizationScopeForRequest', () => {
       allowedIds: null,
       tenantId: 'target-tenant',
     })
+  })
+})
+
+describe('resolveFeatureCheckContext', () => {
+  it('binds a feature-authorized organization subset to an all-organizations request', async () => {
+    const em = createMockEm(ALL_ORGS)
+    const rbac = {
+      loadAcl: jest.fn(async () => ({
+        isSuperAdmin: false,
+        features: ['eudr.statements.view', 'eudr.risk.view'],
+        organizations: null,
+      })),
+      resolveFeatureOrganizationAccess: jest.fn(async () => ({
+        unrestricted: false,
+        filterOrganizationIds: () => ['org-a'],
+      })),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbac
+        throw new Error(`Unexpected dependency: ${name}`)
+      },
+    } as unknown as AwilixContainer
+    const auth = createAuth({ sub: 'user-1' })
+    const request = {
+      headers: {
+        get: (name: string) => name === 'cookie'
+          ? `om_selected_org=${ALL_ORGANIZATIONS_COOKIE_VALUE}`
+          : null,
+      },
+    }
+
+    const featureContext = await resolveFeatureCheckContext({
+      container,
+      auth,
+      request,
+      requiredFeatures: ['eudr.risk.view'],
+    })
+
+    expect(rbac.resolveFeatureOrganizationAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['eudr.risk.view'],
+      { tenantId: 'tenant-1' },
+    )
+    expect((em.find as jest.Mock).mock.calls[1]?.[1]).toMatchObject({ tenant: 'tenant-1', deletedAt: null })
+    expect(featureContext.organizationId).toBe('org-a')
+    expect(featureContext.allowedOrganizationIds).toEqual(['org-a'])
+    expect(featureContext.scope).toEqual({
+      selectedId: null,
+      filterIds: ['org-a'],
+      allowedIds: ['org-a'],
+      tenantId: 'tenant-1',
+    })
+
+    const handlerScope = await resolveOrganizationScopeForRequest({ container, auth, request })
+    expect(handlerScope).toEqual(featureContext.scope)
+
+    const otherRequestScope = await resolveOrganizationScopeForRequest({
+      container,
+      auth,
+      request: {
+        headers: request.headers,
+      },
+    })
+    expect(otherRequestScope.filterIds).toBeNull()
+    expect(otherRequestScope.allowedIds).toBeNull()
+  })
+
+  it('does not enumerate organizations when feature access is unrestricted', async () => {
+    const em = createMockEm(ALL_ORGS)
+    const rbac = {
+      loadAcl: jest.fn(async () => ({
+        isSuperAdmin: false,
+        features: ['eudr.risk.view'],
+        organizations: null,
+      })),
+      resolveFeatureOrganizationAccess: jest.fn(async () => ({
+        unrestricted: true,
+        filterOrganizationIds: () => [],
+      })),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbac
+        throw new Error(`Unexpected dependency: ${name}`)
+      },
+    } as unknown as AwilixContainer
+    const auth = createAuth({ sub: 'user-global' })
+    const request = {
+      headers: {
+        get: (name: string) => name === 'cookie'
+          ? `om_selected_org=${ALL_ORGANIZATIONS_COOKIE_VALUE}`
+          : null,
+      },
+    }
+
+    const featureContext = await resolveFeatureCheckContext({
+      container,
+      auth,
+      request,
+      requiredFeatures: ['eudr.risk.view'],
+    })
+
+    expect(featureContext.scope.filterIds).toBeNull()
+    expect(featureContext.scope.allowedIds).toBeNull()
+    expect(em.find).toHaveBeenCalledTimes(1)
+  })
+
+  it('still narrows an authenticated super-admin flag when RBAC proves only restricted access', async () => {
+    const em = createMockEm(ALL_ORGS)
+    const rbac = {
+      loadAcl: jest.fn(async () => ({
+        isSuperAdmin: true,
+        features: ['*'],
+        organizations: null,
+      })),
+      resolveFeatureOrganizationAccess: jest.fn(async () => ({
+        unrestricted: false,
+        filterOrganizationIds: () => ['org-a'],
+      })),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbac
+        throw new Error(`Unexpected dependency: ${name}`)
+      },
+    } as unknown as AwilixContainer
+
+    const featureContext = await resolveFeatureCheckContext({
+      container,
+      auth: createAuth({ sub: 'super-user', isSuperAdmin: true }),
+      request: {
+        headers: {
+          get: () => `om_selected_org=${ALL_ORGANIZATIONS_COOKIE_VALUE}`,
+        },
+      },
+      requiredFeatures: ['eudr.risk.view'],
+    })
+
+    expect(featureContext.scope.filterIds).toEqual(['org-a'])
+    expect(featureContext.scope.allowedIds).toEqual(['org-a'])
+    expect(rbac.resolveFeatureOrganizationAccess).toHaveBeenCalledWith(
+      'super-user',
+      ['eudr.risk.view'],
+      { tenantId: 'tenant-1' },
+    )
   })
 })

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -571,6 +571,52 @@ describe('resolveFeatureCheckContext', () => {
     expect(em.find).toHaveBeenCalledTimes(1)
   })
 
+  it('binds an empty scope when the feature is authorized in no visible organization', async () => {
+    const em = createMockEm(ALL_ORGS)
+    const rbac = {
+      loadAcl: jest.fn(async () => ({
+        isSuperAdmin: false,
+        features: ['api_keys.view'],
+        organizations: [],
+      })),
+      resolveFeatureOrganizationAccess: jest.fn(async () => ({
+        unrestricted: false,
+        filterOrganizationIds: () => [],
+      })),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbac
+        throw new Error(`Unexpected dependency: ${name}`)
+      },
+    } as unknown as AwilixContainer
+    const auth = createAuth({ sub: 'user-empty-scope', orgId: null })
+    const request = {
+      headers: {
+        get: () => null,
+      },
+    }
+
+    const featureContext = await resolveFeatureCheckContext({
+      container,
+      auth,
+      request,
+      requiredFeatures: ['api_keys.view'],
+    })
+
+    expect(featureContext.organizationId).toBeNull()
+    expect(featureContext.allowedOrganizationIds).toEqual([])
+    expect(featureContext.scope).toEqual({
+      selectedId: null,
+      filterIds: [],
+      allowedIds: [],
+      tenantId: 'tenant-1',
+    })
+    await expect(resolveOrganizationScopeForRequest({ container, auth, request }))
+      .resolves.toEqual(featureContext.scope)
+  })
+
   it('still narrows an authenticated super-admin flag when RBAC proves only restricted access', async () => {
     const em = createMockEm(ALL_ORGS)
     const rbac = {

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -134,6 +134,7 @@ export async function invalidateOrganizationScopeCacheForTenant(
 // staleness risk: the memo lives only for the lifetime of one request and is
 // dropped with the request object by the GC.
 const orgScopeRequestMemo = new WeakMap<object, Map<string, Promise<OrganizationScope>>>()
+const featureScopeRequestMemo = new WeakMap<object, { userId: string; scope: OrganizationScope }>()
 
 function getRequestScopeMemo(request: unknown): Map<string, Promise<OrganizationScope>> | null {
   if (!request || (typeof request !== 'object' && typeof request !== 'function')) return null
@@ -144,6 +145,24 @@ function getRequestScopeMemo(request: unknown): Map<string, Promise<Organization
     orgScopeRequestMemo.set(key, memo)
   }
   return memo
+}
+
+function bindFeatureScopeToRequest(
+  request: unknown,
+  userId: string,
+  scope: OrganizationScope,
+): void {
+  if (!request || (typeof request !== 'object' && typeof request !== 'function')) return
+  featureScopeRequestMemo.set(request as object, { userId, scope })
+}
+
+function getFeatureScopeForRequest(
+  request: unknown,
+  userId: string,
+): OrganizationScope | null {
+  if (!request || (typeof request !== 'object' && typeof request !== 'function')) return null
+  const entry = featureScopeRequestMemo.get(request as object)
+  return entry?.userId === userId ? entry.scope : null
 }
 
 function normalizeOrganizationId(value: unknown): string | null {
@@ -402,6 +421,11 @@ export async function resolveOrganizationScopeForRequest({
     return { selectedId: null, filterIds: null, allowedIds: null, tenantId: null }
   }
 
+  if (selectedId === undefined && tenantOverride === undefined) {
+    const featureScope = getFeatureScopeForRequest(request, auth.sub)
+    if (featureScope) return featureScope
+  }
+
   let em: EntityManager | null = null
   let rbac: RbacService | null = null
   try { em = container.resolve<EntityManager>('em') } catch { em = null }
@@ -532,14 +556,64 @@ export async function resolveFeatureCheckContext({
   request,
   selectedId,
   tenantId,
+  requiredFeatures,
 }: {
   container: AwilixContainer
   auth: AuthContext | null | undefined
-  request?: Request | { cookies?: { get: (name: string) => { value: string } | undefined } }
+  request?: Request | {
+    cookies?: { get: (name: string) => { value: string } | undefined }
+    headers?: { get(name: string): string | null }
+  }
   selectedId?: string | null
   tenantId?: string | null
+  requiredFeatures?: readonly string[]
 }): Promise<FeatureCheckContext> {
-  const scope = await resolveOrganizationScopeForRequest({ container, auth, request, selectedId, tenantId })
+  let scope = await resolveOrganizationScopeForRequest({ container, auth, request, selectedId, tenantId })
+  if (
+    auth?.sub
+    && request
+    && scope.selectedId === null
+    && scope.tenantId
+    && Array.isArray(requiredFeatures)
+    && requiredFeatures.length > 0
+  ) {
+    const em = container.resolve<EntityManager>('em')
+    const rbac = container.resolve<RbacService>('rbacService')
+    const featureAccess = await rbac.resolveFeatureOrganizationAccess(
+      auth.sub,
+      requiredFeatures,
+      { tenantId: scope.tenantId },
+    )
+    if (!featureAccess.unrestricted) {
+      const organizationFilter: FilterQuery<Organization> = {
+        tenant: scope.tenantId,
+        deletedAt: null,
+        ...(Array.isArray(scope.filterIds) ? { id: { $in: scope.filterIds } } : {}),
+      }
+      const organizations = await em.find(Organization, organizationFilter, {
+        fields: ['id', 'ancestorIds'],
+      })
+      const candidateOrganizationIds = new Set(
+        organizations.map((organization) => String(organization.id)),
+      )
+      const featureOrganizationIds = featureAccess.filterOrganizationIds(
+        organizations.map((organization) => ({
+          id: String(organization.id),
+          ancestorIds: Array.isArray(organization.ancestorIds) ? organization.ancestorIds : [],
+        })),
+      )
+      const approvedOrganizationIds = Array.from(new Set(
+        featureOrganizationIds.filter((organizationId) => candidateOrganizationIds.has(organizationId)),
+      ))
+      scope = {
+        selectedId: null,
+        filterIds: approvedOrganizationIds,
+        allowedIds: approvedOrganizationIds,
+        tenantId: scope.tenantId,
+      }
+    }
+    bindFeatureScopeToRequest(request, auth.sub, scope)
+  }
   const allowedOrganizationIds = scope.allowedIds ?? null
   const authOrgId = auth?.orgId ?? null
   const organizationId =

--- a/packages/core/src/modules/eudr/__integration__/TC-EUDR-018.spec.ts
+++ b/packages/core/src/modules/eudr/__integration__/TC-EUDR-018.spec.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  apiRequestWithSelectedOrg,
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { expectId, getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+export const integrationMeta = {
+  dependsOnModules: ['eudr'],
+}
+
+const STATEMENTS_PATH = '/api/eudr/statements'
+const RISK_PATH = '/api/eudr/risk-assessments'
+const ALL_ORGANIZATIONS = '__all__'
+
+type RiskListResponse = {
+  items?: Array<{
+    criteria?: Record<string, { note?: string | null }>
+  }>
+}
+
+async function createStatement(
+  request: APIRequestContext,
+  token: string,
+  organizationId: string,
+  title: string,
+): Promise<string> {
+  const response = await apiRequestWithSelectedOrg(request, 'POST', STATEMENTS_PATH, {
+    token,
+    selectedOrgId: organizationId,
+    data: { title, commodity: 'coffee', actorRole: 'operator' },
+  })
+  expect(response.status(), `statement fixture failed: ${response.status()}`).toBe(201)
+  return expectId((await readJsonSafe<{ id?: string }>(response))?.id, 'statement fixture id')
+}
+
+async function createRiskAssessment(
+  request: APIRequestContext,
+  token: string,
+  organizationId: string,
+  statementId: string,
+  marker: string,
+): Promise<string> {
+  const response = await apiRequestWithSelectedOrg(request, 'POST', RISK_PATH, {
+    token,
+    selectedOrgId: organizationId,
+    data: {
+      statementId,
+      criteria: { land_title_permits: { answer: 'no_concern', note: marker } },
+      conclusion: 'negligible',
+    },
+  })
+  expect(response.status(), `risk fixture failed: ${response.status()}`).toBe(201)
+  return expectId((await readJsonSafe<{ id?: string }>(response))?.id, 'risk fixture id')
+}
+
+async function deleteScopedRecord(
+  request: APIRequestContext,
+  token: string,
+  organizationId: string,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!id) return
+  await apiRequestWithSelectedOrg(request, 'DELETE', `${path}?id=${encodeURIComponent(id)}`, {
+    token,
+    selectedOrgId: organizationId,
+  }).catch(() => undefined)
+}
+
+function containsMarker(body: RiskListResponse | null, marker: string): boolean {
+  return (body?.items ?? []).some((item) => (
+    Object.values(item.criteria ?? {}).some((criterion) => criterion.note === marker)
+  ))
+}
+
+test.describe('TC-EUDR-018: all-organization feature scope', () => {
+  test('never exposes risk assessments from organizations lacking eudr.risk.view', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const { organizationId: homeOrganizationId, tenantId } = getTokenContext(superadminToken)
+    const stamp = randomUUID().slice(0, 8)
+    const password = 'StrongSecret123!'
+    const scopedEmail = `qa-eudr-018-scoped-${stamp}@example.com`
+    const noRiskEmail = `qa-eudr-018-none-${stamp}@example.com`
+    const homeMarker = `TC-EUDR-018-HOME-${stamp}`
+    const victimMarker = `TC-EUDR-018-VICTIM-${stamp}`
+    let victimOrganizationId: string | null = null
+    let statementsRoleId: string | null = null
+    let riskRoleId: string | null = null
+    let scopedUserId: string | null = null
+    let noRiskUserId: string | null = null
+    let homeStatementId: string | null = null
+    let victimStatementId: string | null = null
+    let homeRiskId: string | null = null
+    let victimRiskId: string | null = null
+
+    try {
+      victimOrganizationId = await createOrganizationFixture(request, superadminToken, {
+        name: `QA TC-EUDR-018 Victim ${stamp}`,
+        tenantId,
+      })
+      statementsRoleId = await createRoleFixture(request, superadminToken, {
+        name: `qa-eudr-018-statements-${stamp}`,
+        tenantId,
+      })
+      riskRoleId = await createRoleFixture(request, superadminToken, {
+        name: `qa-eudr-018-risk-${stamp}`,
+        tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: statementsRoleId,
+        features: ['eudr.statements.view'],
+        organizations: null,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: riskRoleId,
+        features: ['eudr.risk.view'],
+        organizations: [homeOrganizationId],
+      })
+      scopedUserId = await createUserFixture(request, superadminToken, {
+        email: scopedEmail,
+        password,
+        organizationId: homeOrganizationId,
+        roles: [statementsRoleId, riskRoleId],
+        name: 'QA TC-EUDR-018 Scoped',
+      })
+      noRiskUserId = await createUserFixture(request, superadminToken, {
+        email: noRiskEmail,
+        password,
+        organizationId: homeOrganizationId,
+        roles: [statementsRoleId],
+        name: 'QA TC-EUDR-018 No Risk',
+      })
+
+      homeStatementId = await createStatement(
+        request,
+        superadminToken,
+        homeOrganizationId,
+        `TC-EUDR-018 Home ${stamp}`,
+      )
+      victimStatementId = await createStatement(
+        request,
+        superadminToken,
+        victimOrganizationId,
+        `TC-EUDR-018 Victim ${stamp}`,
+      )
+      homeRiskId = await createRiskAssessment(
+        request,
+        superadminToken,
+        homeOrganizationId,
+        homeStatementId,
+        homeMarker,
+      )
+      victimRiskId = await createRiskAssessment(
+        request,
+        superadminToken,
+        victimOrganizationId,
+        victimStatementId,
+        victimMarker,
+      )
+
+      const scopedToken = await getAuthToken(request, scopedEmail, password)
+      const homeResponse = await apiRequestWithSelectedOrg(request, 'GET', `${RISK_PATH}?pageSize=100`, {
+        token: scopedToken,
+        selectedOrgId: homeOrganizationId,
+      })
+      expect(homeResponse.status(), 'explicit authorized organization should succeed').toBe(200)
+      expect(containsMarker(await readJsonSafe<RiskListResponse>(homeResponse), homeMarker)).toBe(true)
+
+      const victimResponse = await apiRequestWithSelectedOrg(request, 'GET', `${RISK_PATH}?pageSize=100`, {
+        token: scopedToken,
+        selectedOrgId: victimOrganizationId,
+      })
+      expect(victimResponse.status(), 'explicit unauthorized organization should be rejected').toBe(403)
+
+      const allResponse = await apiRequestWithSelectedOrg(request, 'GET', `${RISK_PATH}?pageSize=100`, {
+        token: scopedToken,
+        selectedOrgId: ALL_ORGANIZATIONS,
+      })
+      expect(allResponse.status(), 'all-organizations request should retain authorized records').toBe(200)
+      const allBody = await readJsonSafe<RiskListResponse>(allResponse)
+      expect(containsMarker(allBody, homeMarker), 'authorized organization marker should remain visible').toBe(true)
+      expect(containsMarker(allBody, victimMarker), 'victim organization marker must not cross the feature boundary').toBe(false)
+
+      const noRiskToken = await getAuthToken(request, noRiskEmail, password)
+      const emptyScopeResponse = await apiRequestWithSelectedOrg(request, 'GET', `${RISK_PATH}?pageSize=100`, {
+        token: noRiskToken,
+        selectedOrgId: ALL_ORGANIZATIONS,
+      })
+      expect(emptyScopeResponse.status(), 'an empty authorized organization set must fail closed').toBe(403)
+
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId: statementsRoleId,
+        features: ['eudr.statements.view', 'eudr.risk.view'],
+        organizations: null,
+      })
+      const globalResponse = await apiRequestWithSelectedOrg(request, 'GET', `${RISK_PATH}?pageSize=100`, {
+        token: noRiskToken,
+        selectedOrgId: ALL_ORGANIZATIONS,
+      })
+      expect(globalResponse.status(), 'a legitimate global feature grant should remain tenant-wide').toBe(200)
+      const globalBody = await readJsonSafe<RiskListResponse>(globalResponse)
+      expect(containsMarker(globalBody, homeMarker)).toBe(true)
+      expect(containsMarker(globalBody, victimMarker)).toBe(true)
+    } finally {
+      if (victimOrganizationId) {
+        await deleteScopedRecord(request, superadminToken, victimOrganizationId, RISK_PATH, victimRiskId)
+        await deleteScopedRecord(request, superadminToken, victimOrganizationId, STATEMENTS_PATH, victimStatementId)
+      }
+      await deleteScopedRecord(request, superadminToken, homeOrganizationId, RISK_PATH, homeRiskId)
+      await deleteScopedRecord(request, superadminToken, homeOrganizationId, STATEMENTS_PATH, homeStatementId)
+      await deleteUserIfExists(request, superadminToken, noRiskUserId)
+      await deleteUserIfExists(request, superadminToken, scopedUserId)
+      await deleteRoleIfExists(request, superadminToken, riskRoleId)
+      await deleteRoleIfExists(request, superadminToken, statementsRoleId)
+      await deleteOrganizationIfExists(request, superadminToken, victimOrganizationId)
+    }
+  })
+})

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -211,12 +211,20 @@ export async function checkAuthorization(
     }
     const featureContainer = await ensureContainer()
     const rbac = featureContainer.resolve<RbacService>('rbacService')
-    const featureContext = await resolveFeatureCheckContext({ container: featureContainer, auth, request: req })
-    const { organizationId } = featureContext
-    const ok = await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
-      tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
-      organizationId,
+    const featureContext = await resolveFeatureCheckContext({
+      container: featureContainer,
+      auth,
+      request: req,
+      requiredFeatures,
     })
+    const { organizationId } = featureContext
+    const ok = Array.isArray(featureContext.allowedOrganizationIds)
+      && featureContext.allowedOrganizationIds.length === 0
+      ? false
+      : await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+          tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
+          organizationId,
+        })
     if (!ok) {
       try {
         const acl = await rbac.loadAcl(auth.sub, { tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null, organizationId })

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -218,13 +218,10 @@ export async function checkAuthorization(
       requiredFeatures,
     })
     const { organizationId } = featureContext
-    const ok = Array.isArray(featureContext.allowedOrganizationIds)
-      && featureContext.allowedOrganizationIds.length === 0
-      ? false
-      : await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
-          tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
-          organizationId,
-        })
+    const ok = await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+      tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
+      organizationId,
+    })
     if (!ok) {
       try {
         const acl = await rbac.loadAcl(auth.sub, { tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null, organizationId })


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-29-fix-all-organization-feature-scope.md
Status: ready-for-review

## Summary

Prevents organization-scoped feature authorization from being evaluated against one organization while an “All Organizations” CRUD request reads records from a broader set. All-organization requests are now narrowed to organizations where the principal holds every required feature, while legitimate tenant-wide grants retain their existing behavior.

## Goal

Ensure feature-gated multi-organization requests can return data only from organizations for which the caller's required permissions have been proven.

## Problem and root cause

The route dispatcher authorized required features against a scalar organization context. For the all-organization selection, that context fell back to the user's home organization. The shared CRUD layer independently interpreted the same request as tenant-wide, allowing the authorization scope and data-query scope to diverge.

## Changes

- derive feature access per organization for staff users, API keys, hierarchy grants, user ACLs, and global or organization-restricted roles
- bind the authorized organization intersection to the request before the route handler resolves CRUD scope
- preserve authenticated empty-scope reads while binding them to a fail-closed empty organization set
- preserve tenant-wide behavior for genuine global feature grants and global super administrators
- mirror the dispatcher change in the standalone app template
- add unit coverage and a self-contained EUDR integration regression

## What changed

- `RbacService.resolveFeatureOrganizationAccess` evaluates all required features against each candidate organization with wildcard, disabled-feature, hierarchy, API-key, and super-admin semantics preserved.
- `resolveFeatureCheckContext` intersects all-organization requests with the proven feature scope and stores that narrowed scope only for the current request.
- The dispatcher distinguishes feature possession from organization visibility: an authorized empty set enters the handler with a request-bound empty scope, so lists stay empty and detail reads stay non-enumerating without weakening the 403 for missing features.
- `TC-EUDR-018` covers an authorized home organization, a forbidden second organization, safe all-organization filtering, an empty authorized set, and a legitimate global grant.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**

- `.ai/specs/2026-07-06-eudr-compliance-module.md`
- `.ai/specs/2026-07-23-consolidated-feature-policy.md`

No specification change is required: this fix restores the documented organization-scoped authorization and CRUD scoping guarantees.

## Testing

- Docker-backed `TC-EUDR-018`, `TC-APIKEY-007`, and `TC-CRM-072` — passed the security regression, authorized-empty-list, and non-enumerating-detail scenarios.
- Docker-backed EUDR integration family — 32/32 tests passed.
- Focused RBAC, organization-scope, and dispatcher Jest suites passed; the post-CI correction added explicit empty-scope and missing-feature coverage.
- App and standalone template dispatcher files are byte-identical.

## Validation

- `yarn build:packages` — passed before generation.
- `yarn generate` — passed; the existing Node 24 OpenAPI bundler fallback warning remained non-fatal.
- `yarn build:packages` — passed after generation.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — passed with the repository's existing advisory unused-key report.
- `yarn typecheck` — passed, 27/27 tasks.
- `yarn test` — passed, 34/34 tasks, using the bundled self-contained Node runtime required by the macOS nested-sandbox tests.
- `yarn build:app` — passed.
- `yarn lint` — passed with 0 errors and 10 pre-existing warnings in unrelated files.
- `yarn template:sync` — reported the existing unrelated `modules.ts` mismatch; direct parity verification for the changed dispatcher file passed.
- `git diff --check` — passed.

## Automated review

- `om-code-review` — approve; the final diff has no blocker, major, minor, or nit findings after the full validation gate.
- Fresh independent review — a focused security-design review confirmed the authorization/query-scope mismatch is closed, empty scopes fail closed, global grants remain functional, and narrowing is request-local.
- Unresolved findings — None.

## Breaking changes

None. No API URL, HTTP method, response shape, database schema, ACL feature ID, import path, or existing required function signature changes. The only denied behavior was access outside the caller's proven organization feature scope.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

The integration regression is module-local under `packages/core/src/modules/eudr/__integration__/` because the EUDR specification defines module-local Playwright coverage. No new generated, locale, or documentation artifact was required.

### Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

No UI-rendering files changed, so the design-system items are not applicable to the diff.

## Labels and delivery

- `review` — The implementation and regression coverage are complete and ready for maintainer review.
- `security` — The change closes an organization-scoped authorization/data-query mismatch.
- `skip-qa` — There is no manually exercisable UI, database, or API-contract change; unit and Docker-backed integration tests cover the affected authorization boundary.
- `priority-high` — Tenant-scope authorization fixes are security-sensitive and should land promptly.
- `risk-high` — The change touches shared route authorization and RBAC scope resolution, so a regression could affect multiple guarded modules.

## Manual QA

Manual UI QA is not applicable. The Docker-backed API integration test exercises the authorized, forbidden, narrowed all-organization, empty-scope, and global-grant paths against a real application and database.

## Linked issues

No public issue. This change addresses a privately submitted security report.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790625580&installation_model_id=432243&pr_number=5778&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5778&signature=3bc2de70c8fc2d1613f0040d45aa5896e13a505aa2bc09ea398edf503c9dd1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->