### PR TITLE
test(staff): pin the timesheet duration suite clock and scope its totals assertions (#5825)

### DIFF
--- a/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import MyTimesheetsPage from '../page'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 
@@ -136,12 +136,52 @@ function saveButton(): HTMLButtonElement {
   return screen.getByRole('button', { name: 'Save Changes' }) as HTMLButtonElement
 }
 
+// The grid's column headers render each visible day's day-of-month number, so a
+// document-wide query for a bare digit can match a calendar header instead of a
+// total. Scope every total assertion to the footer row that carries them.
+function totalsRow(): HTMLElement {
+  return screen.getByText('Daily Total').closest('tr') as HTMLElement
+}
+
 function typeAndBlur(input: HTMLInputElement, value: string): void {
   fireEvent.change(input, { target: { value } })
   fireEvent.blur(input, { target: { value } })
 }
 
 describe('MyTimesheetsPage — duration entry (#4846)', () => {
+  // The page derives the visible week from the wall clock, so an unpinned clock makes
+  // every rendered day number — and any assertion that could collide with one — depend
+  // on the day the suite runs. Pin it to a week that deliberately contains a day
+  // numbered 2 (2026-09-02) so the totals-scoping guard below is exercised on every run
+  // instead of only during weeks that happen to contain that collision. Local-time parts
+  // keep this independent of the runner's timezone, and only Date is faked so the timer
+  // functions Testing Library's waitFor relies on stay real.
+  beforeAll(() => {
+    jest.useFakeTimers({
+      doNotFake: [
+        'cancelAnimationFrame',
+        'cancelIdleCallback',
+        'clearImmediate',
+        'clearInterval',
+        'clearTimeout',
+        'hrtime',
+        'nextTick',
+        'performance',
+        'queueMicrotask',
+        'requestAnimationFrame',
+        'requestIdleCallback',
+        'setImmediate',
+        'setInterval',
+        'setTimeout',
+      ],
+      now: new Date(2026, 8, 1, 12, 0, 0),
+    })
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
     stubApiRoutes()
@@ -220,11 +260,14 @@ describe('MyTimesheetsPage — duration entry (#4846)', () => {
   it('stops counting a cell in the totals once its pending value becomes invalid', async () => {
     const inputs = await renderGrid()
     typeAndBlur(inputs[0], '2')
-    await waitFor(() => expect(screen.getAllByText('2').length).toBeGreaterThan(0))
+    await waitFor(() => expect(within(totalsRow()).getAllByText('2').length).toBeGreaterThan(0))
 
     typeAndBlur(inputs[0], 'abc')
     await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
-    expect(screen.queryAllByText('2')).toHaveLength(0)
+    expect(within(totalsRow()).queryAllByText('2')).toHaveLength(0)
+    // The pinned week still renders a day-of-month header reading 2, which is exactly
+    // what a document-wide query would wrongly count as a surviving total.
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0)
   })
 
   it('names every duration cell after its own project and date', async () => {


### PR DESCRIPTION
## 🎯 Goal

Fixes #5825.

The staff timesheets duration-entry suite carries a date-dependent (time-bomb) assertion that has been turning the required `test` check red on **every open PR** since the current week began containing a day numbered `2`. This unblocks the whole queue: at the time of writing it is the sole failure on #5829, #5821 and #5819, and one of two on #5827 and #5822.

## 🔍 Root cause

`packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx`, the case *"stops counting a cell in the totals once its pending value becomes invalid"*:

```ts
typeAndBlur(inputs[0], '2')
await waitFor(() => expect(screen.getAllByText('2').length).toBeGreaterThan(0))
typeAndBlur(inputs[0], 'abc')
await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
expect(screen.queryAllByText('2')).toHaveLength(0)
```

Both assertions query the **whole document** for the bare text `2`. The grid's header row renders one day-of-month number per visible day (`page.tsx:887`, `<div className="text-xs">{date.getDate()}</div>`) and the suite pins no date, so it renders the *real* current week. In any week containing a day numbered `2`, that header satisfies the query:

```
Expected length: 0
Received length: 1
Received array:  [<div class="text-xs">2</div>]
```

The surviving node is a **calendar header**, not a total — so this is a test defect, not a product regression. The positive assertion was unsound for the same reason: a calendar header alone could satisfy it, letting the test pass without the totals ever updating.

## 📋 Change

Test-only; no product code touched.

1. **Scope both assertions to the totals.** A new `totalsRow()` helper resolves the footer row carrying the daily and grand totals, and the assertions run through `within(totalsRow())`. A calendar day number can no longer satisfy them — the fix is date-independent by construction, and the positive assertion now genuinely proves the totals updated.
2. **Pin the suite clock to a week that deliberately contains the 2nd** (`2026-09-01`, local-time parts so it is timezone-independent). Rather than dodging the collision, this makes the suite render it on **every** run, so the scoping guard is exercised continuously instead of one week in four. Only `Date` is faked — every timer function is listed in `doNotFake`, so Testing Library's `waitFor` keeps its real-timer path.
3. **Lock the regression.** A final assertion documents that the day-of-month header reading `2` is still in the document while the totals no longer contain it — pinning the exact confusion that caused the bug.

## 🧪 Verification

Reproduced the failure on a clean branch off `develop` (`421cefe66`) before changing anything — identical to the CI failure.

Proved the new guard bites: re-introducing the old document-wide assertion on top of this branch fails **deterministically**, with the original error, on every run:

```
● stops counting a cell in the totals once its pending value becomes invalid
  Received length: 1
  Received array:  [<div class="text-xs">2</div>]
Tests: 1 failed, 14 passed, 15 total
```

Validation gate:

| Command | Result |
|---|---|
| `yarn build:packages` | ✅ 27/27 |
| `yarn generate` | ✅ |
| `yarn i18n:check-sync` | ✅ all locales in sync |
| `yarn i18n:check-usage` | ✅ advisory only (pre-existing, untouched by this change) |
| `yarn typecheck` | ✅ 27/27 |
| `yarn test` (`@open-mercato/core`) | ✅ **1467 suites / 11886 tests passed, 0 failed** |
| `yarn lint` | ✅ 0 errors (10 pre-existing warnings, none in this file) |
| `yarn build:app` | ✅ |

`@open-mercato/core#test` is precisely the job that was failing in CI; it is now green.

## 💥 Backward compatibility

None. A single test file changes; no contract surface, no product behavior, no schema.

## 📸 QA

`skip-qa` — no UI-rendering file is touched (the only changed `.tsx` is a test), the database structure and API surface are unchanged, no `BACKWARD_COMPATIBILITY.md` contract is affected, and the changed behavior is itself covered by an automated test in this PR. This meets the automated-verification exemption.

## 🔭 Follow-up (not in scope here)

#5825 notes that the repo's `Check for time-bomb test literals` CI step did not catch this, because the coupling is to the *rendered calendar* rather than to a date literal in the test source. Worth a separate issue against that checker rather than widening this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790873089&installation_model_id=432243&pr_number=5831&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5831&signature=2f97d152b0d1fc5ebf05c5e14a4f06a9f35a686a1cb94b389d8549f47202d4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->