### PR TITLE
fix(docs): correct Edit this page repository path

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -52,7 +52,7 @@ const config: Config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.ts'),
           routeBasePath: '/',
-          editUrl: 'https://github.com/open-mercato/open-mercato/tree/main/docs',
+          editUrl: 'https://github.com/open-mercato/open-mercato/tree/main/apps/docs',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },


### PR DESCRIPTION
## Summary

Fix the documentation site's broken **Edit this page** links.

Docusaurus appends the site-relative `docs/...` path to the configured `editUrl`. The previous base generated links under `main/docs/docs/...`, while the documentation sources live under `apps/docs/docs/...`.

## Changes

- Point the Docusaurus `editUrl` base to `apps/docs`.
- Preserve the existing documentation routes and content.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- Ran `yarn workspace open-mercato-docs build` successfully.
- Confirmed generated links target existing files, for example:
  `https://github.com/open-mercato/open-mercato/tree/main/apps/docs/docs/tutorials/testing.mdx`
- Ran `git diff --check` successfully.
- No integration coverage is required because this is a documentation configuration correction with no application runtime, API, or database impact.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790771216&installation_model_id=432243&pr_number=5813&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5813&signature=4e1aefb2e766204337e6771d134a8c837b90cb5c9b220fdd9aacb66e1664ccb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->