### PR TITLE
fix(integrations): enable wildcard response enrichers (#5786)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -657,7 +657,7 @@ Run `yarn generate` or rely on `predev`/`prebuild`.
 
 ## Response Enrichers
 
-Response enrichers let a module add computed fields to another module's CRUD API responses (similar to GraphQL Federation).
+Response enrichers add computed fields to other modules' CRUD API responses.
 
 ### Creating an Enricher
 
@@ -668,7 +668,7 @@ import type { ResponseEnricher } from '@open-mercato/shared/lib/crud/response-en
 
 const myEnricher: ResponseEnricher = {
   id: 'mymodule.customer-metrics',
-  targetEntity: 'customers.person',     // entity to enrich
+  targetEntity: 'customers.person',     // use '*' for all; context.targetEntity stays concrete
   features: ['mymodule.view'],           // required ACL features
   priority: 10,                          // higher runs first
   timeout: 2000,                         // ms, default 2000

--- a/packages/core/src/modules/integrations/data/__tests__/enrichers.test.ts
+++ b/packages/core/src/modules/integrations/data/__tests__/enrichers.test.ts
@@ -1,0 +1,128 @@
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import {
+  applyResponseEnrichers,
+  applyResponseEnricherToRecord,
+} from '@open-mercato/shared/lib/crud/enricher-runner'
+import { registerResponseEnrichers } from '@open-mercato/shared/lib/crud/enricher-registry'
+import { enrichers } from '../enrichers'
+import { SyncExternalIdMapping } from '../entities'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+const mockedFindWithDecryption = jest.mocked(findWithDecryption)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  registerResponseEnrichers([{ moduleId: 'integrations', enrichers }])
+})
+
+describe('external ID mapping response enricher', () => {
+  it('enriches a concrete entity through the wildcard registry entry', async () => {
+    const forkedEm = { id: 'forked-em' }
+    const em = { fork: jest.fn(() => forkedEm) }
+    const mapping = Object.assign(new SyncExternalIdMapping(), {
+      id: 'mapping-1',
+      integrationId: 'example-provider',
+      internalEntityType: 'customers.person',
+      internalEntityId: 'record-1',
+      externalId: 'external-42',
+      syncStatus: 'synced' as const,
+      lastSyncedAt: new Date('2026-08-30T12:00:00.000Z'),
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+    })
+    mockedFindWithDecryption.mockResolvedValue([mapping])
+
+    const result = await applyResponseEnricherToRecord(
+      { id: 'record-1', displayName: 'Ada Lovelace' },
+      'customers.person',
+      {
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        userFeatures: ['integrations.view'],
+        em,
+        container: {},
+      },
+    )
+
+    expect(mockedFindWithDecryption).toHaveBeenCalledWith(
+      forkedEm,
+      SyncExternalIdMapping,
+      {
+        internalEntityType: 'customers.person',
+        internalEntityId: 'record-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      },
+      undefined,
+      { organizationId: 'org-1', tenantId: 'tenant-1' },
+    )
+    expect(result.record).toMatchObject({
+      id: 'record-1',
+      displayName: 'Ada Lovelace',
+      _integrations: {
+        'example-provider': {
+          externalId: 'external-42',
+          lastSyncedAt: '2026-08-30T12:00:00.000Z',
+          syncStatus: 'synced',
+        },
+      },
+    })
+    expect(result._meta.enrichedBy).toEqual(['integrations.external-id-mapping'])
+  })
+
+  it('batch-enriches a concrete entity list through the wildcard registry entry', async () => {
+    const forkedEm = { id: 'forked-em' }
+    const em = { fork: jest.fn(() => forkedEm) }
+    const mapping = Object.assign(new SyncExternalIdMapping(), {
+      id: 'mapping-1',
+      integrationId: 'example-provider',
+      internalEntityType: 'customers.person',
+      internalEntityId: 'record-1',
+      externalId: 'external-42',
+      syncStatus: 'synced' as const,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+    })
+    mockedFindWithDecryption.mockResolvedValue([mapping])
+
+    const result = await applyResponseEnrichers(
+      [{ id: 'record-1' }, { id: 'record-2' }],
+      'customers.person',
+      {
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        userFeatures: ['integrations.view'],
+        em,
+        container: {},
+      },
+    )
+
+    expect(mockedFindWithDecryption).toHaveBeenCalledTimes(1)
+    expect(mockedFindWithDecryption).toHaveBeenCalledWith(
+      forkedEm,
+      SyncExternalIdMapping,
+      expect.objectContaining({
+        internalEntityType: 'customers.person',
+        internalEntityId: { $in: ['record-1', 'record-2'] },
+      }),
+      undefined,
+      { organizationId: 'org-1', tenantId: 'tenant-1' },
+    )
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: 'record-1',
+        _integrations: {
+          'example-provider': expect.objectContaining({ externalId: 'external-42' }),
+        },
+      }),
+      { id: 'record-2', _integrations: {} },
+    ])
+    expect(result._meta.enrichedBy).toEqual(['integrations.external-id-mapping'])
+  })
+})

