### PR TITLE
fix(di): stop Awilix CLASSIC registrations breaking under identifier mangling

### DIFF
--- a/packages/core/src/modules/auth/di.ts
+++ b/packages/core/src/modules/auth/di.ts
@@ -40,25 +40,25 @@ export function register(container: AppContainer) {
   // Register or override core auth service
   container.register({ authService: asClass(AuthService).scoped() })
   container.register({
-    authPrincipalService: asFunction(function authPrincipalServiceFactory(em: EntityManager) {
+    authPrincipalService: asFunction(function authPrincipalServiceFactory(cradle: { em: EntityManager }) {
       return new DefaultAuthPrincipalService(
-        em,
+        cradle.em,
         resolveOptionalOrganizationHierarchyService(container),
       )
-    }).scoped(),
+    }).scoped().proxy(),
   })
   // Resolve optional infrastructure lazily so Auth still works when Directory
   // is disabled and in lean CLI/test containers without a CacheStrategy.
   // Setting `OM_RBAC_DEFAULT_CACHE=on` opts into the in-process fallback;
   // an explicitly registered cache always wins.
   container.register({
-    rbacService: asFunction(function rbacServiceFactory(em: EntityManager) {
+    rbacService: asFunction(function rbacServiceFactory(cradle: { em: EntityManager }) {
       const configuredCache = resolveOptionalCache(container)
       return new RbacService(
-        em,
+        cradle.em,
         configuredCache ?? (isRbacDefaultCacheEnabled() ? createRbacFallbackCache() : undefined),
         resolveOptionalOrganizationHierarchyService(container),
       )
-    }).scoped(),
+    }).scoped().proxy(),
   })
 }

--- a/packages/core/src/modules/customer_accounts/di.ts
+++ b/packages/core/src/modules/customer_accounts/di.ts
@@ -28,7 +28,7 @@ export function register(container: AppContainer) {
   container.register({ customerInvitationService: asClass(CustomerInvitationService).scoped() })
   container.register({
     domainMappingService: asFunction(
-      function domainMappingServiceFactory(em: EntityManager) {
+      function domainMappingServiceFactory(cradle: { em: EntityManager }) {
         // Resolve the cache lazily so registrations from `bootstrap(container)` (which runs after
         // module DI registrars) are visible. Awilix CLASSIC mode would fail to resolve a
         // destructured `cache` param if the key is not yet registered; using `hasRegistration`
@@ -42,8 +42,8 @@ export function register(container: AppContainer) {
         } catch {
           cacheService = undefined
         }
-        return new DomainMappingService(em, cacheService ? { cacheService } : undefined)
+        return new DomainMappingService(cradle.em, cacheService ? { cacheService } : undefined)
       },
-    ).scoped(),
+    ).scoped().proxy(),
   })
 }

