### PR TITLE
feat(harness): standalone harness generalization for unenumerated business modules

### DIFF
--- a/.ai/specs/2026-08-29-standalone-harness-generalization.md
+++ b/.ai/specs/2026-08-29-standalone-harness-generalization.md
@@ -1,7 +1,7 @@
 ---
 title: Standalone Harness Generalization for Unenumerated Business Modules
 date: 2026-08-29
-status: draft
+status: in-progress
 ---
 
 # Standalone Harness Generalization for Unenumerated Business Modules
@@ -47,7 +47,7 @@ Four tracks, independently landable, ordered by leverage over cost. Every change
 
 ### Track 4: honest decision-label scoring
 
-- Replace the `decisionVocabulary ?? requiredDecisions` fallback in the evaluator's prompt builder with deterministic distractor injection: the effective vocabulary is `requiredDecisions` plus distractors sampled from a family-level label pool derived from the catalog, seeded by case ID so prompts stay reproducible per catalog version. `validateCatalog` enforces that the effective vocabulary is at least twice the size of `requiredDecisions` (or that the case declares an explicit vocabulary meeting the same ratio).
+- Replace the `decisionVocabulary ?? requiredDecisions` fallback in the evaluator's prompt builder with deterministic distractor injection: the effective vocabulary is `requiredDecisions` plus `max(|requiredDecisions|, 4)` distractors sampled from the case's family label pool, then the whole-catalog pool, seeded by case ID and required labels so prompts stay reproducible per catalog version; the result is sorted so required labels are not positionally identifiable. Declared vocabularies pass through verbatim and keep the existing at-least-one-contrastive-label rule; `validateCatalog` fails closed when assembly cannot add a single distractor, and the assembled vocabulary is recorded in the sanitized result for audit. The grader already fails any selected non-required label, so distractors make the dimension meaningful with grading unchanged.
 - Add an advisory validator listing single-use labels to drive a later consolidation pass of the 608-label space toward a smaller canonical set; consolidation itself is out of scope here.
 - This changes the assembled prompt for up to 215 cases, so Track 4 requires a full `yarn harness:release` re-certification, not only targeted case runs. `promptHash` (sha256 of the case's task prompt) is unaffected.
 
@@ -83,3 +83,4 @@ Four tracks, independently landable, ordered by leverage over cost. Every change
 ## Changelog
 
 - 2026-08-29: Initial draft from the multi-model robustness and over-specificity audit.
+- 2026-08-29: Implemented in this branch: Track 1 (blueprint `No Matching Row` fallback; root keyword-map default arm, paid for by reclaiming unpinned root bytes, both roots mirrored), Track 2 (`generateAppLocalModuleFacts` in `yarn generate` emitting `.ai/guides/app-modules/<id>/`, gated on the installed `.ai/guides` harness; progressive-path classification, `pathReferenceExists` tolerance, `contracts.md` pointer, template gitignore), Track 3 relocation (the Complete Library Contract moved to `om-module-scaffold/references/library-contract.md`; OMH-185/193 own and require it; the staff-inference section reheaded domain-neutral), and Track 4 (deterministic distractor assembly, catalog validation, advisory single-use-label count, vocabulary recorded in results). Still pending: the Track 3 transfer case, Track 1 routing cases for unenumerated domains, live failure-first runner evidence, and the full `yarn harness:release` re-certification on a Linux/Bubblewrap host.

--- a/.ai/specs/2026-08-29-standalone-harness-generalization.md
+++ b/.ai/specs/2026-08-29-standalone-harness-generalization.md
@@ -1,6 +1,6 @@
 ---
 title: Standalone Harness Generalization for Unenumerated Business Modules
-date: 2026-08-31
+date: 2026-08-29
 status: draft
 ---
 
@@ -12,7 +12,7 @@ The standalone-app agent harness (routing knowledge, blueprints, fact sheets, an
 
 ## Problem Statement
 
-Audit evidence (2026-08-31, measured against the shipped 234-case catalog):
+Audit evidence (2026-08-29, measured against the shipped 234-case catalog):
 
 1. **Fact-sheet monopoly.** Module fact sheets are generated only for `@open-mercato/*` packages (`packages/create-app/build.mjs`, `packages/cli/src/lib/generators/module-facts-discovery.ts`), and `assertPackageModuleFactsOnly` (`packages/cli/src/lib/generators/module-facts.ts`) throws on any app-local fact. `yarn generate` writes nothing under `.ai/guides/`. A user's own module in `src/modules/` therefore never has a fact sheet, while 163/234 cases (70%) lean on that asset class. The router hands a `customers` task a curated sheet, a blueprint row, and a keyword-map entry; it hands a user's `bookings` module nothing but raw source.
 2. **Blueprint row matching with no miss handler.** The root router's `module-data` row makes loading `om-module-scaffold/references/business-one-shot-blueprints.md` and picking its "exact key" mandatory for every business one-shot. The file holds 42 rows (only 3 greenfield), instructs "Pick the closest row" and "Once a row matches, its route key is binding", and has no branch for a brief that matches no row. A generic brief is forced to impersonate the nearest CRM row.
@@ -82,4 +82,4 @@ Four tracks, independently landable, ordered by leverage over cost. Every change
 
 ## Changelog
 
-- 2026-08-31: Initial draft from the multi-model robustness and over-specificity audit.
+- 2026-08-29: Initial draft from the multi-model robustness and over-specificity audit.

--- a/.ai/specs/2026-08-31-standalone-harness-generalization.md
+++ b/.ai/specs/2026-08-31-standalone-harness-generalization.md
@@ -1,0 +1,85 @@
+---
+title: Standalone Harness Generalization for Unenumerated Business Modules
+date: 2026-08-31
+status: draft
+---
+
+# Standalone Harness Generalization for Unenumerated Business Modules
+
+## TLDR
+
+The standalone-app agent harness (routing knowledge, blueprints, fact sheets, and the evaluation catalog under `packages/create-app/agentic/`) is measurably tuned to an enumerated roster of built-in domains plus three novel-domain fixtures (`library`, `room_bookings`, `room_calendar_sync`). Agent work on a generic business module that nobody enumerated (a reporting module, a clinic booking module, an asset registry) falls off the enumerated paths at four layers: fact-sheet availability, blueprint row matching, the root keyword map, and decision-label scoring. This spec defines four remediation tracks that make the knowledge and grading layers domain-open without weakening any trusted oracle or security boundary.
+
+## Problem Statement
+
+Audit evidence (2026-08-31, measured against the shipped 234-case catalog):
+
+1. **Fact-sheet monopoly.** Module fact sheets are generated only for `@open-mercato/*` packages (`packages/create-app/build.mjs`, `packages/cli/src/lib/generators/module-facts-discovery.ts`), and `assertPackageModuleFactsOnly` (`packages/cli/src/lib/generators/module-facts.ts`) throws on any app-local fact. `yarn generate` writes nothing under `.ai/guides/`. A user's own module in `src/modules/` therefore never has a fact sheet, while 163/234 cases (70%) lean on that asset class. The router hands a `customers` task a curated sheet, a blueprint row, and a keyword-map entry; it hands a user's `bookings` module nothing but raw source.
+2. **Blueprint row matching with no miss handler.** The root router's `module-data` row makes loading `om-module-scaffold/references/business-one-shot-blueprints.md` and picking its "exact key" mandatory for every business one-shot. The file holds 42 rows (only 3 greenfield), instructs "Pick the closest row" and "Once a row matches, its route key is binding", and has no branch for a brief that matches no row. A generic brief is forced to impersonate the nearest CRM row.
+3. **A published answer key inside shared knowledge.** 25.4% of the blueprint file (7,336 of 28,830 bytes, the "Complete Library Contract" section; 35.5% with "Canonical Staff Record Inference") is an ID-level and signature-level contract for exactly two catalog cases (OMH-185, OMH-193). `writable-ast-oracles.mjs` grades those same literals (`library:book`, `library.books.create`, `room_bookings.bookings.view`). Writable scores on 12 of 49 cases partly measure adherence to a published crib sheet rather than transferable module-building skill, and every unrelated business one-shot pays those bytes on every trigger.
+4. **Closed keyword map.** The `Module-Specific Facts` map in `agentic/shared/AGENTS.md.template` enumerates 16 host domains with no default arm. "Booking", "report", "asset", "shift" resolve to nothing, so an agent either force-maps to a wrong built-in host or routes with no domain grounding.
+5. **Decision-label scoring is an answer key that does not exist at runtime.** Only 19/234 cases declare a `decisionVocabulary`; for the other 215 the evaluator's prompt builder falls back to `decisionVocabulary ?? requiredDecisions`, handing the model the exact required labels with zero distractors. The label space holds 608 distinct labels, 403 of them (66%) used exactly once. The most-required label (`tenant-scope`, 24 cases) appears nowhere in `AGENTS.md.template` or any shipped skill. The dimension is inflated and untransferable.
+
+The routing rules themselves (Axis 1 and Axis 2 tables, `om-data-model-design`, `src/modules/example`) are genuinely domain-neutral; the overfitting is concentrated in the knowledge and grading layers.
+
+## Proposed Solution
+
+Four tracks, independently landable, ordered by leverage over cost. Every change to a skill, blueprint, case, oracle, or router file is a knowledge-contract change and MUST follow the nine-step procedure in `packages/create-app/agentic/shared/ai/skills/om-evolve-harness/references/knowledge-change.md` (failure-first evidence, one smallest owner, synchronized counts, knowledge-change manifest validated with `yarn workspace create-mercato-app harness:validate-knowledge-change`).
+
+### Track 1: no-match fallback in the blueprint and the keyword map
+
+- Add an explicit "no matching row" branch to `business-one-shot-blueprints.md`: when no row's domain matches the brief, a new binding key (working name `generic-business-module`) applies. Its bounded context is the module-scaffold core procedure, `src/modules/example`, and the `om-data-model-design` route; impersonating the nearest domain row is explicitly forbidden.
+- Add a default arm to the `Module-Specific Facts` keyword map in `AGENTS.md.template`: an unmatched domain noun means no installed host owns the domain; route `module-data` with the example reference and do not force-map to the nearest built-in.
+- Root byte budget constraint: the generated root currently sits about 142 bytes under the 12 KiB target (`STANDALONE_ROOT_TARGET_BYTES`), so the default arm's bytes must be reclaimed elsewhere in the root or the shed-index fallback accepted deliberately (`packages/create-app/src/lib/agent-instruction-budget.test.ts` pins the choice). The change must land identically in `packages/create-app/template/AGENTS.md`; `root-instruction-parity.test.ts` enforces byte parity past the H1.
+- Evaluations: add or extend routing cases whose prompts use unenumerated domain nouns and whose expected route is the generic branch. Failure-first: today these briefs route to the nearest enumerated row.
+
+### Track 2: fact sheets for app-local modules
+
+- Generate fact sheets for modules under `src/modules/` into a separate tree, `.ai/guides/app-modules/<id>/`, as a `yarn generate` post-step in the standalone app. Reuse `renderModuleFactsDirectory` and the app-local discovery path that already projects `example` into `.ai/guides/reference-modules/`. The separate tree preserves the `assertPackageModuleFactsOnly` invariant for published package output; no change to the package build.
+- Router integration: extend the generated module-guides block with one pointer line for app-local sheets (same budget discipline as Track 1) and classify `.ai/guides/app-modules/` as progressive context in the evaluator's `isInitialContextPath` and in the budget test's mirror of that list.
+- Staleness contract: sheets are regenerated by `yarn generate`; the standalone `AGENTS.md` guidance and `packages/create-app/agentic/shared/AGENTS.md.template` must state that, per the create-app rule that generator post-steps and standalone agent guidance stay aligned.
+- Evaluations: a routing case whose correct context is the app-local sheet of a fixture app's own module, plus coverage that a writable fixture module's sheet exists after `yarn generate` in the prepared target.
+
+### Track 3: move the library answer key into case-owned fixtures
+
+- Relocate "Complete Library Contract" and "Canonical Staff Record Inference" (about 10.2 KB) from `business-one-shot-blueprints.md` into narrow reference files that only OMH-185 and OMH-193 declare in their case context. Every other business one-shot trigger drops those bytes; non-library work never reads library IDs. The two cases keep one smallest owner each (the relocated reference), and their oracles are untouched (oracles are case-scoped by design).
+- Add one writable transfer case in a domain with no published contract anywhere in the knowledge layer, graded by a new case-scoped oracle, to measure genuine generalization instead of crib-sheet recall. This is a catalog addition and carries the full count-pin checklist: `cases.schema.json` (`minItems`/`maxItems` and ID patterns), `validators.json` (`expectedCaseCount`), the literals in `agent-surface-coverage.test.ts` and `agent-harness-evaluator.test.ts`, and the prose counts in `packages/create-app/README.md`, `ai/harness/README.md`, `ai/harness/RELEASE.md`, and `packages/create-app/AGENT-HARNESS.md`.
+
+### Track 4: honest decision-label scoring
+
+- Replace the `decisionVocabulary ?? requiredDecisions` fallback in the evaluator's prompt builder with deterministic distractor injection: the effective vocabulary is `requiredDecisions` plus distractors sampled from a family-level label pool derived from the catalog, seeded by case ID so prompts stay reproducible per catalog version. `validateCatalog` enforces that the effective vocabulary is at least twice the size of `requiredDecisions` (or that the case declares an explicit vocabulary meeting the same ratio).
+- Add an advisory validator listing single-use labels to drive a later consolidation pass of the 608-label space toward a smaller canonical set; consolidation itself is out of scope here.
+- This changes the assembled prompt for up to 215 cases, so Track 4 requires a full `yarn harness:release` re-certification, not only targeted case runs. `promptHash` (sha256 of the case's task prompt) is unaffected.
+
+## Data and Contract Surfaces
+
+- New files: `.ai/guides/app-modules/<id>/*.md` (generated, never hand-edited), relocated blueprint reference files under the harness fixture tree, new case and oracle entries for the transfer case.
+- Modified knowledge owners: `business-one-shot-blueprints.md`, `agentic/shared/AGENTS.md.template` plus `template/AGENTS.md`, the generated module-guides block, `om-module-scaffold/SKILL.md` where it names the blueprint contract.
+- Modified tooling: the standalone `yarn generate` pipeline (app-local sheet emission), `evaluate-agent-harness.mjs` (`isInitialContextPath`, vocabulary assembly, `validateCatalog` vocabulary ratio), `cases.schema.json`/`validators.json` for the new case.
+- No product API routes, database schema, or UI surfaces change. No `BACKWARD_COMPATIBILITY.md` contract surface is touched; blueprint keys are harness-internal routing contracts governed by the knowledge-change procedure, and the retired direct-match keys keep a deprecation note in the blueprint for one release.
+
+## Verification and Coverage
+
+- Per track: failure-first evidence for every new or changed evaluation (the evaluation must fail against the pre-change knowledge owner and pass after), retained as sanitized summaries only.
+- Deterministic gate after every track: `yarn harness:validate --all` from a fresh scaffold generated from the changed sources.
+- Full release suite (`yarn harness:release`, Linux with Bubblewrap) after Track 3 (catalog count change) and Track 4 (prompt change); Tracks 1 and 2 need it only when their routing cases land.
+- Unit coverage: `agent-instruction-budget.test.ts` (root budget and shed decision), `root-instruction-parity.test.ts` (both roots), `agent-surface-coverage.test.ts` and `agent-harness-evaluator.test.ts` (counts, vocabulary ratio validator, progressive-path classification), template sync tests for any `template/` mirror.
+- No app API or UI paths are affected, so no new Playwright integration tests are required; harness lanes are the integration coverage for this change.
+
+## Risks and Impact Review
+
+- **Root budget overflow** (medium, standalone scaffolds): Tracks 1 and 2 both add root bytes against about 142 bytes of headroom. Mitigation: reclaim bytes in the same edit or accept the shed-index fallback deliberately; the budget test fails closed either way. Residual: a slightly terser root.
+- **Score regression on certified lanes** (medium, release gate): Track 3 removes crib bytes and Track 4 removes the answer-key fallback, so measured pass rates on existing cases may drop, which is the honest baseline surfacing, not a regression. Mitigation: land each track behind its own release-suite run and record the before/after cohort in the refresh report. Residual: a re-baselined pass rate.
+- **Distractor sampling instability** (low): a poorly seeded pool could make a case flaky across catalog versions. Mitigation: seed by case ID plus catalog hash, pin the pool derivation in `validateCatalog`, and keep the assembled vocabulary in the sanitized result for audit.
+- **App-local sheet staleness** (low): a stale `.ai/guides/app-modules/` sheet could mislead routing. Mitigation: regenerate on every `yarn generate`, mark the tree generated-only, and have the router prefer source over a sheet whose module folder is missing.
+
+## Out of Scope
+
+- Consolidating the 608-label decision space (advisory validator only in Track 4).
+- A second-model portability dimension in the release gate (same runner, different model); tracked separately.
+- Skill-wide prompt-token reduction (blueprint splitting beyond Track 3, shared untrusted-content reference, `om-auto-*` override dedupe); candidates for a follow-up spec.
+- The evaluator fixes already delivered on PR #5804 (matrix-declared timeout floors, composed-retry result caps, judge-lane floor, release `--reasoning-effort` pass-through, root parity test).
+
+## Changelog
+
+- 2026-08-31: Initial draft from the multi-model robustness and over-specificity audit.

--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -359,6 +359,7 @@ describe('init command failure output', () => {
       generateModuleEntities: jest.fn().mockResolvedValue(undefined),
       generateModuleDi: jest.fn().mockResolvedValue(undefined),
       generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+      generateAppLocalModuleFacts: jest.fn().mockResolvedValue(undefined),
       generateOpenApi: jest.fn().mockResolvedValue(undefined),
     }))
     jest.doMock('../lib/resolver', () => ({
@@ -405,6 +406,7 @@ describe('init command failure output', () => {
       generateModuleEntities: jest.fn().mockResolvedValue(undefined),
       generateModuleDi: jest.fn().mockResolvedValue(undefined),
       generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+      generateAppLocalModuleFacts: jest.fn().mockResolvedValue(undefined),
       generateOpenApi: jest.fn().mockResolvedValue(undefined),
     }))
     jest.doMock('../lib/resolver', () => ({
@@ -454,6 +456,7 @@ describe('init command failure output', () => {
       generateModuleEntities: jest.fn().mockResolvedValue(undefined),
       generateModuleDi: jest.fn().mockResolvedValue(undefined),
       generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+      generateAppLocalModuleFacts: jest.fn().mockResolvedValue(undefined),
       generateOpenApi: jest.fn().mockResolvedValue(undefined),
     }))
     jest.doMock('../lib/db', () => ({
@@ -554,6 +557,7 @@ describe('generate post-step structural invalidation', () => {
     const generateModuleEntities = jest.fn().mockResolvedValue(undefined)
     const generateModuleDi = jest.fn().mockResolvedValue(undefined)
     const generateModulePackageSources = jest.fn().mockResolvedValue(undefined)
+    const generateAppLocalModuleFacts = jest.fn().mockResolvedValue(undefined)
     const generateOpenApi = jest.fn().mockResolvedValue(undefined)
     const invalidate = jest.fn().mockResolvedValue({
       cacheEntriesDeleted: 2,
@@ -568,6 +572,7 @@ describe('generate post-step structural invalidation', () => {
       generateModuleEntities,
       generateModuleDi,
       generateModulePackageSources,
+      generateAppLocalModuleFacts,
       generateOpenApi,
     }))
     jest.doMock('../lib/resolver', () => ({
@@ -609,6 +614,7 @@ describe('generate post-step structural invalidation', () => {
       generateModuleEntities: jest.fn().mockResolvedValue(unchangedResult),
       generateModuleDi: jest.fn().mockResolvedValue(unchangedResult),
       generateModulePackageSources: jest.fn().mockResolvedValue(unchangedResult),
+      generateAppLocalModuleFacts: jest.fn().mockResolvedValue(unchangedResult),
       generateOpenApi: jest.fn().mockResolvedValue(unchangedResult),
     }
     const invalidate = jest.fn()
@@ -649,6 +655,7 @@ describe('generate post-step structural invalidation', () => {
     const generateModuleEntities = jest.fn().mockResolvedValue(undefined)
     const generateModuleDi = jest.fn().mockResolvedValue(undefined)
     const generateModulePackageSources = jest.fn().mockResolvedValue(undefined)
+    const generateAppLocalModuleFacts = jest.fn().mockResolvedValue(undefined)
     const generateOpenApi = jest.fn().mockResolvedValue(undefined)
     const invalidate = jest.fn().mockRejectedValue(new Error('cache maintenance unavailable'))
 
@@ -658,6 +665,7 @@ describe('generate post-step structural invalidation', () => {
       generateModuleEntities,
       generateModuleDi,
       generateModulePackageSources,
+      generateAppLocalModuleFacts,
       generateOpenApi,
     }))
     jest.doMock('../lib/resolver', () => ({
@@ -694,6 +702,7 @@ describe('generate post-step structural invalidation', () => {
       generateModuleEntities: generate,
       generateModuleDi: generate,
       generateModulePackageSources: generate,
+      generateAppLocalModuleFacts: generate,
       generateOpenApi: generate,
     }))
     jest.doMock('../lib/resolver', () => ({

--- a/packages/cli/src/__tests__/module-facts-app-local.test.ts
+++ b/packages/cli/src/__tests__/module-facts-app-local.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createResolver } from '../lib/resolver'
+import { generateAppLocalModuleFacts } from '../lib/generators/module-facts-app-local'
+
+describe('generateAppLocalModuleFacts', () => {
+  let appDir: string
+
+  beforeEach(() => {
+    appDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'om-app-facts-')))
+  })
+
+  afterEach(() => {
+    fs.rmSync(appDir, { recursive: true, force: true })
+  })
+
+  const stageModule = (id: string) => {
+    const moduleRoot = path.join(appDir, 'src', 'modules', id)
+    fs.mkdirSync(moduleRoot, { recursive: true })
+    fs.writeFileSync(path.join(moduleRoot, 'index.ts'), 'export const metadata = { requires: [] }\n')
+  }
+
+  it('is a no-op in an app without the agent harness', async () => {
+    stageModule('bookings')
+    const result = await generateAppLocalModuleFacts({ resolver: createResolver(appDir), quiet: true })
+    expect(result.filesWritten).toEqual([])
+    expect(fs.existsSync(path.join(appDir, '.ai'))).toBe(false)
+  })
+
+  it('projects app modules into .ai/guides/app-modules, stays byte-stable, and prunes removed modules', async () => {
+    stageModule('bookings')
+    fs.mkdirSync(path.join(appDir, '.ai', 'guides'), { recursive: true })
+
+    const first = await generateAppLocalModuleFacts({ resolver: createResolver(appDir), quiet: true })
+    const sheet = path.join(appDir, '.ai', 'guides', 'app-modules', 'bookings', 'index.md')
+    expect(fs.existsSync(sheet)).toBe(true)
+    expect(first.filesWritten.length).toBeGreaterThan(0)
+
+    const second = await generateAppLocalModuleFacts({ resolver: createResolver(appDir), quiet: true })
+    expect(second.filesWritten).toEqual([])
+
+    fs.rmSync(path.join(appDir, 'src', 'modules', 'bookings'), { recursive: true, force: true })
+    const third = await generateAppLocalModuleFacts({ resolver: createResolver(appDir), quiet: true })
+    expect(third.filesWritten.length).toBeGreaterThan(0)
+    expect(fs.existsSync(path.join(appDir, '.ai', 'guides', 'app-modules'))).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/generators/index.ts
+++ b/packages/cli/src/lib/generators/index.ts
@@ -9,4 +9,5 @@ export {
 export { generateModuleEntities, type ModuleEntitiesOptions } from './module-entities'
 export { generateModuleDi, type ModuleDiOptions } from './module-di'
 export { generateModulePackageSources, type ModulePackageSourcesOptions } from './module-package-sources'
+export { generateAppLocalModuleFacts, type AppLocalModuleFactsOptions } from './module-facts-app-local'
 export { generateOpenApi, type GenerateOpenApiOptions } from './openapi'

--- a/packages/cli/src/lib/generators/module-facts-app-local.ts
+++ b/packages/cli/src/lib/generators/module-facts-app-local.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { PackageResolver } from '../resolver'
+import { createGeneratorResult, type GeneratorResult } from '../utils'
+import { discoverAppLocalModuleSources, discoverPackageModuleSources } from './module-facts-discovery'
+import { extractLocalReferenceModuleFacts } from './module-facts'
+
+export interface AppLocalModuleFactsOptions {
+  resolver: PackageResolver
+  quiet?: boolean
+}
+
+function writeIfChanged(file: string, content: string, result: GeneratorResult): void {
+  if (fs.existsSync(file) && fs.readFileSync(file, 'utf8') === content) return
+  fs.writeFileSync(file, content)
+  result.filesWritten.push(file)
+}
+
+/**
+ * Projects each enabled `@app` module's fact sheet into `.ai/guides/app-modules/<id>/`,
+ * mirroring the sectioned layout of the installed-package sheets under
+ * `.ai/guides/modules/`. Package output stays untouched: every projection runs through
+ * the disposable activated batch in `extractLocalReferenceModuleFacts`, so the
+ * package-only invariant on normal fact output holds.
+ *
+ * Gated on the installed agent harness, not repo topology: `apps/mercato` has no
+ * `.ai/guides` tree and must keep producing byte-identical generator output, while every
+ * scaffolded standalone app ships one. Extraction failures degrade to a warning for that
+ * module; the knowledge layer must never block code generation.
+ */
+export async function generateAppLocalModuleFacts(
+  options: AppLocalModuleFactsOptions,
+): Promise<GeneratorResult> {
+  const { resolver, quiet } = options
+  const result = createGeneratorResult()
+  const guidesDir = path.join(resolver.getAppDir(), '.ai', 'guides')
+  if (!fs.existsSync(guidesDir)) return result
+  const outputRoot = path.join(guidesDir, 'app-modules')
+  const sources = discoverAppLocalModuleSources(resolver)
+  const emitted = new Set<string>()
+
+  if (sources.length > 0) {
+    let packageSources: ReturnType<typeof discoverPackageModuleSources>
+    try {
+      packageSources = discoverPackageModuleSources(resolver)
+    } catch {
+      packageSources = []
+    }
+    const registryPath = path.join(resolver.getOutputDir(), 'modules.runtime.generated.ts')
+    let coreVersion: string | null = null
+    try {
+      const corePackage = path.join(resolver.getAppDir(), 'node_modules', '@open-mercato', 'core', 'package.json')
+      coreVersion = (JSON.parse(fs.readFileSync(corePackage, 'utf8')) as { version?: string }).version ?? null
+    } catch {
+      coreVersion = null
+    }
+
+    for (const reference of sources) {
+      try {
+        const { directory, warnings } = extractLocalReferenceModuleFacts({
+          packageSources,
+          reference,
+          registryPath: fs.existsSync(registryPath) ? registryPath : null,
+          coreVersion,
+        })
+        const moduleDir = path.join(outputRoot, reference.moduleId)
+        fs.mkdirSync(moduleDir, { recursive: true })
+        const expected = new Set(['index.md', ...directory.sections.map((section) => `${section.slug}.md`)])
+        writeIfChanged(path.join(moduleDir, 'index.md'), directory.index, result)
+        for (const section of directory.sections) {
+          writeIfChanged(path.join(moduleDir, `${section.slug}.md`), section.markdown, result)
+        }
+        for (const stale of fs.readdirSync(moduleDir)) {
+          if (expected.has(stale)) continue
+          fs.rmSync(path.join(moduleDir, stale), { recursive: true, force: true })
+          result.filesWritten.push(path.join(moduleDir, stale))
+        }
+        emitted.add(reference.moduleId)
+        if (!quiet) for (const warning of warnings) console.warn(warning)
+      } catch (error) {
+        if (!quiet) {
+          const message = error instanceof Error ? error.message : String(error)
+          console.warn(`[module-facts][app-local] skipped ${reference.moduleId}: ${message}`)
+        }
+      }
+    }
+  }
+
+  if (fs.existsSync(outputRoot)) {
+    for (const staleModule of fs.readdirSync(outputRoot)) {
+      if (emitted.has(staleModule)) continue
+      fs.rmSync(path.join(outputRoot, staleModule), { recursive: true, force: true })
+      result.filesWritten.push(path.join(outputRoot, staleModule))
+    }
+    if (fs.readdirSync(outputRoot).length === 0) fs.rmdirSync(outputRoot)
+  }
+
+  if (!quiet && emitted.size > 0) {
+    console.log(`[module-facts] projected ${emitted.size} app-local module fact sheet(s) → .ai/guides/app-modules/`)
+  }
+  return result
+}

--- a/packages/cli/src/lib/generators/module-facts-discovery.ts
+++ b/packages/cli/src/lib/generators/module-facts-discovery.ts
@@ -135,6 +135,24 @@ export function discoverLocalReferenceModuleSource(options: {
 }
 
 /**
+ * Every enabled `@app` module with readable TypeScript source under `src/modules/<id>`.
+ * Disabled directories stay out: their surfaces are inert, so a fact sheet would claim
+ * behavior the app does not run.
+ */
+export function discoverAppLocalModuleSources(resolver: PackageResolver): ModuleFactSource[] {
+  const appDir = resolver.getAppDir()
+  const sources: ModuleFactSource[] = []
+  const seen = new Set<string>()
+  for (const entry of resolver.loadEnabledModules()) {
+    if (entry.from !== '@app' || seen.has(entry.id)) continue
+    seen.add(entry.id)
+    const source = discoverLocalReferenceModuleSource({ appRoot: appDir, moduleId: entry.id })
+    if (source) sources.push(source)
+  }
+  return sources.sort((left, right) => left.moduleId.localeCompare(right.moduleId))
+}
+
+/**
  * Appends the local reference source to the package batch, rejecting a duplicate module
  * id *before* assignment. A package that already provides the same id would otherwise be
  * silently replaced by (or silently replace) the app-local projection, and the emitted

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -787,6 +787,7 @@ async function runGeneratorSuite(quiet: boolean): Promise<boolean> {
     generateModuleEntities,
     generateModuleDi,
     generateModulePackageSources,
+    generateAppLocalModuleFacts,
     generateOpenApi,
   } = await import('./lib/generators')
   const resolver = createResolver()
@@ -796,6 +797,7 @@ async function runGeneratorSuite(quiet: boolean): Promise<boolean> {
     await generateModuleEntities({ resolver, quiet }),
     await generateModuleDi({ resolver, quiet }),
     await generateModulePackageSources({ resolver, quiet }),
+    await generateAppLocalModuleFacts({ resolver, quiet }),
     await generateOpenApi({ resolver, quiet }),
   ]
   return results.some((result) => (result?.filesWritten.length ?? 0) > 0)

--- a/packages/create-app/agentic/guides/contracts.md
+++ b/packages/create-app/agentic/guides/contracts.md
@@ -2,6 +2,8 @@
 
 Use this guide for entities, APIs, commands, scoping, compatibility, migrations, events, workers, search, and cache. Use `customers` as the CRUD reference after resolving its installed source.
 
+This app's own modules get generated fact sheets too: read `.ai/guides/app-modules/<id>/index.md` for a targeted `src/modules/<id>` module instead of re-deriving its surfaces from source. `yarn generate` refreshes them, so treat a sheet older than the module's source as stale and regenerate.
+
 ## Entity and Scope Contract
 
 - Define entity classes together in `src/modules/<id>/data/entities.ts`; import decorators from `@mikro-orm/decorators/legacy` and ORM types from the installed MikroORM package.

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -102,16 +102,15 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ### Token-Efficient Assembly Policy
 
-- Load matched guides once, then only needed references/facts.
-- Hard budgets: guide > skill > references; open a reference only for its named subject.
+- Load matched guides once, then only needed references/facts; never bulk-read trees.
+- Budgets: guide > skill > references; open a reference only for its named subject.
 - `spec-pr` reads template via spec-delivery.
 - Inspect app call sites before bounded `framework-context`.
 - Additive page/form/table/conflict UI skips it.
-- Never bulk-read guide, skill, fact, or source trees.
 
 ## Module-Specific Facts
 
-Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal+customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Big fact-sheets: read in sections.
+Mechanisms: events/subscribers→events; long operation→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal+customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Other domains→no installed host: a new app module owns them (module-data); never force-map a host.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->

--- a/packages/create-app/agentic/shared/ai/harness/cases.json
+++ b/packages/create-app/agentic/shared/ai/harness/cases.json
@@ -16404,7 +16404,7 @@
     ],
     "owner": {
       "kind": "skill",
-      "path": ".ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md",
+      "path": ".ai/skills/om-module-scaffold/references/library-contract.md",
       "ruleIds": [
         "BC-01",
         "BC-02",
@@ -16449,6 +16449,7 @@
         ".ai/guides/extensions.md",
         ".ai/skills/om-module-scaffold/SKILL.md",
         ".ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md",
+        ".ai/skills/om-module-scaffold/references/library-contract.md",
         ".ai/skills/om-module-scaffold/references/api-and-domain.md",
         ".ai/skills/om-module-scaffold/references/module-surfaces.md",
         ".ai/skills/om-data-model-design/SKILL.md",
@@ -17344,7 +17345,7 @@
     ],
     "owner": {
       "kind": "skill",
-      "path": ".ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md",
+      "path": ".ai/skills/om-module-scaffold/references/library-contract.md",
       "ruleIds": [
         "BC-01",
         "BC-02",
@@ -17383,6 +17384,7 @@
         ".ai/guides/extensions.md",
         ".ai/skills/om-module-scaffold/SKILL.md",
         ".ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md",
+        ".ai/skills/om-module-scaffold/references/library-contract.md",
         ".ai/skills/om-module-scaffold/references/api-and-domain.md",
         ".ai/skills/om-module-scaffold/references/module-surfaces.md",
         ".ai/skills/om-data-model-design/SKILL.md",

--- a/packages/create-app/agentic/shared/ai/harness/result.schema.json
+++ b/packages/create-app/agentic/shared/ai/harness/result.schema.json
@@ -17,6 +17,7 @@
     "selectedSkills": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
     "selectedContext": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
     "decisions": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
+    "decisionVocabulary": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
     "violations": { "type": "array", "items": { "type": "string", "maxLength": 300 } },
     "attempts": { "type": "integer", "minimum": 1, "maximum": 3 },
     "corrections": { "type": "integer", "minimum": 0, "maximum": 2 },

--- a/packages/create-app/agentic/shared/ai/skills/om-evolve-harness/references/case-template.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-evolve-harness/references/case-template.md
@@ -29,7 +29,7 @@ Use the next contiguous `OMH-NNN` ID. Take the shape of an adjacent case from `.
 Copy the shape from an adjacent case, never its budgets. Calibrate them from this case's own measured
 footprint in a scaffolded controller: sum the on-disk size of `context.required` plus every
 `context.allowedExtra` path, counting a path toward the *initial* budgets unless it lives under
-`/references/`, `.ai/framework-context/`, `.ai/guides/modules/`, `.ai/guides/reference-modules/`, `.ai/guides/upstream/`, or `.agents/skills/`. Round up to leave real
+`/references/`, `.ai/framework-context/`, `.ai/guides/app-modules/`, `.ai/guides/modules/`, `.ai/guides/reference-modules/`, `.ai/guides/upstream/`, or `.agents/skills/`. Round up to leave real
 slack — a budget equal to the declared set fails a correct run on one incidental read — then confirm
 against a clean passing live trace rather than a neighbouring case's envelope.
 

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/business-one-shot-blueprints.md
@@ -15,11 +15,15 @@ Load this reference when the user describes a business outcome rather than files
 
 Once a row matches, its route key is binding: invoke every unparenthesized route letter and its skill before implementation. Scalar IDs or snapshots keep modules independent, but they do not remove `U` when the slice still links to, enriches, guards, or renders installed-module behavior. A parenthesized route remains conditional on the parenthesized reason.
 
-## Canonical Staff Record Inference
+## No Matching Row
+
+A row matches only when its business domain genuinely matches the brief. When no row's domain matches, the brief is an unenumerated business domain and this fallback is binding instead: route `M`, adding `B`, `W`, `P`, or `A` only where the brief itself demands that surface, read the three complete-module procedures below, and invoke `om-data-model-design` with `src/modules/example` as the structural reference. Do not impersonate the nearest domain row; its stable IDs, invariants, and slices belong to its own domain. The generic invariants still apply: tenant+organization scope, command-owned writes with undo and optimistic locking, encrypted PII reads, stable IDs, and the Completion Rule at the end of this file.
+
+## Canonical Record-Management Inference
 
 Immediately after this file and before any optional specialist reference, directly read all three complete-module procedures: `.ai/skills/om-module-scaffold/references/api-and-domain.md`, `.ai/skills/om-module-scaffold/references/module-surfaces.md`, and `.ai/skills/om-module-scaffold/references/verification.md`. When context is bounded, these required procedures win over allowed-extra references. Their canonical exports, callbacks, placements, and verification paths are binding; do not substitute plausible alternatives such as `locales/` for `i18n/` or module-level tests for `commands/__tests__/`.
 
-Business briefs should describe outcomes; translate familiar staff record-management language into the framework's canonical surfaces without making the user name them:
+Business briefs should describe outcomes; translate familiar record-management language into the framework's canonical surfaces without making the user name them:
 
 - “Browse/search/filter, add, correct, remove, and recover from mistakes” means a controlled-search `DataTable` with an add link and guarded `RowActions`, backed by `CrudForm` create/edit/delete flows. Preserve `initialValues`, use the documented CRUD helpers, and expose stable DataTable and CrudForm host IDs unless the domain requires a purpose-built interaction.
 - “Extra fields administrators add later must survive create, edit, clear, and reload” means one stable custom-field entity ID across the route and forms, `collectCustomFieldValues` at submission, initial custom-field values on edit, and reset/restore maps during update and delete undo.
@@ -160,7 +164,7 @@ Before stopping, run `yarn generate` and then `yarn typecheck`. Any diagnostic m
 |---|---|---|---|---|
 | “Add localized privacy, terms, and help pages.” | App content module; UMES menu injection when linked in installed UI | `M+B+U` | versioned content, locale resolution, public routes, navigation/footer links, publish preview | safe rendering; explicit publication/version dates; locale fallback; legal history remains retrievable |
 | “Create a tenant onboarding wizard for CRM setup.” | App onboarding module + UMES setup hooks/widgets | `M+U+B+W` | resumable steps, defaults/import/invitations, completion state, welcome notification | setup hooks idempotent; scoped progress; safe retry; secrets never stored in wizard state |
-| “Build a library management system.” | New app module | `M+B+W` | books/copies/members, checkout/return/renew/reservation commands, admin UI/search, overdue jobs | copy availability is transactional; no double checkout; due dates use tenant zone; member PII protected |
+| “Build a library management system.” | New app module; final check against `.ai/skills/om-module-scaffold/references/library-contract.md` | `M+B+W` | books/copies/members, checkout/return/renew/reservation commands, admin UI/search, overdue jobs | copy availability is transactional; no double checkout; due dates use tenant zone; member PII protected |
 | “Build a field-service management app tied to CRM customers.” | App module + UMES customer links + optional mapping provider | `M+U+B+W+P` | work orders, technicians, schedule, visit notes/photos, customer panel, dispatch notifications | scalar customer IDs/snapshots; assignment conflicts prevented; mobile/error states; jobs retry idempotently |
 | “Build an equipment rental business app.” | New app module + optional payment/shipping providers | `M+B+W+P` | assets, availability, reservations, checkout/return, damage/deposit, calendar | overlapping reservations rejected atomically; money snapshots; asset condition audit; provider failures recoverable |
 | “Build appointment booking connected to CRM.” | App module + UMES customer handoff + notification provider | `M+U+B+W+P` | public availability, booking/reschedule/cancel, CRM match/create, reminders, admin calendar | public scope derived server-side; slot hold is atomic; time-zone/DST correctness; submission/reminder dedupe |

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/library-contract.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/library-contract.md
@@ -1,0 +1,51 @@
+# Complete Library Contract
+
+Load this reference only when the selected blueprint row is the complete library app, or when a case declares it directly. It is a bounded worked contract for that single domain.
+
+When the selected row is the complete library app, do a final source-level check against this bounded contract before generation; do not generalize these library IDs into other domains:
+
+The required procedures plus this bounded contract resolve the library slice's framework choices. Do not route `framework-context` or load its resolver for this slice; spend that context on the three mandatory complete-module references instead.
+
+- Export and default-export `features` with exact IDs `library.books.view` and `library.books.manage`. Export `setup: ModuleSetupConfig = { defaultRoleFeatures }`; a detached `defaultRoleFeatures` export is not discovered setup.
+- Use entity ID `library:book`. The `makeCrudRoute` ORM keys are `tenantField` and `orgField`; its list keys are `schema`, `buildFilters`, and `transformItem`. Keep response transforms in supported `response` callbacks, register `library.books.create`, `library.books.update`, and `library.books.delete` with concrete `registerCommand(...)` calls, and use the installed `createCrudOpenApiFactory` signature exactly.
+- Keep custom fields in the framework data engine rather than an entity JSON column. Submission calls `collectCustomFieldValues`; snapshots call `loadCustomFieldSnapshot`; update and delete undo each call `buildCustomFieldResetMap` and restore through `setCustomFields` in the same `withAtomicFlush` boundary.
+- Each command object owns its calls: create/update/delete undo call `extractUndoPayload` from `@open-mercato/shared/lib/commands/undo` and `emitCrudUndoSideEffects`; update/delete execute call the object-form `enforceCommandOptimisticLock`. Direct book reads call a scoped helper from `@open-mercato/shared/lib/encryption/find`.
+- Export `searchConfig` using `fieldPolicy`, `buildSource` with `checksumSource`, `formatResult`, and `resolveUrl`. The list UI connects `searchValue`/`onSearchChange` to the API `search` filter and exposes add, linked edit, and guarded delete actions.
+- Put Jest command/undo proof in `commands/__tests__/` with imports from `@jest/globals`, and put every visible `library.*` key in `i18n/en.json`. Run generation, the focused test, and typecheck; fix every diagnostic instead of leaving a plausible sketch.
+- Keep the first implementation bounded to the required Books vertical slice. Use one `commands/books.ts` with typed `CommandHandler<Input, Result>` objects and keep every transaction, lock, undo, reset-map, and side-effect call inside its owning exported command object—do not hide oracle-significant behavior in shared helpers. Avoid optional locales, standalone widget/event/enricher files, or extra entities until the required slice generates, tests, and typechecks.
+- Do not guess imports or add unsupported convenience options. In particular, `features` needs no invented ACL type, a CRUD list has no `find`, `response` is a callback rather than a schema, `useConfirmDialog` comes from `@open-mercato/ui/backend/confirm-dialog`, and search checksum data is the inline `checksumSource` object rather than a helper import. Re-open the exact reference for any remaining signature before writing it.
+- A current `CommandHandler<Input, Result>` implements `execute(input, ctx)` and returns `Result` directly. It captures undo state with `prepare(input, ctx)`, `captureAfter(input, result, ctx)`, and `buildLog({ result, snapshots })`; never destructure `{ input, ctx }` in `execute` or return `{ result, undo }`. Lock with `enforceCommandOptimisticLock({ resourceKind, resourceId, current, expected, request: ctx.request })`.
+- Treat every lifecycle signature as a compile-time contract, not pseudocode. Use method syntax exactly as shown below: `async prepare(input, ctx)`, `async execute(input, ctx)`, and `async captureAfter(input, result, ctx)`. The only lifecycle callback that receives an object containing `input` is `buildLog({ input, result, ctx, snapshots })`; `undo` receives `{ input, ctx, logEntry }`. Never write `execute: async ({ input, ctx })`, `prepare: async ({ input, ctx })`, or `captureAfter: async ({ result })`.
+- Import only `loadCustomFieldSnapshot` and `buildCustomFieldResetMap` from `@open-mercato/shared/lib/commands/customFieldSnapshots`; call the former with `(em, { entityId, recordId, tenantId, organizationId })`. Persist through `dataEngine.setCustomFields({ entityId, recordId, tenantId, organizationId, values, notify: false })`; there is no shared `lib/data/custom-fields` helper and UI-only `collectCustomFieldValues` never belongs in a command.
+- Normalize command-side `Record<string, unknown>` custom-field payloads with `normalizeCustomFieldValues` from `@open-mercato/shared/lib/commands/helpers` before passing them to `dataEngine.setCustomFields`; do not cast an unknown-valued record to satisfy its primitive-value contract.
+- The concrete direct-book finder calls `findOneWithDecryption(em, Book, { id, tenant_id, organization_id }, undefined, { tenantId, organizationId })` and rejects null. Do not attach a decryption finder to `makeCrudRoute`; its QueryEngine already decrypts the list.
+- Import `Input` from `@open-mercato/ui/primitives/input` and use shared `Input`, `Button`, and `Alert` primitives for any filter/retry controls—never raw `<input>` or `<button>`. Do not create any test outside `commands/__tests__/` until typecheck is green; avoid speculative API tests, and express database uniqueness in the reviewed migration rather than an unsupported `unique` option on `@Index`.
+
+Use this shape literally for the command lifecycle and direct read, filling in the mutations and snapshots without changing the signatures:
+
+```ts
+const findBook = async (em: EntityManager, id: string, scope: Scope) => {
+  const book = await findOneWithDecryption(
+    em,
+    Book,
+    { id, tenant_id: scope.tenantId, organization_id: scope.organizationId },
+    undefined,
+    { tenantId: scope.tenantId, organizationId: scope.organizationId },
+  )
+  if (!book) throw new Error('library.book_not_found')
+  return book
+}
+
+export const updateBook: CommandHandler<UpdateInput, Result> = {
+  id: 'library.books.update',
+  async prepare(input, ctx) { /* return { before } */ },
+  async execute(input, ctx) { /* mutate atomically; return { id, updatedAt } */ },
+  async captureAfter(input, result, ctx) { /* return after snapshot */ },
+  buildLog({ input, result, ctx, snapshots }) { /* store snapshots in payload.undo */ },
+  async undo({ input, ctx, logEntry }) { /* extract payload, call buildCustomFieldResetMap, restore, emit undo effects */ },
+}
+```
+
+Create and delete use these exact same lifecycle signatures; do not convert any of them to single-argument arrow callbacks. Delete undo must call `buildCustomFieldResetMap` inside the delete command before restoring custom fields; create/update/delete undo each call `extractUndoPayload` and `emitCrudUndoSideEffects` inside their own object.
+
+Before stopping, run `yarn generate` and then `yarn typecheck`. Any diagnostic mentioning a lifecycle property on the input type (for example, “Property 'input' does not exist on type …”) proves a callback was incorrectly destructured: repair all create/update/delete callbacks to the method signatures above and rerun until the typecheck is silent. Then run the command test; a written-but-unchecked module is not complete.

--- a/packages/create-app/agentic/shared/scripts/evaluate-agent-harness.mjs
+++ b/packages/create-app/agentic/shared/scripts/evaluate-agent-harness.mjs
@@ -1025,6 +1025,12 @@ function pathReferenceExists(root, reference) {
     const generatedModuleRoot = path.join(root, '.ai', 'guides', 'modules')
     return !fs.existsSync(generatedModuleRoot) || fs.existsSync(path.resolve(root, reference))
   }
+  // App-local sheets exist only after `yarn generate` runs in a prepared target, so a
+  // case may reference one the controller has not generated yet.
+  if (reference.startsWith('.ai/guides/app-modules/')) {
+    const appModuleRoot = path.join(root, '.ai', 'guides', 'app-modules')
+    return !fs.existsSync(appModuleRoot) || fs.existsSync(path.resolve(root, reference))
+  }
   if (reference.includes('*') || reference.includes('?')) {
     return walkFiles(root).some((file) => globToRegExp(reference).test(file))
   }
@@ -1279,6 +1285,8 @@ function validateCatalog({ root, cases, registry, releaseMatrix, fixtures, seeds
       add(id, 'decisionVocabulary must include every required decision')
     } else if (item.decisionVocabulary && item.decisionVocabulary.length === item.requiredDecisions.length) {
       add(id, 'decisionVocabulary must add at least one contrastive decision')
+    } else if (!item.decisionVocabulary && effectiveDecisionVocabulary(item, cases).length <= (item.requiredDecisions ?? []).length) {
+      add(id, 'assembled decision vocabulary must add at least one distractor')
     }
     for (const message of validateSpecRoutingDeclaration(item)) add(id, message)
     if (!isUniqueStringArray(item.forbiddenPatterns, { min: 1 })) add(id, 'forbiddenPatterns must not be empty')
@@ -2571,6 +2579,7 @@ export function observedContext(stdout, root, caseRecord, writable, reviewExpect
 function isInitialContextPath(relative) {
   return !relative.includes('/references/')
     && !relative.startsWith('.ai/framework-context/')
+    && !relative.startsWith('.ai/guides/app-modules/')
     && !relative.startsWith('.ai/guides/modules/')
     && !relative.startsWith('.ai/guides/reference-modules/')
     && !relative.startsWith('.ai/guides/upstream/')
@@ -2617,7 +2626,7 @@ function contextStats(root, paths, metadata = {}) {
   }
 }
 
-function evaluateRouting(caseRecord, response, stats, readOrder = [], observedWrites = []) {
+function evaluateRouting(caseRecord, response, stats, readOrder = [], observedWrites = [], offeredDecisions = undefined) {
   const failures = [...evaluateSpecRoutingDecision(caseRecord, response, observedWrites)]
   const selectedRoutes = new Set(response.selectedRouter)
   for (const required of caseRecord.expectedRouter.required) if (!selectedRoutes.has(required)) failures.push(`missing route ${required}`)
@@ -2686,7 +2695,7 @@ function evaluateRouting(caseRecord, response, stats, readOrder = [], observedWr
     }
   }
   const selectedDecisions = new Set(response.decisions)
-  const decisionVocabulary = new Set(caseRecord.decisionVocabulary ?? caseRecord.requiredDecisions)
+  const decisionVocabulary = new Set(offeredDecisions ?? caseRecord.decisionVocabulary ?? caseRecord.requiredDecisions)
   for (const required of caseRecord.requiredDecisions) if (!selectedDecisions.has(required)) failures.push(`missing decision ${required}`)
   for (const selected of selectedDecisions) {
     if (!decisionVocabulary.has(selected)) failures.push(`unexpected decision ${selected}`)
@@ -2754,12 +2763,41 @@ function runnerVersion(runner, root) {
   return String(result.stdout || result.stderr).trim().slice(0, 200)
 }
 
-function buildPrompt(caseRecord, root, writable, frameworkContextEntries = []) {
+// A case without an authored decisionVocabulary used to receive its requiredDecisions verbatim,
+// which made the decisions dimension a distractor-free answer key. The effective vocabulary is
+// assembled deterministically instead: required labels plus seeded distractors from the case's
+// family pool, then the whole-catalog pool, sorted so required labels are not positionally
+// identifiable. Seeding by case id and required labels keeps every prompt reproducible for one
+// catalog version.
+export function effectiveDecisionVocabulary(caseRecord, catalog) {
+  if (caseRecord.decisionVocabulary) return [...caseRecord.decisionVocabulary]
+  const required = caseRecord.requiredDecisions ?? []
+  const poolLabels = (items) => [...new Set(items.flatMap((item) => [
+    ...(item.requiredDecisions ?? []),
+    ...(item.decisionVocabulary ?? []),
+  ]))].filter((label) => !required.includes(label)).sort()
+  const familyPool = poolLabels(catalog.filter((item) => item.family === caseRecord.family))
+  const globalPool = poolLabels(catalog).filter((label) => !familyPool.includes(label))
+  const target = Math.max(required.length, 4)
+  const distractors = []
+  let cursor = sha256(`${caseRecord.id}:${required.join(',')}`)
+  for (const pool of [familyPool, globalPool]) {
+    const available = [...pool]
+    while (available.length && distractors.length < target) {
+      cursor = sha256(cursor)
+      distractors.push(available.splice(Number.parseInt(cursor.slice(0, 8), 16) % available.length, 1)[0])
+    }
+    if (distractors.length >= target) break
+  }
+  return [...required, ...distractors].sort()
+}
+
+function buildPrompt(caseRecord, root, writable, frameworkContextEntries = [], catalog = [caseRecord]) {
   const skillRoot = path.join(root, '.ai', 'skills')
   const localSkills = fs.existsSync(skillRoot) ? fs.readdirSync(skillRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort() : []
   const externalSkills = [...discoverExternalSkills(root)]
   const availableSkills = [...new Set([...localSkills, ...externalSkills])].sort()
-  const decisionVocabulary = caseRecord.decisionVocabulary ?? caseRecord.requiredDecisions
+  const decisionVocabulary = effectiveDecisionVocabulary(caseRecord, catalog)
   const modeInstruction = writable
     ? 'This is an explicitly disposable writable evaluation. You must implement the complete request with repeated use of the allowlisted harness write tool before returning the routing object, then re-read the completed implementation. A manifest of intended files, metadata-only stub, TODO, placeholder, or response that only plans/routes fails: create every requested source, API, command, UI, registration, locale, migration snapshot, and focused test surface inside the write allowlist. You may read allowlisted target source files as implementation inputs, but selectedContext records only instruction/fact paths and must never include those target source paths. Write only inside the allowlist provided after the task; do not use network access or inspect environment values.'
     : 'Work read-only: do not edit files, run mutations, use network access, or inspect environment values. Do not implement the request. Accept the task premise for routing; fixture and implementation-target paths may be absent in this controller, so do not inspect them or report their absence as a blocker.'
@@ -3650,6 +3688,14 @@ function deterministicRun(selected, validation) {
     } else console.log(`PASS ${item.id} — ${item.owner.path}`)
   }
   console.log(`Deterministic: ${selected.length - [...validation.errorsByCase.entries()].filter(([id, errors]) => selected.some((item) => item.id === id) && errors.length).length}/${selected.length} selected cases passed`)
+  const labelUses = new Map()
+  for (const item of selected) {
+    for (const label of new Set([...(item.requiredDecisions ?? []), ...(item.decisionVocabulary ?? [])])) {
+      labelUses.set(label, (labelUses.get(label) ?? 0) + 1)
+    }
+  }
+  const singleUseLabels = [...labelUses.values()].filter((count) => count === 1).length
+  console.log(`Advisory: ${singleUseLabels} of ${labelUses.size} decision labels appear in exactly one selected case (consolidation candidates)`)
   return failed ? EXIT_FAILURE : EXIT_PASS
 }
 
@@ -3666,7 +3712,7 @@ export function resolveLiveCaseTimeout(options, model, caseTimeout = 0) {
   return Math.max(runnerTimeout, caseTimeout)
 }
 
-function liveRun({ options, selected, registry, releaseMatrix, fixtures, root, harnessDir, resultSchema }) {
+function liveRun({ options, selected, cases, registry, releaseMatrix, fixtures, root, harnessDir, resultSchema }) {
   const schemaPath = path.join(harnessDir, 'routing-response.schema.json')
   const version = runnerVersion(options.runner, root)
   const model = options.model ?? releaseMatrix.routing.runners[options.runner].modelSelector
@@ -3704,7 +3750,8 @@ function liveRun({ options, selected, registry, releaseMatrix, fixtures, root, h
       const beforeOracle = writable ? runOracle(evaluationCase, runRoot, root, registry, 'before') : { failures: [], invalid: [] }
       if (beforeOracle.invalid.length) throw new Error(`${caseRecord.id}: invalid writable oracle setup: ${beforeOracle.invalid.join('; ')}`)
       if (writable && beforeOracle.failures.length === 0) throw new Error(`${caseRecord.id}: writable oracle already passes before the edit`)
-      const prompt = buildPrompt(evaluationCase, runRoot, writable, preparedFrameworkContext.entries) + (writable ? `\n\nImplement the task only under these allowed app-relative paths: ${caseRecord.allowedWrites.join(', ')}. Do not change anything else.` : '')
+      const offeredDecisions = effectiveDecisionVocabulary(evaluationCase, cases)
+      const prompt = buildPrompt(evaluationCase, runRoot, writable, preparedFrameworkContext.entries, cases) + (writable ? `\n\nImplement the task only under these allowed app-relative paths: ${caseRecord.allowedWrites.join(', ')}. Do not change anything else.` : '')
       const allowedReads = caseReadAllowlist(evaluationCase, writable, runRoot)
       // Root immutability is resolved before writable-pattern matching, including inside the
       // fail-closed tool server, so a declared example root can never be written.
@@ -3754,7 +3801,7 @@ function liveRun({ options, selected, registry, releaseMatrix, fixtures, root, h
             .filter((entry) => isSafeRelative(entry) && isPathInside(runRoot, path.resolve(runRoot, entry)) && fs.existsSync(path.resolve(runRoot, entry)))
           declaredStats = contextStats(runRoot, [...new Set(declared)].sort())
           const observedWrites = specRoutingObservedWrites(evaluationCase, writable, specRoutingBefore, runRoot)
-          violations.push(...evaluateRouting(evaluationCase, response, stats, trace.readOrder, observedWrites))
+          violations.push(...evaluateRouting(evaluationCase, response, stats, trace.readOrder, observedWrites, offeredDecisions))
         } else violations.push(`${attempt.kind}: ${sanitize(attempt.error, runRoot)}`)
         return { response, trace, stats, declaredStats, violations }
       }
@@ -3856,6 +3903,7 @@ function liveRun({ options, selected, registry, releaseMatrix, fixtures, root, h
         selectedSkills: recursivelySanitize(response.selectedSkills, runRoot),
         selectedContext: recursivelySanitize(response.selectedContext, runRoot),
         decisions: recursivelySanitize(response.decisions, runRoot),
+        ...(caseRecord.decisionVocabulary ? {} : { decisionVocabulary: recursivelySanitize(offeredDecisions, runRoot) }),
         violations: violations.map((entry) => sanitize(entry, runRoot, RESULT_VIOLATION_LIMIT)),
         attempts: executions.length,
         corrections: executions.length - 1,
@@ -3917,7 +3965,7 @@ function main() {
       console.error(`catalog validation failed before live evaluation: ${catalogFailures.join('; ')}`)
       return EXIT_FAILURE
     }
-    return liveRun({ options, selected, registry, releaseMatrix, fixtures, root, harnessDir, resultSchema })
+    return liveRun({ options, selected, cases, registry, releaseMatrix, fixtures, root, harnessDir, resultSchema })
   } catch (error) {
     console.error(sanitize(error.message, root))
     return EXIT_INVALID

--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -151,8 +151,8 @@ try {
 
 // The app-local example is disabled in every preset, so it is never a package module and
 // never enters the normal outputs. It is projected into its own reference bundle from the
-// template root here; scaffold setup and `mercato agentic:init` recompute the same bundle
-// from the generated app's own `src/modules/example`.
+// template root here; scaffold setup and `mercato agentic:init` copy this prebuilt bundle
+// verbatim. Live app-local projections come from `yarn generate` (app-modules sheets).
 const REFERENCE_MODULE_IDS = ['example']
 
 const sources = discoverPackageModuleSources(createResolver(resolve(packagesDir, '..')))

--- a/packages/create-app/src/lib/agent-harness-evaluator.test.ts
+++ b/packages/create-app/src/lib/agent-harness-evaluator.test.ts
@@ -87,6 +87,7 @@ type StoredReviewResult = {
 function isInitialContextPath(relative: string): boolean {
   return !relative.includes('/references/')
     && !relative.startsWith('.ai/framework-context/')
+    && !relative.startsWith('.ai/guides/app-modules/')
     && !relative.startsWith('.ai/guides/modules/')
     && !relative.startsWith('.ai/guides/reference-modules/')
     && !relative.startsWith('.ai/guides/upstream/')
@@ -492,6 +493,32 @@ test('live timeout policy gives slow default runners measured floors without ove
   assert.equal(evaluator.resolveLiveCaseTimeout({ ...defaultOptions, runner: 'claude', reasoningEffort: undefined }, 'sonnet'), 600_000)
   assert.equal(evaluator.resolveLiveCaseTimeout({ ...defaultOptions, runner: 'claude', reasoningEffort: undefined, timeoutExplicit: true }, 'sonnet'), 300_000)
   assert.equal(evaluator.resolveLiveCaseTimeout(defaultOptions, 'gpt-5.4-mini', 1_000_000), 1_000_000)
+})
+
+test('assembled decision vocabularies add deterministic distractors and keep declared vocabularies verbatim', async () => {
+  type DecisionCase = { id: string; family: string; requiredDecisions?: string[]; decisionVocabulary?: string[] }
+  const evaluator = await import(pathToFileURL(sourceEvaluator).href) as {
+    effectiveDecisionVocabulary: (caseRecord: DecisionCase, catalog: DecisionCase[]) => string[]
+  }
+  const catalog = JSON.parse(fs.readFileSync(path.join(sourceHarness, 'cases.json'), 'utf8')) as DecisionCase[]
+  const catalogLabels = new Set(catalog.flatMap((item) => [...(item.requiredDecisions ?? []), ...(item.decisionVocabulary ?? [])]))
+
+  const declared = catalog.find((item) => item.decisionVocabulary)
+  assert.ok(declared)
+  assert.deepEqual(evaluator.effectiveDecisionVocabulary(declared, catalog), declared.decisionVocabulary)
+
+  const assembled = catalog.filter((item) => !item.decisionVocabulary)
+  assert.ok(assembled.length > 0)
+  for (const caseRecord of [assembled[0], assembled.at(-1) as DecisionCase]) {
+    const required = caseRecord.requiredDecisions ?? []
+    const vocabulary = evaluator.effectiveDecisionVocabulary(caseRecord, catalog)
+    assert.deepEqual(vocabulary, evaluator.effectiveDecisionVocabulary(caseRecord, catalog))
+    assert.deepEqual(vocabulary, [...vocabulary].sort())
+    assert.equal(new Set(vocabulary).size, vocabulary.length)
+    for (const label of required) assert.ok(vocabulary.includes(label), `required ${label} missing`)
+    assert.equal(vocabulary.length, required.length + Math.max(required.length, 4))
+    for (const label of vocabulary) assert.ok(catalogLabels.has(label), `invented distractor ${label}`)
+  }
 })
 
 test('trace-start recovery recognizes only bounded unavailable-read startup reports', async () => {

--- a/packages/create-app/src/lib/agent-instruction-budget.test.ts
+++ b/packages/create-app/src/lib/agent-instruction-budget.test.ts
@@ -29,6 +29,8 @@ const ROOT_SOURCES = [
 // progressive context, not part of the initial payload.
 function isInitialContext(relativePath: string): boolean {
   return !relativePath.includes('/references/')
+    && !relativePath.startsWith('.ai/framework-context/')
+    && !relativePath.startsWith('.ai/guides/app-modules/')
     && !relativePath.startsWith('.ai/guides/modules/')
     && !relativePath.startsWith('.ai/guides/reference-modules/')
     && !relativePath.startsWith('.ai/guides/upstream/')

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -102,16 +102,15 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ### Token-Efficient Assembly Policy
 
-- Load matched guides once, then only needed references/facts.
-- Hard budgets: guide > skill > references; open a reference only for its named subject.
+- Load matched guides once, then only needed references/facts; never bulk-read trees.
+- Budgets: guide > skill > references; open a reference only for its named subject.
 - `spec-pr` reads template via spec-delivery.
 - Inspect app call sites before bounded `framework-context`.
 - Additive page/form/table/conflict UI skips it.
-- Never bulk-read guide, skill, fact, or source trees.
 
 ## Module-Specific Facts
 
-Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal+customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Big fact-sheets: read in sections.
+Mechanisms: events/subscribers→events; long operation→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal+customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Other domains→no installed host: a new app module owns them (module-data); never force-map a host.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -101,6 +101,7 @@ skills-lock.json
 
 # on-demand installed framework context and local LLM evaluation evidence
 .ai/framework-context/
+.ai/guides/app-modules/
 .ai/harness/results/
 
 # raw agent transcripts may contain credentials, private prompts, and tool output


### PR DESCRIPTION
Spec (`.ai/specs/2026-08-29-standalone-harness-generalization.md`) plus the implementation of its four tracks. Background: the harness's knowledge and grading layers were tuned to enumerated domains, so work on a generic custom module routed and scored worse than catalog scenarios.

- **Track 1**: the business one-shot blueprint gets a binding `No Matching Row` fallback (route `M` + `om-data-model-design` + `src/modules/example`, never impersonate the nearest domain row) and the root keyword map a default arm for unmatched domain nouns. Both roots stay byte-identical past the H1 and the generated root stays 16 B under the 12 KiB target by reclaiming unpinned bytes, not by raising the target.
- **Track 2**: `yarn generate` now projects each enabled `@app` module's fact sheet into `.ai/guides/app-modules/<id>/` (new `generateAppLocalModuleFacts` step in the CLI, reusing the disposable activated batch, so the package-only invariant on normal fact output is untouched). Gated on the installed `.ai/guides` harness, so `apps/mercato` output is byte-identical. Classified as progressive context in the evaluator, both test mirrors, and the om-evolve-harness calibration template; `contracts.md` points at the sheets; the template gitignores them.
- **Track 3**: the 7.3 KB Complete Library Contract (an answer key for OMH-185/193 that every business one-shot paid for) moves to `om-module-scaffold/references/library-contract.md`; the two cases own and require the new file, the library blueprint row points at it, and the staff-inference section is reheaded domain-neutral.
- **Track 4**: cases without an authored `decisionVocabulary` no longer receive their required labels verbatim; the evaluator assembles deterministic seeded distractors (family pool, then catalog pool, sorted so required labels are not positionally identifiable), `validateCatalog` fails closed when assembly cannot add one, the deterministic gate prints a single-use-label advisory, and assembled vocabularies land in sanitized results. Grading is unchanged; it already failed any non-required label.

Verified: create-mercato-app suite 879 pass / 0 fail (5 env skips), CLI jest green except the pre-existing `module-facts.bc-guard` failure (fails identically on develop in this checkout; environment-dependent node_modules state), `tsc --noEmit` clean in both packages, new unit tests for the app-local generator and the distractor assembly.

Note: this branch touches `evaluate-agent-harness.mjs`/`result.schema.json` regions adjacent to #5804; land #5804 first and this will need a trivial rebase.