### PR TITLE
fix(messages,search): parse decrypted jsonb fields back to objects (#5789)

### DIFF
--- a/packages/core/src/modules/messages/api/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/__tests__/route.test.ts
@@ -123,7 +123,7 @@ function mockListContext(options: {
   return { em, cache }
 }
 
-function mockMessageRows() {
+function mockMessageRows(actionData: unknown = null) {
   findWithDecryptionMock.mockImplementation(async (_em, entity) => {
     if (entity?.name === 'Message') {
       return [{
@@ -138,7 +138,7 @@ function mockMessageRows() {
         subject: 'Subject',
         senderUserId: userId,
         priority: 'normal',
-        actionData: null,
+        actionData,
         actionTaken: null,
         sentAt: new Date('2026-06-18T06:00:00.000Z'),
         threadId: messageId,
@@ -234,6 +234,35 @@ describe('messages /api/messages POST', () => {
 
     expect(response.status).toBe(201)
     expect(commandBus.execute).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('messages /api/messages GET hasActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    isCrudCacheEnabledMock.mockReturnValue(false)
+  })
+
+  it('reports hasActions true when actionData round-trips as an encrypted JSON string', async () => {
+    mockMessageRows(JSON.stringify({ actions: [{ id: 'approve', label: 'Approve' }] }))
+    mockListContext()
+
+    const response = await GET(new Request('http://localhost/api/messages?folder=inbox'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.items[0].hasActions).toBe(true)
+  })
+
+  it('reports hasActions false when actionData has no actions', async () => {
+    mockMessageRows(null)
+    mockListContext()
+
+    const response = await GET(new Request('http://localhost/api/messages?folder=inbox'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.items[0].hasActions).toBe(false)
   })
 })
 

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -22,6 +22,7 @@ import {
   composeSourceHintSchema,
   resolveComposeSourceChannelType,
 } from '../lib/composeSourceChannelType'
+import { resolveMessageActionData } from '../lib/actions'
 import { MESSAGE_ATTACHMENT_ENTITY_ID } from '../lib/constants'
 import { getMessageType } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
@@ -382,7 +383,7 @@ export async function GET(req: Request) {
         if (!message) return null
         const body = typeof message.body === 'string' ? message.body : ''
         const bodyPreview = body.substring(0, 150) + (body.length > 150 ? '...' : '')
-        const actionData = message.actionData ?? null
+        const actionData = resolveMessageActionData(message)
         return {
           ...(senderMetaById.get(row.sender_user_id)
             ? {

--- a/packages/search/src/__tests__/vector-index-security.test.ts
+++ b/packages/search/src/__tests__/vector-index-security.test.ts
@@ -228,3 +228,48 @@ describe('VectorIndexService encryption fail-closed (issue #2716)', () => {
     expect(driver.upsertCalls[0].resultTitle).toBe('Title')
   })
 })
+
+describe('VectorIndexService decrypted result parse-back (issue #5789)', () => {
+  const passthroughEncryptionService = (): TenantDataEncryptionService =>
+    ({
+      isEnabled: () => true,
+      decryptEntityPayload: async (_entityId: string, payload: Record<string, unknown>) => payload,
+    }) as unknown as TenantDataEncryptionService
+
+  it('parses links/payload back to objects when decryptEntityPayload returns sealed JSON strings', async () => {
+    const driver = createDriver({
+      query: async () => [
+        {
+          entityId: 'demo:item',
+          recordId: 'rec-6',
+          organizationId: null,
+          score: 0.9,
+          checksum: 'abc',
+          resultTitle: 'Visible Title',
+          resultSubtitle: null,
+          resultIcon: null,
+          resultBadge: null,
+          resultSnapshot: null,
+          primaryLinkHref: null,
+          primaryLinkLabel: null,
+          links: '[{"href":"/backend/demo/rec-6","label":"View","kind":"primary"}]',
+          payload: '{"foo":"bar"}',
+        },
+      ],
+    })
+    const captured: CapturedEmbeddingInput = { value: null }
+    const service = createService({
+      driver,
+      embeddingService: createEmbeddingService(captured),
+      queryEngine: createQueryEngine({ id: 'rec-6' }),
+      moduleConfigs: [{ entities: [{ entityId: 'demo:item' }] }],
+      encryptionService: passthroughEncryptionService(),
+    })
+
+    const results = await service.search({ tenantId: 'tenant-1', query: 'anything' })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].links).toEqual([{ href: '/backend/demo/rec-6', label: 'View', kind: 'primary' }])
+    expect(results[0].metadata).toEqual({ foo: 'bar' })
+  })
+})

--- a/packages/search/src/vector/services/vector-index.service.ts
+++ b/packages/search/src/vector/services/vector-index.service.ts
@@ -2,6 +2,7 @@ import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import {
   type VectorModuleConfig,
   type VectorEntityConfig,
@@ -269,6 +270,8 @@ export class VectorIndexService {
         args.tenantId,
         args.organizationId,
       )
+      const decryptedLinks = (decrypted as any).links ?? args.links
+      const decryptedPayload = (decrypted as any).payload ?? args.payload
       return {
         resultTitle: String((decrypted as any).resultTitle ?? args.resultTitle),
         resultSubtitle: ((decrypted as any).resultSubtitle ?? args.resultSubtitle) as any,
@@ -276,8 +279,8 @@ export class VectorIndexService {
         resultSnapshot: ((decrypted as any).resultSnapshot ?? args.resultSnapshot) as any,
         primaryLinkHref: ((decrypted as any).primaryLinkHref ?? args.primaryLinkHref) as any,
         primaryLinkLabel: ((decrypted as any).primaryLinkLabel ?? args.primaryLinkLabel) as any,
-        links: ((decrypted as any).links ?? args.links) as any,
-        payload: ((decrypted as any).payload ?? args.payload) as any,
+        links: (typeof decryptedLinks === 'string' ? parseDecryptedFieldValue(decryptedLinks) : decryptedLinks) as any,
+        payload: (typeof decryptedPayload === 'string' ? parseDecryptedFieldValue(decryptedPayload) : decryptedPayload) as any,
       }
     } catch (err) {
       searchDebugWarn('vector.index', 'Vector entry decryption failed; refusing to return ciphertext as plaintext', {


### PR DESCRIPTION
Closes #5789

## 🎯 Goal
Restore correct behavior for two jsonb encryption read paths so `hasActions` on the messages list and `links`/`payload` on vector search results reflect real data instead of raw ciphertext-shaped JSON strings once tenant data encryption is enabled.

## 🔍 Problem
`encryptFields` JSON-stringifies a non-string value before sealing it, and `decryptFields`/`decryptEntityPayload` deliberately never auto-parse the result back (#1810) — callers must call `parseDecryptedFieldValue` themselves. Two call sites forgot to: the messages list route always reported `hasActions: false` for any message carrying action data, and `VectorIndexService.decryptResultFields` returned `links`/`payload` as raw strings, so any caller of `VectorIndexService.search`/`listIndexEntries` got a ciphertext-shaped string instead of the parsed value.

## 🔍 Root Cause
- `packages/core/src/modules/messages/api/route.ts` built `hasActions` from `message.actionData ?? null` directly instead of routing through `resolveMessageActionData()` — the helper `packages/core/src/modules/messages/lib/actions.ts` already exports and the message *detail* route already uses — so `actionData?.actions?.length` was always `undefined` when encryption is on.
- `packages/search/src/vector/services/vector-index.service.ts`'s `decryptResultFields` called `service.decryptEntityPayload(...)` and returned `links`/`payload` straight from the result with no parse-back.

## What Changed
- `packages/core/src/modules/messages/api/route.ts` — import `resolveMessageActionData` from `../lib/actions` and use it to compute `actionData` in the list route, matching the pattern the detail route already uses.
- `packages/search/src/vector/services/vector-index.service.ts` — `decryptResultFields` now applies `parseDecryptedFieldValue` to `links`/`payload` when the decrypted value comes back as a string, mirroring the pattern already used by `ActionLogService.decryptEntryPayload` and `AccessLogService.list`.

## What's intentionally out of scope
The issue separately flagged a third, explicitly "worth deciding" problem: `vector.strategy.ts`'s own `search()` calls `this.vectorDriver.query()` directly and never reaches `VectorIndexService`/`decryptResultFields` at all, so it stays broken independent of this fix (including a `hit.links.map is not a function` crash under encryption). The issue author scoped that out of the required suggested fix pending a design decision on whether the strategy should route through `VectorIndexService`, so it is left unaddressed here.

## 🧪 Tests
- `yarn workspace @open-mercato/core test -- messages/api/__tests__/route.test.ts` — 9 passed (2 new: `hasActions` true from a JSON-string `actionData`, false with none). Verified both fail on the pre-fix code.
- `yarn workspace @open-mercato/search test -- vector-index-security.test.ts` — 6 passed (1 new: `links`/`payload` parsed back from sealed JSON strings). Verified it fails on the pre-fix code.
- Full validation gate: `build:packages` → `generate` → `build:packages` → `i18n:check-sync` → `i18n:check-usage` → `typecheck` → `test` → `build:app` — all green except one pre-existing, unrelated failure: `create-mercato-app#test`'s bubblewrap sandbox-isolation tests, which fail in this environment because the sandbox lacks unprivileged user/network namespaces (`Bubblewrap isolation probe failed`, `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`) — untouched by this change.

## 💥 Breaking Changes
None — pure read-path fix, no schema or contract change.

## 🔒 Security impact
Both call sites read data that `TenantDataEncryptionService` already decrypted for the caller's own tenant/organization — no new decryption, no new access path, no key material handled. The change is a pure post-decrypt parse step (`parseDecryptedFieldValue`, JSON-parsing a string that only appears when it starts with `{`/`[`, otherwise returned unchanged), applied only after the existing tenant-scoped `decryptEntityPayload`/`resolveMessageActionData` calls succeed. It does not alter who can trigger decryption, what is decrypted, or the encrypt/decrypt boundary itself, and does not touch encryption keys, ciphertext storage, or the fail-closed error path (`decryptResultFields` still throws on decrypt failure instead of returning ciphertext). Net effect: previously-broken data (raw ciphertext-shaped JSON strings, or `hasActions` silently false) becomes correctly visible to the same caller who was already authorized to see it.