--- a/packages/enterprise/src/modules/record_locks/di.ts
+++ b/packages/enterprise/src/modules/record_locks/di.ts
@@ -13,44 +13,48 @@ import { createRecordLockCrudMutationGuardService } from './lib/crudMutationGuar
 
 export function register(container: AppContainer) {
   container.register({
-    recordLockService: asFunction((
-      em: EntityManager,
-      moduleConfigService?: ModuleConfigService | null,
-      actionLogService?: ActionLogService | null,
-      rbacService?: RbacService | null,
-    ) =>
+    recordLockService: asFunction((cradle: {
+      em: EntityManager
+      moduleConfigService?: ModuleConfigService | null
+      actionLogService?: ActionLogService | null
+      rbacService?: RbacService | null
+    }) =>
       createRecordLockService({
-        em,
-        moduleConfigService: moduleConfigService ?? null,
-        actionLogService: actionLogService ?? null,
-        rbacService: rbacService ?? null,
+        em: cradle.em,
+        moduleConfigService: cradle.moduleConfigService ?? null,
+        actionLogService: cradle.actionLogService ?? null,
+        rbacService: cradle.rbacService ?? null,
       }),
-    ).scoped(),
+    ).scoped().proxy(),
     // CRUD guard decorator: chains the OSS `updated_at` floor first (built here
     // because this DI key overrides the platform default), then adds the
     // record_locks enrichment. record_locks can only ADD a 409, never skip the
     // floor (S1/H2). Spec: .ai/specs/enterprise/2026-06-09-record-locks-unified-coverage.md (Phase 0)
-    crudMutationGuardService: asFunction((
-      recordLockService: RecordLockService,
-      em: EntityManager,
-    ) =>
+    // `.proxy()`: CLASSIC injection resolves by parameter NAME, which a bundler
+    // may rename — see the comment on the platform default in
+    // packages/shared/src/lib/di/container.ts. A silent failure here disables
+    // the record-lock 409 as well as the OSS floor beneath it.
+    crudMutationGuardService: asFunction((cradle: {
+      recordLockService: RecordLockService
+      em: EntityManager
+    }) =>
       createRecordLockCrudMutationGuardService(
-        recordLockService,
+        cradle.recordLockService,
         createOptimisticLockGuardService({
-          getEm: () => em,
+          getEm: () => cradle.em,
           readers: getAllOptimisticLockReaders(),
         }),
       ),
-    ).scoped(),
+    ).scoped().proxy(),
     // Command guard override: lock-backed `resolveExpected` derived from
     // authoritative server state (never requiring a client lock token, H2),
     // awaited by `enforceCommandOptimisticLockWithGuards`. The OSS floor still
     // runs first inside that runner.
-    commandOptimisticLockGuardService: asFunction((recordLockService: RecordLockService) =>
+    commandOptimisticLockGuardService: asFunction((cradle: { recordLockService: RecordLockService }) =>
       createCommandOptimisticLockGuardService({
         resolveExpected: ({ expectedFromHeader, resourceKind }) =>
-          recordLockService.resolveExpectedVersion({ expectedFromHeader, resourceKind }),
+          cradle.recordLockService.resolveExpectedVersion({ expectedFromHeader, resourceKind }),
       }),
-    ).scoped(),
+    ).scoped().proxy(),
   })
 }

