### PR TITLE
fix(integrations): gate credentials form on integrations.credentials.manage (#5816)

### DIFF
--- a/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
+++ b/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
@@ -56,8 +56,8 @@ The integration detail page must stop offering an editable credentials form and 
 
 ### Phase 2: Verification
 
-- [ ] 2.1 Re-run the full `validation.commands` gate on this worktree and record the runner and results
-- [ ] 2.2 Run `om-auto-review-pr 5843 --autofix` and drive it to a clean verdict, landing any fixes as new commits
+- [x] 2.1 Re-run the full `validation.commands` gate on this worktree and record the runner and results — dda52ed64 (no code change; local runner, all commands green except `create-mercato-app`'s AI-harness oracle suites, which need the `codex`/`claude` CLIs)
+- [x] 2.2 Run `om-auto-review-pr 5843 --autofix` and drive it to a clean verdict, landing any fixes as new commits — c9ca75eb4
 
 ### Phase 3: Finalize
 

--- a/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
+++ b/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
@@ -1,0 +1,65 @@
+# Execution plan — gate the integrations credentials form on `integrations.credentials.manage` (adopted from PR #5843)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-09-03 because PR #5843 carried no execution plan.
+**PR:** #5843 · **Branch:** `fix/issue-5816-credentials-form-acl-gate` · **Base:** `develop`
+**Author:** @adeptofvoltron — this plan interprets their intent; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+The integration detail page must stop offering an editable credentials form and an active "Save" button to a viewer who lacks `integrations.credentials.manage`, showing an explicit read-only permission state instead — closing issue #5816.
+
+## Scope
+
+- `packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx` — the credentials tab body and the FormHeader save affordance.
+- `packages/core/src/modules/integrations/backend/integrations/useIntegrationCredentialsFeatureAccess.ts` — the client feature-check hook.
+- `packages/core/src/modules/integrations/i18n/*.json` — the permission-notice string in all five locales.
+- The module's `__tests__` for the credentials tab.
+
+## Non-goals
+
+- Changing the authorization boundary itself. The backend already fails closed with `403` on `GET`/`PUT /api/integrations/{id}/credentials`; this PR only aligns the client affordance with it.
+- Gating any other integrations affordance (health check, provider config, webhooks). Issue #5816 names the credentials form only; anything else belongs in a follow-up.
+- Manual UI QA. The PR carries `needs-qa`; a QA reviewer (or `om-auto-qa-pr`) owns that gate, and this run never sets `qa`/`qa-approved`.
+- Work on #4471, the PR that surfaced this bug. It ships no form component and is not touched here.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| The goal is a client-side permission gate on the credentials form, not an authorization fix | Issue #5816 body ("this is an affordance problem rather than a security one"), with the wire-level 403 table proving the data layer is already fail-closed | high |
+| The expected end state is a read-only permission notice, consistent with the `sync_excel` rendering | Issue #5816 "Expected" section | high |
+| The implementation is complete as of `aec3dd42b` | `git diff origin/develop...HEAD` — hook added, `page.tsx` gated, 5 locales updated, 2 new tests plus 1 updated test | high |
+| The full validation gate already passed on this branch | The `om-fix` run-summary comment (#5510161638) and the PR body's Tests section, both listing the ordered gate with results | high |
+| CI is green on the head commit | **get-pr-checks** on `aec3dd42b`: `test`, `lint`, `ds-lint`, `docker-build`, `ephemeral-integration`, `documents-multi-instance`, `CodeQL` (×3), `audit-scope`, `scope`, `license/cla` all SUCCESS; no failures | high |
+| The authoritative code-review pass never ran | Comment #5510173469 — `om-auto-review-pr` took over the chain lock at 2026-09-02T13:18:48Z and posted nothing afterwards; `gh pr view` reports zero reviews and `reviewDecision: REVIEW_REQUIRED` | high |
+| No human or bot has asked for changes | Zero reviews, zero inline review comments on the PR | high |
+| Labels and priority/risk were already normalized by `om-open-pr` | Comment #5510158389 (`🏷️ label rationale`) and the current label set (`bug`, `review`, `needs-qa`, `priority-medium`, `risk-medium`) | high |
+
+## Assumptions
+
+- **The implementation needs no further code.** Every acceptance criterion in #5816 traces to a landed change and a landed test, and CI is green. If the review pass disagrees, its findings become new Progress steps rather than a new plan.
+- **The 2 pre-existing `warranty_claims/__tests__/quantity.test.ts` failures reported by the earlier run are environmental, not regressions.** They are locale-dependent (`pl_PL.UTF-8` comma decimal separator) and the file has no diff against `develop`; CI's `test` job is green on this head. This run re-runs the gate and will re-confirm rather than assume.
+- **The PR stays a draft until the plan completes.** `om-open-pr` opened it as a pipeline draft, so the "draft while in-progress" rule applies and `mark-pr-ready` is the completion signal.
+
+## Risks
+
+- Low. The change is client-side rendering in one module, additively gated on an existing ACL feature, with tests covering both the permitted and denied branches.
+- The remaining work is verification, not implementation, so the main risk is a review finding that reopens the code — handled by looping the review pass until clean.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Add `useIntegrationCredentialsFeatureAccess`, gate `showCredentialActions` and the credentials tab body in `page.tsx`, add the `integrations.detail.credentials.noPermission` key to all 5 locales, and cover both branches with `credentials-permission-gate.test.tsx` (plus the `credentials-conflict.test.tsx` mock update) — aec3dd42b
+
+### Phase 2: Verification
+
+- [ ] 2.1 Re-run the full `validation.commands` gate on this worktree and record the runner and results
+- [ ] 2.2 Run `om-auto-review-pr 5843 --autofix` and drive it to a clean verdict, landing any fixes as new commits
+
+### Phase 3: Finalize
+
+- [ ] 3.1 Post the comprehensive resume summary comment on PR #5843
+- [ ] 3.2 Update the PR body to `Status: complete`, promote the draft with `mark-pr-ready`, reconfirm the label set, and release the `in-progress` lock

--- a/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
+++ b/.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
@@ -61,5 +61,11 @@ The integration detail page must stop offering an editable credentials form and 
 
 ### Phase 3: Finalize
 
-- [ ] 3.1 Post the comprehensive resume summary comment on PR #5843
-- [ ] 3.2 Update the PR body to `Status: complete`, promote the draft with `mark-pr-ready`, reconfirm the label set, and release the `in-progress` lock
+- [x] 3.1 Post the comprehensive resume summary comment on PR #5843 — 98b858f8a (comment #5522660102)
+- [x] 3.2 Update the PR body to `Status: complete`, promote the draft with `mark-pr-ready`, reconfirm the label set, and release the `in-progress` lock — 98b858f8a
+
+### Follow-ups this run deliberately did not do
+
+- The "Check health" action on the same page is ungated in the same way (`POST /api/integrations/{id}/health` returns `403` for a viewer without `integrations.manage`, per #5816's evidence table). Out of scope for #5816's stated expectation; wants its own issue.
+- The feature-check hook now exists in three near-identical copies (`useWebhookFeatureAccess`, `useWmsInventoryMutationAccess`, `useIntegrationCredentialsFeatureAccess`). Extracting a shared `useFeatureAccess(features)` helper pairs naturally with the health-action fix above.
+- Two untested branches in the credentials gate: the in-flight spinner, and the fail-closed path where `/api/auth/feature-check` rejects outright.

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
@@ -86,6 +86,7 @@ import IntegrationDetailPage from '../page'
 
 const NO_PERMISSION_MESSAGE = 'You do not have permission to manage credentials for this integration.'
 const SAVE_ACTION_LABEL = 'Save credentials'
+const FORBIDDEN_FLASH_MESSAGE = 'Access denied: you are missing the required permission "integrations.credentials.manage". Contact your administrator.'
 
 const dict = {
   'integrations.detail.credentials.noPermission': NO_PERMISSION_MESSAGE,
@@ -141,14 +142,29 @@ function makeResponse(status: number, body: unknown): Response {
   } as unknown as Response
 }
 
-function mockApiResponses(granted: string[]) {
+// `granted: null` makes the feature check itself fail, exercising the hook's fail-closed path.
+function mockApiResponses(granted: string[] | null) {
   apiCallMock.mockImplementation((url: unknown, init?: RequestInit) => {
     const href = typeof url === 'string' ? url : ''
     if (href.includes('/api/auth/feature-check')) {
+      if (granted === null) return Promise.reject(new Error('[internal] feature-check unavailable'))
       const body = { ok: granted.length > 0, granted, userId: 'user-1' }
       return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
     }
     if (href.includes('/credentials')) {
+      // Mirrors the real transport: `/api/integrations/{id}/credentials` is guarded by
+      // `requireFeatures: ['integrations.credentials.manage']`, so an unprivileged viewer gets a
+      // 403 whose body carries `requiredFeatures`. `apiFetch` turns that into an "Access denied"
+      // flash plus a thrown `ForbiddenError` unless the caller opts out with the standard header.
+      if (!granted?.includes('integrations.credentials.manage')) {
+        const headers = new Headers(init?.headers)
+        if (headers.get('x-om-forbidden-redirect') !== '0') {
+          flashMock(FORBIDDEN_FLASH_MESSAGE, 'warning')
+          return Promise.reject(new Error('[internal] Forbidden'))
+        }
+        const body = { error: 'Forbidden', requiredFeatures: ['integrations.credentials.manage'] }
+        return Promise.resolve({ ok: false, status: 403, result: null, response: makeResponse(403, body) })
+      }
       const body = {
         credentials: { publishableKey: 'pk_test_123', secretKey: '__om_secret_unchanged__' },
         secretFieldsConfigured: { secretKey: true },
@@ -184,6 +200,44 @@ describe('Integration credentials — permission gate (#5816)', () => {
 
     expect(container.querySelector('form')).toBeNull()
     expect(container.querySelector('[data-crud-field-id="secretKey"]')).toBeNull()
+    expect(findSaveAction(container)).toBeNull()
+  })
+
+  it('loads credentials with the forbidden-flash opt-out so an unprivileged viewer gets no "Access denied" toast', async () => {
+    mockApiResponses([])
+
+    const { container } = renderWithProviders(
+      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
+      { dict },
+    )
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent(NO_PERMISSION_MESSAGE)
+    })
+
+    const credentialsRequest = apiCallMock.mock.calls.find(([url, init]) => (
+      typeof url === 'string'
+      && url.includes('/credentials')
+      && (init as RequestInit | undefined)?.method === undefined
+    ))
+    expect(credentialsRequest).toBeTruthy()
+    expect(new Headers((credentialsRequest?.[1] as RequestInit).headers).get('x-om-forbidden-redirect')).toBe('0')
+    expect(flashMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed to the permission notice when the feature check itself fails', async () => {
+    mockApiResponses(null)
+
+    const { container } = renderWithProviders(
+      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
+      { dict },
+    )
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent(NO_PERMISSION_MESSAGE)
+    })
+
+    expect(container.querySelector('form')).toBeNull()
     expect(findSaveAction(container)).toBeNull()
   })
 

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
@@ -85,10 +85,19 @@ jest.mock('@open-mercato/ui/backend/utils/customFieldForms', () => ({
 import IntegrationDetailPage from '../page'
 
 const NO_PERMISSION_MESSAGE = 'You do not have permission to manage credentials for this integration.'
+const SAVE_ACTION_LABEL = 'Save credentials'
 
 const dict = {
   'integrations.detail.credentials.noPermission': NO_PERMISSION_MESSAGE,
+  'integrations.detail.credentials.save': SAVE_ACTION_LABEL,
   'integrations.detail.credentials.secretConfigured': 'Configured. Enter a new value to replace it.',
+}
+
+// The Save action is a FormHeader button rendered outside the credentials <form>,
+// so asserting on the form alone would not catch it leaking to an unprivileged viewer.
+function findSaveAction(container: HTMLElement): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll('button'))
+    .find((button) => button.textContent?.trim() === SAVE_ACTION_LABEL) ?? null
 }
 
 const integrationDetail = {
@@ -175,6 +184,7 @@ describe('Integration credentials — permission gate (#5816)', () => {
 
     expect(container.querySelector('form')).toBeNull()
     expect(container.querySelector('[data-crud-field-id="secretKey"]')).toBeNull()
+    expect(findSaveAction(container)).toBeNull()
   })
 
   it('renders the editable credentials form for a viewer with integrations.credentials.manage', async () => {
@@ -191,5 +201,6 @@ describe('Integration credentials — permission gate (#5816)', () => {
 
     expect(container.querySelector('[data-crud-field-id="secretKey"]')).not.toBeNull()
     expect(container).not.toHaveTextContent(NO_PERMISSION_MESSAGE)
+    expect(findSaveAction(container)).not.toBeNull()
   })
 })

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-permission-gate.test.tsx
@@ -1,19 +1,17 @@
 /**
  * @jest-environment jsdom
  *
- * Regression for #3676: when saving integration credentials hits an optimistic-lock
- * 409, the credentials form must surface the conflict on the unified
- * RecordConflictBanner with a localized message — not toast the raw `record_modified`
- * code, and not silently swallow the conflict. The page hands the failure to its host
- * CrudForm via raiseCrudError (status + body), so CrudForm's existing conflict path
- * runs. Before the fix the handler threw createCrudFormError('record_modified'), which
- * CrudForm could not recognize as a conflict, so no bar appeared and the toast showed
- * the raw key.
+ * Regression for #5816: the integration detail page must not render an editable
+ * credentials form (or an enabled "Save" action) to a user who lacks
+ * `integrations.credentials.manage`. Before the fix, `showCredentialActions` and
+ * the credentials tab body only checked whether the provider declared credential
+ * fields — never the viewer's ACL grants — so any provider with real fields (e.g.
+ * Stripe-shaped credentials) rendered an editable form and an active Save button
+ * to every viewer, even though the backend correctly rejects the write with 403.
  */
 import * as React from 'react'
-import { act, fireEvent, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
-import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 const apiCallMock = jest.fn()
 const flashMock = jest.fn()
@@ -51,8 +49,6 @@ jest.mock('@open-mercato/ui/backend/utils/apiCall', () => {
   }
 })
 
-// runMutation must actually execute the operation so the credentials PUT (and its 409)
-// flows through to the page's failure handling — the bug lives in that handler.
 jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
   useGuardedMutation: () => ({
     runMutation: async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
@@ -87,13 +83,11 @@ jest.mock('@open-mercato/ui/backend/utils/customFieldForms', () => ({
 }))
 
 import IntegrationDetailPage from '../page'
-import { dismissRecordConflict, getRecordConflictForTest } from '@open-mercato/ui/backend/conflicts'
 
-const RECORD_MODIFIED_MESSAGE = 'This record was modified by someone else. Refresh and try again.'
+const NO_PERMISSION_MESSAGE = 'You do not have permission to manage credentials for this integration.'
 
 const dict = {
-  'ui.forms.flash.recordModified': RECORD_MODIFIED_MESSAGE,
-  'ui.forms.errors.required': 'This field is required',
+  'integrations.detail.credentials.noPermission': NO_PERMISSION_MESSAGE,
   'integrations.detail.credentials.secretConfigured': 'Configured. Enter a new value to replace it.',
 }
 
@@ -125,13 +119,6 @@ const integrationDetail = {
   analytics: { lastActivityAt: null, totalCount: 0, errorCount: 0, errorRate: 0, dailyCounts: [0, 0, 0, 0, 0, 0, 0] },
 }
 
-const conflictBody = {
-  error: 'record_modified',
-  code: OPTIMISTIC_LOCK_CONFLICT_CODE,
-  currentUpdatedAt: '2026-06-29T10:00:00.000Z',
-  expectedUpdatedAt: '2026-06-29T09:00:00.000Z',
-}
-
 function makeResponse(status: number, body: unknown): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -145,29 +132,17 @@ function makeResponse(status: number, body: unknown): Response {
   } as unknown as Response
 }
 
-function mockApiResponses(secretConfigured = true) {
+function mockApiResponses(granted: string[]) {
   apiCallMock.mockImplementation((url: unknown, init?: RequestInit) => {
     const href = typeof url === 'string' ? url : ''
-    const method = (init?.method ?? 'GET').toUpperCase()
     if (href.includes('/api/auth/feature-check')) {
-      const body = { ok: true, granted: ['integrations.credentials.manage'], userId: 'user-1' }
+      const body = { ok: granted.length > 0, granted, userId: 'user-1' }
       return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
     }
     if (href.includes('/credentials')) {
-      if (method === 'PUT') {
-        return Promise.resolve({
-          ok: false,
-          status: 409,
-          result: conflictBody,
-          response: makeResponse(409, conflictBody),
-        })
-      }
       const body = {
-        credentials: {
-          publishableKey: 'pk_test_123',
-          ...(secretConfigured ? { secretKey: '__om_secret_unchanged__' } : {}),
-        },
-        secretFieldsConfigured: { secretKey: secretConfigured },
+        credentials: { publishableKey: 'pk_test_123', secretKey: '__om_secret_unchanged__' },
+        secretFieldsConfigured: { secretKey: true },
         updatedAt: '2026-06-29T09:00:00.000Z',
       }
       return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
@@ -180,93 +155,41 @@ function mockApiResponses(secretConfigured = true) {
   })
 }
 
-describe('Integration credentials — optimistic-lock conflict surfacing (#3676)', () => {
+describe('Integration credentials — permission gate (#5816)', () => {
   beforeEach(() => {
     apiCallMock.mockReset()
     flashMock.mockReset()
-    dismissRecordConflict()
-    mockApiResponses()
   })
 
-  afterEach(() => {
-    dismissRecordConflict()
-  })
-
-  it('surfaces a stale-save 409 on the unified conflict bar with a localized message (no raw record_modified toast)', async () => {
-    const { container } = renderWithProviders(
-      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
-      { dict },
-    )
-
-    let form: HTMLFormElement | null = null
-    await waitFor(() => {
-      form = container.querySelector('form')
-      expect(form).not.toBeNull()
-    })
-
-    const secretField = container.querySelector('[data-crud-field-id="secretKey"]')
-    const secretInput = secretField?.querySelector('input')
-    expect(secretInput).not.toBeNull()
-    expect(secretInput).toHaveValue('')
-    expect(secretField).toHaveTextContent('Configured. Enter a new value to replace it.')
-    expect(container).not.toHaveTextContent('__om_secret_unchanged__')
-
-    const revealButton = secretField?.querySelector('button[aria-pressed]')
-    expect(revealButton).not.toBeNull()
-    fireEvent.click(revealButton as HTMLButtonElement)
-    expect(secretInput).toHaveAttribute('type', 'text')
-    expect(secretInput).toHaveValue('')
-
-    await act(async () => {
-      fireEvent.submit(form as unknown as HTMLFormElement)
-    })
-
-    await waitFor(() => {
-      const entry = getRecordConflictForTest()
-      expect(entry).not.toBeNull()
-      expect(entry?.message).toBe(RECORD_MODIFIED_MESSAGE)
-    })
-
-    // The raw enum string must never reach the user as a toast.
-    expect(flashMock).not.toHaveBeenCalledWith('record_modified', 'error')
-    expect(flashMock).not.toHaveBeenCalledWith(RECORD_MODIFIED_MESSAGE, 'error')
-
-    // Sanity: the credentials PUT was actually attempted.
-    const putCall = apiCallMock.mock.calls.find(
-      ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
-    )
-    expect(putCall).toBeTruthy()
-    expect(JSON.parse(String((putCall?.[1] as RequestInit).body))).toEqual({
-      credentials: { publishableKey: 'pk_test_123' },
-      unchangedSecretFields: ['secretKey'],
-    })
-  })
-
-  it('keeps an unconfigured required secret mandatory and does not submit an empty value', async () => {
-    apiCallMock.mockReset()
-    mockApiResponses(false)
+  it('hides the editable credentials form and Save action from a viewer without integrations.credentials.manage', async () => {
+    mockApiResponses([])
 
     const { container } = renderWithProviders(
       <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
       { dict },
     )
 
-    let form: HTMLFormElement | null = null
     await waitFor(() => {
-      form = container.querySelector('form')
-      expect(form).not.toBeNull()
+      expect(container).toHaveTextContent(NO_PERMISSION_MESSAGE)
     })
 
-    await act(async () => {
-      fireEvent.submit(form as HTMLFormElement)
-    })
+    expect(container.querySelector('form')).toBeNull()
+    expect(container.querySelector('[data-crud-field-id="secretKey"]')).toBeNull()
+  })
 
-    const secretField = container.querySelector('[data-crud-field-id="secretKey"]')
-    await waitFor(() => expect(secretField).toHaveTextContent('This field is required'))
+  it('renders the editable credentials form for a viewer with integrations.credentials.manage', async () => {
+    mockApiResponses(['integrations.credentials.manage'])
 
-    const putCall = apiCallMock.mock.calls.find(
-      ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
+    const { container } = renderWithProviders(
+      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
+      { dict },
     )
-    expect(putCall).toBeUndefined()
+
+    await waitFor(() => {
+      expect(container.querySelector('form')).not.toBeNull()
+    })
+
+    expect(container.querySelector('[data-crud-field-id="secretKey"]')).not.toBeNull()
+    expect(container).not.toHaveTextContent(NO_PERMISSION_MESSAGE)
   })
 })

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -58,6 +58,7 @@ import {
   type SecretFieldsConfigured,
 } from '../credential-secret-fields'
 import { isValidCredentialUrl } from '../../../lib/credentials-field-validation'
+import { useIntegrationCredentialsFeatureAccess } from '../useIntegrationCredentialsFeatureAccess'
 
 type CredentialField = IntegrationCredentialField
 type BuiltInIntegrationDetailTab = 'credentials' | 'version' | 'health' | 'logs' | 'data-sync-schedule'
@@ -463,6 +464,10 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
   const [activeTab, setActiveTab] = React.useState<IntegrationDetailTab>('credentials')
 
   const credentialsFormId = React.useId()
+  const {
+    isLoading: isLoadingCredentialsAccess,
+    canManageCredentials,
+  } = useIntegrationCredentialsFeatureAccess()
 
   const resolveCurrentIntegrationId = React.useCallback(() => {
     return integrationId ?? (
@@ -1032,7 +1037,10 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     ? 'border-status-success-border bg-status-success-bg text-status-success-text'
     : 'border-status-neutral-border bg-status-neutral-bg text-status-neutral-text'
 
-  const showCredentialActions = showCredentialsTab && activeTab === 'credentials' && credentialFormFields.length > 0
+  const showCredentialActions = showCredentialsTab
+    && activeTab === 'credentials'
+    && credentialFormFields.length > 0
+    && canManageCredentials
 
   React.useEffect(() => {
     setActiveTab(resolveRequestedIntegrationDetailTab(searchParams?.get('tab'), visibleTabIds))
@@ -1280,6 +1288,14 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
                   <p className="text-sm text-muted-foreground">
                     {t('integrations.detail.credentials.notConfigured')}
                   </p>
+                ) : isLoadingCredentialsAccess ? (
+                  <div className="flex justify-center py-8"><Spinner /></div>
+                ) : !canManageCredentials ? (
+                  <EmptyState
+                    size="sm"
+                    icon={<Key className="h-8 w-8" aria-hidden="true" />}
+                    title={t('integrations.detail.credentials.noPermission', 'You do not have permission to manage credentials for this integration.')}
+                  />
                 ) : (
                   <CrudForm<Record<string, unknown>>
                     key={`${resolvedIntegration.id}:${credentialsFormKey}`}

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -66,6 +66,11 @@ type IntegrationDetailTab = BuiltInIntegrationDetailTab | string
 
 const UNSUPPORTED_CREDENTIAL_FIELD_TYPES = new Set<CredentialFieldType>(['oauth', 'ssh_keypair'])
 
+// `/api/integrations/{id}/credentials` requires `integrations.credentials.manage`, so a viewer
+// without the grant gets an expected 403 that the permission notice already explains. Opting out
+// of the global forbidden handling keeps it from raising an "Access denied" flash and throwing.
+const credentialsRequestHeaders = { 'x-om-forbidden-redirect': '0' } as const
+
 function isEditableCredentialField(field: CredentialField): boolean {
   return !UNSUPPORTED_CREDENTIAL_FIELD_TYPES.has(field.type)
 }
@@ -521,7 +526,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
       updatedAt?: string | null
     }>(
       `/api/integrations/${encodeURIComponent(currentIntegrationId)}/credentials`,
-      undefined,
+      { headers: credentialsRequestHeaders },
       { fallback: null },
     )
     if (call.ok && call.result) {

--- a/packages/core/src/modules/integrations/backend/integrations/useIntegrationCredentialsFeatureAccess.ts
+++ b/packages/core/src/modules/integrations/backend/integrations/useIntegrationCredentialsFeatureAccess.ts
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from 'react'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { hasFeature } from '@open-mercato/shared/security/features'
+
+type FeatureCheckResponse = {
+  granted?: string[]
+}
+
+export function useIntegrationCredentialsFeatureAccess() {
+  const [granted, setGranted] = React.useState<string[]>([])
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const call = await apiCall<FeatureCheckResponse>('/api/auth/feature-check', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            features: ['integrations.credentials.manage'],
+          }),
+        })
+
+        if (!cancelled) {
+          setGranted(Array.isArray(call.result?.granted) ? call.result.granted : [])
+        }
+      } catch {
+        if (!cancelled) setGranted([])
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return {
+    isLoading,
+    granted,
+    canManageCredentials: hasFeature(granted, 'integrations.credentials.manage'),
+  }
+}

--- a/packages/core/src/modules/integrations/i18n/de.json
+++ b/packages/core/src/modules/integrations/i18n/de.json
@@ -11,6 +11,7 @@
   "integrations.detail.back": "Zurück zu Integrationen",
   "integrations.detail.backToList": "Zurück zu Integrationen",
   "integrations.detail.credentials.bundleShared": "Gemeinsame Zugangsdaten aus Paket: {bundle}",
+  "integrations.detail.credentials.noPermission": "Sie haben keine Berechtigung, die Zugangsdaten für diese Integration zu verwalten.",
   "integrations.detail.credentials.notConfigured": "Noch keine Zugangsdaten konfiguriert",
   "integrations.detail.credentials.save": "Zugangsdaten speichern",
   "integrations.detail.credentials.saveError": "Zugangsdaten konnten nicht gespeichert werden",

--- a/packages/core/src/modules/integrations/i18n/en.json
+++ b/packages/core/src/modules/integrations/i18n/en.json
@@ -11,6 +11,7 @@
   "integrations.detail.back": "Back to Integrations",
   "integrations.detail.backToList": "Back to integrations",
   "integrations.detail.credentials.bundleShared": "Shared credentials from bundle: {bundle}",
+  "integrations.detail.credentials.noPermission": "You do not have permission to manage credentials for this integration.",
   "integrations.detail.credentials.notConfigured": "No credentials configured yet",
   "integrations.detail.credentials.save": "Save Credentials",
   "integrations.detail.credentials.saveError": "Failed to save credentials",

--- a/packages/core/src/modules/integrations/i18n/es.json
+++ b/packages/core/src/modules/integrations/i18n/es.json
@@ -11,6 +11,7 @@
   "integrations.detail.back": "Volver a integraciones",
   "integrations.detail.backToList": "Volver a integraciones",
   "integrations.detail.credentials.bundleShared": "Credenciales compartidas del paquete: {bundle}",
+  "integrations.detail.credentials.noPermission": "No tiene permiso para gestionar las credenciales de esta integración.",
   "integrations.detail.credentials.notConfigured": "No hay credenciales configuradas",
   "integrations.detail.credentials.save": "Guardar credenciales",
   "integrations.detail.credentials.saveError": "No se pudieron guardar las credenciales",

--- a/packages/core/src/modules/integrations/i18n/ko.json
+++ b/packages/core/src/modules/integrations/i18n/ko.json
@@ -11,6 +11,7 @@
   "integrations.detail.back": "통합으로 돌아가기",
   "integrations.detail.backToList": "통합 목록으로 돌아가기",
   "integrations.detail.credentials.bundleShared": "번들에서 공유된 자격 증명: {bundle}",
+  "integrations.detail.credentials.noPermission": "이 통합의 자격 증명을 관리할 권한이 없습니다.",
   "integrations.detail.credentials.notConfigured": "아직 구성된 자격 증명이 없습니다",
   "integrations.detail.credentials.save": "자격 증명 저장",
   "integrations.detail.credentials.saveError": "자격 증명 저장에 실패했습니다",

--- a/packages/core/src/modules/integrations/i18n/pl.json
+++ b/packages/core/src/modules/integrations/i18n/pl.json
@@ -11,6 +11,7 @@
   "integrations.detail.back": "Powrót do integracji",
   "integrations.detail.backToList": "Wróć do integracji",
   "integrations.detail.credentials.bundleShared": "Współdzielone dane z pakietu: {bundle}",
+  "integrations.detail.credentials.noPermission": "Nie masz uprawnień do zarządzania danymi uwierzytelniającymi tej integracji.",
   "integrations.detail.credentials.notConfigured": "Brak skonfigurowanych danych",
   "integrations.detail.credentials.save": "Zapisz dane",
   "integrations.detail.credentials.saveError": "Nie udało się zapisać danych",


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md
Status: complete

Closes #5816

## 🎯 Goal
- Stop offering a user without `integrations.credentials.manage` an editable credentials form with an active "Save" button on the integration detail page.

## 🔍 Problem
The integration detail page (`/backend/integrations/[id]`) renders an editable credentials form and an active "Save" button to every viewer, regardless of ACL grants. The backend correctly returns 403 for `GET`/`PUT /api/integrations/{id}/credentials` when the viewer lacks `integrations.credentials.manage`, so no secret values are ever exposed and no unauthorized write can succeed — but the user is invited to do work that cannot succeed, and the behavior is inconsistent with `sync_excel`, which happens to show a safe read-only state for the same user.

## 🔍 Root Cause
`showCredentialActions` and the credentials tab body in `packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx` only checked whether the provider declared credential fields (`credentialFormFields.length > 0`) — never the viewer's ACL grants. `sync_excel` only renders safely because that provider declares zero credential fields (`credentials.fields: []`), which is coincidental: any provider with real fields (e.g. `channel_ses`, `channel_resend`) hit the editable branch for every viewer.

## What Changed
- Added `useIntegrationCredentialsFeatureAccess` (`packages/core/src/modules/integrations/backend/integrations/useIntegrationCredentialsFeatureAccess.ts`), a client hook mirroring the existing `useWebhookFeatureAccess` pattern: it POSTs `/api/auth/feature-check` for `integrations.credentials.manage` and exposes `canManageCredentials`.
- `page.tsx`: gated `showCredentialActions` (drives the FormHeader Save button) on `canManageCredentials`; the credentials tab body now shows a spinner while the check is loading and a read-only `EmptyState` permission notice when the viewer lacks the feature, instead of the editable `CrudForm`. The existing zero-fields "not configured" branch (`sync_excel`'s case) is unchanged.
- Added the `integrations.detail.credentials.noPermission` i18n key to all 5 locales (`en`, `de`, `es`, `ko`, `pl`).
- Execution plan for this work: `.ai/runs/2026-09-03-issue-5816-credentials-form-acl-gate.md` (reconstructed by `om-auto-continue-pr`, which also finished the outstanding review pass).

## 🧪 Tests
- Added `credentials-permission-gate.test.tsx` — 2 cases: a viewer without the feature sees the permission notice, no credentials form, no `secretKey` field **and no "Save credentials" action**; a viewer with the feature sees all of them render as before. The Save-action assertions were added during review (`c9ca75eb4`): that button is a `FormHeader` submit rendered outside the `CrudForm`, so the original form-level assertions passed even with the ACL gate removed — verified by mutation.
- Updated `credentials-conflict.test.tsx` (pre-existing, unrelated to permissions) to grant the feature in its mock, since it implicitly assumed an always-editable form.
- Full validation gate, re-run on the final head: `build:packages` ✅ → `generate` ✅ → `build:packages` ✅ → `i18n:check-sync` ✅ → `i18n:check-usage` ✅ → `typecheck` ✅ → `test` ✅ → `build:app` ✅. `@open-mercato/core` is **11,940 passed / 2 skipped / 0 failed** — the two `warranty_claims/quantity.test.ts` failures reported by the original run did **not** reproduce. The only failing suites anywhere are `create-mercato-app`'s AI-harness oracle tests, which need the `codex`/`claude` CLIs this machine lacks; CI's `test` job is green on this branch. All 113 integrations-module tests pass.

## 💥 Breaking Changes
- None. No API contract, DB schema, or event changes — this only tightens client-side rendering to match the backend's existing (and unchanged) authorization behavior.

## Security impact
- This PR touches access control (a client-side permission gate) but does not change the authorization boundary itself: the backend already fail-closed with 403 for `GET`/`PUT /api/integrations/{id}/credentials` for a viewer without `integrations.credentials.manage`, and continues to do so unchanged. The fix removes a UI affordance that invited a doomed write; it does not grant or revoke any access. No secret values were ever exposed to the under-privileged role before or after this change — the credentials endpoint returns a schema plus `secretFieldsConfigured` booleans, never stored secret values.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947019&installation_model_id=432243&pr_number=5843&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5843&signature=d6d7e4738c15540860cc3f16d8a494dc690d20954adcece093edaf6b9c9095fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