--- a/packages/shared/src/lib/crud/__tests__/enricher-registry.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/enricher-registry.test.ts
@@ -37,6 +37,22 @@ describe('enricher-registry', () => {
       expect(result[0].enricher.id).toBe('a.tier')
     })
 
+    it('includes wildcard enrichers in priority order for a concrete entity', () => {
+      registerResponseEnrichers([
+        {
+          moduleId: 'mod-a',
+          enrichers: [
+            makeEnricher({ id: 'a.exact', targetEntity: 'customers.person', priority: 10 }),
+            makeEnricher({ id: 'a.wildcard', targetEntity: '*', priority: 50 }),
+            makeEnricher({ id: 'a.other', targetEntity: 'sales.order', priority: 100 }),
+          ],
+        },
+      ])
+
+      const result = getEnrichersForEntity('customers.person')
+      expect(result.map((entry) => entry.enricher.id)).toEqual(['a.wildcard', 'a.exact'])
+    })
+
     it('returns enrichers regardless of queryEngine config', () => {
       registerResponseEnrichers([
         {

--- a/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/enricher-runner.test.ts
@@ -1,0 +1,59 @@
+import type { EnricherContext, ResponseEnricher } from '../response-enricher'
+import { registerResponseEnrichers } from '../enricher-registry'
+import { applyResponseEnricherToRecord } from '../enricher-runner'
+
+describe('enricher runner', () => {
+  it('partitions wildcard read-through cache entries by concrete entity', async () => {
+    const cacheEntries = new Map<string, unknown>()
+    const cache = {
+      get: jest.fn(async (key: string) => cacheEntries.get(key)),
+      set: jest.fn(async (key: string, value: unknown) => {
+        cacheEntries.set(key, value)
+      }),
+    }
+    const enrichOne = jest.fn(
+      async (record: Record<string, unknown>, context: EnricherContext) => ({
+        ...record,
+        enrichedFrom: context.targetEntity,
+      }),
+    )
+    const enricher: ResponseEnricher<
+      Record<string, unknown>,
+      { enrichedFrom: string | undefined }
+    > = {
+      id: 'test.wildcard-cache',
+      targetEntity: '*',
+      timeout: 10,
+      cache: { strategy: 'read-through', ttl: 60_000 },
+      enrichOne,
+    }
+    registerResponseEnrichers([{ moduleId: 'test', enrichers: [enricher] }])
+
+    const context: EnricherContext = {
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      em: {},
+      container: { resolve: () => cache },
+    }
+
+    const personResult = await applyResponseEnricherToRecord(
+      { id: 'shared-id' },
+      'customers.person',
+      context,
+    )
+    const orderResult = await applyResponseEnricherToRecord(
+      { id: 'shared-id' },
+      'sales.order',
+      context,
+    )
+
+    expect(personResult.record).toMatchObject({ enrichedFrom: 'customers.person' })
+    expect(orderResult.record).toMatchObject({ enrichedFrom: 'sales.order' })
+    expect(enrichOne).toHaveBeenCalledTimes(2)
+    expect(Array.from(cacheEntries.keys())).toEqual([
+      expect.stringContaining('entity:customers.person'),
+      expect.stringContaining('entity:sales.order'),
+    ])
+  })
+})

--- a/packages/shared/src/lib/crud/enricher-registry.ts
+++ b/packages/shared/src/lib/crud/enricher-registry.ts
@@ -87,7 +87,8 @@ export function getEnrichersForEntity(
   selector?: EnricherSurfaceSelector,
 ): EnricherRegistryEntry[] {
   const entityEntries = getResponseEnrichers().filter(
-    (entry) => entry.enricher.targetEntity === targetEntity,
+    (entry) =>
+      entry.enricher.targetEntity === targetEntity || entry.enricher.targetEntity === '*',
   )
 
   if (!selector || selector.surface === 'api-response') {

--- a/packages/shared/src/lib/crud/enricher-runner.ts
+++ b/packages/shared/src/lib/crud/enricher-runner.ts
@@ -137,11 +137,12 @@ function resolveCache(context: EnricherContext): CacheLike | null {
 function buildCacheKey(
   enricher: ResponseEnricher,
   context: EnricherContext,
+  targetEntity: string,
   mode: 'one' | 'many',
   recordIds: string[],
 ): string {
   const sortedIds = [...recordIds].sort((a, b) => a.localeCompare(b))
-  return `umes:enricher:${enricher.id}:tenant:${context.tenantId}:org:${context.organizationId}:mode:${mode}:ids:${JSON.stringify(sortedIds)}`
+  return `umes:enricher:${enricher.id}:entity:${targetEntity}:tenant:${context.tenantId}:org:${context.organizationId}:mode:${mode}:ids:${JSON.stringify(sortedIds)}`
 }
 
 function extractRecordId(record: Record<string, unknown>): string {
@@ -235,7 +236,9 @@ export async function applyResponseEnrichers<T extends Record<string, unknown>>(
       let result: T[]
       const recordIds = currentItems.map((item) => extractRecordId(item))
       const shouldUseCache = enricher.cache?.strategy === 'read-through'
-      const cacheKey = shouldUseCache ? buildCacheKey(enricher, context, 'many', recordIds) : null
+      const cacheKey = shouldUseCache
+        ? buildCacheKey(enricher, context, targetEntity, 'many', recordIds)
+        : null
       if (shouldUseCache && cacheKey) {
         const cached = await readEnricherCache<T[]>(cache, cacheKey)
         if (cached) {
@@ -334,7 +337,9 @@ export async function applyResponseEnricherToRecord<T extends Record<string, unk
     try {
       const recordId = extractRecordId(currentRecord)
       const shouldUseCache = enricher.cache?.strategy === 'read-through'
-      const cacheKey = shouldUseCache ? buildCacheKey(enricher, context, 'one', [recordId]) : null
+      const cacheKey = shouldUseCache
+        ? buildCacheKey(enricher, context, targetEntity, 'one', [recordId])
+        : null
       if (shouldUseCache && cacheKey) {
         const cached = await readEnricherCache<T>(cache, cacheKey)
         if (cached) {

--- a/packages/shared/src/lib/crud/enricher-runner.ts
+++ b/packages/shared/src/lib/crud/enricher-runner.ts
@@ -212,6 +212,7 @@ export async function applyResponseEnrichers<T extends Record<string, unknown>>(
   context: EnricherContext,
   preFilteredEntries?: EnricherRegistryEntry[],
 ): Promise<EnrichmentResult<T>> {
+  const enricherContext: EnricherContext = { ...context, targetEntity }
   const activeEntries = preFilteredEntries
     ? filterByACLAndTenant(preFilteredEntries, context)
     : getActiveEnrichers(targetEntity, context)
@@ -246,7 +247,7 @@ export async function applyResponseEnrichers<T extends Record<string, unknown>>(
 
       if (enricher.enrichMany) {
         result = await Promise.race([
-          enricher.enrichMany(currentItems, context) as Promise<T[]>,
+          enricher.enrichMany(currentItems, enricherContext) as Promise<T[]>,
           timeoutPromise(timeout),
         ])
       } else {
@@ -311,6 +312,7 @@ export async function applyResponseEnricherToRecord<T extends Record<string, unk
   context: EnricherContext,
   preFilteredEntries?: EnricherRegistryEntry[],
 ): Promise<SingleEnrichmentResult<T>> {
+  const enricherContext: EnricherContext = { ...context, targetEntity }
   const activeEntries = preFilteredEntries
     ? filterByACLAndTenant(preFilteredEntries, context)
     : getActiveEnrichers(targetEntity, context)
@@ -342,7 +344,7 @@ export async function applyResponseEnricherToRecord<T extends Record<string, unk
         }
       }
       const result = await Promise.race([
-        enricher.enrichOne(currentRecord, context) as Promise<T>,
+        enricher.enrichOne(currentRecord, enricherContext) as Promise<T>,
         timeoutPromise(timeout),
       ])
 

--- a/packages/shared/src/lib/crud/response-enricher.ts
+++ b/packages/shared/src/lib/crud/response-enricher.ts
@@ -17,6 +17,8 @@ export interface EnricherContext {
   organizationId: string
   tenantId: string
   userId: string
+  /** Concrete entity currently being enriched, including for wildcard enrichers. */
+  targetEntity?: string
   em: unknown
   container: unknown
   requestedFields?: string[]
@@ -53,7 +55,7 @@ export interface ResponseEnricher<TRecord = any, TEnriched = any> {
   /** Unique identifier: `<module>.<enricher-name>` */
   id: string
 
-  /** Target entity to enrich: `<module>.<entity>` (e.g., 'customers.person') */
+  /** Target entity to enrich: `<module>.<entity>` (e.g., 'customers.person') or `*` for all entities. */
   targetEntity: string
 
   /** ACL features required for this enricher to run */


### PR DESCRIPTION
Closes #5786

## 🎯 Goal
- Restore external-ID mapping enrichment on concrete CRUD entities so integrations can expose their `_integrations` metadata through the documented wildcard response enricher.

## 🔍 Problem
The integrations module registers its external-ID response enricher with `targetEntity: '*'`, but concrete CRUD responses never selected that entry. As a result, mapped external IDs were absent from every entity response.

## 🔍 Root Cause
The shared enricher registry only matched exact entity names. In addition, the runner did not pass the concrete entity name into `EnricherContext`, so the wildcard integrations enricher could not scope its mapping lookup even after selection.

## What Changed
- Teach the shared response-enricher registry to include wildcard entries while preserving global priority ordering and surface filtering.
- Pass the concrete target entity to both single-record and batch enrichers through an additive optional context field.
- Add registry coverage for exact/wildcard ordering and end-to-end integrations coverage for tenant-scoped single and batch external-ID mapping enrichment.
- Clarify the wildcard contract in the shared type documentation and response-enricher contributor guidance.

## 🧪 Tests
- `yarn workspace @open-mercato/shared test src/lib/crud/__tests__/enricher-registry.test.ts --runInBand` — 13 tests passed.
- `yarn workspace @open-mercato/core test src/modules/integrations/data/__tests__/enrichers.test.ts --runInBand` — 2 tests passed.
- Local CI gate passed for both `yarn build:packages` runs, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, and `yarn build:app`.
- `yarn test` completed 33 of 34 package tasks successfully. The unchanged `create-mercato-app` package reproducibly fails its standalone writable-AST oracle because the oracle reports its contained `yarn typecheck` gate timed out; an isolated rerun fails identically. All affected suites and the other monorepo test tasks passed.
- `yarn agents:check-budget` and `git diff --check` passed.

## 💥 Breaking Changes
- None. The context field is optional and additive; wildcard matching restores the existing documented contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790719221&installation_model_id=432243&pr_number=5798&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5798&signature=a81762833dca8b71fc3ec7c87e6a88f52d272ec4a79fbcc2d73d9d194f999cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->