### PR TITLE
feat(customers): cache deals aggregate responses (#5785)

### DIFF
--- a/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
+++ b/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
@@ -49,10 +49,10 @@ Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/c
 
 ### Phase 1: Route-local read-through cache
 
-- [ ] 1.1 Add cache eligibility, key, and tag helpers
-- [ ] 1.2 Return schema-validated cache hits before aggregate computation
-- [ ] 1.3 Store final responses with TTL, tags, tenant context, and fail-open handling
-- [ ] 1.4 Preserve disabled, bypassed, invalid, unauthorized, and failure behavior
+- [x] 1.1 Add cache eligibility, key, and tag helpers — 2f2593dbfc
+- [x] 1.2 Return schema-validated cache hits before aggregate computation — 2f2593dbfc
+- [x] 1.3 Store final responses with TTL, tags, tenant context, and fail-open handling — 2f2593dbfc
+- [x] 1.4 Preserve disabled, bypassed, invalid, unauthorized, and failure behavior — 2f2593dbfc
 
 ### Phase 2: Regression proof and delivery gate
 

--- a/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
+++ b/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
@@ -45,6 +45,8 @@ Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/c
 
 ## Progress
 
+PR: #5796
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Route-local read-through cache
@@ -59,4 +61,4 @@ Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/c
 - [x] 2.1 Add focused unit cache coverage — b2a921e52d
 - [x] 2.2 Add self-contained TC-CRM-5785 integration coverage — b2a921e52d
 - [x] 2.3 Pass focused and configured validation gates — a629178e5e (all change-scoped checks pass; full `yarn test` is blocked only by the reproducible, unrelated `staff/timesheets/page.durationEntry.test.tsx` baseline failure)
-- [ ] 2.4 Pass authoritative review/autofix and complete handoff
+- [x] 2.4 Pass authoritative review/autofix and complete handoff — 431ba105f4 (clean automated verdict; GitHub formal self-approval is unavailable to the PR author)

--- a/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
+++ b/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
@@ -1,0 +1,62 @@
+# Deals aggregate response cache — execution plan
+
+Source doc: .ai/specs/2026-08-30-deals-aggregate-response-cache.md
+
+## Goal
+
+Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/customers/deals/aggregate` so repeated kanban aggregate reads skip SQL and currency conversion while preserving the existing request, response, authorization, and invalidation contracts.
+
+## Scope
+
+- Add route-local cache eligibility, canonical key construction, schema-validated reads, fail-open writes, and `customers.deal` collection tags.
+- Cover disabled, bypassed, hit, miss, malformed, failure, normalization, partitioning, and multi-organization behavior with focused unit tests.
+- Add a self-contained integration test proving an observable cache hit, explicit query-parameter bypasses, and command-driven invalidation.
+- Run the configured validation gate and the authoritative automated review/autofix pass before marking the pull request complete.
+
+## Non-goals
+
+- No caching for `search` or `isStuck` requests.
+- No cache changes for other deal or customer routes.
+- No single-flight locking, new cache backend, environment variable, schema migration, UI, response header, API shape, ACL, event, or locale change.
+- No attempt to invalidate this short-lived response when exchange rates or wall-clock-relative overdue state changes.
+
+## Implementation Plan
+
+### Phase 1: Route-local read-through cache
+
+1. Add route-local constants and pure helpers for eligibility, filter-set normalization, SHA-256 key construction, and `customers.deal` collection tags.
+2. Resolve the opt-in cache after effective tenant and organization scope, then return a schema-validated hit before base-currency work.
+3. Store the final aggregate response for 30 seconds with per-organization collection tags, tenant cache context, and fail-open error handling.
+4. Preserve the uncached control flow for bypassed, disabled, unauthorized, invalid, and cache-failure requests.
+
+### Phase 2: Regression proof and delivery gate
+
+5. Add focused unit coverage for hits, misses, disabled/bypassed requests, malformed values, backend errors, key normalization and partitioning, and exact tags.
+6. Add the self-contained `TC-CRM-5785` integration scenario covering an observable hit, both bypasses, and supported-write invalidation.
+7. Run focused tests followed by every configured validation command in order, fixing only regressions introduced by this change.
+8. Run `om-auto-review-pr` in autofix mode, record the verdict and any follow-up commits, and complete the PR handoff.
+
+## Risks
+
+- A missing tenant, currency-scope organization, organization-set, or filter axis could expose or conflate scoped aggregates. The key builder and tests must pin every response input.
+- Using a resource tag other than `customers.deal` would miss existing post-commit invalidation. Tests must assert the shared collection tags exactly.
+- Cache backend failures must never turn the existing successful route into an error path. Both read and write failures remain fail-open.
+- Fully converted totals may lag exchange-rate changes or a midnight overdue transition for up to 30 seconds; the short TTL is the accepted bound.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Route-local read-through cache
+
+- [ ] 1.1 Add cache eligibility, key, and tag helpers
+- [ ] 1.2 Return schema-validated cache hits before aggregate computation
+- [ ] 1.3 Store final responses with TTL, tags, tenant context, and fail-open handling
+- [ ] 1.4 Preserve disabled, bypassed, invalid, unauthorized, and failure behavior
+
+### Phase 2: Regression proof and delivery gate
+
+- [ ] 2.1 Add focused unit cache coverage
+- [ ] 2.2 Add self-contained TC-CRM-5785 integration coverage
+- [ ] 2.3 Pass focused and configured validation gates
+- [ ] 2.4 Pass authoritative review/autofix and complete handoff

--- a/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
+++ b/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
@@ -58,5 +58,5 @@ Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/c
 
 - [x] 2.1 Add focused unit cache coverage — b2a921e52d
 - [x] 2.2 Add self-contained TC-CRM-5785 integration coverage — b2a921e52d
-- [ ] 2.3 Pass focused and configured validation gates
+- [x] 2.3 Pass focused and configured validation gates — a629178e5e (all change-scoped checks pass; full `yarn test` is blocked only by the reproducible, unrelated `staff/timesheets/page.durationEntry.test.tsx` baseline failure)
 - [ ] 2.4 Pass authoritative review/autofix and complete handoff

--- a/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
+++ b/.ai/runs/2026-08-30-deals-aggregate-response-cache.md
@@ -56,7 +56,7 @@ Add a tenant-safe, organization-safe 30-second read-through cache to `GET /api/c
 
 ### Phase 2: Regression proof and delivery gate
 
-- [ ] 2.1 Add focused unit cache coverage
-- [ ] 2.2 Add self-contained TC-CRM-5785 integration coverage
+- [x] 2.1 Add focused unit cache coverage — b2a921e52d
+- [x] 2.2 Add self-contained TC-CRM-5785 integration coverage — b2a921e52d
 - [ ] 2.3 Pass focused and configured validation gates
 - [ ] 2.4 Pass authoritative review/autofix and complete handoff

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-5785-deals-aggregate-cache.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-5785-deals-aggregate-cache.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import {
+  createDealFixture,
+  createPipelineFixture,
+  createPipelineStageFixture,
+  deleteEntityByBody,
+  deleteEntityIfExists,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+
+type AggregateStage = {
+  stageId: string
+  count: number
+  byCurrency: Array<{ currency: string; total: number; count: number }>
+}
+
+type AggregateResponse = {
+  perStage?: AggregateStage[]
+}
+
+async function readAggregate(
+  request: APIRequestContext,
+  token: string,
+  pipelineId: string,
+  extraQuery = '',
+): Promise<AggregateResponse> {
+  const query = `pipelineId=${encodeURIComponent(pipelineId)}${extraQuery}`
+  const response = await apiRequest(
+    request,
+    'GET',
+    `/api/customers/deals/aggregate?${query}`,
+    { token },
+  )
+  expect(response.status(), 'deals aggregate request should succeed').toBe(200)
+  return (await readJsonSafe(response)) as AggregateResponse
+}
+
+function expectStageAggregate(
+  response: AggregateResponse,
+  stageId: string,
+  expectedCount: number,
+  expectedUsdTotal: number,
+): void {
+  const stage = (response.perStage ?? []).find((candidate) => candidate.stageId === stageId)
+  expect(stage, 'aggregate should include the unique test stage').toBeTruthy()
+  expect(stage?.count, 'stage deal count').toBe(expectedCount)
+  const usd = (stage?.byCurrency ?? []).find((entry) => entry.currency === 'USD')
+  expect(usd, 'stage aggregate should include USD totals').toBeTruthy()
+  expect(usd?.count, 'USD deal count').toBe(expectedCount)
+  expect(usd?.total, 'USD deal total').toBe(expectedUsdTotal)
+}
+
+test.describe('TC-CRM-5785: deals aggregate response cache', () => {
+  test('hits the cache, bypasses dynamic filters, and invalidates after a supported deal write', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    let pipelineId: string | null = null
+    let stageId: string | null = null
+    let firstDealId: string | null = null
+    let secondDealId: string | null = null
+
+    try {
+      pipelineId = await createPipelineFixture(request, token, {
+        name: `TC-CRM-5785 Pipeline ${stamp}`,
+      })
+      stageId = await createPipelineStageFixture(request, token, {
+        pipelineId,
+        label: `TC-CRM-5785 Stage ${stamp}`,
+        order: 0,
+      })
+      firstDealId = await createDealFixture(request, token, {
+        title: `TC-CRM-5785 First ${stamp}`,
+        pipelineId,
+        pipelineStageId: stageId,
+        valueAmount: 100,
+        valueCurrency: 'USD',
+        status: 'open',
+      })
+
+      const warmed = await readAggregate(request, token, pipelineId)
+      expectStageAggregate(warmed, stageId, 1, 100)
+
+      await withClient(async (client) => {
+        await client.query(
+          'UPDATE customer_deals SET value_amount = $1 WHERE id = $2',
+          [250, firstDealId],
+        )
+      })
+
+      const cached = await readAggregate(request, token, pipelineId)
+      expectStageAggregate(cached, stageId, 1, 100)
+
+      const searchBypass = await readAggregate(request, token, pipelineId, '&search=')
+      expectStageAggregate(searchBypass, stageId, 1, 250)
+
+      const stuckBypass = await readAggregate(request, token, pipelineId, '&isStuck=false')
+      expectStageAggregate(stuckBypass, stageId, 1, 250)
+
+      secondDealId = await createDealFixture(request, token, {
+        title: `TC-CRM-5785 Second ${stamp}`,
+        pipelineId,
+        pipelineStageId: stageId,
+        valueAmount: 50,
+        valueCurrency: 'USD',
+        status: 'open',
+      })
+
+      const invalidated = await readAggregate(request, token, pipelineId)
+      expectStageAggregate(invalidated, stageId, 2, 300)
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/deals', secondDealId)
+      await deleteEntityIfExists(request, token, '/api/customers/deals', firstDealId)
+      await deleteEntityByBody(request, token, '/api/customers/pipeline-stages', stageId)
+      await deleteEntityByBody(request, token, '/api/customers/pipelines', pipelineId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/api/deals/aggregate/__tests__/cache.test.ts
+++ b/packages/core/src/modules/customers/api/deals/aggregate/__tests__/cache.test.ts
@@ -1,0 +1,333 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const otherTenantId = '11111111-1111-4111-8111-111111111112'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const otherOrganizationId = '22222222-2222-4222-8222-222222222223'
+const thirdOrganizationId = '22222222-2222-4222-8222-222222222224'
+const userId = '33333333-3333-4333-8333-333333333333'
+const otherUserId = '33333333-3333-4333-8333-333333333334'
+const pipelineId = '44444444-4444-4444-8444-444444444444'
+const otherPipelineId = '44444444-4444-4444-8444-444444444445'
+const ownerUserId = '55555555-5555-4555-8555-555555555555'
+const otherOwnerUserId = '55555555-5555-4555-8555-555555555556'
+const personId = '66666666-6666-4666-8666-666666666666'
+const otherPersonId = '66666666-6666-4666-8666-666666666667'
+const companyId = '77777777-7777-4777-8777-777777777777'
+const otherCompanyId = '77777777-7777-4777-8777-777777777778'
+
+const getAuthFromRequestMock = jest.fn()
+const resolveOrganizationScopeForRequestMock = jest.fn()
+const resolveDealsOrganizationIdsMock = jest.fn()
+const resolveOptionalBaseCurrencyCodeMock = jest.fn()
+const executeMock = jest.fn()
+const getRatesMock = jest.fn()
+const runWithCacheTenantMock = jest.fn((_tenantId: string | null, operation: () => unknown) => operation())
+const findMatchingEntityIdsBySearchTokensAcrossSourcesMock = jest.fn()
+const fetchStuckDealIdsMock = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+}
+
+const entityManager = {
+  getConnection: () => ({ execute: executeMock }),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return entityManager
+    if (name === 'cache') return cache
+    if (name === 'exchangeRateService') return { getRates: getRatesMock }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => getAuthFromRequestMock(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => resolveOrganizationScopeForRequestMock(args)),
+}))
+
+jest.mock('../../../../lib/dealsOrganizationScope', () => ({
+  resolveDealsOrganizationIds: jest.fn((args: unknown) => resolveDealsOrganizationIdsMock(args)),
+}))
+
+jest.mock('../../../../lib/optionalBaseCurrency', () => ({
+  resolveOptionalBaseCurrencyCode: jest.fn((...args: unknown[]) => resolveOptionalBaseCurrencyCodeMock(...args)),
+}))
+
+jest.mock('../../../utils', () => ({
+  findMatchingEntityIdsBySearchTokensAcrossSources: jest.fn((...args: unknown[]) => (
+    findMatchingEntityIdsBySearchTokensAcrossSourcesMock(...args)
+  )),
+}))
+
+jest.mock('../../../../lib/stuckDeals', () => ({
+  fetchStuckDealIds: jest.fn((...args: unknown[]) => fetchStuckDealIdsMock(...args)),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((tenant: string | null, operation: () => unknown) => (
+    runWithCacheTenantMock(tenant, operation)
+  )),
+}))
+
+const originalEnvironment = { ...process.env }
+
+const aggregateRows = [
+  {
+    stage_id: '88888888-8888-4888-8888-888888888888',
+    currency: 'USD',
+    total: '1250',
+    count: '2',
+    open_count: '1',
+  },
+]
+
+const cachedResponse = {
+  baseCurrencyCode: 'USD',
+  perStage: [
+    {
+      stageId: '88888888-8888-4888-8888-888888888888',
+      count: 2,
+      openCount: 1,
+      totalInBaseCurrency: 1250,
+      byCurrency: [{ currency: 'USD', total: 1250, count: 2 }],
+      convertedAll: true,
+      missingRateCurrencies: [],
+    },
+  ],
+}
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+function makeScope(activeTenantId = tenantId, activeOrganizationId = organizationId) {
+  return {
+    selectedId: activeOrganizationId,
+    filterIds: [activeOrganizationId],
+    allowedIds: [activeOrganizationId],
+    tenantId: activeTenantId,
+  }
+}
+
+function makeAuth(activeTenantId = tenantId, activeUserId = userId) {
+  return {
+    sub: activeUserId,
+    tenantId: activeTenantId,
+    orgId: organizationId,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env = { ...originalEnvironment }
+  getAuthFromRequestMock.mockResolvedValue(makeAuth())
+  resolveOrganizationScopeForRequestMock.mockResolvedValue(makeScope())
+  resolveDealsOrganizationIdsMock.mockResolvedValue([organizationId])
+  resolveOptionalBaseCurrencyCodeMock.mockResolvedValue('USD')
+  executeMock.mockResolvedValue(aggregateRows)
+  getRatesMock.mockResolvedValue(new Map())
+  cache.get.mockResolvedValue(null)
+  cache.set.mockResolvedValue(undefined)
+  findMatchingEntityIdsBySearchTokensAcrossSourcesMock.mockResolvedValue([])
+  fetchStuckDealIdsMock.mockResolvedValue([])
+})
+
+afterAll(() => {
+  process.env = originalEnvironment
+})
+
+describe('GET /api/customers/deals/aggregate caching', () => {
+  it('does not resolve or touch the cache when the CRUD cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request('http://localhost/api/customers/deals/aggregate'))
+
+    expect(response.status).toBe(200)
+    expect(container.resolve).not.toHaveBeenCalledWith('cache')
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('stores a miss for 30 seconds with every contributing deal collection tag', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    resolveDealsOrganizationIdsMock.mockResolvedValue([
+      otherOrganizationId,
+      organizationId,
+      otherOrganizationId,
+    ])
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request(
+      `http://localhost/api/customers/deals/aggregate?pipelineId=${pipelineId}&status=open&status=won`,
+    ))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual(cachedResponse)
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    expect(resolveOptionalBaseCurrencyCodeMock).toHaveBeenCalledTimes(1)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(runWithCacheTenantMock).toHaveBeenCalledTimes(2)
+    expect(runWithCacheTenantMock).toHaveBeenNthCalledWith(1, tenantId, expect.any(Function))
+    expect(runWithCacheTenantMock).toHaveBeenNthCalledWith(2, tenantId, expect.any(Function))
+
+    const [key, value, options] = cache.set.mock.calls[0]
+    expect(key).toMatch(/^customers:deal:aggregate:v1:[a-f0-9]{64}$/)
+    expect(value).toEqual(cachedResponse)
+    expect(options).toEqual({
+      ttl: 30_000,
+      tags: [
+        `crud:customers.deal:tenant:${tenantId}:org:${organizationId}:collection`,
+        `crud:customers.deal:tenant:${tenantId}:org:${otherOrganizationId}:collection`,
+      ],
+    })
+  })
+
+  it('returns a schema-valid hit before base-currency, SQL, and exchange-rate work', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cache.get.mockResolvedValue(cachedResponse)
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request('http://localhost/api/customers/deals/aggregate'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(cachedResponse)
+    expect(resolveOptionalBaseCurrencyCodeMock).not.toHaveBeenCalled()
+    expect(executeMock).not.toHaveBeenCalled()
+    expect(getRatesMock).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('treats a malformed cached value as a miss and overwrites it', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cache.get.mockResolvedValue({ baseCurrencyCode: 'USD', perStage: 'invalid' })
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request('http://localhost/api/customers/deals/aggregate'))
+
+    expect(response.status).toBe(200)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    expect(cache.set.mock.calls[0][1]).toEqual(cachedResponse)
+  })
+
+  it('fails open when cache reads or writes throw', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cache.get.mockRejectedValueOnce(new Error('cache read failed'))
+    cache.set.mockRejectedValueOnce(new Error('cache write failed'))
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request('http://localhost/api/customers/deals/aggregate'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(cachedResponse)
+    expect(executeMock).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['empty search', 'search='],
+    ['false isStuck', 'isStuck=false'],
+  ])('bypasses cache reads and writes when %s is present', async (_label, query) => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request(`http://localhost/api/customers/deals/aggregate?${query}`))
+
+    expect(response.status).toBe(200)
+    expect(container.resolve).not.toHaveBeenCalledWith('cache')
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(executeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('normalizes organization and filter sets without changing the currency-scope organization', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    resolveDealsOrganizationIdsMock
+      .mockResolvedValueOnce([organizationId, thirdOrganizationId, otherOrganizationId, thirdOrganizationId])
+      .mockResolvedValueOnce([organizationId, otherOrganizationId, thirdOrganizationId])
+    const { GET } = await loadRoute()
+    const firstQuery = [
+      `pipelineId=${pipelineId}`,
+      'status=won',
+      'status=open',
+      'status=won',
+      `ownerUserId=${otherOwnerUserId}`,
+      `ownerUserId=${ownerUserId}`,
+      `personId=${otherPersonId}`,
+      `personId=${personId}`,
+      `companyId=${otherCompanyId}`,
+      `companyId=${companyId}`,
+    ].join('&')
+    const secondQuery = [
+      `pipelineId=${pipelineId}`,
+      'status=open',
+      'status=won',
+      `ownerUserId=${ownerUserId}`,
+      `ownerUserId=${otherOwnerUserId}`,
+      `personId=${personId}`,
+      `personId=${otherPersonId}`,
+      `companyId=${companyId}`,
+      `companyId=${otherCompanyId}`,
+    ].join('&')
+
+    await GET(new Request(`http://localhost/api/customers/deals/aggregate?${firstQuery}`))
+    await GET(new Request(`http://localhost/api/customers/deals/aggregate?${secondQuery}`))
+
+    expect(cache.set).toHaveBeenCalledTimes(2)
+    expect(cache.set.mock.calls[0][0]).toBe(cache.set.mock.calls[1][0])
+    expect(cache.set.mock.calls[0][2].tags).toEqual(cache.set.mock.calls[1][2].tags)
+  })
+
+  it('partitions every tenant, scope, and aggregate-filter input while omitting caller identity', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+
+    const readKey = async (query = '', options?: {
+      activeTenantId?: string
+      activeUserId?: string
+      organizationIds?: string[]
+    }) => {
+      const activeTenantId = options?.activeTenantId ?? tenantId
+      getAuthFromRequestMock.mockResolvedValueOnce(makeAuth(activeTenantId, options?.activeUserId ?? userId))
+      resolveOrganizationScopeForRequestMock.mockResolvedValueOnce(makeScope(activeTenantId))
+      resolveDealsOrganizationIdsMock.mockResolvedValueOnce(options?.organizationIds ?? [organizationId])
+      await GET(new Request(`http://localhost/api/customers/deals/aggregate${query ? `?${query}` : ''}`))
+      return cache.set.mock.calls.at(-1)?.[0] as string
+    }
+
+    const baselineKey = await readKey()
+    const sameScopeOtherUserKey = await readKey('', { activeUserId: otherUserId })
+    const variantKeys = [
+      await readKey('', { activeTenantId: otherTenantId }),
+      await readKey('', { organizationIds: [otherOrganizationId, organizationId] }),
+      await readKey('', { organizationIds: [organizationId, otherOrganizationId] }),
+      await readKey(`pipelineId=${otherPipelineId}`),
+      await readKey('status=won'),
+      await readKey(`ownerUserId=${otherOwnerUserId}`),
+      await readKey(`personId=${otherPersonId}`),
+      await readKey(`companyId=${otherCompanyId}`),
+      await readKey('expectedCloseAtFrom=2026-01-01'),
+      await readKey('expectedCloseAtTo=2026-12-31'),
+      await readKey('isOverdue=true'),
+    ]
+
+    expect(sameScopeOtherUserKey).toBe(baselineKey)
+    expect(new Set(variantKeys).size).toBe(variantKeys.length)
+    expect(variantKeys).not.toContain(baselineKey)
+  })
+})

--- a/packages/core/src/modules/customers/api/deals/aggregate/route.ts
+++ b/packages/core/src/modules/customers/api/deals/aggregate/route.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager as CoreEntityManager } from '@mikro-orm/core'
 import type { EntityManager as PgEntityManager } from '@mikro-orm/postgresql'
+import { runWithCacheTenant } from '@open-mercato/cache'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -11,6 +13,12 @@ import type { ExchangeRateService } from '@open-mercato/core/modules/currencies/
 import { parseBooleanFromUnknown } from '@open-mercato/shared/lib/boolean'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+import {
+  buildCollectionTags,
+  debugCrudCache,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 import { readQueryParamList } from '@open-mercato/shared/lib/crud/query-params'
 import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -21,6 +29,8 @@ import { E } from '#generated/entities.ids.generated'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customers')
+const DEALS_AGGREGATE_CACHE_RESOURCE = 'customers.deal'
+const DEALS_AGGREGATE_CACHE_TTL_MS = 30_000
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.deals.view'] },
@@ -44,6 +54,40 @@ const querySchema = z.object({
   expectedCloseAtFrom: z.string().optional(),
   expectedCloseAtTo: z.string().optional(),
 })
+
+type AggregateQuery = z.infer<typeof querySchema>
+
+function normalizeStringSet(values: string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => value.trim())))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+}
+
+function buildDealsAggregateCacheKey(params: {
+  tenantId: string
+  currencyScopeOrganizationId: string | null
+  organizationIds: string[]
+  query: AggregateQuery
+}): string {
+  const signature = {
+    tenantId: params.tenantId,
+    currencyScopeOrganizationId: params.currencyScopeOrganizationId,
+    organizationIds: normalizeStringSet(params.organizationIds),
+    pipelineId: params.query.pipelineId ?? null,
+    status: normalizeStringSet(params.query.status),
+    ownerUserId: normalizeStringSet(params.query.ownerUserId),
+    personId: normalizeStringSet(params.query.personId),
+    companyId: normalizeStringSet(params.query.companyId),
+    expectedCloseAtFrom: params.query.expectedCloseAtFrom ?? null,
+    expectedCloseAtTo: params.query.expectedCloseAtTo ?? null,
+    isOverdue: params.query.isOverdue === true,
+  }
+  const digest = createHash('sha256').update(JSON.stringify(signature)).digest('hex')
+  return `customers:deal:aggregate:v1:${digest}`
+}
+
+function isDealsAggregateCacheEligible(searchParams: URLSearchParams): boolean {
+  return !searchParams.has('search') && !searchParams.has('isStuck')
+}
 
 type StageBreakdownByCurrency = {
   currency: string
@@ -175,6 +219,42 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const orgFilterIds = await resolveDealsOrganizationIds({ em, scope, auth, tenantId: effectiveTenantId })
+  const aggregateCache = isDealsAggregateCacheEligible(params) && isCrudCacheEnabled()
+    ? resolveCrudCache(container)
+    : null
+  const aggregateCacheKey = aggregateCache
+    ? buildDealsAggregateCacheKey({
+        tenantId: effectiveTenantId,
+        currencyScopeOrganizationId: orgFilterIds[0] ?? null,
+        organizationIds: orgFilterIds,
+        query: parsed.data,
+      })
+    : null
+
+  if (aggregateCache && aggregateCacheKey) {
+    try {
+      const cached = await runWithCacheTenant(
+        effectiveTenantId,
+        () => aggregateCache.get(aggregateCacheKey),
+      )
+      const cachedResponse = aggregateResponseSchema.safeParse(cached)
+      if (cachedResponse.success) {
+        return NextResponse.json(cachedResponse.data)
+      }
+      if (cached !== null && cached !== undefined) {
+        debugCrudCache('get-invalid', {
+          resource: DEALS_AGGREGATE_CACHE_RESOURCE,
+          key: aggregateCacheKey,
+        })
+      }
+    } catch (err) {
+      debugCrudCache('get', {
+        resource: DEALS_AGGREGATE_CACHE_RESOURCE,
+        key: aggregateCacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
 
   // Raw SQL is used here intentionally — the route only projects non-encrypted columns
   // (`pipeline_stage_id`, `value_amount`, `value_currency`, `status`, plus filters). It
@@ -441,6 +521,28 @@ export async function GET(req: Request) {
   const response: AggregateResponse = {
     baseCurrencyCode,
     perStage: Array.from(stageMap.values()),
+  }
+
+  if (aggregateCache && aggregateCacheKey) {
+    try {
+      await runWithCacheTenant(
+        effectiveTenantId,
+        () => aggregateCache.set(aggregateCacheKey, response, {
+          ttl: DEALS_AGGREGATE_CACHE_TTL_MS,
+          tags: buildCollectionTags(
+            DEALS_AGGREGATE_CACHE_RESOURCE,
+            effectiveTenantId,
+            normalizeStringSet(orgFilterIds),
+          ),
+        }),
+      )
+    } catch (err) {
+      debugCrudCache('store', {
+        resource: DEALS_AGGREGATE_CACHE_RESOURCE,
+        key: aggregateCacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   return NextResponse.json(response)


### PR DESCRIPTION
Closes #5785
Tracking plan: .ai/runs/2026-08-30-deals-aggregate-response-cache.md
Status: complete

## 🎯 Goal

- Cache eligible `GET /api/customers/deals/aggregate` responses for 30 seconds so repeated kanban reads skip aggregate SQL and currency conversion without changing request, response, authorization, or invalidation contracts.

## What Changed

- Added a tenant- and organization-partitioned read-through cache behind the existing `ENABLE_CRUD_API_CACHE` opt-in.
- Bypassed caching whenever `search` or `isStuck` is present, including empty and false-valued parameters.
- Schema-validated cached values, failed open on cache backend errors, and tagged entries with the existing `customers.deal` invalidation resource.
- Added focused unit coverage plus a self-contained real-stack integration scenario for observable hits, bypasses, and supported-write invalidation.

## 🧪 Tests

- Focused route tests: 16 passed.
- `TC-CRM-5785` ephemeral integration scenario: 1 passed.
- `yarn generate`, both `yarn build:packages` passes, i18n checks, `yarn typecheck`, and `yarn build:app`: passed.
- The local full `yarn test` run encountered one reproducible unrelated assertion in `staff/timesheets/page.durationEntry.test.tsx`, a file unchanged by this PR; the final-head GitHub `test` job passed the complete repository suite.
- Final-head GitHub CI passed all applicable checks, including the ephemeral integration job.
- Automated diff review: clean, with no actionable findings. GitHub formal self-approval is unavailable because the authenticated reviewer is the PR author; branch protection remains authoritative.

## 💥 Breaking Changes

- None. The endpoint request, response, authorization, database, event, and public import contracts are unchanged.

## 📋 Progress

All tracking-plan steps are complete.
