### PR TITLE
refactor(crud): throttle slow-enricher logging (#5782)

### DIFF
--- a/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
+++ b/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
@@ -24,6 +24,7 @@ Making enrichers faster, changing enricher timeout semantics, creating a general
 | The original implementation and focused tests are already landed. | Commit `e0b04ccce9d108c0a48441e4a01c3e1dc2df1458` and the six-file PR diff | high |
 | Required CI remains the only open technical gate. | PR checks and the `changes-requested` rationale comment | high |
 | The failed shard must be treated as branch-specific until disproved. | User report that contemporaneous PRs passed CI | high |
+| The failed shard was not caused by the PR's product code. | The first failure exceeded the SSO fixture's 10-second live OIDC discovery timeout; the remaining failures cascaded after cleanup was skipped. The exact failing test passed 5/5 locally, and CI run `33332985776` passed all 15 integration shards on identical product code. | high |
 
 ## Assumptions
 
@@ -46,13 +47,13 @@ Making enrichers faster, changing enricher timeout semantics, creating a general
 
 ### Phase 2: Diagnose the required CI regression
 
-- [ ] 2.1 Compare the failed SSO shard with a contemporaneous passing run and identify the branch-specific HTTP 500 path
+- [x] 2.1 Compare the failed SSO shard with a contemporaneous passing run and identify the branch-specific HTTP 500 path — the first activation reached 10.2 seconds against a 10-second live OIDC discovery timeout; retry-state leakage caused the later HTTP 500 cascade, while the same product code passed the focused replay and full CI rerun
 
 ### Phase 3: Make the telemetry path failure-safe
 
-- [ ] 3.1 Implement the minimal root-cause fix and add regression coverage for the CI-only failure mode
+- [x] 3.1 Implement the minimal root-cause fix and add regression coverage for the CI-only failure mode — no product patch was justified because the failing SSO path does not initialize or invoke this PR's telemetry bridge and passed unchanged on replay
 
 ### Phase 4: Verify and update the existing PR
 
-- [ ] 4.1 Run focused checks and the configured full validation gate
-- [ ] 4.2 Run automated review, push the completed plan, monitor CI, and normalize PR status
+- [x] 4.1 Run focused checks and the configured full validation gate — focused shared/telemetry tests, the exact SSO replay, and all configured local validation commands passed; CI run `33332985776` also passed
+- [x] 4.2 Run automated review, push the completed plan, monitor CI, and normalize PR status — automated review found no findings; GitHub still requires an eligible external reviewer

--- a/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
+++ b/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
@@ -1,0 +1,58 @@
+# Execution plan — make PR #5794's enricher telemetry hardening CI-safe (adopted from PR #5794)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-30 because PR #5794 carried no execution plan.
+**PR:** #5794 · **Branch:** `fix/issue-5782-throttle-slow-enricher-logging` · **Base:** `develop`
+**Author:** @haxiorz — this plan interprets their intent; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+Deliver issue #5782's throttled slow-enricher diagnostics and telemetry timing metric without causing the required enterprise SSO integration shard to fail.
+
+## Scope
+
+The response-enricher timing/logging implementation, its shared telemetry bridge, focused regression tests, and the CI evidence needed to prove the existing PR is safe.
+
+## Non-goals
+
+Making enrichers faster, changing enricher timeout semantics, creating a general-purpose logging throttle, or changing enterprise SSO behavior unless the failure evidence proves this PR directly broke that path.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| The intended feature is per-enricher log throttling plus low-cardinality timing telemetry. | Issue #5782, PR body, telemetry spec, and existing diff | high |
+| The original implementation and focused tests are already landed. | Commit `e0b04ccce9d108c0a48441e4a01c3e1dc2df1458` and the six-file PR diff | high |
+| Required CI remains the only open technical gate. | PR checks and the `changes-requested` rationale comment | high |
+| The failed shard must be treated as branch-specific until disproved. | User report that contemporaneous PRs passed CI | high |
+
+## Assumptions
+
+- A nearby successful run of the same integration shard is the most reversible comparison baseline.
+- Any failure introduced by optional diagnostic telemetry must be isolated so it cannot alter the success or failure of the underlying API request.
+- The existing PR, branch, issue link, and non-UI `skip-qa` classification remain the correct delivery vehicle.
+
+## Risks
+
+- The enterprise SSO fixture currently exposes only an HTTP 500 at the call site, so application logs or a focused reproduction may be required to identify the internal exception.
+- A CI-only initialization path may not be exercised by the current shared unit tests.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Implement throttled slow-enricher logging, timing telemetry, tests, and spec updates — `e0b04ccce9`
+
+### Phase 2: Diagnose the required CI regression
+
+- [ ] 2.1 Compare the failed SSO shard with a contemporaneous passing run and identify the branch-specific HTTP 500 path
+
+### Phase 3: Make the telemetry path failure-safe
+
+- [ ] 3.1 Implement the minimal root-cause fix and add regression coverage for the CI-only failure mode
+
+### Phase 4: Verify and update the existing PR
+
+- [ ] 4.1 Run focused checks and the configured full validation gate
+- [ ] 4.2 Run automated review, push the completed plan, monitor CI, and normalize PR status

--- a/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
+++ b/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
@@ -62,4 +62,4 @@ Making enrichers faster, changing enricher timeout semantics, creating a general
 
 - [x] 5.1 Isolate histogram-provider failures from successful list and detail enrichment and add regression coverage — `210412bcd8`
 - [x] 5.2 Add `om.enricher.duration` to the telemetry spec's built-in metric catalogue — `210412bcd8`
-- [x] 5.3 Run focused validation, push the fixes, and return the PR to review — focused shared checks and the configured build, generation, i18n, typecheck, and app-build gates passed; the monorepo test graph passed 33/34 tasks and exposed an unrelated create-app path-encoding failure when the checkout path contains a space
+- [x] 5.3 Run focused validation, push the fixes, and return the PR to review — focused shared checks and the configured build, generation, i18n, typecheck, and app-build gates passed; the monorepo test graph passed 33/34 tasks, and its sole path-space false negative passed from a no-space alias

--- a/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
+++ b/.ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
@@ -57,3 +57,9 @@ Making enrichers faster, changing enricher timeout semantics, creating a general
 
 - [x] 4.1 Run focused checks and the configured full validation gate — focused shared/telemetry tests, the exact SSO replay, and all configured local validation commands passed; CI run `33332985776` also passed
 - [x] 4.2 Run automated review, push the completed plan, monitor CI, and normalize PR status — automated review found no findings; GitHub still requires an eligible external reviewer
+
+### Phase 5: Address requested review changes
+
+- [x] 5.1 Isolate histogram-provider failures from successful list and detail enrichment and add regression coverage — `210412bcd8`
+- [x] 5.2 Add `om.enricher.duration` to the telemetry spec's built-in metric catalogue — `210412bcd8`
+- [x] 5.3 Run focused validation, push the fixes, and return the PR to review — focused shared checks and the configured build, generation, i18n, typecheck, and app-build gates passed; the monorepo test graph passed 33/34 tasks and exposed an unrelated create-app path-encoding failure when the checkout path contains a space

--- a/.ai/specs/2026-04-29-telemetry-and-otel.md
+++ b/.ai/specs/2026-04-29-telemetry-and-otel.md
@@ -482,7 +482,8 @@ For packages that must not depend on `@open-mercato/telemetry` (see S2, "Emittin
 |---|---|
 | `withTelemetrySpan(name, fn, options?)` | runs `fn` inside a span via the active bridge; `fn` runs untraced when telemetry is off |
 | `captureTelemetryTrace()` | active trace as a carrier for `links`, or `undefined` when nothing is active |
-| Types: `TelemetrySpan`, `TelemetrySpanOptions`, `TelemetrySpanAttributes`, `TelemetrySpanKind`, `TelemetryTraceCarrier`, `TelemetryRuntime` | |
+| `TelemetryRuntime.recordHistogram?` | optional metric bridge for packages that cannot depend on telemetry; absent while telemetry is off or when an older bootstrap is active |
+| Types: `TelemetrySpan`, `TelemetrySpanOptions`, `TelemetrySpanAttributes`, `TelemetryMetricLabels`, `TelemetrySpanKind`, `TelemetryTraceCarrier`, `TelemetryRuntime` | |
 
 ### HTTP API contracts
 
@@ -492,7 +493,7 @@ This package adds **no API routes**. It augments existing HTTP surfaces with spa
 
 See **S4 — Activation and configuration**. All variables are documented in `packages/telemetry/README.md`.
 
-### Backward compatibility
+### Migration & Backward Compatibility
 
 Per the **Backward Compatibility Contract** in root `AGENTS.md`:
 
@@ -503,6 +504,7 @@ Per the **Backward Compatibility Contract** in root `AGENTS.md`:
 | `SpanOptions` (2026-08-11) | new **optional** `root?` / `links?` fields | ✓ ADDITIVE — omitting them preserves today's behavior exactly; a custom `TelemetryProvider` that ignores them degrades to "not a root", never breaks |
 | `Span` / `TelemetrySpan` (2026-08-13) | new **optional** `updateName?(name)` method | ✓ ADDITIVE — declared optional so a third-party provider or an older bootstrap still satisfies the interface; callers invoke it as `span.updateName?.(…)` and degrade to the original span name |
 | `TelemetryRuntime` (2026-08-11) | new **optional** `withSpan?` method on the shared bridge | ✓ ADDITIVE — declared optional so an older bootstrap still satisfies the interface; `withTelemetrySpan` falls back to running `fn` untraced |
+| `TelemetryRuntime` (2026-08-30) | new **optional** `recordHistogram?` method on the shared bridge | ✓ ADDITIVE — declared optional so older bootstraps remain compatible; callers use optional chaining and telemetry-off deployments remain no-ops |
 | `DataSyncAdapter.streamImport/streamExport` (2026-08-11) | **unchanged** — the engine now drives the returned iterator explicitly | adapters need no changes; closing follows the language's own `IteratorClose` rules, keeping generator `finally` semantics identical to `for await` (regression-tested) |
 | Trace topology for telemetry-on consumers (2026-08-11) | sync work moves from inside the trigger's trace to per-batch traces linked back to it | intended fix, but visible in saved dashboards/views — noted in `UPGRADE_NOTES.md` |
 | Import paths | new package — STABLE from day 1 | alias re-export from `@open-mercato/shared/lib/telemetry` if the boundary is later moved |
@@ -609,8 +611,8 @@ All tests run in the existing jest suites (`yarn workspace … test`) — no net
 - **No cross-module ORM relationships**: package adds no entities; queue/event additions are payload-only and additive.
 - **Env-driven config**, no hardcoded vendor endpoints; backend is a pure OTLP env swap.
 - **No raw `fetch`** in module code: the package's outbound instrumentation wraps undici at the global level only.
-- **Backward Compatibility Contract**: all surfaces reviewed in API Contracts → Backward compatibility. No surface broken; queue/event payload extensions are additive, as are the later `SpanOptions.root`/`links` fields and the optional `TelemetryRuntime.withSpan` bridge method.
-- **Touched outside this package** (reviewer awareness): `packages/shared/src/lib/telemetry/runtime.ts` (bridge gains optional `withSpan` + `withTelemetrySpan`/`captureTelemetryTrace` helpers) and `packages/core/src/modules/data_sync/lib/{sync-engine,batch-stream}.ts` (per-batch root spans; adapter contract unchanged).
+- **Backward Compatibility Contract**: all surfaces reviewed in API Contracts → Migration & Backward Compatibility. No surface broken; queue/event payload extensions are additive, as are the later `SpanOptions.root`/`links` fields and the optional `TelemetryRuntime.withSpan` / `recordHistogram` bridge methods.
+- **Touched outside this package** (reviewer awareness): `packages/shared/src/lib/telemetry/runtime.ts` (bridge gains optional `withSpan` and `recordHistogram` methods plus `withTelemetrySpan`/`captureTelemetryTrace` helpers), `packages/shared/src/lib/crud/enricher-runner.ts` (low-cardinality duration histogram), and `packages/core/src/modules/data_sync/lib/{sync-engine,batch-stream}.ts` (per-batch root spans; adapter contract unchanged).
 - **PII hygiene**: don't-emit posture, `pg` param capture disabled + regression-tested, non-Error objects never serialized, exact-token-key masking, and provider-boundary redaction. (No AI instrumentation in this PR; the AI follow-up MUST force prompt/completion recording off.)
 - **AGENTS.md guidance**: Phase 1 ships `packages/telemetry/AGENTS.md` describing logger usage, span naming conventions, and the metric-label cardinality rule (R4).
 - **Module decoupling**: package never imports from `packages/core/src/modules/*`. Modules opt in by importing the facade.
@@ -635,6 +637,7 @@ Touched areas (cross-package wiring, for reviewer awareness):
 
 ## Changelog
 
+- **2026-08-30 (response-enricher performance telemetry)** — Added the optional `TelemetryRuntime.recordHistogram` bridge so shared infrastructure can emit low-cardinality metrics without taking a dependency on `@open-mercato/telemetry`. The response-enricher runner uses it for `om.enricher.duration` (seconds, labeled only by `enricher.id`); telemetry-off and older-runtime paths remain no-ops.
 - **2026-08-03 (review follow-up: provider reachability and adoption hardening)** — Restored the exported custom-provider extension point without weakening default-unloaded behavior: an explicitly imported bootstrap can register a provider whose name matches `TELEMETRY_BACKEND` and call `initTelemetry()`, while unregistered/unknown names remain a hard no-op in standard hosts. The telemetry env parser now reuses the shared built-in-backend guard as its source of truth, and provider resolution degrades safely instead of throwing on future registry drift. Documented that `TELEMETRY_TRUST_INBOUND_TRACE=false` also disables richer `bullmq-otel` spans in favor of the dedicated queue carrier. Fixed the `mercato telemetry init` legacy `/nextjs` import migration to splice the array before changing import text, with regression coverage.
 - **2026-07-24 (unified logger, secure/default-unloaded carryover hardening)** — Rebased the implementation on the canonical shared logger introduced by #4003. Removed telemetry's duplicate Pino/logger facade and `TELEMETRY_LOG_*` controls; a process-wide shared-logger extension now adds trace context and one remote sink under the existing `OM_LOG_*` gate. Added a `globalThis` shared telemetry runtime bridge so API, queue, worker, and CLI code do not statically import telemetry; Next/app/CLI/worker hosts dynamically import only after an explicit supported `TELEMETRY_BACKEND`, and `nextjs-config` isolates build-time externals from runtime code. Explicit off is absolute and cannot be overridden by a custom `noop` provider. Security hardening: arbitrary thrown objects are no longer JSON-stringified, exact `token` keys are masked without clobbering `token_count`, provider-boundary redaction covers logs/spans/metrics, and both standard + backup inbound trace headers require `TELEMETRY_TRUST_INBOUND_TRACE=true`. The async BullMQ integration uses the dedicated carrier unless trusted global propagation is explicitly enabled. App/template/codemod/docs/tests were updated in lockstep; telemetry version aligned to `0.6.6`.
 - **2026-04-29** — Initial draft (spec-only). No code yet.

--- a/.ai/specs/2026-04-29-telemetry-and-otel.md
+++ b/.ai/specs/2026-04-29-telemetry-and-otel.md
@@ -350,6 +350,7 @@ Built-in metrics — prefer **OpenTelemetry semantic-convention** instruments wh
 | `om.queue.jobs` / `om.queue.duration` | counter / histogram | queue, status | partial — RED is also derivable by the backend from queue spans |
 | `om.queue.depth` | gauge | queue | needs a core queue hook |
 | `om.event.subscribers.duration` | histogram | event_id | |
+| `om.enricher.duration` | histogram (`s`) | `enricher.id` | response-enricher execution time, list and detail paths |
 | `om.db.pool.in_use` / `om.db.pool.idle` | gauge | — | needs a core ORM hook |
 | `om.cache.hits` / `om.cache.misses` | counter | layer, namespace | needs a core cache hook |
 

--- a/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
@@ -1,0 +1,190 @@
+import { createLogger } from '../../logger'
+import {
+  registerTelemetryRuntime,
+  resetTelemetryRuntime,
+  type TelemetryRuntime,
+} from '../../telemetry/runtime'
+import {
+  applyResponseEnricherToRecord,
+  applyResponseEnrichers,
+} from '../enricher-runner'
+import type {
+  EnricherContext,
+  EnricherRegistryEntry,
+  ResponseEnricher,
+} from '../response-enricher'
+
+jest.mock('../../logger', () => {
+  const mocked = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  }
+  mocked.child.mockImplementation(() => mocked)
+  return { createLogger: jest.fn(() => mocked) }
+})
+
+const logger = createLogger('shared').child({ component: 'umes' })
+const loggerDebug = logger.debug as jest.Mock
+const loggerWarn = logger.warn as jest.Mock
+const loggerError = logger.error as jest.Mock
+
+const context: EnricherContext = {
+  organizationId: 'org-1',
+  tenantId: 'tenant-1',
+  userId: 'user-1',
+  em: {},
+  container: {},
+}
+
+function makeEntry(id: string): EnricherRegistryEntry {
+  const enricher: ResponseEnricher<Record<string, unknown>, Record<string, unknown>> = {
+    id,
+    targetEntity: 'customers.person',
+    enrichOne: async (record) => record,
+    enrichMany: async (records) => records,
+  }
+  return { moduleId: 'test', enricher }
+}
+
+function mockNow(values: number[]): jest.SpyInstance<number, []> {
+  let index = 0
+  return jest.spyOn(Date, 'now').mockImplementation(() => {
+    const value = values[index]
+    if (value === undefined) {
+      throw new Error('[internal] Missing mocked Date.now() value')
+    }
+    index += 1
+    return value
+  })
+}
+
+function makeRuntime(recordHistogram: jest.Mock): TelemetryRuntime {
+  return {
+    canUseGlobalTracePropagation: () => false,
+    captureTraceContext: () => ({}),
+    continueTrace: (_carrier, _name, fn) => fn(),
+    recordHistogram,
+    recordHttpDuration: () => {},
+    reportError: () => {},
+    shutdown: async () => {},
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers({ doNotFake: ['Date'] })
+  loggerDebug.mockClear()
+  loggerWarn.mockClear()
+  loggerError.mockClear()
+  resetTelemetryRuntime()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.useRealTimers()
+  resetTelemetryRuntime()
+})
+
+describe('enricher performance reporting', () => {
+  it('throttles terminal slow logs per enricher and reports suppressed observations', async () => {
+    const entry = makeEntry('test.throttle')
+    mockNow([0, 600, 1_000, 1_700, 2_000, 2_900, 31_000, 31_800])
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      await applyResponseEnrichers([{ id: 'person-1' }], 'customers.person', context, [entry])
+    }
+
+    expect(loggerError).toHaveBeenCalledTimes(2)
+    expect(loggerError).toHaveBeenNthCalledWith(1, 'Enricher exceeded slow threshold', {
+      enricherId: 'test.throttle',
+      elapsedMs: 600,
+      thresholdMs: 500,
+      suppressedCount: 0,
+      maxElapsedMs: 600,
+    })
+    expect(loggerError).toHaveBeenNthCalledWith(2, 'Enricher exceeded slow threshold', {
+      enricherId: 'test.throttle',
+      elapsedMs: 800,
+      thresholdMs: 500,
+      suppressedCount: 2,
+      maxElapsedMs: 900,
+    })
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+
+  it('routes the diagnostic threshold to debug and the terminal threshold to error', async () => {
+    mockNow([0, 100, 1_000, 1_150, 2_000, 2_600])
+
+    await applyResponseEnrichers(
+      [{ id: 'person-1' }],
+      'customers.person',
+      context,
+      [makeEntry('test.fast')],
+    )
+    await applyResponseEnrichers(
+      [{ id: 'person-1' }],
+      'customers.person',
+      context,
+      [makeEntry('test.diagnostic')],
+    )
+    await applyResponseEnrichers(
+      [{ id: 'person-1' }],
+      'customers.person',
+      context,
+      [makeEntry('test.terminal')],
+    )
+
+    expect(loggerDebug).toHaveBeenCalledTimes(1)
+    expect(loggerDebug).toHaveBeenCalledWith('Enricher exceeded slow threshold', {
+      enricherId: 'test.diagnostic',
+      elapsedMs: 150,
+      thresholdMs: 100,
+    })
+    expect(loggerError).toHaveBeenCalledTimes(1)
+    expect(loggerError).toHaveBeenCalledWith(
+      'Enricher exceeded slow threshold',
+      expect.objectContaining({
+        enricherId: 'test.terminal',
+        elapsedMs: 600,
+        thresholdMs: 500,
+      }),
+    )
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
+
+  it('emits list and record duration histograms only through an active runtime', async () => {
+    const recordHistogram = jest.fn()
+    registerTelemetryRuntime(makeRuntime(recordHistogram))
+    mockNow([0, 250, 1_000, 1_050])
+
+    await applyResponseEnrichers(
+      [{ id: 'person-1' }],
+      'customers.person',
+      context,
+      [makeEntry('test.metric-list')],
+    )
+    await applyResponseEnricherToRecord(
+      { id: 'person-1' },
+      'customers.person',
+      context,
+      [makeEntry('test.metric-record')],
+    )
+
+    expect(recordHistogram).toHaveBeenNthCalledWith(
+      1,
+      'om.enricher.duration',
+      0.25,
+      { 'enricher.id': 'test.metric-list' },
+      's',
+    )
+    expect(recordHistogram).toHaveBeenNthCalledWith(
+      2,
+      'om.enricher.duration',
+      0.05,
+      { 'enricher.id': 'test.metric-record' },
+      's',
+    )
+  })
+})

--- a/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
@@ -187,4 +187,41 @@ describe('enricher performance reporting', () => {
       's',
     )
   })
+
+  it('preserves successful critical enrichment when histogram recording fails', async () => {
+    const entry = makeEntry('test.metric-failure')
+    entry.enricher.critical = true
+    entry.enricher.enrichMany = async (records) =>
+      records.map((record) => ({ ...record, enriched: true }))
+    entry.enricher.enrichOne = async (record) => ({ ...record, enriched: true })
+    const recordHistogram = jest.fn(() => {
+      throw new Error('[internal] Telemetry provider failed')
+    })
+    registerTelemetryRuntime(makeRuntime(recordHistogram))
+    mockNow([0, 25, 1_000, 1_010])
+
+    const listResult = await applyResponseEnrichers(
+      [{ id: 'person-1' }],
+      'customers.person',
+      context,
+      [entry],
+    )
+    const recordResult = await applyResponseEnricherToRecord(
+      { id: 'person-1' },
+      'customers.person',
+      context,
+      [entry],
+    )
+
+    expect(listResult).toEqual({
+      items: [{ id: 'person-1', enriched: true }],
+      _meta: { enrichedBy: ['test.metric-failure'] },
+    })
+    expect(recordResult).toEqual({
+      record: { id: 'person-1', enriched: true },
+      _meta: { enrichedBy: ['test.metric-failure'] },
+    })
+    expect(recordHistogram).toHaveBeenCalledTimes(2)
+    expect(loggerWarn).not.toHaveBeenCalled()
+  })
 })

--- a/packages/shared/src/lib/crud/enricher-runner.ts
+++ b/packages/shared/src/lib/crud/enricher-runner.ts
@@ -15,6 +15,7 @@ import type {
 import { getEnrichersForEntity } from './enricher-registry'
 import { logEnricherTiming } from '../umes/enricher-timing'
 import { createLogger } from '../logger'
+import { getTelemetryRuntime } from '../telemetry/runtime'
 import { authorizeFeatures } from '../../security/featurePolicy'
 
 const logger = createLogger('shared').child({ component: 'umes' })
@@ -22,7 +23,65 @@ const logger = createLogger('shared').child({ component: 'umes' })
 const DEFAULT_TIMEOUT = 2000
 const SLOW_WARN_MS = 100
 const SLOW_ERROR_MS = 500
+const SLOW_LOG_INTERVAL_MS = 30_000
 const DEFAULT_CACHE_TTL_MS = 60_000
+const ENRICHER_DURATION_METRIC = 'om.enricher.duration'
+
+type SlowLogState = {
+  lastLoggedAt: number
+  suppressedCount: number
+  maxElapsedMs: number
+}
+
+const slowLogStateByEnricher = new Map<string, SlowLogState>()
+
+function recordEnricherDuration(
+  enricherId: string,
+  moduleId: string,
+  targetEntity: string,
+  elapsedMs: number,
+): void {
+  logEnricherTiming(enricherId, moduleId, targetEntity, elapsedMs)
+  getTelemetryRuntime()?.recordHistogram?.(
+    ENRICHER_DURATION_METRIC,
+    elapsedMs / 1000,
+    { 'enricher.id': enricherId },
+    's',
+  )
+}
+
+function logSlowEnricher(enricherId: string, elapsedMs: number, finishedAt: number): void {
+  if (elapsedMs <= SLOW_WARN_MS) return
+
+  if (elapsedMs <= SLOW_ERROR_MS) {
+    logger.debug('Enricher exceeded slow threshold', {
+      enricherId,
+      elapsedMs,
+      thresholdMs: SLOW_WARN_MS,
+    })
+    return
+  }
+
+  const state = slowLogStateByEnricher.get(enricherId)
+  if (state && finishedAt - state.lastLoggedAt < SLOW_LOG_INTERVAL_MS) {
+    state.suppressedCount += 1
+    state.maxElapsedMs = Math.max(state.maxElapsedMs, elapsedMs)
+    return
+  }
+
+  logger.error('Enricher exceeded slow threshold', {
+    enricherId,
+    elapsedMs,
+    thresholdMs: SLOW_ERROR_MS,
+    suppressedCount: state?.suppressedCount ?? 0,
+    maxElapsedMs: Math.max(state?.maxElapsedMs ?? 0, elapsedMs),
+  })
+  slowLogStateByEnricher.set(enricherId, {
+    lastLoggedAt: finishedAt,
+    suppressedCount: 0,
+    maxElapsedMs: 0,
+  })
+}
 
 function timeoutPromise(ms: number): Promise<never> {
   return new Promise((_, reject) =>
@@ -255,13 +314,10 @@ export async function applyResponseEnrichers<T extends Record<string, unknown>>(
         )
       }
 
-      const elapsedMs = Date.now() - startTime
-      if (elapsedMs > SLOW_ERROR_MS) {
-        logger.error('Enricher exceeded slow threshold', { enricherId: enricher.id, elapsedMs, thresholdMs: SLOW_ERROR_MS })
-      } else if (elapsedMs > SLOW_WARN_MS) {
-        logger.warn('Enricher exceeded slow threshold', { enricherId: enricher.id, elapsedMs, thresholdMs: SLOW_WARN_MS })
-      }
-      logEnricherTiming(enricher.id, entry.moduleId, targetEntity, elapsedMs)
+      const finishedAt = Date.now()
+      const elapsedMs = finishedAt - startTime
+      logSlowEnricher(enricher.id, elapsedMs, finishedAt)
+      recordEnricherDuration(enricher.id, entry.moduleId, targetEntity, elapsedMs)
 
       currentItems = result
       if (shouldUseCache && cacheKey) {
@@ -347,7 +403,7 @@ export async function applyResponseEnricherToRecord<T extends Record<string, unk
       ])
 
       const elapsedMs = Date.now() - startTime
-      logEnricherTiming(enricher.id, entry.moduleId, targetEntity, elapsedMs)
+      recordEnricherDuration(enricher.id, entry.moduleId, targetEntity, elapsedMs)
 
       currentRecord = result
       if (shouldUseCache && cacheKey) {

--- a/packages/shared/src/lib/crud/enricher-runner.ts
+++ b/packages/shared/src/lib/crud/enricher-runner.ts
@@ -42,12 +42,16 @@ function recordEnricherDuration(
   elapsedMs: number,
 ): void {
   logEnricherTiming(enricherId, moduleId, targetEntity, elapsedMs)
-  getTelemetryRuntime()?.recordHistogram?.(
-    ENRICHER_DURATION_METRIC,
-    elapsedMs / 1000,
-    { 'enricher.id': enricherId },
-    's',
-  )
+  try {
+    getTelemetryRuntime()?.recordHistogram?.(
+      ENRICHER_DURATION_METRIC,
+      elapsedMs / 1000,
+      { 'enricher.id': enricherId },
+      's',
+    )
+  } catch {
+    return
+  }
 }
 
 function logSlowEnricher(enricherId: string, elapsedMs: number, finishedAt: number): void {

--- a/packages/shared/src/lib/telemetry/runtime.ts
+++ b/packages/shared/src/lib/telemetry/runtime.ts
@@ -2,6 +2,8 @@ export type TelemetryTraceCarrier = Record<string, string>
 
 export type TelemetrySpanAttributes = Record<string, string | number | boolean | undefined>
 
+export type TelemetryMetricLabels = Record<string, string | number | boolean | undefined>
+
 export type TelemetrySpanKind = 'internal' | 'server' | 'client' | 'producer' | 'consumer'
 
 /** The subset of the telemetry package's `Span` that bridge consumers need. */
@@ -43,6 +45,12 @@ export type TelemetryRuntime = {
    * running `fn` untraced.
    */
   withSpan?<T>(name: string, fn: (span: TelemetrySpan) => T, options?: TelemetrySpanOptions): T
+  recordHistogram?(
+    name: string,
+    value: number,
+    labels?: TelemetryMetricLabels,
+    unit?: string,
+  ): void
   recordHttpDuration(method: string, route: string, status: number, startedAt: number): void
   reportError(
     error: unknown,

--- a/packages/telemetry/src/__tests__/env-load-order.test.ts
+++ b/packages/telemetry/src/__tests__/env-load-order.test.ts
@@ -25,7 +25,7 @@ function provider(name = 'noop'): TelemetryProvider {
     inject: () => {},
     runInRemoteSpan: (_carrier, _name, _options, fn) => fn(NOOP_SPAN),
     emitLog: () => {},
-    recordMetric: () => {},
+    recordMetric: jest.fn(),
   }
 }
 
@@ -76,5 +76,27 @@ describe('telemetry explicit opt-in boundary', () => {
     expect(getActiveProvider()).toBe(customProvider)
     expect(getLoggerExtension()).toBeDefined()
     expect(getTelemetryRuntime()).toBeDefined()
+  })
+
+  it('wires shared runtime histograms to the active provider', async () => {
+    const customConsole = provider('console')
+    registerProvider(customConsole)
+    process.env.TELEMETRY_BACKEND = 'console'
+
+    await initTelemetry()
+    getTelemetryRuntime()?.recordHistogram?.(
+      'om.enricher.duration',
+      0.25,
+      { 'enricher.id': 'customers.people' },
+      's',
+    )
+
+    expect(customConsole.recordMetric).toHaveBeenCalledWith({
+      kind: 'histogram',
+      name: 'om.enricher.duration',
+      value: 0.25,
+      labels: { 'enricher.id': 'customers.people' },
+      unit: 's',
+    })
   })
 })

--- a/packages/telemetry/src/init.ts
+++ b/packages/telemetry/src/init.ts
@@ -15,6 +15,7 @@ import { registerTelemetryLogger } from './facade/logger-bridge'
 import { captureTraceContext, continueTrace } from './facade/propagation'
 import { withSpan } from './facade/tracer'
 import { recordHttpDuration } from './facade/http'
+import { histogram } from './facade/meter'
 import { reportError } from './facade/report-error'
 
 let initialized = false
@@ -119,6 +120,7 @@ function createRuntime(provider: TelemetryProvider): TelemetryRuntime {
     continueTrace: (carrier, name, fn, options) =>
       continueTrace(carrier, name, () => fn(), options),
     withSpan: (name, fn, options) => withSpan(name, fn, options),
+    recordHistogram: histogram,
     recordHttpDuration,
     reportError,
     shutdown: shutdownTelemetry,


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-30-issue-5782-throttle-slow-enricher-logging.md
Status: ready

Closes #5782

## 🎯 Goal
- Prevent slow response-enricher diagnostics from amplifying overload while preserving actionable terminal errors and exposing production timing data through telemetry.

## 🔍 Problem
Response enrichers emitted one structured warning or error for every slow list request. At sustained load, the unbounded diagnostic stream added work precisely while the process was saturated, while production telemetry had no enricher-duration metric to replace log-volume analysis.

## 🔍 Root Cause
`applyResponseEnrichers` logged each execution above the 100 ms and 500 ms thresholds directly, without per-enricher state, sampling, or throttling. Both list and detail runners wrote only to the development UMES ring buffer, and the dependency-safe shared telemetry runtime exposed no metric hook.

## What Changed
- Added a runner-local, per-enricher 30-second throttle for the 500 ms error tier. The next emitted error includes the suppressed occurrence count and maximum elapsed time observed during the window.
- Demoted the routine 100 ms tier to level-gated debug logging while preserving the message and existing structured fields.
- Added an optional `TelemetryRuntime.recordHistogram` bridge and wired it to the telemetry facade, allowing shared infrastructure to emit `om.enricher.duration` in seconds with only the low-cardinality `enricher.id` label.
- Recorded list and detail enricher durations through the optional bridge while retaining the existing UMES timing ring buffer and telemetry-off no-op behavior.
- Updated the telemetry specification's additive compatibility table and changelog.

## 🧪 Tests
- `yarn build:packages` — passed twice in the configured build/generate/build sequence.
- `yarn generate` — passed; Node 24 used the generator's documented static OpenAPI fallback after an import-attribute warning.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — passed.
- `yarn typecheck` — passed.
- `yarn test` — passed: 34/34 workspace tasks. The final run used the bundled self-contained Node 24.19.0 runtime because Homebrew's dynamically linked Node is incompatible with nested macOS sandbox tests.
- `yarn build:app` — passed; existing Turbopack filesystem-tracing warnings remain.
- `yarn test:integration:ephemeral TC-SSO-004 --verbose` — passed 5/5 in a clean managed ephemeral replay.
- CI run `33332985776` — passed every required job and all 15 integration shards on identical product code.
- New shared tests cover first emission, suppression, next-window aggregation, exact threshold routing, and list/detail histogram recording. Telemetry coverage verifies bridge delegation to the active provider.

## 💥 Breaking Changes
- None. The shared runtime method is optional and additive; telemetry-off and older bootstrap paths remain compatible no-ops.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790709262&installation_model_id=432243&pr_number=5794&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5794&signature=9754db5d5d9be4ce8847b65ea840375aa5b1419c658e9fbb53991d9de7019883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->