--- a/packages/shared/src/lib/di/__tests__/di-injection-mode.test.ts
+++ b/packages/shared/src/lib/di/__tests__/di-injection-mode.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Awilix resolves CLASSIC-mode dependencies by parsing PARAMETER NAMES out of the
+ * function source (`packages/shared/src/lib/di/container.ts` creates the container
+ * with `InjectionMode.CLASSIC`). Any bundler that renames identifiers therefore
+ * breaks resolution: Turbopack renamed `em` to `em2` in a dev chunk and Awilix
+ * looked up a registration that does not exist.
+ *
+ * That failure is silent where it matters most. `resolveCrudMutationGuardService`
+ * catches the AwilixResolutionError and returns null, `bridgeLegacyGuard` returns
+ * null in turn, and the mutation proceeds with optimistic locking — and the
+ * enterprise record-lock 409 layered on top of it — NOT enforced. The write still
+ * answers 201, so nothing surfaces except a warning line.
+ *
+ * `.proxy()` makes a registration read its dependencies as PROPERTIES of the
+ * cradle (`cradle.em`), and property names survive mangling. This guard pins that
+ * every `asFunction` registration which takes an argument opts into it.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(__dirname, '../../../../../..')
+const scanRoots = ['packages', 'apps'].map((dir) => path.join(repoRoot, dir))
+
+function collectDiFiles(dir: string, out: string[]): void {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.next' || entry === '.mercato') continue
+    const full = path.join(dir, entry)
+    let isDir = false
+    try {
+      isDir = statSync(full).isDirectory()
+    } catch {
+      continue
+    }
+    if (isDir) {
+      collectDiFiles(full, out)
+    } else if (entry === 'di.ts' || entry === 'container.ts') {
+      out.push(full)
+    }
+  }
+}
+
+const diFiles: string[] = []
+for (const root of scanRoots) collectDiFiles(root, diFiles)
+
+const toRepoRelative = (file: string) => path.relative(repoRoot, file)
+
+/**
+ * Does this `asFunction(...)` body declare a parameter?
+ *
+ * Only INLINE function expressions can be judged statically — an arrow or a
+ * `function` expression written at the registration. A bare reference
+ * (`asFunction(createThing)`) is deliberately skipped: its signature lives in
+ * another module, and guessing would produce exactly the false positive this
+ * comment replaced.
+ */
+function declaresParameter(chunk: string): boolean {
+  const body = chunk.replace(/^\s*/, '')
+  if (body.startsWith('(')) {
+    return !/^\(\s*\)/.test(body)
+  }
+  const fn = body.match(/^(?:async\s+)?function\s*[A-Za-z0-9_$]*\s*\(([^)]*)\)/)
+  if (fn) return fn[1].trim().length > 0
+  return false
+}
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ')
+}
+
+describe('Awilix registrations survive identifier mangling', () => {
+  it('scans the whole workspace, not a truncated slice of it', () => {
+    // A floor, because the readdir above swallows its errors: without one, a scan
+    // that collapsed to nothing would report green and the guard would pass vacuously.
+    expect(diFiles.length).toBeGreaterThan(20)
+  })
+
+  it('has no argument-taking asFunction registration that skips .proxy()', () => {
+    const offenders: string[] = []
+
+    for (const file of diFiles) {
+      const source = stripComments(readFileSync(file, 'utf8'))
+      // Split on the registration boundary so each `asFunction(...)` is checked
+      // against the `.proxy()` that belongs to it, not one later in the file.
+      const chunks = source.split(/asFunction\(/).slice(1)
+      for (const chunk of chunks) {
+        if (!declaresParameter(chunk)) continue
+        // Chunks are split at each `asFunction(`, so the only `.proxy()` a chunk
+        // can contain is the one chained onto its own registration.
+        if (!/\.proxy\(\)/.test(chunk)) {
+          offenders.push(toRepoRelative(file))
+        }
+      }
+    }
+
+    expect(Array.from(new Set(offenders))).toEqual([])
+  })
+})

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -224,12 +224,21 @@ export async function createRequestContainer(): Promise<AppContainer> {
     // registrations override this default via Awilix replace semantics —
     // see the enterprise `record_locks` module for the canonical override.
     // Spec: .ai/specs/implemented/2026-05-25-oss-optimistic-locking.md
-    crudMutationGuardService: asFunction((em: EntityManager) =>
+    // `.proxy()` is load-bearing, not stylistic. The container runs in CLASSIC
+    // injection mode, where Awilix resolves dependencies by parsing PARAMETER
+    // NAMES out of the function source. A bundler that renames `em` to `em2` —
+    // Turbopack does, on a scope collision — makes Awilix look up a registration
+    // that does not exist, and `resolveCrudMutationGuardService` swallows the
+    // AwilixResolutionError and returns null, so `bridgeLegacyGuard` silently
+    // drops the guard and every mutation runs with optimistic locking NOT
+    // enforced. Reading `cradle.em` resolves by property name, which survives
+    // mangling. Pinned by `di-injection-mode.test.ts`.
+    crudMutationGuardService: asFunction((cradle: { em: EntityManager }) =>
       createOptimisticLockGuardService({
-        getEm: () => em,
+        getEm: () => cradle.em,
         readers: getAllOptimisticLockReaders(),
       }),
-    ).scoped(),
+    ).scoped().proxy(),
     // Default OSS command-level optimistic-lock guard, awaited by
     // `enforceCommandOptimisticLockWithGuards` for Command-pattern writes.
     // Header/explicit-token compare only (no `resolveExpected`), so it is

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -166,6 +166,10 @@ export const REPO_WIDE_GUARDS = [
         path: 'src/modules/__tests__/cli-registry-boundary.test.ts',
         scans: 'packages/ and apps/ — runtime files reading the CLI-only module registry',
       },
+      {
+        path: 'src/lib/di/__tests__/di-injection-mode.test.ts',
+        scans: 'every di.ts and container.ts under packages/ and apps/ — argument-taking asFunction registrations that skip .proxy(), which CLASSIC injection resolves by parameter name and a bundler may rename. The registrations it guards live in core, enterprise and app modules rather than in shared, so the turbo filter never selects this workspace for the PRs that can break them (#5861).',
+      },
     ],
   },
   {


### PR DESCRIPTION
## What this fixes

`createRequestContainer` builds the container with `InjectionMode.CLASSIC` (`packages/shared/src/lib/di/container.ts:209`), where Awilix resolves dependencies by parsing **parameter names out of the function source**. Any bundler that renames identifiers breaks that lookup. Turbopack does, on a scope collision:

```
WARN  [shared:crud] CRUD mutation guard service could not be resolved;
                    the legacy guard bridge is disabled
AwilixResolutionError: Could not resolve 'em2'.
  Resolution path: crudMutationGuardService -> em2
```

The parameter `em` had become `em2`, so Awilix looked up a registration that does not exist.

## Why it matters

**It fails silently.** `resolveCrudMutationGuardService` catches the `AwilixResolutionError` and returns `null` (`mutation-guard-service.ts:44`); `bridgeLegacyGuard` returns `null` on a null service (`mutation-guard-registry.ts:131`). The guard is then simply absent from the guard list and the write proceeds — the `POST` that surfaced this answered **201**.

So every mutation in that state ran with **OSS optimistic locking, and the enterprise record-lock 409 layered on top of it, not enforced**. A concurrent-edit conflict that should answer 409 goes through and the later write wins. Nothing surfaces but a warning line.

## The fix

Seven registrations across four files took a positional parameter without `.proxy()`. All sit on paths where silent failure is expensive:

| File | Registrations |
|---|---|
| `shared/lib/di/container.ts` | `crudMutationGuardService` — the optimistic-lock floor |
| `enterprise/record_locks/di.ts` | `recordLockService`, `crudMutationGuardService`, `commandOptimisticLockGuardService` |
| `core/auth/di.ts` | `rbacService`, `authPrincipalService` — RBAC resolution |
| `core/customer_accounts/di.ts` | `domainMappingService` |

Each now reads its dependencies as **properties of the cradle** and chains `.proxy()`. Property names survive mangling. This is the convention `directory`, `attachments` and `payment_gateways` already follow — the codebase had the right pattern, these registrations just predate or missed it.

## The guard

`packages/shared/src/lib/di/__tests__/di-injection-mode.test.ts`, in the style of the repo's existing workspace guards.

It earned its place: it found **three of the seven that a hand grep missed** — `recordLockService` (parameters on the following line), plus `rbacService` and `authPrincipalService` (named function expressions rather than arrows). It deliberately skips bare factory references (`asFunction(createThing)`), whose signatures live in another module and cannot be judged statically, and it carries a scan floor so a collapsed scan cannot pass vacuously.

## Scope

**Pre-existing on `develop`** — unrelated to any feature branch. It surfaced while watching verbose dev-server logs during an unrelated write.

## Verification

`packages/core` 1478 suites / 12031 tests · `packages/cli` 96 / 1834 · `yarn typecheck` 27/27 · lint clean (the one warning in `container.ts` is pre-existing, confirmed by stashing).

Both suites were run with `--runInBand`: the parallel `yarn test` fails a *different* package on each run with **0 failed tests**, a jest-worker crash under memory pressure on this machine that does not reproduce in CI.

## Risk

No route, response shape, database column, event id or public signature changes — only how four DI factories receive their already-registered dependencies. The behavioural change is that guards which were silently skipped now run, so a concurrent-edit conflict that previously slipped through will correctly answer 409.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791012898&installation_model_id=432243&pr_number=5861&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5861&signature=c068194ae240d8a16074ff88a62818891ee890c1ad1e7fbaa8422e4b588a379c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->