### PR TITLE
feat(telemetry): add OTLP Docker topology and fail-fast bootstrap

### DIFF
--- a/.ai/runs/2026-08-31-telemetry-docker-topology.md
+++ b/.ai/runs/2026-08-31-telemetry-docker-topology.md
@@ -60,7 +60,7 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 ### Phase 1: Fail-fast OTLP bootstrap
 
 - [x] 1.1 Replace selected-OTLP fallback with an actionable startup error — 95e7942f6c
-- [x] 1.2 Add deterministic OTLP bootstrap unit coverage — 95e7942f6c
+- [x] 1.2 Add deterministic OTLP bootstrap unit coverage — 95e7942f6c; 04a857173f
 - [x] 1.3 Run focused telemetry validation and compatibility review — 95e7942f6c
 
 ### Phase 2: Docker topology and collector example
@@ -72,6 +72,6 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 
 ### Phase 3: Operator documentation and delivery gates
 
-- [ ] 3.1 Add the runtime telemetry guide, navigation entry, and logging cross-link
-- [ ] 3.2 Run focused documentation/topology checks and audit both-spec coverage
+- [x] 3.1 Add the runtime telemetry guide, navigation entry, and logging cross-link — 0e14f9bb98
+- [x] 3.2 Run focused documentation/topology checks and audit both-spec coverage — 04a857173f
 - [ ] 3.3 Run the full validation, review, and final delivery gates

--- a/.ai/runs/2026-08-31-telemetry-docker-topology.md
+++ b/.ai/runs/2026-08-31-telemetry-docker-topology.md
@@ -57,6 +57,8 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
+PR: #5799
+
 ### Phase 1: Fail-fast OTLP bootstrap
 
 - [x] 1.1 Replace selected-OTLP fallback with an actionable startup error — 95e7942f6c
@@ -74,4 +76,4 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 
 - [x] 3.1 Add the runtime telemetry guide, navigation entry, and logging cross-link — 0e14f9bb98
 - [x] 3.2 Run focused documentation/topology checks and audit both-spec coverage — 04a857173f
-- [ ] 3.3 Run the full validation, review, and final delivery gates
+- [x] 3.3 Run the full validation, review, and final delivery gates — 97e20d8951

--- a/.ai/runs/2026-08-31-telemetry-docker-topology.md
+++ b/.ai/runs/2026-08-31-telemetry-docker-topology.md
@@ -59,9 +59,9 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 
 ### Phase 1: Fail-fast OTLP bootstrap
 
-- [ ] 1.1 Replace selected-OTLP fallback with an actionable startup error
-- [ ] 1.2 Add deterministic OTLP bootstrap unit coverage
-- [ ] 1.3 Run focused telemetry validation and compatibility review
+- [x] 1.1 Replace selected-OTLP fallback with an actionable startup error — 95e7942f6c
+- [x] 1.2 Add deterministic OTLP bootstrap unit coverage — 95e7942f6c
+- [x] 1.3 Run focused telemetry validation and compatibility review — 95e7942f6c
 
 ### Phase 2: Docker topology and collector example
 

--- a/.ai/runs/2026-08-31-telemetry-docker-topology.md
+++ b/.ai/runs/2026-08-31-telemetry-docker-topology.md
@@ -1,0 +1,77 @@
+# Telemetry Docker topology and OTLP bootstrap
+
+Source doc: `.ai/specs/2026-08-30-telemetry-docker-topology.md`
+Companion source doc: `.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md`
+
+Engine: om-auto-create-pr (steps: 10, --loop: no)
+
+## Goal
+
+Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by wiring its runtime settings through supported Docker topologies, providing an opt-in local collector, and failing clearly when an explicitly selected OTLP backend lacks its optional runtime packages.
+
+## Scope
+
+- Preserve OpenTelemetry packages as optional dependencies.
+- Replace the selected-OTLP console fallback with a boot-time error that preserves the original import failure as its cause.
+- Forward the supported telemetry and OTLP environment variables through the root full-app Compose topology, its Traefik overlay, and the create-app template.
+- Add profile-gated collector services and byte-identical collector examples to the root topology and create-app template without publishing collector ports.
+- Add deterministic runtime and deployment contract tests.
+- Document direct OTLP export, the local collector profile, endpoint semantics, headers, sampling, trust, validation, and troubleshooting.
+
+## Non-goals
+
+- Moving OpenTelemetry packages from `optionalDependencies` to regular production dependencies.
+- Enabling telemetry or the collector by default.
+- Adding a production observability backend, authentication proxy, TLS termination, or public collector ingress.
+- Changing telemetry backend names, public package exports, database structures, or API routes.
+- Adding rendered application UI.
+
+## Implementation Plan
+
+### Phase 1: Fail-fast OTLP bootstrap
+
+1. Replace console fallback with an actionable startup error for explicitly selected OTLP backends while retaining the import error as `cause`.
+2. Add deterministic unit coverage for success, failure, no-fallback, disabled telemetry, and retry behavior.
+3. Run the telemetry package's focused test, type, and build checks and re-read the runtime diff for compatibility.
+
+### Phase 2: Docker topology and collector example
+
+1. Forward the supported telemetry and OTLP variables through all three app Compose definitions with consistent defaults.
+2. Add an opt-in, profile-gated collector service and byte-identical root/template collector configurations without host port publication.
+3. Add deterministic source-contract coverage for environment parity, profile gating, endpoint semantics, private ports, and config parity.
+4. Validate the root and create-app Compose graphs in disabled and telemetry-profile modes.
+
+### Phase 3: Operator documentation and delivery gates
+
+1. Add the runtime telemetry guide, sidebar entry, and logging cross-link.
+2. Run focused documentation and topology checks and audit the combined diff against both approved specs.
+3. Run the configured full validation gate, authoritative PR review with autofix, and final delivery checks.
+
+## Risks
+
+- Compose interpolation or overlay replacement rules could produce topology-specific drift; parsed contract tests and `docker compose config` checks cover every supported file combination.
+- Dynamic import failures vary by package manager and install mode; tests assert a stable operator-facing message and preserved cause rather than package-manager-specific error text.
+- Collector images and OTLP endpoint semantics can drift; the example pins an image version and documents that application containers use the collector service name rather than `localhost`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fail-fast OTLP bootstrap
+
+- [ ] 1.1 Replace selected-OTLP fallback with an actionable startup error
+- [ ] 1.2 Add deterministic OTLP bootstrap unit coverage
+- [ ] 1.3 Run focused telemetry validation and compatibility review
+
+### Phase 2: Docker topology and collector example
+
+- [ ] 2.1 Forward telemetry and OTLP variables through all supported Compose definitions
+- [ ] 2.2 Add profile-gated collector services and byte-identical example configurations
+- [ ] 2.3 Add deterministic Docker topology contract coverage
+- [ ] 2.4 Validate disabled and telemetry-profile Compose graphs
+
+### Phase 3: Operator documentation and delivery gates
+
+- [ ] 3.1 Add the runtime telemetry guide, navigation entry, and logging cross-link
+- [ ] 3.2 Run focused documentation/topology checks and audit both-spec coverage
+- [ ] 3.3 Run the full validation, review, and final delivery gates

--- a/.ai/runs/2026-08-31-telemetry-docker-topology.md
+++ b/.ai/runs/2026-08-31-telemetry-docker-topology.md
@@ -65,10 +65,10 @@ Make Open Mercato's optional OTLP telemetry mode deployable and diagnosable by w
 
 ### Phase 2: Docker topology and collector example
 
-- [ ] 2.1 Forward telemetry and OTLP variables through all supported Compose definitions
-- [ ] 2.2 Add profile-gated collector services and byte-identical example configurations
-- [ ] 2.3 Add deterministic Docker topology contract coverage
-- [ ] 2.4 Validate disabled and telemetry-profile Compose graphs
+- [x] 2.1 Forward telemetry and OTLP variables through all supported Compose definitions — 1e1a1d69b4
+- [x] 2.2 Add profile-gated collector services and byte-identical example configurations — 1e1a1d69b4
+- [x] 2.3 Add deterministic Docker topology contract coverage — 1e1a1d69b4
+- [x] 2.4 Validate disabled and telemetry-profile Compose graphs — 1e1a1d69b4
 
 ### Phase 3: Operator documentation and delivery gates
 

--- a/.ai/specs/2026-08-30-telemetry-docker-topology.md
+++ b/.ai/specs/2026-08-30-telemetry-docker-topology.md
@@ -1,0 +1,330 @@
+# OTLP Telemetry in the Standard Docker Topology
+
+## 📝 TLDR
+
+Wire the existing opt-in `@open-mercato/telemetry` runtime into the standard and standalone-app Docker Compose topologies. Operators will be able to pass the documented telemetry environment into the app container and start a diagnostic OpenTelemetry Collector through an explicit Compose profile, while telemetry remains completely off by default.
+
+This supplements `.ai/specs/2026-04-29-telemetry-and-otel.md`, whose package architecture is already implemented and intentionally left deployment infrastructure out of scope. The independently deployable missing-optional-dependency behavior requested by the same issue is specified separately in `.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md`; both specs may land through one coordinated implementation PR without conflating their design contracts.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirmation |
+|---|----------|-----------------|-----------|--------------|
+| Q1 | Does issue #5783 describe one independently deployable capability, or should generic OTLP missing-dependency hardening be specified separately from Docker topology enablement? | Split the generic runtime hardening into a companion spec while keeping this document focused on Docker topology. | A fresh-context scope reviewer confirmed that either change can ship without the other; separate contracts keep both specs cohesive while issue #5783 can still coordinate their delivery. | ok |
+| Q2 | Should the example collector be a commented Compose snippet or a profile-gated runnable service with a checked-in minimal configuration? | Add a profile-gated service and a checked-in minimal configuration that receives OTLP over HTTP and writes the three signals to the collector's debug exporter. | A runnable profile is testable and harder to rot than commented YAML; Compose profiles leave the default topology unchanged and are the official mechanism for opt-in services. | ok |
+
+Neither default changes a public API, database schema, or the behavior of deployments that leave telemetry unset. No assumption requires human confirmation before implementation.
+
+## 📝 Overview
+
+Open Mercato already initializes telemetry from the web, worker, scheduler, and CLI host paths only after `isTelemetryBackendEnabled()` reports an explicit backend. The OTLP provider exports traces, metrics, and logs over OTLP/HTTP and auto-instruments `pg` and `undici`. The missing layer is deployment wiring: the app container receives none of the telemetry variables documented in `apps/mercato/.env.example`, and the supported topology has no collector service.
+
+The implementation follows two established upstream mechanisms:
+
+- Docker Compose profiles make optional services absent from the default application model and activate them only through `--profile` or `COMPOSE_PROFILES`, which is the correct fit for an off-by-default diagnostic collector ([Docker Compose profiles](https://docs.docker.com/compose/how-tos/profiles/)).
+- The OTLP exporter standard uses `OTEL_EXPORTER_OTLP_ENDPOINT` as the common base URL and appends `/v1/traces`, `/v1/metrics`, and `/v1/logs` for OTLP/HTTP. A single in-network endpoint can therefore carry all three signals ([OpenTelemetry Protocol exporter specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/)).
+
+The collector example intentionally uses the debug exporter rather than pretending to be a production backend. It gives operators a deterministic smoke-test destination and a starting configuration; production routing, retention, dashboards, and credentials remain choices of the selected observability backend.
+
+## 📝 Problem Statement
+
+The supported production-style Docker image contains the telemetry workspace and normally installs its optional dependencies, but runtime configuration stops at the host. `TELEMETRY_BACKEND` and the standard OTEL exporter variables are not passed through the `app` service in either the fullapp topology or the standalone create-app topology. Setting the variables in the host `.env` file therefore does not activate telemetry inside the container.
+
+This creates three concrete failures:
+
+1. Operators can follow the documented `.env.example` block and still receive no server-side traces, metrics, or remote logs from a standard Docker deployment.
+2. There is no supported, local collector target with which to prove the pipeline before adding a vendor endpoint and credentials.
+3. A custom image built without optional dependencies can explicitly request `TELEMETRY_BACKEND=otlp` and receive console fallback output, making a broken production configuration look partially healthy.
+
+The 2026-08 production-topology benchmark exposed the operational consequence: query attribution fell back to `pg_stat_statements` and log scraping because the deployment topology could not enable the telemetry package already present in the codebase.
+
+## 📝 Proposed Solution
+
+### In scope
+
+- Pass the complete documented telemetry configuration from the host environment into the `app` service in:
+  - `docker-compose.fullapp.yml`;
+  - `docker-compose.fullapp.traefik.yml`;
+  - `packages/create-app/template/docker-compose.fullapp.yml`.
+- Add a `telemetry` Compose profile containing an OpenTelemetry Collector service to the root and standalone-app templates.
+- Add byte-equivalent minimal collector configuration files for the monorepo topology and the standalone template.
+- Add deployment documentation, Compose contract tests, and template parity coverage.
+
+### Out of scope
+
+- New spans, metrics, log fields, sampling algorithms, or instrumentation packages.
+- Browser/RUM telemetry.
+- A bundled production observability backend, dashboards, storage, alerting, or retention.
+- Publishing collector ports to the host by default.
+- Changing telemetry provider initialization or dependency placement; the companion fail-fast spec owns that independent runtime behavior.
+- Adding image build arguments or baking telemetry configuration into the Dockerfile. Runtime endpoints and credentials must remain runtime environment, not image metadata.
+
+## 📝 Architecture
+
+### Topology
+
+```text
+host .env
+   |
+   | selected TELEMETRY_* and OTEL_* values
+   v
+app container -- OTLP/HTTP --> otel-collector container -- debug exporter --> collector logs
+       |                            ^
+       |                            |
+       +-- web/workers/scheduler ---+  shared Compose network, no host port
+```
+
+The existing app bootstrap remains the only activation authority. Compose merely passes values through; it does not infer, rewrite, or default `TELEMETRY_BACKEND`. With the variable unset, the host check prevents the telemetry package and SDK from loading exactly as today.
+
+### Compose environment contract
+
+Each app service passes these values without secrets or production defaults:
+
+| Variable | Compose value | Purpose |
+|----------|---------------|---------|
+| `TELEMETRY_BACKEND` | `${TELEMETRY_BACKEND:-}` | Explicit selector: `otlp`, `signoz`, `newrelic`, `console`, or off when blank. |
+| `TELEMETRY_SAMPLING_RATIO` | `${TELEMETRY_SAMPLING_RATIO:-}` | Optional SDK sampling override. |
+| `TELEMETRY_TRUST_INBOUND_TRACE` | `${TELEMETRY_TRUST_INBOUND_TRACE:-false}` | Keeps inbound trace trust disabled unless the operator opts in. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `${OTEL_EXPORTER_OTLP_ENDPOINT:-}` | OTLP/HTTP base URL; for the bundled profile use `http://otel-collector:4318`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `${OTEL_EXPORTER_OTLP_HEADERS:-}` | Optional vendor authentication header string; remains runtime-only. |
+| `OTEL_SERVICE_NAME` | `${OTEL_SERVICE_NAME:-open-mercato}` | Stable service identity. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `${OTEL_RESOURCE_ATTRIBUTES:-}` | Optional deployment/environment attributes. |
+
+The standard OTEL endpoint and headers are passed verbatim. Compose files do not contain vendor credentials, example secrets, or an enabled backend default.
+
+The Traefik file is an overlay and normally merges with `docker-compose.fullapp.yml`; it repeats the telemetry environment mapping under its `app` fragment because issue #5783 explicitly treats every supported topology file as a contract. A contract test locks the variable set across both root files and the standalone template so the duplication cannot drift silently.
+
+### Collector profile
+
+Both production-style Compose trees add an `otel-collector` service with:
+
+- `profiles: [telemetry]`, so ordinary `docker compose up` does not create it;
+- a version-pinned official OpenTelemetry Collector image;
+- a read-only mount of `docker/otel-collector-config.yaml`;
+- the existing `mercato-network-fullapp` network;
+- no host-published ports;
+- an OTLP receiver bound to the container network on `0.0.0.0:4318`;
+- a batch processor and debug exporter for traces, metrics, and logs.
+
+The OTLP receiver supports traces, metrics, and logs over HTTP, and `/v1/traces`, `/v1/metrics`, and `/v1/logs` are its standard paths ([OTLP receiver reference](https://pkg.go.dev/go.opentelemetry.io/collector/receiver/otlpreceiver)).
+
+Operators start the diagnostic pipeline with an explicit command such as:
+
+```bash
+TELEMETRY_BACKEND=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+docker compose -f docker-compose.fullapp.yml --profile telemetry up --build
+```
+
+The app does not declare a hard `depends_on` edge to the profiled collector. Such an edge would make the default profile invalid or couple startup to an optional diagnostic component. OTLP exporter retry behavior absorbs collector start order, and an unavailable collector must not prevent an otherwise valid app from running.
+
+### Dockerfile decision
+
+No Dockerfile configuration or dependency-category change is required. The existing runner stage copies `packages/telemetry/package.json` and runs `yarn workspaces focus @open-mercato/app --production`, which installs optional dependencies unless an image builder explicitly excludes them. Runtime telemetry configuration must not become Docker `ARG` or baked `ENV`, because endpoints and authentication headers vary per deployment and may contain secrets.
+
+## 📝 Data Model
+
+Not applicable. The change adds no entity, table, migration, cache, queue payload, persistent state, or tenant-scoped data. The collector example receives the existing redacted telemetry signals and writes them only to its ephemeral debug output.
+
+## 📝 API Contracts
+
+Not applicable. No HTTP route, CLI command, event, queue name, public TypeScript export, or generated registry changes. The only new operator contract is additive Compose environment pass-through plus the optional `telemetry` profile.
+
+## 📝 UI/UX
+
+Not applicable. There is no application UI. The operator experience is documented Compose commands, expected collector log output, and troubleshooting for absent SDK packages or an unreachable collector.
+
+## 📝 Deployment and Operations
+
+The runtime documentation adds a dedicated telemetry page and links it from the framework runtime sidebar. It covers:
+
+1. the unchanged off-by-default behavior;
+2. direct export to a managed OTLP endpoint;
+3. local diagnostic export through `--profile telemetry`;
+4. the exact environment variables forwarded by Compose;
+5. how to inspect collector logs for all three signals;
+6. the difference between a diagnostic debug exporter and a production backend;
+7. failure messages for omitted optional dependencies and an unreachable endpoint;
+8. the security rule that exporter headers stay in deployment secrets and must never be committed.
+
+The existing structured-logging page links to the deployment page instead of duplicating the environment table.
+
+## 📝 Edge Cases & Failure Scenarios
+
+| Scenario | Required behavior | Verification |
+|----------|-------------------|--------------|
+| Telemetry variables are absent | Compose passes blank/default values; app bootstrap does not import telemetry; collector profile is absent. | Compose contract test plus existing default-unloaded/Next.js tests. |
+| Collector profile starts after the app | App remains up; exporter retries until the receiver is available. | Compose smoke command documented; no hard dependency edge. |
+| Collector is unavailable after startup | Application behavior continues; exporter failures remain telemetry-layer failures and are observable in logs. | Existing provider isolation behavior; documentation. |
+| `OTEL_EXPORTER_OTLP_HEADERS` contains credentials | Value is passed only as runtime environment, never echoed by tests/docs or stored in image layers. | Source review and secret-free fixtures. |
+| Root and template Compose files drift | Contract test fails on missing/mismatched telemetry variables, profile, mount, or collector config parity. | New Node test and template sync gate. |
+| Traefik overlay is used with the base file | Overlay merge retains the same telemetry values and labels; no duplicate service is created. | `docker compose config` validation when Docker Compose is available. |
+
+## 📝 Migration & Backward Compatibility
+
+This is additive for all default and supported deployments:
+
+- telemetry remains off when `TELEMETRY_BACKEND` is unset, blank, `noop`, or unknown;
+- no existing environment variable is renamed or removed;
+- no public function, type, import path, API route, event, schema, DI key, feature ID, notification ID, CLI command, or generated file changes;
+- default `docker compose up` starts the same services as before because the collector is profile-gated;
+- direct managed-backend export continues to work without starting the bundled collector.
+
+Rollback is a normal code/config rollback: remove the environment mappings and collector service/config. No stored data or migration state exists.
+
+## 📝 Testing Strategy
+
+### Deployment contract tests
+
+- Add a root Node test that asserts the app environment contains the exact telemetry variable set in the base, Traefik overlay, and standalone template Compose files.
+- Assert the collector is profile-gated, mounts the expected config read-only, joins the app network, and publishes no host ports.
+- Assert the monorepo and standalone collector configs are byte-identical and define OTLP/HTTP receiver, batch processor, debug exporter, and trace/metric/log pipelines.
+- Run `docker compose ... config` for the base and base+Traefik combinations when the CLI is available; the deterministic source assertions remain the CI-safe gate when Docker is unavailable.
+- Run `yarn template:sync` to ensure app-shell/template rules remain satisfied and the targeted standalone tests covering copied Docker assets.
+
+### Documentation and integration coverage
+
+- Build the docs application or run its smallest available link/build validation so the new sidebar route resolves.
+- Manual smoke, documented rather than made a mandatory networked CI test: start the telemetry profile, make one app request and one database-backed request, then verify collector logs contain at least one trace, metric, and log record.
+- No browser/UI QA is required because no rendered application surface changes.
+
+## 📝 Risks & Impact Review
+
+### Collector debug output exposes telemetry to container logs
+
+- **Scenario**: An operator enables the example profile in a shared environment and forwards collector logs more broadly than intended.
+- **Severity**: Medium.
+- **Affected area**: Deployment log pipeline.
+- **Mitigation**: Keep the profile opt-in, publish no collector ports, retain existing provider-boundary redaction, label the debug exporter diagnostic-only, and document replacement with a production exporter.
+- **Residual risk**: Redacted span names and low-cardinality attributes are still operational metadata; operators must apply their normal log access controls.
+
+### Compose duplication drifts
+
+- **Scenario**: A telemetry variable or collector setting is updated in the root topology but omitted from the Traefik overlay or standalone template.
+- **Severity**: Medium.
+- **Affected area**: Monorepo and generated standalone deployments.
+- **Mitigation**: Lock the exact environment set and byte-identical collector configs with a deterministic test; include the create-app template in the same implementation step.
+- **Residual risk**: Comments may still differ intentionally, but runtime keys and collector behavior are guarded.
+
+### Collector or backend is unreachable
+
+- **Scenario**: The app starts before the collector, DNS is wrong, or a managed endpoint is unavailable.
+- **Severity**: Low.
+- **Affected area**: Telemetry export only.
+- **Mitigation**: Do not make the app depend on the optional collector; rely on OTLP exporter retries and preserve provider failure isolation after successful initialization.
+- **Residual risk**: Telemetry may be delayed or dropped during a prolonged outage, but business traffic continues.
+
+### Image and startup cost
+
+- **Scenario**: Operators assume the profile adds no cost while optional SDK packages are still installed in standard production images.
+- **Severity**: Low.
+- **Affected area**: Image size and telemetry-enabled startup.
+- **Mitigation**: Keep default runtime unloaded, document that `optionalDependencies` are normally installed, and avoid adding any dependency or image layer in this change.
+- **Residual risk**: Standard images retain the existing OTEL package bytes; there is no new delta from dependency placement.
+
+## 📋 Phasing
+
+### Phase 1 — Standard topology wiring
+
+Pass the complete environment contract through every supported app Compose surface and add the diagnostic collector profile/config to both the monorepo and standalone template.
+
+### Phase 2 — Operator documentation and validation
+
+Document direct and collector-backed activation, lock topology/template parity with tests, and validate the full change through the repository's configured gate.
+
+Both phases ship together because environment pass-through without a documented/testable collector path would leave the same operator dead end, while a collector profile without app wiring could receive nothing from the standard topology.
+
+## 📋 Implementation Plan
+
+### Phase 1 — Standard topology wiring
+
+1. Add the exact telemetry environment mapping to the `app` services in `docker-compose.fullapp.yml`, `docker-compose.fullapp.traefik.yml`, and `packages/create-app/template/docker-compose.fullapp.yml`.
+2. Add the `otel-collector` service under `profiles: [telemetry]` to the root and standalone Compose files, using the shared service name, internal network, version-pinned image, read-only config mount, and no published ports.
+3. Add byte-identical `docker/otel-collector-config.yaml` and `packages/create-app/template/docker/otel-collector-config.yaml` files with OTLP/HTTP, batch, and debug pipelines for traces, metrics, and logs.
+4. Add a deterministic topology contract test under `scripts/__tests__/` covering environment parity, opt-in profile semantics, collector network/ports/mounts, and config parity.
+5. Run the topology test, Compose configuration validation, and targeted create-app/template checks.
+
+### Phase 2 — Operator documentation and full validation
+
+6. Add `apps/docs/docs/framework/runtime/telemetry.mdx`, link it from `apps/docs/sidebars.ts`, and add a concise pointer from the structured-logging telemetry section.
+7. Validate the docs route/build and run the configured repository validation sequence using one runner selected by the repository probe rules.
+8. Update this spec's changelog with the implementation result and exact validation evidence; retain it in the pending/root specs directory until the feature is merged and deployed.
+
+### File Manifest
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `docker-compose.fullapp.yml` | Modify | Pass telemetry env and add the opt-in collector. |
+| `docker-compose.fullapp.traefik.yml` | Modify | Keep overlay app environment contract explicit and in parity. |
+| `docker/otel-collector-config.yaml` | Add | Root diagnostic collector pipeline. |
+| `packages/create-app/template/docker-compose.fullapp.yml` | Modify | Give generated standalone apps the same opt-in topology. |
+| `packages/create-app/template/docker/otel-collector-config.yaml` | Add | Standalone diagnostic collector pipeline. |
+| `scripts/__tests__/fullapp-compose-telemetry.test.mjs` | Add | Guard topology and template parity. |
+| `apps/docs/docs/framework/runtime/telemetry.mdx` | Add | Document Docker and managed-backend enablement. |
+| `apps/docs/docs/framework/runtime/logging.mdx` | Modify | Link logging users to telemetry deployment guidance. |
+| `apps/docs/sidebars.ts` | Modify | Expose the new runtime documentation page. |
+| `.ai/specs/2026-08-30-telemetry-docker-topology.md` | Add/Update | Source design and implementation evidence. |
+
+## Final Compliance Report — 2026-08-30
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `packages/telemetry/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| Root `AGENTS.md` | Preserve behavior unless the issue/spec requests a change. | Compliant | Compose merely forwards operator-provided values and the new collector service is profile-gated. |
+| Root `AGENTS.md` | Ask before adding production dependencies. | Compliant | No dependency is added or moved; the existing OTEL packages stay optional. |
+| Root `AGENTS.md` | App environment changes must stay aligned with the create-app template. | Compliant | Runtime environment pass-through and collector assets are implemented in root and standalone topology together. |
+| `.ai/specs/AGENTS.md` | Non-trivial cross-file features require an implementation-accurate spec with tests. | Compliant | This spec defines exact files, failure modes, integration coverage, phasing, and rollback. |
+| `packages/telemetry/AGENTS.md` | Host integration is default-unloaded and unset/noop is absolute off. | Compliant | Compose does not default the backend; host gating remains the activation authority. |
+| `packages/telemetry/AGENTS.md` | OpenTelemetry packages stay optional and import only from `provider/otlp-provider.ts`. | Compliant | This topology spec does not change dependency placement or provider code. |
+| `packages/telemetry/AGENTS.md` | Do not expose PII, credentials, request bodies, SQL parameters, or arbitrary thrown properties. | Compliant | Headers remain runtime secrets; the loader error retains only a safe message and `cause`; existing provider redaction remains intact. |
+| `packages/create-app/AGENTS.md` | Keep app/template behavior aligned and validate standalone output. | Compliant | The template receives equivalent Compose/config changes and deterministic parity coverage. |
+| `BACKWARD_COMPATIBILITY.md` | Do not remove or narrow protected public contracts. | Compliant | No protected type, function, import, route, event, schema, DI, feature, notification, CLI, or generated-file surface changes. |
+| Root `AGENTS.md` data/security rules | Tenant scoping, zod input validation, encryption, mutation guards. | N/A | No data model, input, API, query, or mutation is introduced. |
+| Root `AGENTS.md` UI/design-system rules | Use canonical UI primitives, i18n, and semantic tokens. | N/A | No application UI or user-facing runtime string is added. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | Both are explicitly not applicable. |
+| API contracts match UI/UX section | Pass | No API or application UI is introduced; operator behavior lives in Compose/docs. |
+| Risks cover all write operations | Pass | There are no persistent writes; deployment, log exposure, drift, availability, and image-cost risks are covered. |
+| Commands defined for all mutations | Pass | No business mutation or command exists. |
+| Cache strategy covers all read APIs | Pass | No cache or read API exists. |
+| Compatibility matches implementation plan | Pass | The plan preserves all protected surfaces and keeps the default Compose model unchanged. |
+| Integration coverage maps to affected paths | Pass | All Compose variants, collector configs, template parity, and docs routing each have an explicit validation step. |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+**Fully compliant: Approved — ready for implementation.**
+
+## Changelog
+
+### 2026-08-30
+
+- Added the focused deployment specification for issue #5783.
+- Split generic missing-dependency runtime hardening into the companion `.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md` after a fresh-context cohesion review.
+- Selected a profile-gated diagnostic collector with exact root/template parity, tests, docs, rollback, and compatibility coverage.
+
+### Review — 2026-08-30
+
+- **Reviewer**: Agent; the initial fresh-context review returned SPLIT, the runtime-hardening capability moved into a companion spec, and a second fresh-context review passed this topology scope as one cohesive deployment capability.
+- **Security**: Passed — secrets remain runtime-only and no new listener is published to the host.
+- **Performance**: Passed — telemetry remains off/unloaded by default and no new dependency or always-on service is added.
+- **Cache**: Passed — no cache surface is involved.
+- **Commands**: Passed — no business command or mutation is involved.
+- **Risks**: Passed — debug-exporter exposure, drift, collector outage, and image cost are covered.
+- **Verdict**: Approved.

--- a/.ai/specs/2026-08-30-telemetry-docker-topology.md
+++ b/.ai/specs/2026-08-30-telemetry-docker-topology.md
@@ -328,3 +328,11 @@ None.
 - **Commands**: Passed — no business command or mutation is involved.
 - **Risks**: Passed — debug-exporter exposure, drift, collector outage, and image cost are covered.
 - **Verdict**: Approved.
+
+### Implementation — 2026-08-31
+
+- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime, deployment, documentation, and regression-test changes are complete at `8b07a5c32a` pending the final delivery-only plan commit.
+- Forwarded the seven supported telemetry/OTLP variables through the root, Traefik-overlay, and create-app Compose definitions.
+- Added the opt-in `telemetry` profile, pinned private collector service, and byte-identical root/template collector configurations without host-published ports or app startup coupling.
+- Added the operator telemetry guide, sidebar entry, logging cross-link, source-contract tests, and disabled/profile Compose graph validation.
+- Validation evidence: `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn lint`, `yarn build:app`, 97 telemetry tests, 47 combined Compose tests, 16 docs checks, and Docker Compose v5.4 config validation all passed. `yarn template:sync` reports only the pre-existing `modules.ts` drift. The local full `yarn test` gate is blocked solely by existing create-app live-harness host/sandbox failures; focused affected suites pass and the prior PR-head GitHub test check passed.

--- a/.ai/specs/2026-08-30-telemetry-docker-topology.md
+++ b/.ai/specs/2026-08-30-telemetry-docker-topology.md
@@ -331,7 +331,7 @@ None.
 
 ### Implementation — 2026-08-31
 
-- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime, deployment, documentation, and regression-test changes are complete at `8b07a5c32a` pending the final delivery-only plan commit.
+- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime, deployment, documentation, regression-test, review, and run-ledger changes are complete at `b403e61f4c`.
 - Forwarded the seven supported telemetry/OTLP variables through the root, Traefik-overlay, and create-app Compose definitions.
 - Added the opt-in `telemetry` profile, pinned private collector service, and byte-identical root/template collector configurations without host-published ports or app startup coupling.
 - Added the operator telemetry guide, sidebar entry, logging cross-link, source-contract tests, and disabled/profile Compose graph validation.

--- a/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
+++ b/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
@@ -1,0 +1,279 @@
+# Fail Fast When an Explicit OTLP Backend Is Unavailable
+
+## 📝 TLDR
+
+Keep the OpenTelemetry SDK packages optional, but reject telemetry bootstrap when an operator explicitly selects a built-in OTLP backend and those packages cannot load. This replaces the misleading console fallback with an actionable configuration failure while preserving the absolute-off, explicit-console, unknown-backend, and registered-custom-provider paths.
+
+This is the runtime-hardening companion to `.ai/specs/2026-08-30-telemetry-docker-topology.md`. A fresh-context cohesion review found that it is independently deployable from Docker topology wiring, so the two behaviors have separate design contracts even when issue #5783 coordinates them into one delivery.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirmation |
+|---|----------|-----------------|-----------|--------------|
+| Q1 | Should the OTEL packages move to regular dependencies, or remain optional with a fail-fast contract for explicitly selected OTLP backends? | Keep every `@opentelemetry/*` package in `optionalDependencies` and fail only when a built-in OTLP backend was explicitly selected but its provider import cannot load. | `packages/telemetry/AGENTS.md` requires optional placement and default-unloaded hosts; a scoped runtime error preserves that architecture while making contradictory operator configuration truthful. | ok |
+
+No public API, schema, dependency version, or dependency category changes. The chosen failure is limited to an explicit configuration that cannot satisfy its requested backend, so no assumption requires human confirmation.
+
+## 📝 Overview
+
+`packages/telemetry/src/init.ts` resolves built-in `otlp`, `signoz`, and `newrelic` aliases by dynamically importing `provider/otlp-provider.ts`. That file is the package's sole importer of the optional OpenTelemetry SDK. Today `loadOtlpProvider()` catches every dynamic-import failure, logs a warning, and returns `ConsoleProvider`.
+
+Optional dependencies are intentionally installable-but-omittable: package managers normally install them, while `--omit=optional` excludes them and leaves the application responsible for handling their absence ([npm `optionalDependencies` contract](https://docs.npmjs.com/files/package.json/#optionaldependencies)). Open Mercato's correct handling depends on operator intent:
+
+- no backend, `noop`, or unknown backend means absolute off and must remain a silent no-op;
+- `console` intentionally uses no OpenTelemetry SDK;
+- a registered custom provider owns its own dependency model;
+- an explicit built-in OTLP alias requests remote export and cannot be fulfilled without the optional SDK.
+
+The last case must fail truthfully rather than substitute a different provider.
+
+## 📝 Problem Statement
+
+The current fallback converts a hard configuration failure into apparent partial success:
+
+1. An operator builds an image without optional dependencies.
+2. The deployment sets `TELEMETRY_BACKEND=otlp`, `signoz`, or `newrelic` and supplies an OTLP endpoint.
+3. The provider import fails.
+4. Open Mercato logs one warning, initializes `ConsoleProvider`, registers the telemetry runtime/logger bridge, and logs `Telemetry initialized`.
+5. No remote traces, metrics, or logs reach the configured backend.
+
+This is worse than a clean startup error because health checks can pass while observability is silently absent. The benchmark and incident workflows that depend on telemetry cannot distinguish a valid OTLP pipeline from local-only console output without inspecting implementation-specific logs.
+
+## 📝 Proposed Solution
+
+Keep the existing provider selection order and dynamic-import boundary, but change the built-in OTLP import failure contract:
+
+- return a real OTLP provider when the import succeeds;
+- throw a dedicated internal `Error` when the import fails;
+- include the normalized built-in backend name in the message;
+- say that OpenTelemetry runtime dependencies are unavailable and explain the three safe remediations: install optional dependencies, choose `console`, or disable telemetry;
+- attach the original thrown value through the standard `cause` option without stringifying arbitrary object properties;
+- never instantiate or register `ConsoleProvider` on this path.
+
+The helper remains internal to `init.ts` (or an unexported neighboring implementation file). There is no new package export, public error class, environment variable, or configuration shape.
+
+### Preserved provider selection
+
+```text
+TELEMETRY_BACKEND unset/blank/noop
+  -> no provider, no package hooks, resolve successfully
+
+registered provider with the exact configured name
+  -> registered provider wins, unchanged
+
+console
+  -> ConsoleProvider, unchanged
+
+otlp/signoz/newrelic
+  -> dynamic import succeeds: OtlpProvider
+  -> dynamic import fails: actionable bootstrap error
+
+unknown/unregistered name
+  -> unsupported warning and disabled telemetry, unchanged
+```
+
+### Error safety
+
+The thrown error message is static apart from the already-normalized backend enum. It must not include:
+
+- endpoint URLs;
+- `OTEL_EXPORTER_OTLP_HEADERS`;
+- environment dumps;
+- arbitrary thrown-object serialization;
+- module resolution search paths.
+
+`cause` preserves diagnostic context for the host/logger without manually expanding values. Tests assert only safe message fragments and error identity, never credential-like fixtures.
+
+## 📝 Architecture
+
+The change stays inside `@open-mercato/telemetry`'s initialization boundary:
+
+```text
+host checks isTelemetryBackendEnabled()
+  -> dynamic import @open-mercato/telemetry
+     -> initTelemetry()
+        -> resolve registered/custom provider first
+        -> resolve built-in provider
+           -> dynamic import ./provider/otlp-provider
+              -> success: start/register OTLP provider
+              -> failure: reject host bootstrap with safe cause chain
+```
+
+Default-unloaded behavior is preserved because the host never imports this package when telemetry is off. OpenTelemetry imports remain confined to `provider/otlp-provider.ts`. No global registry or logger/runtime bridge is mutated until `provider.start()` succeeds, so a provider-load rejection leaves telemetry uninitialized and re-initializable after configuration is corrected.
+
+For deterministic testing, the internal loader may accept an optional importer function or use a module mock, provided the injection seam is not exported from the package root. Production calls use the real dynamic import.
+
+## 📝 Data Model
+
+Not applicable. No persistent state, entity, migration, cache, tenant scope, or data flow changes.
+
+## 📝 API Contracts
+
+Not applicable. No HTTP route, CLI command, public TypeScript export, event, queue payload, DI key, or generated artifact changes.
+
+## 📝 UI/UX
+
+Not applicable. This is an operator-visible startup failure, documented in the companion telemetry deployment page; it adds no application UI or translatable end-user string.
+
+## 📝 Edge Cases & Failure Scenarios
+
+| Scenario | Required behavior | Verification |
+|----------|-------------------|--------------|
+| Backend unset, blank, or `noop` | Resolve without importing provider code or registering hooks. | Existing default-unloaded and init tests. |
+| Backend `console` | Start `ConsoleProvider` without importing OpenTelemetry packages. | Existing console provider test. |
+| Backend is an unknown unregistered string | Keep the current unsupported warning and disabled result. | Existing env/registry test. |
+| Exact custom provider is registered | Custom provider starts before built-in resolution and is unaffected even if its name resembles a future backend. | Existing custom-provider env-load-order test. |
+| Built-in OTLP alias and provider import succeeds | Start `OtlpProvider`; active provider/runtime/logger bridge register once. | Existing in-memory OTLP integration plus focused init assertion. |
+| Built-in OTLP alias and provider import fails | Reject with safe actionable error and original `cause`; no console provider, active provider, logger extension, or runtime bridge. | New deterministic loader-failure unit test. |
+| Initialization is retried after failure | A corrected configuration can call `initTelemetry()` again because `initialized` was never set. | New retry regression test. |
+| Provider module loads but `provider.start()` fails | Preserve current rejection and re-initializable state; do not rewrite it as a missing-dependency error. | Existing initialization ordering test or focused assertion. |
+
+## 📝 Migration & Backward Compatibility
+
+No protected contract from `BACKWARD_COMPATIBILITY.md` changes. The internal helper is not exported, all public function signatures/import paths remain stable, and no route/schema/event/DI/ACL/notification/CLI/generated surface changes.
+
+Default behavior remains byte-for-byte equivalent for telemetry-off deployments. Explicit console, unknown, and custom-provider behavior also remains unchanged.
+
+The sole intentional behavior correction affects a contradictory opt-in configuration: a built-in remote backend is selected while its runtime packages are unavailable. That configuration currently cannot perform its requested export. It now fails startup with remediation instead of silently switching providers. Operators migrate by rebuilding with optional dependencies included, selecting `TELEMETRY_BACKEND=console`, or unsetting/disabling telemetry.
+
+Rollback restores the catch-and-console-fallback implementation. There is no stored state to migrate or undo.
+
+## 📝 Testing Strategy
+
+- Preserve existing tests for the off path, explicit console provider, unknown backend, registered custom provider, OTLP integration, and initialization idempotency.
+- Add an internal importer seam or module mock that forces the dynamic import to reject with a known `Error`.
+- Assert `initTelemetry()` rejects with a message naming the selected built-in backend and safe remediation.
+- Assert `error.cause` is the original error object.
+- Assert no active provider, console provider, logger extension, or shared runtime bridge was installed.
+- Correct the importer/configuration and assert a subsequent call can initialize successfully.
+- Run `yarn workspace @open-mercato/telemetry test`, `yarn workspace @open-mercato/telemetry build`, and `yarn typecheck` within the selected validation runner.
+
+No network, database, Docker daemon, or browser is required.
+
+## 📝 Risks & Impact Review
+
+### Misconfigured deployments stop instead of degrading
+
+- **Scenario**: A custom image intentionally omits optional packages but leaves a built-in OTLP backend selected; after upgrade, its host process exits during bootstrap.
+- **Severity**: Medium.
+- **Affected area**: Web, worker, scheduler, or CLI hosts sharing the explicit telemetry configuration.
+- **Mitigation**: Limit failure to built-in OTLP aliases, provide exact remediation, document it beside deployment steps, and preserve off/console/custom paths with regression tests.
+- **Residual risk**: The deployment remains unavailable until corrected; accepted because remote telemetry was explicitly required and console substitution is a false success.
+
+### Import failure is misclassified
+
+- **Scenario**: The provider module exists but throws for an internal code defect, and the error message describes runtime dependencies as unavailable.
+- **Severity**: Medium.
+- **Affected area**: Telemetry-enabled startup and diagnostics.
+- **Mitigation**: Preserve the original `cause`, keep the message broad enough to cover unavailable/unusable runtime packages, and let package tests exercise the real provider import path.
+- **Residual risk**: The top-level remediation may be incomplete for a provider code defect, but the cause chain retains the concrete failure for debugging.
+
+### Error content leaks configuration
+
+- **Scenario**: A module-loader error or arbitrary thrown value contains a path or configuration value and is manually interpolated into the public message.
+- **Severity**: Medium.
+- **Affected area**: Startup logs.
+- **Mitigation**: Use a static top-level message, attach the original value only as standard `cause`, never serialize arbitrary properties, and test with a credential-like cause that the message omits it.
+- **Residual risk**: A host that logs full error causes may expose module paths from the runtime; no new endpoint/header values are added by this change.
+
+### Retry leaves partial global state
+
+- **Scenario**: A failed initialization mutates a provider/logger/runtime global and a retry double-registers or observes stale state.
+- **Severity**: Low.
+- **Affected area**: Process-local telemetry registry.
+- **Mitigation**: Keep the failure before `provider.start()`, `setActiveProvider`, logger extension, runtime registration, and `initialized=true`; assert clean retry behavior.
+- **Residual risk**: None beyond pre-existing provider module evaluation side effects, which the import-only provider file does not register globally before construction.
+
+## 📋 Phasing
+
+### Phase 1 — Internal fail-fast contract
+
+Replace the built-in OTLP console fallback with the safe actionable error while preserving provider selection and optional import boundaries.
+
+### Phase 2 — Regression and operator coverage
+
+Pin every provider-selection branch and retry invariant in unit tests, then link the failure/remediation from the Docker telemetry documentation delivered by the companion topology spec.
+
+## 📋 Implementation Plan
+
+### Phase 1 — Internal fail-fast contract
+
+1. Refactor the internal OTLP provider loader in `packages/telemetry/src/init.ts` so a dynamic-import failure throws the documented safe error with `cause` instead of returning `ConsoleProvider`.
+2. Keep built-in provider resolution, custom-provider precedence, and state mutation ordering unchanged.
+3. Build the telemetry package to verify the internal error/cause shape against the repository's TypeScript target.
+
+### Phase 2 — Regression and operator coverage
+
+4. Add focused unit coverage for real OTLP success, forced importer failure, safe message/cause, no console/runtime fallback, and successful retry after correction.
+5. Run the telemetry unit suite and typecheck.
+6. Ensure the companion Docker telemetry documentation explains the error and the install/console/off remediation paths.
+7. Update this spec's changelog with implementation and validation evidence; retain it in the pending/root specs directory until merged and deployed.
+
+### File Manifest
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/telemetry/src/init.ts` | Modify | Replace false-success console fallback with an internal actionable error. |
+| `packages/telemetry/src/__tests__/telemetry.test.ts` or a focused init test | Modify/Add | Pin provider-selection, failure, cause, clean state, and retry behavior. |
+| `apps/docs/docs/framework/runtime/telemetry.mdx` | Coordinate | Document remediation through the companion topology implementation. |
+| `.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md` | Add/Update | Source design and implementation evidence. |
+
+## Final Compliance Report — 2026-08-30
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `packages/telemetry/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| Root `AGENTS.md` | Preserve behavior unless the issue/spec explicitly requests a change. | Compliant | Issue #5783 explicitly requests loud failure when optional OTLP packages are absent; all other provider paths remain unchanged. |
+| Root `AGENTS.md` | Ask before adding production dependencies. | Compliant | No dependency is added, moved, or re-versioned. |
+| `.ai/specs/AGENTS.md` | Significant behavior changes require an implementation-accurate spec and tests. | Compliant | The affected branch, state invariants, failure modes, rollback, and tests are explicit. |
+| `packages/telemetry/AGENTS.md` | Host integration remains default-unloaded and unset/noop is absolute off. | Compliant | The host/off path is untouched and regression-tested. |
+| `packages/telemetry/AGENTS.md` | OpenTelemetry packages stay optional and may only be imported by `provider/otlp-provider.ts`. | Compliant | Dependency placement and the dynamic import boundary remain unchanged. |
+| `packages/telemetry/AGENTS.md` | Never emit credentials, PII, SQL parameters, request bodies, or arbitrary thrown-object properties. | Compliant | The new top-level error is static and the original value is attached only as `cause`. |
+| `BACKWARD_COMPATIBILITY.md` | Protected types, signatures, import paths, and other contract surfaces may not break. | Compliant | The loader/error remains internal and no protected surface changes. |
+| Root data/API/UI rules | Tenant scoping, validation, encryption, mutation guards, design system, and i18n. | N/A | No data, API, mutation, or application UI is involved. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | Both are not applicable. |
+| API contracts match UI/UX section | Pass | All are not applicable; operator failure is startup-only. |
+| Risks cover all state changes | Pass | Clean initialization state and retry are explicit. |
+| Commands defined for all mutations | Pass | No business mutation exists. |
+| Cache strategy covers all read APIs | Pass | No cache or read API exists. |
+| Compatibility matches implementation plan | Pass | Only an internal false-success branch changes; all protected paths are pinned. |
+| Tests map to every behavior branch | Pass | Off, console, unknown, custom, OTLP success, OTLP failure, and retry are covered. |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+**Fully compliant: Approved — ready for implementation.**
+
+## Changelog
+
+### 2026-08-30
+
+- Split missing-optional-dependency runtime hardening from the Docker topology spec after a fresh-context cohesion review.
+- Kept OTEL packages optional and specified a safe, actionable failure limited to explicit built-in OTLP aliases.
+- Added clean-state, retry, secrets-safety, compatibility, and validation requirements.
+
+### Review — 2026-08-30
+
+- **Reviewer**: Agent; a fresh-context review passed this as one cohesive runtime-hardening capability after it was split from Docker topology work.
+- **Security**: Passed — the error is static, credentials are excluded, and arbitrary causes are not manually serialized.
+- **Performance**: Passed — the off path and dynamic import boundary are unchanged.
+- **Cache**: Passed — no cache surface is involved.
+- **Commands**: Passed — no business command or mutation is involved.
+- **Risks**: Passed — startup availability, misclassification, error leakage, and retry state are covered.
+- **Verdict**: Approved.

--- a/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
+++ b/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
@@ -280,8 +280,8 @@ None.
 
 ### Implementation — 2026-08-31
 
-- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime hardening is complete at `8b07a5c32a` pending the final delivery-only plan commit.
+- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime hardening, legacy CLI migration, review, and run-ledger changes are complete at `b403e61f4c`.
 - Replaced the selected-OTLP console fallback with an internal actionable error that retains the original import failure as `cause`, leaves initialization state clean, and permits retry after correction while keeping OpenTelemetry packages optional.
 - Marked only that intentional dependency failure for propagation through the reusable Next.js helper; unrelated provider initialization failures remain best effort.
 - Terminated the shipped app host at its instrumentation boundary with exit code 1 and a sanitized top-level stderr message, mirrored the behavior into the create-app template and `mercato telemetry init` output, and added regression coverage that proves the nested cause is not printed.
-- Validation evidence: the telemetry suite passes 97/97 tests, the app host-boundary test passes, the CLI telemetry-init suite passes 13/13, telemetry and CLI package typechecks pass, and the full repository `yarn typecheck` and `yarn lint` gates pass (with 10 pre-existing warnings only).
+- Validation evidence: the telemetry suite passes 97/97 tests, the app host-boundary test passes, the CLI telemetry-init suite passes 16/16, telemetry and CLI package typechecks pass, and the full repository `yarn typecheck` and `yarn lint` gates pass (with 10 pre-existing warnings only).

--- a/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
+++ b/.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md
@@ -277,3 +277,11 @@ None.
 - **Commands**: Passed — no business command or mutation is involved.
 - **Risks**: Passed — startup availability, misclassification, error leakage, and retry state are covered.
 - **Verdict**: Approved.
+
+### Implementation — 2026-08-31
+
+- Implemented in PR #5799 on `feat/telemetry-docker-topology`; the runtime hardening is complete at `8b07a5c32a` pending the final delivery-only plan commit.
+- Replaced the selected-OTLP console fallback with an internal actionable error that retains the original import failure as `cause`, leaves initialization state clean, and permits retry after correction while keeping OpenTelemetry packages optional.
+- Marked only that intentional dependency failure for propagation through the reusable Next.js helper; unrelated provider initialization failures remain best effort.
+- Terminated the shipped app host at its instrumentation boundary with exit code 1 and a sanitized top-level stderr message, mirrored the behavior into the create-app template and `mercato telemetry init` output, and added regression coverage that proves the nested cause is not printed.
+- Validation evidence: the telemetry suite passes 97/97 tests, the app host-boundary test passes, the CLI telemetry-init suite passes 13/13, telemetry and CLI package typechecks pass, and the full repository `yarn typecheck` and `yarn lint` gates pass (with 10 pre-existing warnings only).

--- a/apps/docs/docs/framework/runtime/logging.mdx
+++ b/apps/docs/docs/framework/runtime/logging.mdx
@@ -157,6 +157,10 @@ an observability outage cannot affect application behavior.
 Keep importing `createLogger` from this page's shared path. Module code must not
 import a provider-specific logger.
 
+To export these normalized records together with traces and metrics, see
+[OTLP Telemetry Deployment](./telemetry) for managed endpoints, the opt-in
+Docker collector profile, sampling, and startup troubleshooting.
+
 ## Redaction — a Safety Net, Not a Guarantee
 
 The server transport configures pino's built-in `redact` for the obvious sensitive keys, censoring values to `[Redacted]`:

--- a/apps/docs/docs/framework/runtime/telemetry.mdx
+++ b/apps/docs/docs/framework/runtime/telemetry.mdx
@@ -1,0 +1,153 @@
+---
+title: OTLP Telemetry Deployment
+description: Enable Open Mercato traces, metrics, and logs through a managed OTLP endpoint or the opt-in Docker collector profile.
+---
+
+# OTLP Telemetry Deployment
+
+Open Mercato can export server-side traces, metrics, and structured logs through OpenTelemetry Protocol over HTTP (OTLP/HTTP). Telemetry is off by default: when `TELEMETRY_BACKEND` is unset, blank, `noop`, or unknown, the application does not load the telemetry runtime or OpenTelemetry SDK.
+
+Use either of these deployment modes:
+
+- **Managed or existing collector** — point the app directly at an OTLP/HTTP endpoint. No bundled collector service is needed.
+- **Local diagnostic collector** — enable the Compose `telemetry` profile. The collector receives all three signals and writes them to its debug exporter so you can verify the pipeline.
+
+The profile is a diagnostic starting point, not a production observability backend. It has no storage, dashboards, retention, or alerting.
+
+## Quick start with the Docker collector
+
+Add these values to the `.env` file beside `docker-compose.fullapp.yml`:
+
+```dotenv
+TELEMETRY_BACKEND=otlp
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=open-mercato
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=local
+```
+
+Start the full app and the opt-in collector:
+
+```bash
+docker compose -f docker-compose.fullapp.yml \
+  --profile telemetry up --build
+```
+
+The same command works from a generated create-app project. With the bundled Traefik overlay, include both files:
+
+```bash
+docker compose \
+  -f docker-compose.fullapp.yml \
+  -f docker-compose.fullapp.traefik.yml \
+  --profile telemetry up --build
+```
+
+Make an application request, exercise a database-backed path, and inspect the collector:
+
+```bash
+docker compose -f docker-compose.fullapp.yml \
+  --profile telemetry logs -f otel-collector
+```
+
+The debug output should eventually contain trace, metric, and log records. Export is batched, so records may not appear on the same line or immediately after the request.
+
+The collector:
+
+- runs only when the `telemetry` profile is selected;
+- listens on port `4318` inside `mercato-network-fullapp`;
+- publishes no port to the host;
+- uses a version-pinned official collector image;
+- loads `docker/otel-collector-config.yaml` read-only;
+- has no hard startup dependency from the app.
+
+[Compose profiles](https://docs.docker.com/compose/how-tos/profiles/) keep the default service graph unchanged. OTLP exporter retry behavior handles collector start order, so telemetry startup does not couple business traffic to this optional service.
+
+## Export directly to an OTLP backend
+
+For a managed vendor or an existing collector, set its base endpoint and authentication headers in deployment secrets, then start the ordinary Compose graph without the `telemetry` profile:
+
+```dotenv
+TELEMETRY_BACKEND=otlp
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com
+OTEL_EXPORTER_OTLP_HEADERS=api-key=replace-with-a-secret
+OTEL_SERVICE_NAME=open-mercato
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+```
+
+```bash
+docker compose -f docker-compose.fullapp.yml up -d
+```
+
+`otlp`, `signoz`, and `newrelic` select the same OTLP provider. Endpoint and header values choose the destination; there is no provider-specific application code path.
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is the common OTLP/HTTP base URL. The standard exporters append `/v1/traces`, `/v1/metrics`, and `/v1/logs`. Do not append a signal path to the common endpoint unless the destination's documentation explicitly requires a non-standard base. See the [OTLP exporter specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/).
+
+Inside the app container, `localhost` refers to the app container itself. Use `http://otel-collector:4318` for the bundled profile or the network-reachable hostname supplied by your collector/vendor.
+
+## Configuration reference
+
+The supported full-app, Traefik overlay, and create-app Compose files forward the same runtime values:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TELEMETRY_BACKEND` | blank (off) | `otlp`, `signoz`, or `newrelic` for OTLP export; `console` for local span/metric diagnostics; `noop` or blank for off. |
+| `TELEMETRY_SAMPLING_RATIO` | `1.0` outside production, `0.1` in production | Root trace sampling ratio from `0.0` through `1.0`. Invalid values use the environment default. |
+| `TELEMETRY_TRUST_INBOUND_TRACE` | `false` | Continue caller-supplied W3C trace context. Enable only behind trusted infrastructure. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | exporter default when blank | Common OTLP/HTTP base endpoint. Use `http://otel-collector:4318` for the bundled profile. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | blank | Comma-separated exporter authentication headers. Store only in deployment secrets. |
+| `OTEL_SERVICE_NAME` | `open-mercato` | Stable service name shown by the collector/backend. |
+| `OTEL_RESOURCE_ATTRIBUTES` | blank | Comma-separated resource attributes such as `deployment.environment=production`. |
+
+The Compose files do not enable a backend or invent credentials. They pass operator-provided values into the app container at runtime, so endpoints and secrets are not baked into the image.
+
+`TELEMETRY_TRUST_INBOUND_TRACE=false` is the safe default because both `traceparent` and the backup trace header are caller-controlled at an HTTP boundary. Queue/event propagation through the dedicated `_trace` carrier continues to work without enabling inbound trust.
+
+## Optional dependency behavior
+
+The OpenTelemetry SDK packages remain `optionalDependencies` so the disabled path stays unloaded. Standard Open Mercato images include them unless the image build explicitly omits optional dependencies.
+
+If `otlp`, `signoz`, or `newrelic` is selected but those packages cannot load, startup fails with an error naming the selected backend and explaining the safe remediations. The application no longer substitutes the console backend, because that would make a broken remote-export configuration appear healthy.
+
+Choose one remediation:
+
+1. Rebuild or install with optional dependencies included.
+2. Set `TELEMETRY_BACKEND=console` when local diagnostic output is intentional.
+3. Unset `TELEMETRY_BACKEND` or set it to `noop` to disable telemetry.
+
+The original module-loading failure is retained as the error cause for diagnostics. The top-level message does not include endpoint URLs, exporter headers, or arbitrary thrown-object values.
+
+## Troubleshooting
+
+### Collector logs are empty
+
+1. Confirm that the profile is active:
+
+   ```bash
+   docker compose -f docker-compose.fullapp.yml --profile telemetry ps
+   ```
+
+2. Check only the non-secret values inside the app container:
+
+   ```bash
+   docker compose -f docker-compose.fullapp.yml exec app printenv TELEMETRY_BACKEND
+   docker compose -f docker-compose.fullapp.yml exec app printenv OTEL_EXPORTER_OTLP_ENDPOINT
+   ```
+
+3. Confirm the endpoint is `http://otel-collector:4318`, not `localhost`.
+4. Exercise a real application and database path, then allow time for batch export.
+5. Inspect app logs for exporter errors and collector logs for receiver/configuration errors.
+
+Do not print `OTEL_EXPORTER_OTLP_HEADERS` during troubleshooting; it commonly contains credentials.
+
+### The collector is unreachable after startup
+
+The application has no hard dependency on the diagnostic collector. After a successful SDK bootstrap, exporter failures stay in the telemetry layer while application traffic continues. Check that both services share `mercato-network-fullapp`, that the `telemetry` profile is active, and that the endpoint uses the `otel-collector` service name.
+
+### Too few or too many traces arrive
+
+Set `TELEMETRY_SAMPLING_RATIO` between `0.0` and `1.0`. The sampler is parent-based: child spans follow their trace's existing decision, while new root traces use the configured ratio. Use `1.0` for a short diagnostic session, then choose a lower production ratio based on traffic and backend cost.
+
+### Debug output is too sensitive or noisy
+
+The bundled collector writes operational telemetry to container logs. It is opt-in and the provider applies its normal redaction, but span names and low-cardinality attributes are still operational metadata. Restrict log access and replace the debug exporter with an authenticated production exporter before using the configuration as a longer-lived deployment.
+
+For application logging behavior, trace correlation, level control, and redaction boundaries, see [Structured Logging](./logging).

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -515,6 +515,7 @@ const sidebars: SidebarsConfig = {
             "framework/runtime/data-engine",
             "framework/runtime/request-lifecycle",
             "framework/runtime/logging",
+            "framework/runtime/telemetry",
           ],
         },
         {

--- a/apps/mercato/src/__tests__/instrumentation-telemetry-bootstrap.test.ts
+++ b/apps/mercato/src/__tests__/instrumentation-telemetry-bootstrap.test.ts
@@ -1,0 +1,44 @@
+describe('telemetry instrumentation bootstrap', () => {
+  const originalBackend = process.env.TELEMETRY_BACKEND
+  const originalNextPhase = process.env.NEXT_PHASE
+  const originalNextRuntime = process.env.NEXT_RUNTIME
+
+  afterEach(() => {
+    jest.resetModules()
+    jest.restoreAllMocks()
+    jest.dontMock('@open-mercato/telemetry/nextjs')
+    if (originalBackend === undefined) delete process.env.TELEMETRY_BACKEND
+    else process.env.TELEMETRY_BACKEND = originalBackend
+    if (originalNextPhase === undefined) delete process.env.NEXT_PHASE
+    else process.env.NEXT_PHASE = originalNextPhase
+    if (originalNextRuntime === undefined) delete process.env.NEXT_RUNTIME
+    else process.env.NEXT_RUNTIME = originalNextRuntime
+  })
+
+  it('writes only the safe bootstrap message to stderr before exiting', async () => {
+    const bootstrapFailure = new Error('safe OTLP dependency remediation')
+    Object.defineProperty(bootstrapFailure, 'cause', {
+      value: new Error('private module path with token=secret-value'),
+    })
+    jest.doMock('@open-mercato/telemetry/nextjs', () => ({
+      registerTelemetryForNextjs: jest.fn(async () => {
+        throw bootstrapFailure
+      }),
+    }))
+    const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const interceptedExit = new Error('process exit intercepted')
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw interceptedExit
+    })
+    process.env.NEXT_RUNTIME = 'nodejs'
+    process.env.NEXT_PHASE = 'phase-production-build'
+    process.env.TELEMETRY_BACKEND = 'otlp'
+    const { register } = await import('../instrumentation')
+
+    await expect(register()).rejects.toBe(interceptedExit)
+
+    expect(stderrWrite).toHaveBeenCalledWith('safe OTLP dependency remediation\n')
+    expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining('secret-value'))
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/apps/mercato/src/instrumentation.ts
+++ b/apps/mercato/src/instrumentation.ts
@@ -27,12 +27,19 @@ export async function register(): Promise<void> {
   // Initialize telemetry (no-op unless TELEMETRY_BACKEND is set). OTEL's NodeSDK
   // is Node-only and incompatible with the edge runtime, so the telemetry
   // bootstrap — which can pull in the SDK — is imported only on the Node.js
-  // runtime. The helper owns init + graceful degrade + shutdown flush.
+  // runtime. The helper owns init + graceful degrade + shutdown flush; a
+  // deliberate configuration failure bubbles here so the host exits loudly.
   if (
     process.env.NEXT_RUNTIME === 'nodejs'
     && isTelemetryBackendEnabled()
   ) {
     const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
-    await registerTelemetryForNextjs()
+    try {
+      await registerTelemetryForNextjs()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+      nodeProcess.exit(1)
+    }
   }
 }

--- a/docker-compose.fullapp.traefik.yml
+++ b/docker-compose.fullapp.traefik.yml
@@ -55,6 +55,14 @@ services:
       - mercato-network-fullapp
 
   app:
+    environment:
+      TELEMETRY_BACKEND: ${TELEMETRY_BACKEND:-}
+      TELEMETRY_SAMPLING_RATIO: ${TELEMETRY_SAMPLING_RATIO:-}
+      TELEMETRY_TRUST_INBOUND_TRACE: ${TELEMETRY_TRUST_INBOUND_TRACE:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-open-mercato}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=mercato-network-${DEPLOY_ENV:-local}"

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -174,6 +174,13 @@ services:
       NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}
+      TELEMETRY_BACKEND: ${TELEMETRY_BACKEND:-}
+      TELEMETRY_SAMPLING_RATIO: ${TELEMETRY_SAMPLING_RATIO:-}
+      TELEMETRY_TRUST_INBOUND_TRACE: ${TELEMETRY_TRUST_INBOUND_TRACE:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-open-mercato}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
       # Bind on all interfaces so Docker's published-port forwarding can reach
       # the server; next start otherwise honors the container's HOSTNAME and
       # binds an address unreachable from the host.
@@ -369,6 +376,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  otel-collector:
+    profiles: [telemetry]
+    image: otel/opentelemetry-collector:0.159.0
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./docker/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
     networks:
       - mercato-network-fullapp
 

--- a/docker/otel-collector-config.yaml
+++ b/docker/otel-collector-config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/packages/cli/src/lib/__tests__/telemetry-init.test.ts
+++ b/packages/cli/src/lib/__tests__/telemetry-init.test.ts
@@ -124,6 +124,8 @@ describe('mercato telemetry init', () => {
     expect(read('.env.example')).toContain('TELEMETRY_BACKEND')
     expect(read('.env.example')).toContain('OTEL_EXPORTER_OTLP_ENDPOINT')
     expect(read('src/instrumentation.ts')).toContain('registerTelemetryForNextjs')
+    expect(read('src/instrumentation.ts')).toContain('nodeProcess.stderr.write')
+    expect(read('src/instrumentation.ts')).toContain('nodeProcess.exit(1)')
 
     const nextConfig = read('next.config.ts')
     expect(nextConfig).toContain('@open-mercato/telemetry/nextjs-config')
@@ -259,6 +261,8 @@ describe('mercato telemetry init', () => {
     const instrumentation = read('src/instrumentation.ts')
     assertParses(instrumentation, 'custom-instrumentation')
     expect(instrumentation).toContain('registerTelemetryForNextjs')
+    expect(instrumentation).toContain('nodeProcess.stderr.write')
+    expect(instrumentation).toContain('nodeProcess.exit(1)')
     expect(instrumentation).toContain("console.log('custom warmup')") // preserved
   })
 

--- a/packages/cli/src/lib/__tests__/telemetry-init.test.ts
+++ b/packages/cli/src/lib/__tests__/telemetry-init.test.ts
@@ -86,6 +86,20 @@ const LEGACY_INSTRUMENTATION = `import { isTelemetryBackendEnabled } from '@open
 export async function register(): Promise<void> {
   if (
     process.env.NEXT_RUNTIME === 'nodejs'
+    && process.env.NEXT_PHASE !== 'phase-production-build'
+  ) {
+    const { assertJwtSecretPolicy } = await import('@open-mercato/shared/lib/auth/jwt')
+    try {
+      assertJwtSecretPolicy()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)
+      nodeProcess.exit(1)
+    }
+  }
+
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs'
     && isTelemetryBackendEnabled()
   ) {
     const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
@@ -290,9 +304,51 @@ describe('mercato telemetry init', () => {
     expect(migrated).toContain('nodeProcess.stderr.write')
     expect(migrated).toContain('nodeProcess.exit(1)')
     expect((migrated.match(/registerTelemetryForNextjs\(\)/g) ?? []).length).toBe(1)
+    expect((migrated.match(/nodeProcess\.exit\(1\)/g) ?? []).length).toBe(2)
 
     await runTelemetryInit([])
     expect(read('src/instrumentation.ts')).toBe(migrated)
+  })
+
+  it('upgrades the older Node-only generated bootstrap', async () => {
+    baseFixture(tmpDir)
+    fs.writeFileSync(path.join(tmpDir, dispatcherPath), SIMPLE_DISPATCHER)
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'instrumentation.ts'),
+      `export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
+    await registerTelemetryForNextjs()
+  }
+}
+`,
+    )
+
+    await runTelemetryInit([])
+    const migrated = read('src/instrumentation.ts')
+
+    assertParses(migrated, 'node-only-instrumentation-migration')
+    expect(migrated).toContain("import { isTelemetryBackendEnabled }")
+    expect(migrated).toContain("process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()")
+    expect(migrated).toContain('nodeProcess.exit(1)')
+  })
+
+  it('leaves an unrecognized custom telemetry bootstrap for a manual update', async () => {
+    baseFixture(tmpDir)
+    fs.writeFileSync(path.join(tmpDir, dispatcherPath), SIMPLE_DISPATCHER)
+    const customInstrumentation = `export async function register(): Promise<void> {
+  const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
+  if (process.env.NEXT_RUNTIME === 'nodejs') await registerTelemetryForNextjs()
+  const nodeProcess = process
+  nodeProcess.exit(1)
+}
+`
+    fs.writeFileSync(path.join(tmpDir, 'src', 'instrumentation.ts'), customInstrumentation)
+
+    await runTelemetryInit([])
+
+    expect(read('src/instrumentation.ts')).toBe(customInstrumentation)
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('manual step for src/instrumentation.ts')
   })
 
   it('is idempotent — a second run changes nothing and does not double-insert', async () => {

--- a/packages/cli/src/lib/__tests__/telemetry-init.test.ts
+++ b/packages/cli/src/lib/__tests__/telemetry-init.test.ts
@@ -81,6 +81,19 @@ async function handleRequest(method: string, req: NextRequest): Promise<Response
 }
 `
 
+const LEGACY_INSTRUMENTATION = `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'
+
+export async function register(): Promise<void> {
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs'
+    && isTelemetryBackendEnabled()
+  ) {
+    const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
+    await registerTelemetryForNextjs()
+  }
+}
+`
+
 describe('mercato telemetry init', () => {
   let tmpDir: string
   let cwd: string
@@ -264,6 +277,22 @@ describe('mercato telemetry init', () => {
     expect(instrumentation).toContain('nodeProcess.stderr.write')
     expect(instrumentation).toContain('nodeProcess.exit(1)')
     expect(instrumentation).toContain("console.log('custom warmup')") // preserved
+  })
+
+  it('upgrades the legacy generated instrumentation and stays idempotent', async () => {
+    baseFixture(tmpDir)
+    fs.writeFileSync(path.join(tmpDir, dispatcherPath), SIMPLE_DISPATCHER)
+    fs.writeFileSync(path.join(tmpDir, 'src', 'instrumentation.ts'), LEGACY_INSTRUMENTATION)
+
+    await runTelemetryInit([])
+    const migrated = read('src/instrumentation.ts')
+    assertParses(migrated, 'legacy-instrumentation-migration')
+    expect(migrated).toContain('nodeProcess.stderr.write')
+    expect(migrated).toContain('nodeProcess.exit(1)')
+    expect((migrated.match(/registerTelemetryForNextjs\(\)/g) ?? []).length).toBe(1)
+
+    await runTelemetryInit([])
+    expect(read('src/instrumentation.ts')).toBe(migrated)
   })
 
   it('is idempotent — a second run changes nothing and does not double-insert', async () => {

--- a/packages/cli/src/lib/telemetry-init.ts
+++ b/packages/cli/src/lib/telemetry-init.ts
@@ -182,17 +182,45 @@ function patchInstrumentation(appDir: string, options: TelemetryInitOptions): St
   }
   const content = readFileSync(path, 'utf8')
   if (content.includes('registerTelemetryForNextjs')) {
-    if (content.includes('isTelemetryBackendEnabled')) {
+    let migrated = content
+    const changes: string[] = []
+    if (!migrated.includes('isTelemetryBackendEnabled')) {
+      migrated =
+        `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'\n` +
+        migrated.replace(
+          `if (process.env.NEXT_RUNTIME === 'nodejs') {`,
+          `if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {`,
+        )
+      changes.push('added the explicit backend import guard')
+    }
+    if (!migrated.includes('nodeProcess.exit(1)')) {
+      const registration = migrated.match(/^([ \t]*)await registerTelemetryForNextjs\(\)[ \t]*$/m)
+      if (!registration) {
+        return {
+          file,
+          status: 'manual',
+          detail: 'existing telemetry bootstrap needs a fail-closed host wrapper',
+          manualSnippet: INSTRUMENTATION_TS,
+        }
+      }
+      const indent = registration[1]
+      const wrappedRegistration = [
+        `${indent}try {`,
+        `${indent}  await registerTelemetryForNextjs()`,
+        `${indent}} catch (err) {`,
+        `${indent}  const nodeProcess = process`,
+        `${indent}  nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)`,
+        `${indent}  nodeProcess.exit(1)`,
+        `${indent}}`,
+      ].join('\n')
+      migrated = migrated.replace(registration[0], wrappedRegistration)
+      changes.push('wrapped OTLP dependency failures with host termination')
+    }
+    if (migrated === content) {
       return { file, status: 'skipped', detail: 'telemetry already wired' }
     }
-    const migrated =
-      `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'\n` +
-      content.replace(
-        `if (process.env.NEXT_RUNTIME === 'nodejs') {`,
-        `if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {`,
-      )
     if (!options.dryRun) writeFileSync(path, migrated)
-    return { file, status: 'patched', detail: 'added the explicit backend import guard' }
+    return { file, status: 'patched', detail: changes.join(' and ') }
   }
   const anchor = content.match(/export\s+async\s+function\s+register\s*\([^)]*\)\s*:\s*Promise<void>\s*\{/)
   if (!anchor || anchor.index === undefined) {

--- a/packages/cli/src/lib/telemetry-init.ts
+++ b/packages/cli/src/lib/telemetry-init.ts
@@ -90,6 +90,22 @@ export async function register(): Promise<void> {
 }
 `
 
+const MULTILINE_TELEMETRY_GUARD = `  if (
+    process.env.NEXT_RUNTIME === 'nodejs'
+    && isTelemetryBackendEnabled()
+  ) {`
+const INLINE_TELEMETRY_GUARD = `  if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {`
+const LEGACY_NODE_TELEMETRY_GUARD = `  if (process.env.NEXT_RUNTIME === 'nodejs') {`
+const TELEMETRY_DYNAMIC_IMPORT = `    const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')`
+const BARE_TELEMETRY_REGISTRATION = `    await registerTelemetryForNextjs()`
+const GUARDED_TELEMETRY_REGISTRATION = `    try {
+      await registerTelemetryForNextjs()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)
+      nodeProcess.exit(1)
+    }`
+
 const DISPATCHER_SNIPPET = `  // add near the other imports:
   import { getTelemetryRuntime } from '@open-mercato/shared/lib/telemetry/runtime'
 
@@ -182,45 +198,45 @@ function patchInstrumentation(appDir: string, options: TelemetryInitOptions): St
   }
   const content = readFileSync(path, 'utf8')
   if (content.includes('registerTelemetryForNextjs')) {
-    let migrated = content
-    const changes: string[] = []
-    if (!migrated.includes('isTelemetryBackendEnabled')) {
-      migrated =
-        `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'\n` +
-        migrated.replace(
-          `if (process.env.NEXT_RUNTIME === 'nodejs') {`,
-          `if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {`,
-        )
-      changes.push('added the explicit backend import guard')
-    }
-    if (!migrated.includes('nodeProcess.exit(1)')) {
-      const registration = migrated.match(/^([ \t]*)await registerTelemetryForNextjs\(\)[ \t]*$/m)
-      if (!registration) {
-        return {
-          file,
-          status: 'manual',
-          detail: 'existing telemetry bootstrap needs a fail-closed host wrapper',
-          manualSnippet: INSTRUMENTATION_TS,
-        }
-      }
-      const indent = registration[1]
-      const wrappedRegistration = [
-        `${indent}try {`,
-        `${indent}  await registerTelemetryForNextjs()`,
-        `${indent}} catch (err) {`,
-        `${indent}  const nodeProcess = process`,
-        `${indent}  nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)`,
-        `${indent}  nodeProcess.exit(1)`,
-        `${indent}}`,
-      ].join('\n')
-      migrated = migrated.replace(registration[0], wrappedRegistration)
-      changes.push('wrapped OTLP dependency failures with host termination')
-    }
-    if (migrated === content) {
+    const guardedBootstraps = [MULTILINE_TELEMETRY_GUARD, INLINE_TELEMETRY_GUARD]
+    const safeBootstrap = guardedBootstraps
+      .map((guard) => `${guard}\n${TELEMETRY_DYNAMIC_IMPORT}\n${GUARDED_TELEMETRY_REGISTRATION}`)
+      .find((bootstrap) => content.includes(bootstrap))
+    if (safeBootstrap) {
       return { file, status: 'skipped', detail: 'telemetry already wired' }
     }
-    if (!options.dryRun) writeFileSync(path, migrated)
-    return { file, status: 'patched', detail: changes.join(' and ') }
+    const guardedLegacyBootstrap = guardedBootstraps
+      .map((guard) => `${guard}\n${TELEMETRY_DYNAMIC_IMPORT}\n${BARE_TELEMETRY_REGISTRATION}`)
+      .find((bootstrap) => content.includes(bootstrap))
+    if (guardedLegacyBootstrap) {
+      const migrated = content.replace(
+        guardedLegacyBootstrap,
+        guardedLegacyBootstrap.replace(BARE_TELEMETRY_REGISTRATION, GUARDED_TELEMETRY_REGISTRATION),
+      )
+      if (!options.dryRun) writeFileSync(path, migrated)
+      return { file, status: 'patched', detail: 'wrapped OTLP dependency failures with host termination' }
+    }
+    const nodeOnlyLegacyBootstrap = `${LEGACY_NODE_TELEMETRY_GUARD}\n${TELEMETRY_DYNAMIC_IMPORT}\n${BARE_TELEMETRY_REGISTRATION}`
+    if (content.includes(nodeOnlyLegacyBootstrap)) {
+      const guardedBootstrap = nodeOnlyLegacyBootstrap
+        .replace(LEGACY_NODE_TELEMETRY_GUARD, INLINE_TELEMETRY_GUARD)
+        .replace(BARE_TELEMETRY_REGISTRATION, GUARDED_TELEMETRY_REGISTRATION)
+      const importLine = `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'\n`
+      const withBootstrap = content.replace(nodeOnlyLegacyBootstrap, guardedBootstrap)
+      const migrated = withBootstrap.includes(importLine) ? withBootstrap : importLine + withBootstrap
+      if (!options.dryRun) writeFileSync(path, migrated)
+      return {
+        file,
+        status: 'patched',
+        detail: 'added the explicit backend guard and wrapped OTLP dependency failures with host termination',
+      }
+    }
+    return {
+      file,
+      status: 'manual',
+      detail: 'existing telemetry bootstrap needs the canonical Node guard and fail-closed host wrapper',
+      manualSnippet: INSTRUMENTATION_TS,
+    }
   }
   const anchor = content.match(/export\s+async\s+function\s+register\s*\([^)]*\)\s*:\s*Promise<void>\s*\{/)
   if (!anchor || anchor.index === undefined) {

--- a/packages/cli/src/lib/telemetry-init.ts
+++ b/packages/cli/src/lib/telemetry-init.ts
@@ -72,13 +72,20 @@ export async function register(): Promise<void> {
   // Initialize telemetry (no-op unless TELEMETRY_BACKEND is set). OTEL's NodeSDK
   // is Node-only and incompatible with the edge runtime, so the telemetry
   // bootstrap — which can pull in the SDK — is imported only on the Node.js
-  // runtime. The helper owns init + graceful degrade + shutdown flush.
+  // runtime. The helper owns init + graceful degrade + shutdown flush; a
+  // deliberate configuration failure bubbles here so the host exits loudly.
   if (
     process.env.NEXT_RUNTIME === 'nodejs'
     && isTelemetryBackendEnabled()
   ) {
     const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
-    await registerTelemetryForNextjs()
+    try {
+      await registerTelemetryForNextjs()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)
+      nodeProcess.exit(1)
+    }
   }
 }
 `
@@ -201,7 +208,13 @@ function patchInstrumentation(appDir: string, options: TelemetryInitOptions): St
     `\n  // Initialize telemetry (no-op unless TELEMETRY_BACKEND is set); Node-only.` +
     `\n  if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {` +
     `\n    const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')` +
-    `\n    await registerTelemetryForNextjs()` +
+    `\n    try {` +
+    `\n      await registerTelemetryForNextjs()` +
+    `\n    } catch (err) {` +
+    `\n      const nodeProcess = process` +
+    `\n      nodeProcess.stderr.write(\`\${err instanceof Error ? err.message : String(err)}\\n\`)` +
+    `\n      nodeProcess.exit(1)` +
+    `\n    }` +
     `\n  }`
   const importLine = `import { isTelemetryBackendEnabled } from '@open-mercato/shared/lib/telemetry/runtime'\n`
   const withImport = content.includes('isTelemetryBackendEnabled')

--- a/packages/create-app/template/docker-compose.fullapp.yml
+++ b/packages/create-app/template/docker-compose.fullapp.yml
@@ -46,6 +46,13 @@ services:
       NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
       DEPLOY_ENV: ${DEPLOY_ENV:-local}
       PORT: ${CONTAINER_PORT:-3000}
+      TELEMETRY_BACKEND: ${TELEMETRY_BACKEND:-}
+      TELEMETRY_SAMPLING_RATIO: ${TELEMETRY_SAMPLING_RATIO:-}
+      TELEMETRY_TRUST_INBOUND_TRACE: ${TELEMETRY_TRUST_INBOUND_TRACE:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-open-mercato}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-open-mercato}
       DB_POOL_MAX: ${DB_POOL_MAX:-20}
       DB_POOL_MIN: ${DB_POOL_MIN:-2}
@@ -223,6 +230,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  otel-collector:
+    profiles: [telemetry]
+    image: otel/opentelemetry-collector:0.159.0
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./docker/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
     networks:
       - mercato-network-fullapp
 

--- a/packages/create-app/template/docker/otel-collector-config.yaml
+++ b/packages/create-app/template/docker/otel-collector-config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/packages/create-app/template/src/__tests__/instrumentation-telemetry-bootstrap.test.ts
+++ b/packages/create-app/template/src/__tests__/instrumentation-telemetry-bootstrap.test.ts
@@ -1,0 +1,44 @@
+describe('telemetry instrumentation bootstrap', () => {
+  const originalBackend = process.env.TELEMETRY_BACKEND
+  const originalNextPhase = process.env.NEXT_PHASE
+  const originalNextRuntime = process.env.NEXT_RUNTIME
+
+  afterEach(() => {
+    jest.resetModules()
+    jest.restoreAllMocks()
+    jest.dontMock('@open-mercato/telemetry/nextjs')
+    if (originalBackend === undefined) delete process.env.TELEMETRY_BACKEND
+    else process.env.TELEMETRY_BACKEND = originalBackend
+    if (originalNextPhase === undefined) delete process.env.NEXT_PHASE
+    else process.env.NEXT_PHASE = originalNextPhase
+    if (originalNextRuntime === undefined) delete process.env.NEXT_RUNTIME
+    else process.env.NEXT_RUNTIME = originalNextRuntime
+  })
+
+  it('writes only the safe bootstrap message to stderr before exiting', async () => {
+    const bootstrapFailure = new Error('safe OTLP dependency remediation')
+    Object.defineProperty(bootstrapFailure, 'cause', {
+      value: new Error('private module path with token=secret-value'),
+    })
+    jest.doMock('@open-mercato/telemetry/nextjs', () => ({
+      registerTelemetryForNextjs: jest.fn(async () => {
+        throw bootstrapFailure
+      }),
+    }))
+    const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const interceptedExit = new Error('process exit intercepted')
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw interceptedExit
+    })
+    process.env.NEXT_RUNTIME = 'nodejs'
+    process.env.NEXT_PHASE = 'phase-production-build'
+    process.env.TELEMETRY_BACKEND = 'otlp'
+    const { register } = await import('../instrumentation')
+
+    await expect(register()).rejects.toBe(interceptedExit)
+
+    expect(stderrWrite).toHaveBeenCalledWith('safe OTLP dependency remediation\n')
+    expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining('secret-value'))
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/create-app/template/src/instrumentation.ts
+++ b/packages/create-app/template/src/instrumentation.ts
@@ -27,12 +27,19 @@ export async function register(): Promise<void> {
   // Initialize telemetry (no-op unless TELEMETRY_BACKEND is set). OTEL's NodeSDK
   // is Node-only and incompatible with the edge runtime, so the telemetry
   // bootstrap — which can pull in the SDK — is imported only on the Node.js
-  // runtime. The helper owns init + graceful degrade + shutdown flush.
+  // runtime. The helper owns init + graceful degrade + shutdown flush; a
+  // deliberate configuration failure bubbles here so the host exits loudly.
   if (
     process.env.NEXT_RUNTIME === 'nodejs'
     && isTelemetryBackendEnabled()
   ) {
     const { registerTelemetryForNextjs } = await import('@open-mercato/telemetry/nextjs')
-    await registerTelemetryForNextjs()
+    try {
+      await registerTelemetryForNextjs()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+      nodeProcess.exit(1)
+    }
   }
 }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -97,7 +97,13 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === 'nodejs' && isTelemetryBackendEnabled()) {
     const { registerTelemetryForNextjs } =
       await import('@open-mercato/telemetry/nextjs')
-    await registerTelemetryForNextjs()
+    try {
+      await registerTelemetryForNextjs()
+    } catch (err) {
+      const nodeProcess = process
+      nodeProcess.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+      nodeProcess.exit(1)
+    }
   }
 }
 ```

--- a/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
+++ b/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
@@ -148,12 +148,8 @@ describe('OTLP dependency bootstrap', () => {
     expect(provider.start).toHaveBeenCalledTimes(1)
   })
 
-  it('terminates the standard Next.js host after a dependency load failure', async () => {
+  it('propagates a dependency load failure through the standard Next.js bootstrap', async () => {
     const importCause = new Error('simulated missing package')
-    const interceptedExit = new Error('process exit intercepted')
-    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw interceptedExit
-    })
     jest.doMock('../provider/otlp-provider', () => {
       throw importCause
     })
@@ -162,8 +158,10 @@ describe('OTLP dependency bootstrap', () => {
     const { registerTelemetryForNextjs } = await import('../nextjs')
     process.env.TELEMETRY_BACKEND = 'otlp'
 
-    await expect(registerTelemetryForNextjs()).rejects.toBe(interceptedExit)
-    expect(exit).toHaveBeenCalledWith(1)
+    await expect(registerTelemetryForNextjs()).rejects.toMatchObject({
+      name: 'OtlpDependencyUnavailableError',
+      cause: importCause,
+    })
   })
 
   it('keeps unrelated provider initialization failures best effort in Next.js', async () => {

--- a/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
+++ b/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
@@ -66,6 +66,7 @@ describe('OTLP dependency bootstrap', () => {
     else process.env.TELEMETRY_BACKEND = originalBackend
     jest.dontMock('../provider/console-provider')
     jest.dontMock('../provider/otlp-provider')
+    jest.dontMock('../init')
     jest.resetModules()
     jest.restoreAllMocks()
   })
@@ -145,6 +146,38 @@ describe('OTLP dependency bootstrap', () => {
 
     expect(loadAttempts).toBe(2)
     expect(provider.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates a dependency load failure through the standard Next.js bootstrap', async () => {
+    const importCause = new Error('simulated missing package')
+    jest.doMock('../provider/otlp-provider', () => {
+      throw importCause
+    })
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    const { registerTelemetryForNextjs } = await import('../nextjs')
+    process.env.TELEMETRY_BACKEND = 'otlp'
+
+    await expect(registerTelemetryForNextjs()).rejects.toMatchObject({
+      name: 'OtlpDependencyUnavailableError',
+      cause: importCause,
+    })
+  })
+
+  it('keeps unrelated provider initialization failures best effort in Next.js', async () => {
+    const startupFailure = new Error('collector configuration rejected')
+    const initTelemetry = jest.fn(async () => {
+      throw startupFailure
+    })
+    jest.doMock('../init', () => ({
+      initTelemetry,
+      shutdownTelemetry: jest.fn(async () => {}),
+    }))
+    const { registerTelemetryForNextjs } = await import('../nextjs')
+    process.env.TELEMETRY_BACKEND = 'otlp'
+
+    await expect(registerTelemetryForNextjs()).resolves.toBeUndefined()
+    expect(initTelemetry).toHaveBeenCalledTimes(1)
   })
 
   it('preserves a provider startup failure and can retry it without misclassifying dependencies', async () => {

--- a/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
+++ b/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
@@ -1,0 +1,139 @@
+import type {
+  Attributes,
+  LogRecord,
+  MetricPoint,
+  Span,
+  SpanOptions,
+  TelemetryProvider,
+  TraceCarrier,
+  TraceContext,
+} from '../types'
+
+function createSpan(): Span {
+  return {
+    setAttribute(_key: string, _value: string | number | boolean): void {},
+    setAttributes(_attributes: Attributes): void {},
+    recordException(_error: unknown): void {},
+    setStatus(_status: 'ok' | 'error', _message?: string): void {},
+    end(): void {},
+  }
+}
+
+function createProvider(name = 'otlp'): TelemetryProvider {
+  const span = createSpan()
+  return {
+    name,
+    supports: ['traces', 'metrics', 'logs', 'errors'],
+    start: jest.fn(async () => {}),
+    shutdown: jest.fn(async () => {}),
+    runInSpan<T>(_name: string, _options: SpanOptions, operation: (activeSpan: Span) => T): T {
+      return operation(span)
+    },
+    activeSpan(): Span | undefined {
+      return span
+    },
+    activeTraceContext(): TraceContext | undefined {
+      return undefined
+    },
+    inject(_carrier: TraceCarrier): void {},
+    runInRemoteSpan<T>(
+      _carrier: TraceCarrier,
+      _name: string,
+      _options: SpanOptions,
+      operation: (activeSpan: Span) => T,
+    ): T {
+      return operation(span)
+    },
+    emitLog(_record: LogRecord): void {},
+    recordMetric(_point: MetricPoint): void {},
+  }
+}
+
+describe('OTLP dependency bootstrap', () => {
+  const originalBackend = process.env.TELEMETRY_BACKEND
+  let shutdownTelemetry: (() => Promise<void>) | undefined
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.restoreAllMocks()
+    shutdownTelemetry = undefined
+    delete process.env.TELEMETRY_BACKEND
+  })
+
+  afterEach(async () => {
+    await shutdownTelemetry?.()
+    if (originalBackend === undefined) delete process.env.TELEMETRY_BACKEND
+    else process.env.TELEMETRY_BACKEND = originalBackend
+    jest.dontMock('../provider/console-provider')
+    jest.dontMock('../provider/otlp-provider')
+    jest.resetModules()
+    jest.restoreAllMocks()
+  })
+
+  it.each(['otlp', 'signoz', 'newrelic'])('fails clearly when %s dependencies cannot load', async (backend) => {
+    const importCause = new Error('simulated missing OpenTelemetry package')
+    const consoleProvider = jest.fn()
+    jest.doMock('../provider/console-provider', () => ({ ConsoleProvider: consoleProvider }))
+    jest.doMock('../provider/otlp-provider', () => {
+      throw importCause
+    })
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    process.env.TELEMETRY_BACKEND = backend
+
+    const failure: unknown = await telemetry.initTelemetry().catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toContain(`OTLP telemetry backend "${backend}" cannot start`)
+    expect((failure as Error).message).toContain('Install optional dependencies')
+    expect((failure as Error).cause).toBe(importCause)
+    expect(consoleProvider).not.toHaveBeenCalled()
+  })
+
+  it('starts the dynamically loaded provider when OTLP dependencies are available', async () => {
+    const provider = createProvider()
+    const OtlpProvider = jest.fn(() => provider)
+    jest.doMock('../provider/otlp-provider', () => ({ OtlpProvider }))
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    process.env.TELEMETRY_BACKEND = 'otlp'
+
+    await telemetry.initTelemetry()
+
+    expect(OtlpProvider).toHaveBeenCalledWith({}, 'otlp')
+    expect(provider.start).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([undefined, 'noop'])('does not resolve OTLP dependencies when telemetry is %s', async (backend) => {
+    const loadOtlpModule = jest.fn(() => ({ OtlpProvider: jest.fn() }))
+    jest.doMock('../provider/otlp-provider', loadOtlpModule)
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    if (backend === undefined) delete process.env.TELEMETRY_BACKEND
+    else process.env.TELEMETRY_BACKEND = backend
+
+    await telemetry.initTelemetry()
+
+    expect(loadOtlpModule).not.toHaveBeenCalled()
+  })
+
+  it('can retry initialization after a dependency load failure', async () => {
+    const provider = createProvider()
+    const importCause = new Error('simulated first-load failure')
+    let loadAttempts = 0
+    jest.doMock('../provider/otlp-provider', () => {
+      loadAttempts += 1
+      if (loadAttempts === 1) throw importCause
+      return { OtlpProvider: jest.fn(() => provider) }
+    })
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    process.env.TELEMETRY_BACKEND = 'otlp'
+
+    await expect(telemetry.initTelemetry()).rejects.toHaveProperty('cause', importCause)
+    await telemetry.initTelemetry()
+
+    expect(loadAttempts).toBe(2)
+    expect(provider.start).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
+++ b/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
@@ -71,7 +71,7 @@ describe('OTLP dependency bootstrap', () => {
   })
 
   it.each(['otlp', 'signoz', 'newrelic'])('fails clearly when %s dependencies cannot load', async (backend) => {
-    const importCause = new Error('simulated missing OpenTelemetry package')
+    const importCause = new Error('simulated missing package at /private/runtime with token=secret-value')
     const consoleProvider = jest.fn()
     jest.doMock('../provider/console-provider', () => ({ ConsoleProvider: consoleProvider }))
     jest.doMock('../provider/otlp-provider', () => {
@@ -86,8 +86,18 @@ describe('OTLP dependency bootstrap', () => {
     expect(failure).toBeInstanceOf(Error)
     expect((failure as Error).message).toContain(`OTLP telemetry backend "${backend}" cannot start`)
     expect((failure as Error).message).toContain('Install optional dependencies')
+    expect((failure as Error).message).not.toContain('/private/runtime')
+    expect((failure as Error).message).not.toContain('secret-value')
     expect((failure as Error).cause).toBe(importCause)
     expect(consoleProvider).not.toHaveBeenCalled()
+    const [{ getActiveProvider }, { getLoggerExtension }, { getTelemetryRuntime }] = await Promise.all([
+      import('../provider/registry'),
+      import('@open-mercato/shared/lib/logger'),
+      import('@open-mercato/shared/lib/telemetry/runtime'),
+    ])
+    expect(getActiveProvider().name).toBe('noop')
+    expect(getLoggerExtension()).toBeUndefined()
+    expect(getTelemetryRuntime()).toBeUndefined()
   })
 
   it('starts the dynamically loaded provider when OTLP dependencies are available', async () => {
@@ -135,5 +145,31 @@ describe('OTLP dependency bootstrap', () => {
 
     expect(loadAttempts).toBe(2)
     expect(provider.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a provider startup failure and can retry it without misclassifying dependencies', async () => {
+    const provider = createProvider()
+    const startupFailure = new Error('collector configuration rejected')
+    jest.mocked(provider.start)
+      .mockRejectedValueOnce(startupFailure)
+      .mockResolvedValueOnce(undefined)
+    jest.doMock('../provider/otlp-provider', () => ({
+      OtlpProvider: jest.fn(() => provider),
+    }))
+    const telemetry = await import('../init')
+    shutdownTelemetry = telemetry.shutdownTelemetry
+    process.env.TELEMETRY_BACKEND = 'otlp'
+
+    await expect(telemetry.initTelemetry()).rejects.toBe(startupFailure)
+    const [{ getActiveProvider }, { getTelemetryRuntime }] = await Promise.all([
+      import('../provider/registry'),
+      import('@open-mercato/shared/lib/telemetry/runtime'),
+    ])
+    expect(getActiveProvider().name).toBe('noop')
+    expect(getTelemetryRuntime()).toBeUndefined()
+
+    await telemetry.initTelemetry()
+
+    expect(provider.start).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
+++ b/packages/telemetry/src/__tests__/init-otlp-dependency.test.ts
@@ -148,8 +148,12 @@ describe('OTLP dependency bootstrap', () => {
     expect(provider.start).toHaveBeenCalledTimes(1)
   })
 
-  it('propagates a dependency load failure through the standard Next.js bootstrap', async () => {
+  it('terminates the standard Next.js host after a dependency load failure', async () => {
     const importCause = new Error('simulated missing package')
+    const interceptedExit = new Error('process exit intercepted')
+    const exit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw interceptedExit
+    })
     jest.doMock('../provider/otlp-provider', () => {
       throw importCause
     })
@@ -158,10 +162,8 @@ describe('OTLP dependency bootstrap', () => {
     const { registerTelemetryForNextjs } = await import('../nextjs')
     process.env.TELEMETRY_BACKEND = 'otlp'
 
-    await expect(registerTelemetryForNextjs()).rejects.toMatchObject({
-      name: 'OtlpDependencyUnavailableError',
-      cause: importCause,
-    })
+    await expect(registerTelemetryForNextjs()).rejects.toBe(interceptedExit)
+    expect(exit).toHaveBeenCalledWith(1)
   })
 
   it('keeps unrelated provider initialization failures best effort in Next.js', async () => {

--- a/packages/telemetry/src/init.ts
+++ b/packages/telemetry/src/init.ts
@@ -23,6 +23,18 @@ let disposeLoggerExtension: (() => void) | undefined
 let disposeRuntime: (() => void) | undefined
 
 const logger = createLogger('telemetry')
+const OTLP_DEPENDENCY_UNAVAILABLE = Symbol.for('open-mercato.telemetry.otlp-dependency-unavailable')
+
+class OtlpDependencyUnavailableError extends Error {
+  constructor(backend: TelemetryBackendName, cause: unknown) {
+    super(
+      `[internal] OTLP telemetry backend "${backend}" cannot start because its OpenTelemetry runtime dependencies are unavailable. Install optional dependencies, set TELEMETRY_BACKEND=console, or unset TELEMETRY_BACKEND to disable telemetry.`,
+      { cause },
+    )
+    this.name = 'OtlpDependencyUnavailableError'
+    Object.defineProperty(this, OTLP_DEPENDENCY_UNAVAILABLE, { value: true })
+  }
+}
 
 /**
  * One-shot bootstrap, invoked from `apps/mercato/instrumentation.ts` (web) and,
@@ -91,10 +103,7 @@ async function loadOtlpProvider(backend: TelemetryBackendName): Promise<Telemetr
   try {
     mod = await import('./provider/otlp-provider')
   } catch (error) {
-    throw new Error(
-      `[internal] OTLP telemetry backend "${backend}" cannot start because its OpenTelemetry runtime dependencies are unavailable. Install optional dependencies, set TELEMETRY_BACKEND=console, or unset TELEMETRY_BACKEND to disable telemetry.`,
-      { cause: error },
-    )
+    throw new OtlpDependencyUnavailableError(backend, error)
   }
   return new mod.OtlpProvider({}, backend)
 }

--- a/packages/telemetry/src/init.ts
+++ b/packages/telemetry/src/init.ts
@@ -82,19 +82,21 @@ async function resolveProvider(backend: TelemetryBackendName): Promise<Telemetry
 
 /**
  * Dynamically load the OTLP provider so `@opentelemetry/*` (optionalDependencies)
- * is imported only when an OTLP backend is selected. Falls back to console if
- * the OTEL packages are absent rather than crashing the app.
+ * is imported only when an OTLP backend is selected. An explicit OTLP selection
+ * must fail at startup when those packages are unavailable instead of silently
+ * switching telemetry semantics.
  */
 async function loadOtlpProvider(backend: TelemetryBackendName): Promise<TelemetryProvider> {
+  let mod: typeof import('./provider/otlp-provider')
   try {
-    const mod = await import('./provider/otlp-provider')
-    return new mod.OtlpProvider({}, backend)
-  } catch (err) {
-    logger.warn('OTLP provider unavailable; falling back to console', {
-      reason: err instanceof Error ? err.message : String(err),
-    })
-    return new ConsoleProvider()
+    mod = await import('./provider/otlp-provider')
+  } catch (error) {
+    throw new Error(
+      `[internal] OTLP telemetry backend "${backend}" cannot start because its OpenTelemetry runtime dependencies are unavailable. Install optional dependencies, set TELEMETRY_BACKEND=console, or unset TELEMETRY_BACKEND to disable telemetry.`,
+      { cause: error },
+    )
   }
+  return new mod.OtlpProvider({}, backend)
 }
 
 /** Flush + tear down the active backend (shutdown hook / `after()`). */

--- a/packages/telemetry/src/nextjs.ts
+++ b/packages/telemetry/src/nextjs.ts
@@ -11,14 +11,19 @@ export { telemetryServerExternalPackages } from './nextjs-config'
 export { recordHttpDuration } from './facade/http'
 
 const logger = createLogger('telemetry')
+const OTLP_DEPENDENCY_UNAVAILABLE = Symbol.for('open-mercato.telemetry.otlp-dependency-unavailable')
+
+function isOtlpDependencyUnavailableError(error: unknown): boolean {
+  return error instanceof Error && Reflect.get(error, OTLP_DEPENDENCY_UNAVAILABLE) === true
+}
 
 /**
  * One-line telemetry bootstrap for a Next.js `instrumentation.ts`. Initializes
- * the active backend (no-op unless `TELEMETRY_BACKEND` is set), degrades to no
- * telemetry on init failure (never bubbles a rejection out of Next's
- * `register()`), and registers a best-effort flush on `SIGTERM`/`SIGINT`. Skips
- * the edge runtime — the OTEL NodeSDK is Node-only — so callers may import it
- * unconditionally, though gating the dynamic import on
+ * the active backend (no-op unless `TELEMETRY_BACKEND` is set), propagates an
+ * explicit OTLP missing-dependency failure, degrades to no telemetry for other
+ * initialization failures, and registers a best-effort flush on
+ * `SIGTERM`/`SIGINT`. Skips the edge runtime — the OTEL NodeSDK is Node-only —
+ * so callers may import it unconditionally, though gating the dynamic import on
  * `NEXT_RUNTIME === 'nodejs'` also keeps the SDK off the edge bundle.
  */
 export async function registerTelemetryForNextjs(): Promise<void> {
@@ -28,6 +33,7 @@ export async function registerTelemetryForNextjs(): Promise<void> {
   try {
     await initTelemetry()
   } catch (error) {
+    if (isOtlpDependencyUnavailableError(error)) throw error
     logger.warn('Init from Next.js instrumentation failed', { err: error })
     return
   }

--- a/packages/telemetry/src/nextjs.ts
+++ b/packages/telemetry/src/nextjs.ts
@@ -19,9 +19,9 @@ function isOtlpDependencyUnavailableError(error: unknown): boolean {
 
 /**
  * One-line telemetry bootstrap for a Next.js `instrumentation.ts`. Initializes
- * the active backend (no-op unless `TELEMETRY_BACKEND` is set), terminates on
- * an explicit OTLP missing-dependency failure, degrades to no telemetry for
- * other initialization failures, and registers a best-effort flush on
+ * the active backend (no-op unless `TELEMETRY_BACKEND` is set), propagates an
+ * explicit OTLP missing-dependency failure, degrades to no telemetry for other
+ * initialization failures, and registers a best-effort flush on
  * `SIGTERM`/`SIGINT`. Skips the edge runtime — the OTEL NodeSDK is Node-only —
  * so callers may import it unconditionally, though gating the dynamic import on
  * `NEXT_RUNTIME === 'nodejs'` also keeps the SDK off the edge bundle.
@@ -33,10 +33,7 @@ export async function registerTelemetryForNextjs(): Promise<void> {
   try {
     await initTelemetry()
   } catch (error) {
-    if (isOtlpDependencyUnavailableError(error)) {
-      logger.error('Init from Next.js instrumentation failed', { err: error })
-      process.exit(1)
-    }
+    if (isOtlpDependencyUnavailableError(error)) throw error
     logger.warn('Init from Next.js instrumentation failed', { err: error })
     return
   }

--- a/packages/telemetry/src/nextjs.ts
+++ b/packages/telemetry/src/nextjs.ts
@@ -19,9 +19,9 @@ function isOtlpDependencyUnavailableError(error: unknown): boolean {
 
 /**
  * One-line telemetry bootstrap for a Next.js `instrumentation.ts`. Initializes
- * the active backend (no-op unless `TELEMETRY_BACKEND` is set), propagates an
- * explicit OTLP missing-dependency failure, degrades to no telemetry for other
- * initialization failures, and registers a best-effort flush on
+ * the active backend (no-op unless `TELEMETRY_BACKEND` is set), terminates on
+ * an explicit OTLP missing-dependency failure, degrades to no telemetry for
+ * other initialization failures, and registers a best-effort flush on
  * `SIGTERM`/`SIGINT`. Skips the edge runtime — the OTEL NodeSDK is Node-only —
  * so callers may import it unconditionally, though gating the dynamic import on
  * `NEXT_RUNTIME === 'nodejs'` also keeps the SDK off the edge bundle.
@@ -33,7 +33,10 @@ export async function registerTelemetryForNextjs(): Promise<void> {
   try {
     await initTelemetry()
   } catch (error) {
-    if (isOtlpDependencyUnavailableError(error)) throw error
+    if (isOtlpDependencyUnavailableError(error)) {
+      logger.error('Init from Next.js instrumentation failed', { err: error })
+      process.exit(1)
+    }
     logger.warn('Init from Next.js instrumentation failed', { err: error })
     return
   }

--- a/scripts/__tests__/fullapp-compose-telemetry.test.mjs
+++ b/scripts/__tests__/fullapp-compose-telemetry.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const ROOT_COMPOSE = 'docker-compose.fullapp.yml'
+const TRAEFIK_COMPOSE = 'docker-compose.fullapp.traefik.yml'
+const TEMPLATE_COMPOSE = 'packages/create-app/template/docker-compose.fullapp.yml'
+const ROOT_COLLECTOR_CONFIG = 'docker/otel-collector-config.yaml'
+const TEMPLATE_COLLECTOR_CONFIG = 'packages/create-app/template/docker/otel-collector-config.yaml'
+
+const TELEMETRY_ENVIRONMENT = {
+  TELEMETRY_BACKEND: '${TELEMETRY_BACKEND:-}',
+  TELEMETRY_SAMPLING_RATIO: '${TELEMETRY_SAMPLING_RATIO:-}',
+  TELEMETRY_TRUST_INBOUND_TRACE: '${TELEMETRY_TRUST_INBOUND_TRACE:-false}',
+  OTEL_EXPORTER_OTLP_ENDPOINT: '${OTEL_EXPORTER_OTLP_ENDPOINT:-}',
+  OTEL_EXPORTER_OTLP_HEADERS: '${OTEL_EXPORTER_OTLP_HEADERS:-}',
+  OTEL_SERVICE_NAME: '${OTEL_SERVICE_NAME:-open-mercato}',
+  OTEL_RESOURCE_ATTRIBUTES: '${OTEL_RESOURCE_ATTRIBUTES:-}',
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.resolve(ROOT, relativePath), 'utf8')
+}
+
+function readYaml(relativePath) {
+  return parse(read(relativePath))
+}
+
+for (const relativePath of [ROOT_COMPOSE, TRAEFIK_COMPOSE, TEMPLATE_COMPOSE]) {
+  test(`${relativePath} forwards the complete telemetry environment contract`, () => {
+    const compose = readYaml(relativePath)
+    const environment = compose.services.app.environment
+
+    for (const [name, value] of Object.entries(TELEMETRY_ENVIRONMENT)) {
+      assert.equal(environment[name], value, `${relativePath} must forward ${name} without rewriting it`)
+    }
+  })
+}
+
+for (const [relativePath, expectedMount] of [
+  [ROOT_COMPOSE, './docker/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro'],
+  [TEMPLATE_COMPOSE, './docker/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro'],
+]) {
+  test(`${relativePath} keeps the diagnostic collector private and opt-in`, () => {
+    const compose = readYaml(relativePath)
+    const collector = compose.services['otel-collector']
+
+    assert.deepEqual(collector.profiles, ['telemetry'])
+    assert.equal(collector.image, 'otel/opentelemetry-collector:0.159.0')
+    assert.deepEqual(collector.command, ['--config=/etc/otelcol/config.yaml'])
+    assert.deepEqual(collector.networks, ['mercato-network-fullapp'])
+    assert.deepEqual(collector.volumes, [expectedMount])
+    assert.equal(collector.ports, undefined, 'collector ports must not be published to the host')
+    assert.equal(compose.services.app.depends_on?.['otel-collector'], undefined)
+  })
+}
+
+test('root and create-app collector configurations are byte-identical', () => {
+  assert.equal(read(ROOT_COLLECTOR_CONFIG), read(TEMPLATE_COLLECTOR_CONFIG))
+})
+
+test('collector example receives and debugs traces, metrics, and logs over OTLP/HTTP', () => {
+  const collector = readYaml(ROOT_COLLECTOR_CONFIG)
+
+  assert.equal(collector.receivers.otlp.protocols.http.endpoint, '0.0.0.0:4318')
+  assert.deepEqual(collector.processors.batch, {})
+  assert.equal(collector.exporters.debug.verbosity, 'basic')
+
+  for (const signal of ['traces', 'metrics', 'logs']) {
+    assert.deepEqual(collector.service.pipelines[signal], {
+      receivers: ['otlp'],
+      processors: ['batch'],
+      exporters: ['debug'],
+    })
+  }
+})


### PR DESCRIPTION
Closes #5783

Tracking plan: `.ai/runs/2026-08-31-telemetry-docker-topology.md`

Source designs:
- `.ai/specs/2026-08-30-telemetry-docker-topology.md`
- `.ai/specs/2026-08-30-telemetry-otlp-missing-dependency-fail-fast.md`

Status: complete

## 🎯 Goal

Make the optional OTLP telemetry mode deployable through every supported Docker topology and fail clearly when an explicitly selected OTLP backend cannot load its optional runtime packages.

## 🛠️ What Changed

- Forwarded the seven supported telemetry/OTLP environment variables through the root Compose file, Traefik overlay, and create-app template.
- Added an opt-in `telemetry` Compose profile with a pinned, private OpenTelemetry Collector and byte-identical root/template collector configurations; the app remains uncoupled from collector startup.
- Replaced the false-success OTLP console fallback with a safe internal dependency error that preserves the original failure as `cause`, keeps retry state clean, and leaves OpenTelemetry packages optional.
- Propagated only that intentional failure through the reusable Next.js helper, then terminated the shipped app at the host boundary with a sanitized top-level stderr message and exit code 1.
- Mirrored the host behavior into the create-app template and `mercato telemetry init`; the CLI structurally upgrades both supported legacy snippets, remains idempotent, and leaves unknown custom shapes for a manual update.
- Added the runtime telemetry guide, sidebar entry, logging cross-link, Compose/source-contract coverage, runtime regression coverage, host-boundary secrecy coverage, and CLI migration coverage.

## 🧪 Verification

Runner: local (no running Compose app container).

| Check | Result |
|---|---|
| `yarn build:packages` (including the latest telemetry/CLI build) | Passed |
| `yarn generate` | Passed; existing Node 24 JSON-import fallback warning only |
| `yarn i18n:check-sync` | Passed |
| `yarn i18n:check-usage` | Passed; 3,827 existing advisory unused keys |
| `yarn typecheck` | Passed |
| `yarn lint` | Passed; 10 pre-existing warnings, 0 errors |
| `yarn build:app` | Passed; existing Turbopack dynamic-filesystem warnings only |
| Telemetry package tests | 97/97 passed |
| CLI telemetry-init tests | 16/16 passed |
| App host-boundary regression | Passed |
| Combined Compose contract tests | 47/47 passed |
| Documentation checks | 16/16 passed |
| Docker Compose v5.4 disabled/profile graphs | Passed for root, Traefik overlay, and template |
| `yarn template:sync` | Only the pre-existing `modules.ts` drift remains |

The local full `yarn test` gate reached only existing create-app live-harness host/sandbox failures (Homebrew `libuv` sandbox denial, a missing tracked hook in a race fixture, and nested typecheck timeouts). All affected suites pass, and the prior PR-head GitHub `test` check passed. Latest-head GitHub checks were pending when this description was updated.

Two independent final reviewers reported no remaining actionable findings after the review/autofix cycle.

## 📸 UI Evidence

UI: n/a — deployment topology, runtime bootstrap, CLI migration, tests, and documentation only.

## 💥 Breaking Changes

None. No public package export, API, database, event, DI, ACL, or UI contract changes. Telemetry and the collector remain disabled by default.

## 📋 Progress

All tracking-plan steps are complete. GitHub still requires an independent human review because the PR author cannot formally approve their own PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790719347&installation_model_id=432243&pr_number=5799&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5799&signature=3684469afaea4d7bcbe1872fba498457f34fecf1879dd42c0fc15fb218ffbe2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
