### PR TITLE
feat(data_sync): adapter-declared applicability for the dashboard's start controls

### DIFF
--- a/.ai/specs/2026-09-02-data-sync-adapter-start-controls.md
+++ b/.ai/specs/2026-09-02-data-sync-adapter-start-controls.md
@@ -1,0 +1,318 @@
+# Data Sync — adapter-declared applicability for the dashboard's start controls
+
+**Status:** draft
+**Module:** `packages/core/src/modules/data_sync`
+**Related:** `.ai/specs/implemented/SPEC-045b-data-sync-hub.md` (§ Run parameters — the end-to-end
+precedent this mirrors)
+
+## TLDR
+
+The Data Sync dashboard's "Run once now" card renders a fixed pair of controls — **Run as full sync**
+and **Batch size** — for every adapter and every entity type. Whether either one means anything for the
+selected entity type is adapter knowledge, and the adapter has no way to say so. This adds an optional
+per-entity-type predicate, `supportsStartControl(control, entityType)`, resolves it in
+`GET /api/data_sync/options`, and has the dashboard render only the controls that apply. Fully
+additive: an adapter that declares nothing sees an identical form and an identical request body, and
+`POST /api/data_sync/run` keeps honouring both fields whatever any adapter declares.
+
+## Overview
+
+One optional method on `DataSyncAdapter`, one pure resolution module, one new field on the options
+response, and conditional rendering on one card. No cursor resolution, no engine behaviour, no database
+change, no new extension point.
+
+The shape deliberately mirrors two things already merged in this module: `persistsSharedCursor` for the
+*mechanism* (an optional per-entity-type predicate defaulting to prior behaviour) and `runParameters`
+for the *path* (an entity-type-scoped declaration, resolved through `api/options.ts`, driving what the
+dashboard renders).
+
+## Problem Statement
+
+`backend/data-sync/page.tsx` renders the start card's two controls as inline JSX, driven by bare local
+state (`React.useState(false)` for `fullSync`, `React.useState('100')` for `batchSize`). There are no
+props, no widget slot, and `extension-points.ts` declares only a data-table host, so nothing on that
+card is extensible today.
+
+### The `fullSync` case
+
+`api/run.ts` resolves the run's start cursor as:
+
+```ts
+const cursor = parsed.data.fullSync
+  ? null
+  : await resolveStartCursor({ syncRunService, adapter, integrationId, entityType, direction, scope })
+```
+
+and `lib/start-cursor.ts` branches on the existing per-entity-type predicate:
+
+```ts
+if (persistsSharedCursor(adapter, entityType)) {
+  return syncRunService.resolveCursor(...)        // the shared `sync_cursors` row
+}
+return syncRunService.resolveResumeCursor(...)    // this entity type's own most recent run
+```
+
+The switch's own help text is *"Ignore the saved cursor and process the entire source again for this
+run"*. For an entity type whose adapter opted out of the shared row there is no saved shared cursor to
+ignore.
+
+**The switch is not therefore dead, and this spec does not claim it is.** The two settings still hand
+the adapter different values:
+
+| `fullSync` | cursor passed to the adapter |
+|---|---|
+| `true` | `null` |
+| `false` | `resolveResumeCursor(...)` — the most recent run's position |
+
+Whether that difference is *observable* depends on what the adapter does with an inherited cursor for
+that entity type, and core has no way to find out:
+
+- An adapter whose cursor is a plain watermark honours the distinction — starting from `null` really
+  does re-read everything.
+- An adapter whose cursor carries identity — one that checks whether an arriving cursor is its own and
+  mints a fresh position when it is not — collapses both settings into the same outcome. For that
+  adapter, on that entity type, ticking the switch changes the request body and changes nothing
+  observable.
+
+Core cannot infer which kind it has. The adapter knows exactly. There is no channel for it to say so —
+that is the defect. The result is a control on the primary operator path that may silently do nothing,
+and an operator who cannot distinguish *"it had no effect"* from *"it worked"*.
+
+Stated at the framework level:
+
+> The dashboard renders a fixed set of start controls regardless of whether they are meaningful for the
+> selected adapter and entity type. Applicability is adapter knowledge; the adapter cannot declare it.
+
+### The `batchSize` case
+
+The same gap, one step milder. `batchSize` reaches the adapter on `StreamImportInput` /
+`StreamExportInput`, and an adapter whose paging is fixed by the source — a provider-paged export, a
+whole-table cursor walk with a server-chosen page size — ignores it. The operator is still offered a
+numeric input, and a value they type is still validated (1–1000) before a run they cannot influence.
+
+### Core already believes applicability is entity-type-dependent
+
+`buildDefaultScheduleState` in the same file guesses it from hardcoded entity-type name strings:
+
+```ts
+const normalized = entityType.trim().toLowerCase()
+const longerInterval = normalized === 'categories' || normalized === 'attributes'
+return {
+  scheduleValue: longerInterval ? '6h' : '1h',
+  fullSync: normalized !== 'products',
+  ...
+}
+```
+
+Generic dashboard code branching on provider-shaped names to decide whether full sync is appropriate.
+It only works for entity types core happens to know by name and misfires silently for any adapter that
+names things differently, and it breaks the module's own rule — *"Keep declarations provider-agnostic —
+never special-case a provider in `data_sync`"* (`data_sync/AGENTS.md`).
+
+This is cited as evidence that the judgement is real and currently unaskable. **Changing that default
+is out of scope here**: it is a different control (the schedule-level switch) with its own
+back-compat surface.
+
+## Proposed Solution
+
+Let the adapter declare, per entity type, which of the dashboard's manual-start controls apply. The
+dashboard renders only those — exactly as it already does for adapter-declared `runParameters`.
+
+```ts
+supportsStartControl?(control: 'fullSync' | 'batchSize', entityType: string): boolean
+```
+
+Omitted method, or any return other than an explicit `false`, means "applies", so an adapter that
+declares nothing keeps today's behaviour byte-for-byte.
+
+### Why per entity type and not per adapter
+
+Per-adapter is the simpler shape and it cannot express the case. The argument is core's own, already
+accepted by maintainers on the `persistsSharedCursor` docstring (`lib/adapter.ts`):
+
+> The predicate is per entity type because one adapter commonly serves both kinds — an incremental feed
+> and a whole-table backfill.
+
+One provider key routinely serves both:
+
+- **change-feed entity types**, whose cursor is a durable position in a queue or log, where full sync
+  genuinely means *re-drain from the beginning* — the control is meaningful;
+- **backfill entity types**, whose cursor is one run's scan state over a table, where a fresh start
+  already begins from the top — the control is inert.
+
+Same adapter, same dashboard, opposite answers. The module already reasons per entity type in
+`persistsSharedCursor` and in `RunParameter.entityType`; a per-adapter flag would be the only
+coarse-grained declaration in the set.
+
+### Why not derive it from `persistsSharedCursor`
+
+A tempting shortcut is to hide the switch whenever `persistsSharedCursor(entityType) === false`. It is
+wrong on both counts:
+
+- it conflates *where the cursor is stored* with *whether restarting from scratch is meaningful* — an
+  opted-out entity type can still have a genuine beginning to restart from;
+- it would silently change the UI for every existing adapter that opted out of the shared cursor row,
+  which is not an additive change.
+
+The two facts are independent and both belong to the adapter to state.
+
+### The serialization boundary
+
+`runParameters` is serializable data; `persistsSharedCursor` is a function and therefore server-side
+only. `api/options.ts` currently ships `runParameters: adapter.runParameters ?? []` alongside
+`supportedEntities`, `direction` and `runMode` — a predicate cannot be shipped as-is. Two options:
+
+1. **The options route resolves it.** Evaluate the predicate for each `supportedEntities` entry and
+   send a resolved map. Keeps the adapter-facing API consistent with `persistsSharedCursor` — an
+   adapter author writes one kind of thing for both.
+2. **Declare data, not a function** — `startControls?: { control: ...; entityType?: string | string[] }[]`,
+   consistent with `runParameters` and serializable without a resolution step.
+
+**This spec takes (1).** The adapter-facing surface is the important one to keep coherent, the
+resolution is four lines, and a predicate composes with whatever the adapter already knows (its own
+entity-kind table) rather than forcing it to enumerate a static list. Option (2) stays available
+additively if a future need arises for declarations the server cannot evaluate.
+
+## Architecture
+
+### 1. `lib/adapter.ts` — the declaration
+
+```ts
+export type DataSyncStartControl = 'fullSync' | 'batchSize'
+
+export interface DataSyncAdapter {
+  // ...
+  supportsStartControl?(control: DataSyncStartControl, entityType: string): boolean
+}
+```
+
+### 2. `lib/start-controls.ts` — resolution, pure and isomorphic
+
+```ts
+export type StartControlApplicability = Record<DataSyncStartControl, boolean>
+export type StartControlMap = Record<string, StartControlApplicability>
+
+/** Server side: evaluate the predicate across `supportedEntities`. */
+export function resolveStartControlMap(adapter: DataSyncAdapter | null | undefined): StartControlMap
+
+/** Client side: read the resolved map for the selected entity type. */
+export function applicableStartControls(
+  map: StartControlMap | null | undefined,
+  entityType: string,
+): StartControlApplicability
+```
+
+`resolveStartControlMap` is **sparse**: an entity type for which every control applies is omitted, so an
+adapter that declares nothing produces `{}` and adds nothing to the wire. `applicableStartControls`
+reads own properties only and returns all-`true` for a missing entry, which makes "no declaration" and
+"nothing restricted" the same single default.
+
+A predicate that throws is treated as *applies*. One adapter's bad predicate must not take down the
+options list — and with it the whole dashboard — for every other integration. `api/options.ts` already
+degrades the same way for credential resolution.
+
+### 3. `api/options.ts` — the wire
+
+One added field per item:
+
+```ts
+startControls: resolveStartControlMap(adapter),
+```
+
+### 4. `backend/data-sync/page.tsx` — conditional rendering
+
+```ts
+const startControls = React.useMemo(
+  () => applicableStartControls(selectedIntegration?.startControls, selectedEntityType),
+  [selectedIntegration, selectedEntityType],
+)
+```
+
+- Each control renders only when it applies. When neither applies, the whole knob row is omitted.
+- When a control does not apply its state is reset to the request default (`fullSync` → `false`,
+  `batchSize` → `'100'`), so switching entity types cannot carry a hidden value forward.
+- A control that does not apply is **omitted from the request body**, letting `runSyncSchema`'s existing
+  defaults (`fullSync: false`, `batchSize: 100`) supply the value — the same value today's form sends.
+- `batchSize`'s client-side 1–1000 check runs only when the input is rendered, so a stale value cannot
+  block a run whose form no longer shows the field.
+- The card's description switches to a variant that does not enumerate controls when any control is
+  hidden.
+
+Before an entity type is selected, `selectedEntityType` is `''`, which matches no entry and so renders
+both controls — today's behaviour for an unselected form.
+
+## Data Models
+
+None. No entity, column, migration or snapshot change.
+
+## API Contracts
+
+### `GET /api/data_sync/options` — additive response field
+
+```jsonc
+{
+  "items": [
+    {
+      "integrationId": "sync_example",
+      "supportedEntities": ["orders.feed", "orders.backfill"],
+      "runParameters": [],
+      // New. Only entity types with a restriction appear; `{}` when nothing is restricted.
+      "startControls": {
+        "orders.backfill": { "fullSync": false, "batchSize": true }
+      }
+    }
+  ]
+}
+```
+
+### `POST /api/data_sync/run` — unchanged
+
+`runSyncSchema` is untouched and the route keeps honouring both fields. A client that posts
+`fullSync: true` for an entity type whose adapter declares the control inapplicable still gets a `null`
+start cursor. This is a UI-applicability change, not a behaviour change — covered by a test.
+
+## Risks & Impact Review
+
+| # | Risk | Severity | Affected area | Mitigation | Residual |
+|---|---|---|---|---|---|
+| 1 | An adapter declares a control inapplicable when it is in fact meaningful, removing a control the operator needs | Medium | Dashboard start card | The declaration is opt-in and defaults to "applies"; the API keeps accepting the field, so a scripted or API client can still send it; documented in `AGENTS.md` and the framework docs | An adapter can misdeclare its own UI. This is the same trust already extended to `runParameters` and `persistsSharedCursor` |
+| 2 | Hidden state is submitted anyway after an entity-type switch | Medium | `POST /api/data_sync/run` | State is reset when a control stops applying **and** the field is omitted from the request body; covered by a test | None |
+| 3 | A throwing predicate breaks the options route for every integration | High | Dashboard load | Each evaluation is guarded and falls back to "applies" | A broken predicate is silent. It cannot make the form show less than today |
+| 4 | The new field breaks an older client reading the options response | Low | API consumers | Purely additive optional field; unknown fields are ignored by existing consumers | None |
+| 5 | Scope creep into cursor semantics | Medium | Engine, run lifecycle | `lib/start-cursor.ts`, `lib/sync-engine.ts` and the run lifecycle are untouched by this change | None |
+
+## Non-goals
+
+- What `fullSync` or `batchSize` **do** when submitted — unchanged.
+- Cursor resolution or engine behaviour of any kind.
+- The schedule-level full-sync switch and its `buildDefaultScheduleState` default (cited as evidence
+  only).
+- New extension points or widget hosts on the dashboard page.
+
+## Final Compliance Report
+
+- **Provider-agnostic** — no provider name or entity-type string is special-cased; the new module reads
+  only `supportedEntities` and the adapter's own predicate.
+- **Backward compatible** — optional interface method (`BACKWARD_COMPATIBILITY.md` §2, Type Definitions
+  & Interfaces) and an additive response field (§7, API Route URLs). Recorded in
+  `BACKWARD_COMPATIBILITY.md`.
+- **Adapter contract growth** — `data_sync/AGENTS.md` asks to check in before changing adapter
+  contracts. Cursor semantics are unchanged, but the contract grows by one optional method; that is the
+  call being requested.
+- **i18n** — one new key added to all five locale files; no hardcoded user-facing string.
+- **Docs** — `data_sync/AGENTS.md` beside the existing "Run parameters" section, and
+  `apps/docs/docs/framework/modules/integrations-data-sync.mdx`.
+
+## Testing
+
+| Surface | Coverage |
+|---|---|
+| `lib/start-controls.ts` | Sparse-map construction, per-entity-type resolution, undeclared adapter → `{}`, non-boolean and throwing predicates, own-property lookup |
+| `GET /api/data_sync/options` | The resolved map on the wire; `{}` for an adapter that declares nothing |
+| `POST /api/data_sync/run` | `fullSync: true` still yields a `null` cursor when the adapter declares the control inapplicable |
+| Dashboard start card | The control does not render for a restricted entity type, renders for an unrestricted one, and an undeclared adapter renders both |
+| Integration (`TC-DS-011`) | Every integration advertises a well-formed `startControls` object keyed only by its own `supportedEntities` |
+
+## Changelog
+
+- **2026-09-02** — Initial spec.

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -395,3 +395,18 @@ Issue #3852 removed the non-cryptographic passkey verification shape from `Passk
 **Why the deprecation protocol does not apply.** The protocol exists to give downstream authors a bridge release. Here the request shape being removed *is* the vulnerability: both values it compared are disclosed by the server, so a bridge would keep the passkey second factor bypassable for a minor version in both login MFA and sudo step-up. A security fix that leaves the hole open is not a fix.
 
 **Migration path.** Send `startAuthentication()` output as `payload.response`. The first-party `PasskeyChallengeVerify` component already does, so shipped UIs are unaffected. Credentials enrolled through the setup path's client-supplied `publicKey` shortcut are **not** reliably rendered unusable by this change — depending on what the client supplied, such a row holds either a key nobody can sign with or a keypair the enroller controls, and the second kind produces assertions this change accepts. That shortcut is a separate open surface (#5296); operator-facing remediation is in [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md).
+
+## Data Sync Start Control Applicability (2026-09-02)
+
+[`.ai/specs/2026-09-02-data-sync-adapter-start-controls.md`](.ai/specs/2026-09-02-data-sync-adapter-start-controls.md) lets a `DataSyncAdapter` declare, per entity type, which of the Data Sync dashboard's manual-start controls apply, so the dashboard stops offering controls that cannot mean anything for the selected entity type. **All changes are additive** and pass the contract-surface checks above:
+
+| Surface | Change | Classification |
+|---------|--------|----------------|
+| Type definitions (§2) | New optional method `DataSyncAdapter.supportsStartControl?(control, entityType)`; new exported type `DataSyncStartControl = 'fullSync' \| 'batchSize'` | ✓ ADDITIVE (optional member, new type — same shape as the `persistsSharedCursor` and `runParameters` additions before it) |
+| Import paths (§4) | New module `data_sync/lib/start-controls.ts` exporting `resolveStartControlMap`, `applicableStartControls`, `StartControlMap`, `StartControlApplicability`, `DATA_SYNC_START_CONTROLS` | ✓ ADDITIVE (new path; nothing moved or re-exported) |
+| API route URLs (§7) | `GET /api/data_sync/options` items gain a `startControls` object; `POST /api/data_sync/run` is unchanged and keeps honouring `fullSync` and `batchSize` whatever an adapter declares | ✓ ADDITIVE (new optional response field, no request-shape change) |
+| Auto-discovery, function signatures, event IDs, widget spot IDs, DB schema, DI names, ACL features, notification IDs, CLI commands, generated files | No change | ✓ n/a |
+
+**Contract commitments**: only an explicit `false` removes a control, so an adapter that declares nothing — or whose predicate returns anything else — renders the same form and sends the same request body as before. A predicate that throws is treated as *applies*, because `api/options.ts` resolves every registered adapter in one response and one broken predicate must not take the dashboard down for the rest. The `startControls` map is sparse and keyed only by the adapter's own `supportedEntities`; a missing entry means every control applies, so a client that ignores the field behaves exactly as today. The declaration governs what the dashboard **offers**, never what the run API **accepts** — that separation MUST hold for any future change here, or an API client posting `fullSync: true` would silently stop getting a full run.
+
+**Migration path for existing adapters**: none. The method is optional and defaults to prior behaviour.

--- a/apps/docs/docs/framework/modules/integrations-data-sync.mdx
+++ b/apps/docs/docs/framework/modules/integrations-data-sync.mdx
@@ -145,6 +145,7 @@ Adapter contract (`data_sync/lib/adapter.ts`) requires:
 - optional `validateConnection(...)`
 - optional `runParameters` — see below
 - optional `persistsSharedCursor(entityType)`
+- optional `supportsStartControl(control, entityType)` — see below
 
 ## Honouring cancellation inside a batch
 
@@ -221,6 +222,34 @@ For a multi-locale deployment, pair each literal with an i18n key — `labelKey`
 Retrying a run re-normalizes the stored values against the adapter's *current* declaration, so parameters you have since removed or re-scoped are dropped and a value that no longer satisfies its declaration fails the retry with a 422 rather than reaching the adapter.
 
 A recurring schedule cannot yet pin an operator-chosen value, but it does apply your declared defaults: the scheduled worker normalizes an empty input against the current declaration, so a scheduled run reaches the adapter with the same set an untouched dashboard form would rather than an empty object. Write the adapter against its defaults, not against `undefined`. A declared default that violates its own declaration skips the scheduled run with a logged error instead of starting it half-applied.
+
+## Start controls the dashboard renders
+
+Alongside your `runParameters`, the "Run once now" card renders two controls the framework owns: **Run as full sync** and **Batch size**. Whether either one means anything depends on what your adapter does with the value for that entity type, which is something core cannot see. Declare it:
+
+```ts
+const adapter: DataSyncAdapter = {
+  providerKey: 'my_provider',
+  direction: 'import',
+  supportedEntities: ['orders.feed', 'orders.backfill'],
+  supportsStartControl: (control, entityType) =>
+    !(control === 'fullSync' && entityType === 'orders.backfill'),
+  // ...
+}
+```
+
+Only an explicit `false` removes a control, so omitting the hook keeps today's form exactly. Return `false` where the operator's choice reaches you and changes nothing observable:
+
+- **`fullSync`** — for an entity type whose cursor carries identity. If you check whether an arriving cursor is your own and mint a fresh position when it is not, then `fullSync: true` (a `null` cursor) and `fullSync: false` (an inherited one) both start you at the top. The switch's help text promises to *"ignore the saved cursor"*, and an operator who ticks it cannot tell "it had no effect" from "it worked".
+- **`batchSize`** — for an entity type whose paging the source fixes, so the value arrives on `StreamImportInput` / `StreamExportInput` and is ignored.
+
+The predicate is per entity type for the same reason `persistsSharedCursor` is: one adapter commonly serves both an incremental feed and a whole-table backfill, and only one of them has a beginning to restart from.
+
+`GET /api/data_sync/options` evaluates the predicate across your `supportedEntities` and ships the result as a sparse `startControls` map — entity types with no restriction are omitted, so an adapter that declares nothing sends `{}`.
+
+**This changes what the dashboard offers, not what the API accepts.** `POST /api/data_sync/run` still honours both fields whatever you declare, so a script or an API client posting `fullSync: true` gets a `null` start cursor as before.
+
+Do not infer the answer from `persistsSharedCursor`. Where a cursor is stored and whether restarting from scratch is meaningful are independent facts — an entity type kept out of the shared row can still have a genuine beginning — and both are yours to state.
 
 ## Shared cursor vs run-scoped cursor
 

--- a/packages/core/src/modules/data_sync/AGENTS.md
+++ b/packages/core/src/modules/data_sync/AGENTS.md
@@ -111,6 +111,7 @@ interface DataSyncAdapter {
   getInitialCursor?(input: { entityType: string; scope: TenantScope }): Promise<string | null>
   getMapping(input: { entityType: string; scope: TenantScope }): Promise<DataMapping>
   persistsSharedCursor?(entityType: string): boolean
+  supportsStartControl?(control: 'fullSync' | 'batchSize', entityType: string): boolean
   validateConnection?(input: {
     entityType: string
     credentials: Record<string, unknown>
@@ -189,6 +190,39 @@ untouched dashboard form would — never an empty object. Write your adapter
 against the defaults, not against `undefined`. A default that violates its own
 declaration skips the scheduled run with a logged error instead of starting it
 with a half-applied set.
+
+### Start controls
+
+The dashboard's "Run once now" card also renders two controls the framework owns
+— **Run as full sync** and **Batch size**. Whether either is meaningful for an
+entity type is adapter knowledge, so an adapter may declare it per entity type:
+
+```typescript
+supportsStartControl: (control, entityType) =>
+  !(control === 'fullSync' && entityType.endsWith('.backfill')),
+```
+
+Only an explicit `false` removes a control; an adapter that declares nothing —
+or returns nothing — keeps today's form exactly. Return `false` where the
+operator's choice reaches the adapter and changes nothing observable: an entity
+type whose cursor carries identity, so an inherited cursor is discarded and the
+run starts from the top whichever way `fullSync` is set; or one whose paging the
+source fixes, so `batchSize` is read and ignored.
+
+`api/options.ts` evaluates the predicate across `supportedEntities` and ships the
+result as `startControls` — a **sparse** map, so an entity type with no
+restriction is omitted and an adapter that declares nothing serializes to `{}`.
+`lib/start-controls.ts` owns both halves (`resolveStartControlMap` server-side,
+`applicableStartControls` in the dashboard); a predicate that throws is treated
+as *applies*, because the options route resolves every registered adapter in one
+response.
+
+**This governs what the dashboard offers, never what the API accepts.**
+`POST /api/data_sync/run` keeps honouring both fields, so a client posting
+`fullSync: true` still gets a `null` start cursor whatever the adapter declares.
+Do not derive applicability from `persistsSharedCursor` — where a cursor is
+stored and whether restarting from scratch is meaningful are independent facts,
+and both belong to the adapter to state.
 
 If the sync provider needs bootstrap credentials, mappings, locales, channels, or other default sync settings after a fresh install, implement a provider-owned env preset flow:
 

--- a/packages/core/src/modules/data_sync/__integration__/TC-DS-011.spec.ts
+++ b/packages/core/src/modules/data_sync/__integration__/TC-DS-011.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+async function readJson(response: APIResponse): Promise<JsonRecord> {
+  return ((await readJsonSafe<JsonRecord>(response)) ?? {}) as JsonRecord
+}
+
+test.describe('TC-DS-011: Data sync start control applicability', () => {
+  test('options expose a well-formed startControls map for every data sync integration', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const response = await apiRequest(request, 'GET', '/api/data_sync/options', { token })
+    expect(response.status()).toBe(200)
+    const body = await readJson(response)
+    const items = Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+
+    // The contract is provider-agnostic: every integration advertises an object
+    // whose keys are its own entity types and whose values state, per control,
+    // whether the dashboard should offer it. An adapter that declares nothing
+    // ships `{}` — the dashboard then renders every control, as it always has.
+    for (const item of items) {
+      const startControls = item.startControls
+      expect(startControls).toBeTruthy()
+      expect(Array.isArray(startControls)).toBe(false)
+      expect(typeof startControls).toBe('object')
+
+      const supportedEntities = Array.isArray(item.supportedEntities)
+        ? (item.supportedEntities as unknown[]).filter((value): value is string => typeof value === 'string')
+        : []
+
+      for (const [entityType, applicability] of Object.entries(startControls as JsonRecord)) {
+        expect(supportedEntities).toContain(entityType)
+        const controls = applicability as JsonRecord
+        expect(typeof controls.fullSync).toBe('boolean')
+        expect(typeof controls.batchSize).toBe('boolean')
+        // A fully applicable entity type is omitted, so a present entry always
+        // restricts at least one control.
+        expect(controls.fullSync === false || controls.batchSize === false).toBe(true)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/data_sync/api/__tests__/options.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/options.test.ts
@@ -1,0 +1,104 @@
+/** @jest-environment node */
+
+import type { DataSyncAdapter } from '../../lib/adapter'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockGetAllIntegrations = jest.fn()
+const mockGetDataSyncAdapter = jest.fn()
+
+const mockCredentialsService = {
+  resolve: jest.fn(),
+}
+
+const mockStateService = {
+  resolveState: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'integrationCredentialsService') return mockCredentialsService
+      if (token === 'integrationStateService') return mockStateService
+      throw new Error(`Unexpected token: ${token}`)
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/shared/modules/integrations/types', () => ({
+  getAllIntegrations: () => mockGetAllIntegrations(),
+}))
+
+jest.mock('../../lib/adapter-registry', () => ({
+  getDataSyncAdapter: (providerKey: string) => mockGetDataSyncAdapter(providerKey),
+}))
+
+import { GET } from '../options'
+
+type OptionsItem = {
+  integrationId: string
+  supportedEntities: string[]
+  startControls: Record<string, { fullSync: boolean; batchSize: boolean }>
+}
+
+function buildAdapter(overrides: Partial<DataSyncAdapter> = {}): DataSyncAdapter {
+  return {
+    providerKey: 'mixed',
+    direction: 'import',
+    supportedEntities: ['orders.feed', 'orders.backfill'],
+    getMapping: async ({ entityType }) => ({ entityType, matchStrategy: 'externalId' as const, fields: [] }),
+    ...overrides,
+  }
+}
+
+async function readItems(): Promise<OptionsItem[]> {
+  const response = await GET(new Request('http://localhost/api/data_sync/options'))
+  expect(response.status).toBe(200)
+  const body = await response.json()
+  return body.items as OptionsItem[]
+}
+
+describe('data_sync options route start controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    mockGetAllIntegrations.mockReturnValue([
+      { id: 'sync_mixed', title: 'Mixed', hub: 'data_sync', providerKey: 'mixed' },
+    ])
+    mockCredentialsService.resolve.mockResolvedValue({})
+    mockStateService.resolveState.mockResolvedValue({ isEnabled: true })
+  })
+
+  it('ships an empty map for an adapter that declares nothing, so the form is unchanged', async () => {
+    mockGetDataSyncAdapter.mockReturnValue(buildAdapter())
+
+    const [item] = await readItems()
+    expect(item.startControls).toEqual({})
+  })
+
+  it('resolves the predicate per entity type and ships only the restrictions', async () => {
+    mockGetDataSyncAdapter.mockReturnValue(buildAdapter({
+      supportsStartControl: (control, entityType) => !(control === 'fullSync' && entityType === 'orders.backfill'),
+    }))
+
+    const [item] = await readItems()
+    expect(item.startControls).toEqual({
+      'orders.backfill': { fullSync: false, batchSize: true },
+    })
+    expect(Object.keys(item.startControls).every((key) => item.supportedEntities.includes(key))).toBe(true)
+  })
+
+  it('still answers 200 when an adapter predicate throws', async () => {
+    mockGetDataSyncAdapter.mockReturnValue(buildAdapter({
+      supportsStartControl: () => {
+        throw new Error('[internal] adapter predicate blew up')
+      },
+    }))
+
+    const [item] = await readItems()
+    expect(item.startControls).toEqual({})
+  })
+})

--- a/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/run.test.ts
@@ -215,6 +215,37 @@ describe('data_sync run route', () => {
     }))
   })
 
+  // `supportsStartControl` governs what the dashboard offers, never what the
+  // API accepts: an API client, a script, or a stale browser tab may still post
+  // the field and must get the documented behaviour.
+  it('honours fullSync even when the adapter declares the control inapplicable', async () => {
+    mockSyncRunService.resolveCursor.mockResolvedValue('shared-cursor')
+    mockGetDataSyncAdapter.mockReturnValueOnce({
+      providerKey: 'excel',
+      runMode: 'generic',
+      direction: 'import',
+      supportedEntities: ['customers.person'],
+      supportsStartControl: () => false,
+    })
+
+    const response = await postHandler(new Request('http://localhost/api/data_sync/run', {
+      method: 'POST',
+      body: JSON.stringify({
+        integrationId: 'generic_sync',
+        entityType: 'customers.person',
+        direction: 'import',
+        fullSync: true,
+        batchSize: 25,
+      }),
+    }))
+
+    expect(response.status).toBe(201)
+    expect(mockSyncRunService.resolveCursor).not.toHaveBeenCalled()
+    expect(mockStartDataSyncRun).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ cursor: null, batchSize: 25 }),
+    }))
+  })
+
   it('normalizes declared run parameters and forwards them to the run', async () => {
     mockGetDataSyncAdapter.mockReturnValueOnce({
       providerKey: 'excel',

--- a/packages/core/src/modules/data_sync/api/options.ts
+++ b/packages/core/src/modules/data_sync/api/options.ts
@@ -6,6 +6,7 @@ import { getAllIntegrations } from '@open-mercato/shared/modules/integrations/ty
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
 import type { IntegrationStateService } from '../../integrations/lib/state-service'
 import { getDataSyncAdapter } from '../lib/adapter-registry'
+import { resolveStartControlMap } from '../lib/start-controls'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['data_sync.view'] },
@@ -56,6 +57,7 @@ export async function GET(req: Request) {
           canStartRun: adapter.runMode !== 'provider',
           supportedEntities: adapter.supportedEntities,
           runParameters: adapter.runParameters ?? [],
+          startControls: resolveStartControlMap(adapter),
           hasCredentials: Boolean(credentials),
           isEnabled,
           settingsPath: `/backend/integrations/${encodeURIComponent(integration.id)}`,

--- a/packages/core/src/modules/data_sync/backend/data-sync/__tests__/page.test.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/__tests__/page.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import type { StartControlMap } from '../../../lib/start-controls'
+
+const apiCallMock = jest.fn()
+const runMutationMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, run: () => unknown) => run(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: runMutationMock, retryLastMutation: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: () => <div data-testid="runs-table" />,
+}))
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/backend/data-sync',
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+import SyncRunsDashboardPage from '../page'
+
+const FULL_SYNC_LABEL = 'Run as full sync'
+const BATCH_SIZE_LABEL = 'Batch size'
+
+function mockOptions(startControls: StartControlMap | undefined, supportedEntities: string[]) {
+  apiCallMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/api/data_sync/options')) {
+      return {
+        ok: true,
+        status: 200,
+        result: {
+          items: [{
+            integrationId: 'sync_mixed',
+            title: 'Mixed',
+            description: null,
+            providerKey: 'mixed',
+            direction: 'import',
+            runMode: 'generic',
+            canStartRun: true,
+            supportedEntities,
+            runParameters: [],
+            startControls,
+            hasCredentials: true,
+            isEnabled: true,
+            settingsPath: '/backend/integrations/sync_mixed',
+          }],
+        },
+      }
+    }
+    if (url.startsWith('/api/data_sync/schedules')) {
+      return { ok: true, status: 200, result: { items: [] } }
+    }
+    if (url.startsWith('/api/data_sync/runs')) {
+      return { ok: true, status: 200, result: { items: [], total: 0, page: 1, totalPages: 1 } }
+    }
+    return { ok: false, status: 404, result: null }
+  })
+}
+
+describe('data sync dashboard start controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders both controls for an adapter that declares nothing', async () => {
+    mockOptions({}, ['orders.feed'])
+
+    renderWithProviders(<SyncRunsDashboardPage />)
+
+    expect(await screen.findByText(FULL_SYNC_LABEL)).toBeInTheDocument()
+    expect(screen.getByText(BATCH_SIZE_LABEL)).toBeInTheDocument()
+  })
+
+  it('renders both controls for an entity type the adapter did not restrict', async () => {
+    mockOptions({ 'orders.backfill': { fullSync: false, batchSize: true } }, ['orders.feed', 'orders.backfill'])
+
+    renderWithProviders(<SyncRunsDashboardPage />)
+
+    expect(await screen.findByText(FULL_SYNC_LABEL)).toBeInTheDocument()
+    expect(screen.getByText(BATCH_SIZE_LABEL)).toBeInTheDocument()
+  })
+
+  it('omits the full sync control for an entity type whose adapter declares it inapplicable', async () => {
+    mockOptions({ 'orders.backfill': { fullSync: false, batchSize: true } }, ['orders.backfill', 'orders.feed'])
+
+    renderWithProviders(<SyncRunsDashboardPage />)
+
+    // The batch size control is the anchor: it still applies, so its presence
+    // proves the card rendered and the absence below is not a mounting failure.
+    expect(await screen.findByText(BATCH_SIZE_LABEL)).toBeInTheDocument()
+    expect(screen.queryByText(FULL_SYNC_LABEL)).not.toBeInTheDocument()
+  })
+
+  it('omits the batch size control for an entity type whose adapter declares it inapplicable', async () => {
+    mockOptions({ 'orders.backfill': { fullSync: true, batchSize: false } }, ['orders.backfill'])
+
+    renderWithProviders(<SyncRunsDashboardPage />)
+
+    expect(await screen.findByText(FULL_SYNC_LABEL)).toBeInTheDocument()
+    expect(screen.queryByText(BATCH_SIZE_LABEL)).not.toBeInTheDocument()
+  })
+
+  it('omits the whole knob row when the adapter restricts every control', async () => {
+    mockOptions({ 'orders.backfill': { fullSync: false, batchSize: false } }, ['orders.backfill'])
+
+    renderWithProviders(<SyncRunsDashboardPage />)
+
+    await waitFor(() => expect(screen.getByText('Start sync')).toBeInTheDocument())
+    expect(screen.queryByText(FULL_SYNC_LABEL)).not.toBeInTheDocument()
+    expect(screen.queryByText(BATCH_SIZE_LABEL)).not.toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -47,7 +47,11 @@ import {
 import { getSyncRunStatusVariant, getSyncSummaryVariant } from '../../lib/syncRunStatus'
 import type { RunParameter } from '../../lib/adapter'
 import { getApplicableRunParameters } from '../../lib/run-parameters'
-import { applicableStartControls, type StartControlMap } from '../../lib/start-controls'
+import {
+  applicableStartControls,
+  type StartControlApplicability,
+  type StartControlMap,
+} from '../../lib/start-controls'
 import {
   RunParameterFields,
   buildDefaultRunParameterValues,
@@ -132,6 +136,17 @@ const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UT
 
 /** Matches `runSyncSchema`'s own default, so omitting the field submits this value. */
 const DEFAULT_BATCH_SIZE = '100'
+
+/**
+ * Keeps the batch size input at its own narrow width without leaving a phantom
+ * track: the second column exists only when the full sync card fills it. With
+ * only that card the row falls back to one full-width column.
+ */
+function startControlsGridClass(controls: StartControlApplicability): string | undefined {
+  if (controls.batchSize && controls.fullSync) return 'sm:grid-cols-[minmax(0,180px)_1fr]'
+  if (controls.batchSize) return 'sm:grid-cols-[minmax(0,180px)]'
+  return undefined
+}
 
 function formatEntityTypeLabel(entityType: string): string {
   return entityType
@@ -828,7 +843,7 @@ export default function SyncRunsDashboardPage() {
                 <Separator className="my-4" />
 
                 {startControls.batchSize || startControls.fullSync ? (
-                  <div className={cn('grid gap-4', startControls.batchSize && 'sm:grid-cols-[minmax(0,180px)_1fr]')}>
+                  <div className={cn('grid gap-4', startControlsGridClass(startControls))}>
                     {startControls.batchSize ? (
                       <div className="space-y-2">
                         <Label className="flex items-center gap-2 text-sm font-medium">

--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -31,6 +31,7 @@ import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { cn } from '@open-mercato/shared/lib/utils'
 import {
   ArrowRightLeft,
   Boxes,
@@ -46,6 +47,7 @@ import {
 import { getSyncRunStatusVariant, getSyncSummaryVariant } from '../../lib/syncRunStatus'
 import type { RunParameter } from '../../lib/adapter'
 import { getApplicableRunParameters } from '../../lib/run-parameters'
+import { applicableStartControls, type StartControlMap } from '../../lib/start-controls'
 import {
   RunParameterFields,
   buildDefaultRunParameterValues,
@@ -87,6 +89,7 @@ type SyncOption = {
   canStartRun?: boolean
   supportedEntities: string[]
   runParameters?: RunParameter[]
+  startControls?: StartControlMap
   hasCredentials: boolean
   isEnabled: boolean
   settingsPath: string
@@ -127,6 +130,9 @@ type SyncScheduleEditorState = {
 
 const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
+/** Matches `runSyncSchema`'s own default, so omitting the field submits this value. */
+const DEFAULT_BATCH_SIZE = '100'
+
 function formatEntityTypeLabel(entityType: string): string {
   return entityType
     .replace(/[_-]+/g, ' ')
@@ -162,7 +168,7 @@ export default function SyncRunsDashboardPage() {
   const [selectedIntegrationId, setSelectedIntegrationId] = React.useState('')
   const [selectedEntityType, setSelectedEntityType] = React.useState('')
   const [selectedDirection, setSelectedDirection] = React.useState<'import' | 'export'>('import')
-  const [batchSize, setBatchSize] = React.useState('100')
+  const [batchSize, setBatchSize] = React.useState(DEFAULT_BATCH_SIZE)
   const [fullSync, setFullSync] = React.useState(false)
   const [paramValues, setParamValues] = React.useState<Record<string, RunParameterFormValue>>({})
   const [scheduleEditor, setScheduleEditor] = React.useState<SyncScheduleEditorState>(() => buildDefaultScheduleState(''))
@@ -261,9 +267,26 @@ export default function SyncRunsDashboardPage() {
     [selectedIntegration, selectedDirection, selectedEntityType],
   )
 
+  // Before an entity is chosen the state is '', which matches no declaration and
+  // so renders both controls — the unselected form as it is today.
+  const startControls = React.useMemo(
+    () => applicableStartControls(selectedIntegration?.startControls, selectedEntityType),
+    [selectedIntegration, selectedEntityType],
+  )
+
   React.useEffect(() => {
     setParamValues(buildDefaultRunParameterValues(runParameters))
   }, [runParameters])
+
+  // A control the form stopped showing must not keep submitting the value the
+  // operator last set for another entity type.
+  React.useEffect(() => {
+    if (!startControls.fullSync) setFullSync(false)
+  }, [startControls.fullSync])
+
+  React.useEffect(() => {
+    if (!startControls.batchSize) setBatchSize(DEFAULT_BATCH_SIZE)
+  }, [startControls.batchSize])
 
   const updateParamValue = React.useCallback((key: string, value: RunParameterFormValue) => {
     setParamValues((current) => ({ ...current, [key]: value }))
@@ -384,20 +407,23 @@ export default function SyncRunsDashboardPage() {
   const handleStartSync = React.useCallback(async () => {
     if (!selectedIntegration || !selectedEntityType) return
 
-    const parsedBatchSize = Number.parseInt(batchSize, 10)
-    if (!Number.isFinite(parsedBatchSize) || parsedBatchSize < 1 || parsedBatchSize > 1000) {
-      flash(t('data_sync.dashboard.start.invalidBatchSize', 'Batch size must be between 1 and 1000.'), 'error')
-      return
-    }
-
     const parameters = buildRunParametersPayload(runParameters, paramValues)
+    // A control the adapter declared inapplicable is left out entirely, so
+    // `runSyncSchema`'s defaults supply exactly what the rendered form sends.
     const requestBody: Record<string, unknown> = {
       integrationId: selectedIntegration.integrationId,
       entityType: selectedEntityType,
       direction: selectedDirection,
-      batchSize: parsedBatchSize,
-      fullSync,
     }
+    if (startControls.batchSize) {
+      const parsedBatchSize = Number.parseInt(batchSize, 10)
+      if (!Number.isFinite(parsedBatchSize) || parsedBatchSize < 1 || parsedBatchSize > 1000) {
+        flash(t('data_sync.dashboard.start.invalidBatchSize', 'Batch size must be between 1 and 1000.'), 'error')
+        return
+      }
+      requestBody.batchSize = parsedBatchSize
+    }
+    if (startControls.fullSync) requestBody.fullSync = fullSync
     if (runParameters.length > 0) requestBody.parameters = parameters
 
     try {
@@ -432,7 +458,7 @@ export default function SyncRunsDashboardPage() {
       const message = error instanceof Error ? error.message : t('data_sync.dashboard.start.error', 'Failed to start sync run')
       flash(message, 'error')
     }
-  }, [batchSize, fullSync, paramValues, router, runMutation, runParameters, selectedDirection, selectedEntityType, selectedIntegration, t])
+  }, [batchSize, fullSync, paramValues, router, runMutation, runParameters, selectedDirection, selectedEntityType, selectedIntegration, startControls, t])
 
   const handleSaveSchedule = React.useCallback(async () => {
     if (!selectedIntegration || !selectedEntityType) return
@@ -791,7 +817,9 @@ export default function SyncRunsDashboardPage() {
                       <h3 className="text-sm font-semibold">{t('data_sync.dashboard.start.runNowTitle', 'Run once now')}</h3>
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      {t('data_sync.dashboard.start.runNowDescription', 'Use this for the next immediate sync. Batch size and full-sync mode apply only to this manual run.')}
+                      {startControls.batchSize && startControls.fullSync
+                        ? t('data_sync.dashboard.start.runNowDescription', 'Use this for the next immediate sync. Batch size and full-sync mode apply only to this manual run.')
+                        : t('data_sync.dashboard.start.runNowDescriptionScoped', 'Use this for the next immediate sync. Anything set here applies only to this manual run.')}
                     </p>
                   </div>
                   <Badge variant="outline">{selectedEntityLabel}</Badge>
@@ -799,30 +827,36 @@ export default function SyncRunsDashboardPage() {
 
                 <Separator className="my-4" />
 
-                <div className="grid gap-4 sm:grid-cols-[minmax(0,180px)_1fr]">
-                  <div className="space-y-2">
-                    <Label className="flex items-center gap-2 text-sm font-medium">
-                      <Gauge className="size-4 text-muted-foreground" />
-                      <span>{t('data_sync.dashboard.start.batchSize', 'Batch size')}</span>
-                    </Label>
-                    <Input
-                      value={batchSize}
-                      onChange={(event) => setBatchSize(event.target.value)}
-                      inputMode="numeric"
-                    />
-                  </div>
-                  <div className="rounded-lg border bg-background p-3">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="space-y-1">
-                        <Label className="text-sm font-medium">{t('data_sync.dashboard.start.fullSync', 'Run as full sync')}</Label>
-                        <p className="text-xs text-muted-foreground">
-                          {t('data_sync.dashboard.start.fullSyncHelp', 'Ignore the saved cursor and process the entire source again for this run.')}
-                        </p>
+                {startControls.batchSize || startControls.fullSync ? (
+                  <div className={cn('grid gap-4', startControls.batchSize && 'sm:grid-cols-[minmax(0,180px)_1fr]')}>
+                    {startControls.batchSize ? (
+                      <div className="space-y-2">
+                        <Label className="flex items-center gap-2 text-sm font-medium">
+                          <Gauge className="size-4 text-muted-foreground" />
+                          <span>{t('data_sync.dashboard.start.batchSize', 'Batch size')}</span>
+                        </Label>
+                        <Input
+                          value={batchSize}
+                          onChange={(event) => setBatchSize(event.target.value)}
+                          inputMode="numeric"
+                        />
                       </div>
-                      <Switch checked={fullSync} onCheckedChange={setFullSync} />
-                    </div>
+                    ) : null}
+                    {startControls.fullSync ? (
+                      <div className="rounded-lg border bg-background p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="space-y-1">
+                            <Label className="text-sm font-medium">{t('data_sync.dashboard.start.fullSync', 'Run as full sync')}</Label>
+                            <p className="text-xs text-muted-foreground">
+                              {t('data_sync.dashboard.start.fullSyncHelp', 'Ignore the saved cursor and process the entire source again for this run.')}
+                            </p>
+                          </div>
+                          <Switch checked={fullSync} onCheckedChange={setFullSync} />
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
-                </div>
+                ) : null}
 
                 {runParameters.length > 0 ? (
                   <div className="mt-4 space-y-3">

--- a/packages/core/src/modules/data_sync/i18n/de.json
+++ b/packages/core/src/modules/data_sync/i18n/de.json
@@ -59,6 +59,7 @@
   "data_sync.dashboard.start.parametersHelp": "Optionale Werte, die diese Integration für den manuellen Lauf akzeptiert.",
   "data_sync.dashboard.start.providerManaged": "Diese Integration startet Synchronisierungsläufe über ihren eigenen Einrichtungsablauf. Öffne die Integrationseinstellungen, um fortzufahren.",
   "data_sync.dashboard.start.runNowDescription": "Use this for the next immediate sync. Batch size and full-sync mode apply only to this manual run.",
+  "data_sync.dashboard.start.runNowDescriptionScoped": "Use this for the next immediate sync. Anything set here applies only to this manual run.",
   "data_sync.dashboard.start.runNowFootnote": "Manual runs show progress immediately and land on the run detail page after launch.",
   "data_sync.dashboard.start.runNowTitle": "Run once now",
   "data_sync.dashboard.start.status.credentialsMissing": "Credentials missing",

--- a/packages/core/src/modules/data_sync/i18n/en.json
+++ b/packages/core/src/modules/data_sync/i18n/en.json
@@ -59,6 +59,7 @@
   "data_sync.dashboard.start.parametersHelp": "Optional values this integration accepts for the manual run.",
   "data_sync.dashboard.start.providerManaged": "This integration starts sync runs from its own setup flow. Open the integration settings page to continue.",
   "data_sync.dashboard.start.runNowDescription": "Use this for the next immediate sync. Batch size and full-sync mode apply only to this manual run.",
+  "data_sync.dashboard.start.runNowDescriptionScoped": "Use this for the next immediate sync. Anything set here applies only to this manual run.",
   "data_sync.dashboard.start.runNowFootnote": "Manual runs show progress immediately and land on the run detail page after launch.",
   "data_sync.dashboard.start.runNowTitle": "Run once now",
   "data_sync.dashboard.start.status.credentialsMissing": "Credentials missing",

--- a/packages/core/src/modules/data_sync/i18n/es.json
+++ b/packages/core/src/modules/data_sync/i18n/es.json
@@ -59,6 +59,7 @@
   "data_sync.dashboard.start.parametersHelp": "Valores opcionales que esta integración acepta para la ejecución manual.",
   "data_sync.dashboard.start.providerManaged": "Esta integración inicia las sincronizaciones desde su propio flujo de configuración. Abre la página de ajustes de la integración para continuar.",
   "data_sync.dashboard.start.runNowDescription": "Use this for the next immediate sync. Batch size and full-sync mode apply only to this manual run.",
+  "data_sync.dashboard.start.runNowDescriptionScoped": "Use this for the next immediate sync. Anything set here applies only to this manual run.",
   "data_sync.dashboard.start.runNowFootnote": "Manual runs show progress immediately and land on the run detail page after launch.",
   "data_sync.dashboard.start.runNowTitle": "Run once now",
   "data_sync.dashboard.start.status.credentialsMissing": "Credentials missing",

--- a/packages/core/src/modules/data_sync/i18n/ko.json
+++ b/packages/core/src/modules/data_sync/i18n/ko.json
@@ -59,6 +59,7 @@
   "data_sync.dashboard.start.parametersHelp": "이 통합이 수동 실행에 대해 허용하는 선택적 값입니다.",
   "data_sync.dashboard.start.providerManaged": "이 통합은 자체 설정 흐름에서 동기화 실행을 시작합니다. 계속하려면 통합 설정 페이지를 여세요.",
   "data_sync.dashboard.start.runNowDescription": "다음 즉시 동기화에 사용하세요. 배치 크기와 전체 동기화 모드는 이 수동 실행에만 적용됩니다.",
+  "data_sync.dashboard.start.runNowDescriptionScoped": "다음 즉시 동기화에 사용하세요. 여기에서 설정한 값은 이 수동 실행에만 적용됩니다.",
   "data_sync.dashboard.start.runNowFootnote": "수동 실행은 즉시 진행 상황을 표시하며 시작 후 실행 상세 페이지로 이동합니다.",
   "data_sync.dashboard.start.runNowTitle": "지금 한 번 실행",
   "data_sync.dashboard.start.status.credentialsMissing": "자격 증명 누락",

--- a/packages/core/src/modules/data_sync/i18n/pl.json
+++ b/packages/core/src/modules/data_sync/i18n/pl.json
@@ -59,6 +59,7 @@
   "data_sync.dashboard.start.parametersHelp": "Opcjonalne wartości akceptowane przez tę integrację dla ręcznego uruchomienia.",
   "data_sync.dashboard.start.providerManaged": "Ta integracja uruchamia synchronizacje z własnego przepływu konfiguracji. Otwórz ustawienia integracji, aby kontynuować.",
   "data_sync.dashboard.start.runNowDescription": "Użyj tej opcji dla najbliższej natychmiastowej synchronizacji. Rozmiar partii i tryb pełnej synchronizacji dotyczą wyłącznie tego ręcznego przebiegu.",
+  "data_sync.dashboard.start.runNowDescriptionScoped": "Użyj tej opcji dla najbliższej natychmiastowej synchronizacji. Ustawienia wprowadzone tutaj dotyczą wyłącznie tego ręcznego przebiegu.",
   "data_sync.dashboard.start.runNowFootnote": "Ręczne przebiegi od razu pokazują postęp, a po uruchomieniu przenoszą na stronę szczegółów przebiegu.",
   "data_sync.dashboard.start.runNowTitle": "Uruchom teraz jednorazowo",
   "data_sync.dashboard.start.status.credentialsMissing": "Brak poświadczeń",

--- a/packages/core/src/modules/data_sync/lib/__tests__/start-controls.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/start-controls.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment node */
+
+import type { DataSyncAdapter } from '../adapter'
+import { applicableStartControls, resolveStartControlMap } from '../start-controls'
+
+function buildAdapter(overrides: Partial<DataSyncAdapter> = {}): DataSyncAdapter {
+  return {
+    providerKey: 'mixed-provider',
+    direction: 'import',
+    supportedEntities: ['orders.feed', 'orders.backfill'],
+    getMapping: async ({ entityType }) => ({ entityType, matchStrategy: 'externalId' as const, fields: [] }),
+    ...overrides,
+  }
+}
+
+describe('resolveStartControlMap', () => {
+  it('returns an empty map for an adapter that declares nothing', () => {
+    expect(resolveStartControlMap(buildAdapter())).toEqual({})
+  })
+
+  it('returns an empty map when no adapter resolved at all', () => {
+    expect(resolveStartControlMap(null)).toEqual({})
+  })
+
+  it('records only the entity types the adapter restricts', () => {
+    const map = resolveStartControlMap(buildAdapter({
+      supportsStartControl: (control, entityType) => !(control === 'fullSync' && entityType === 'orders.backfill'),
+    }))
+
+    expect(map).toEqual({
+      'orders.backfill': { fullSync: false, batchSize: true },
+    })
+  })
+
+  it('records each control independently for the same entity type', () => {
+    const map = resolveStartControlMap(buildAdapter({
+      supportedEntities: ['orders.backfill'],
+      supportsStartControl: () => false,
+    }))
+
+    expect(map).toEqual({
+      'orders.backfill': { fullSync: false, batchSize: false },
+    })
+  })
+
+  it('treats any return other than an explicit false as applicable', () => {
+    const map = resolveStartControlMap(buildAdapter({
+      supportsStartControl: (() => undefined) as unknown as DataSyncAdapter['supportsStartControl'],
+    }))
+
+    expect(map).toEqual({})
+  })
+
+  // One adapter's broken predicate must not fail `api/data_sync/options`, which
+  // evaluates every registered adapter in a single response.
+  it('treats a throwing predicate as applicable', () => {
+    const map = resolveStartControlMap(buildAdapter({
+      supportsStartControl: () => {
+        throw new Error('[internal] adapter predicate blew up')
+      },
+    }))
+
+    expect(map).toEqual({})
+  })
+
+  it('never asks about an entity type the adapter does not support', () => {
+    const supportsStartControl = jest.fn(() => true)
+    resolveStartControlMap(buildAdapter({ supportedEntities: ['orders.feed'], supportsStartControl }))
+
+    const askedEntityTypes = new Set(supportsStartControl.mock.calls.map((call) => (call as unknown[])[1]))
+    expect([...askedEntityTypes]).toEqual(['orders.feed'])
+  })
+})
+
+describe('applicableStartControls', () => {
+  it('applies every control for an entity type the map does not restrict', () => {
+    expect(applicableStartControls({ 'orders.backfill': { fullSync: false, batchSize: true } }, 'orders.feed'))
+      .toEqual({ fullSync: true, batchSize: true })
+  })
+
+  it('applies every control when the integration shipped no map', () => {
+    expect(applicableStartControls(undefined, 'orders.feed')).toEqual({ fullSync: true, batchSize: true })
+  })
+
+  it('applies every control before an entity type is selected', () => {
+    expect(applicableStartControls({ 'orders.backfill': { fullSync: false, batchSize: true } }, ''))
+      .toEqual({ fullSync: true, batchSize: true })
+  })
+
+  it('reads the declaration for a restricted entity type', () => {
+    expect(applicableStartControls({ 'orders.backfill': { fullSync: false, batchSize: true } }, 'orders.backfill'))
+      .toEqual({ fullSync: false, batchSize: true })
+  })
+
+  it('ignores inherited properties so a prototype-shaped entity type keeps its controls', () => {
+    expect(applicableStartControls({}, 'constructor')).toEqual({ fullSync: true, batchSize: true })
+    expect(applicableStartControls({}, '__proto__')).toEqual({ fullSync: true, batchSize: true })
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/__tests__/start-controls.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/start-controls.test.ts
@@ -63,6 +63,26 @@ describe('resolveStartControlMap', () => {
     expect(map).toEqual({})
   })
 
+  // On a plain object literal `map.__proto__ = value` sets the prototype rather
+  // than creating an own property, so the restriction would serialize away and
+  // reach the dashboard as "every control applies".
+  it('keeps a prototype-named entity type as a serializable own entry', () => {
+    const map = resolveStartControlMap(buildAdapter({
+      supportedEntities: ['__proto__'],
+      supportsStartControl: (control) => control !== 'fullSync',
+    }))
+
+    expect(Object.keys(map)).toEqual(['__proto__'])
+
+    // Read the round-tripped entry through a descriptor: an object literal
+    // cannot express the expectation, because `{ __proto__: ... }` sets the
+    // prototype there too.
+    const overWire = JSON.parse(JSON.stringify(map))
+    expect(Object.keys(overWire)).toEqual(['__proto__'])
+    expect(Object.getOwnPropertyDescriptor(overWire, '__proto__')?.value)
+      .toEqual({ fullSync: false, batchSize: true })
+  })
+
   it('never asks about an entity type the adapter does not support', () => {
     const supportsStartControl = jest.fn(() => true)
     resolveStartControlMap(buildAdapter({ supportedEntities: ['orders.feed'], supportsStartControl }))

--- a/packages/core/src/modules/data_sync/lib/adapter.ts
+++ b/packages/core/src/modules/data_sync/lib/adapter.ts
@@ -275,21 +275,31 @@ export interface DataSyncAdapter {
    */
   persistsSharedCursor?(entityType: string): boolean
   /**
-   * Whether a manual-start control is meaningful for this entity type. Only an
-   * explicit `false` removes a control, so an adapter that declares nothing —
-   * or returns nothing — keeps today's form exactly.
+   * Whether a control on the Data Sync dashboard's "Run once now" card is
+   * meaningful for this entity type. Only an explicit `false` removes a
+   * control, so an adapter that declares nothing — or returns nothing — keeps
+   * today's form exactly.
    *
    * Return `false` for an entity type where the operator's choice reaches the
    * adapter and changes nothing observable: an entity type whose cursor carries
    * identity, so an inherited cursor is discarded and the run starts from the
    * top whichever way `fullSync` is set; or one whose paging the source fixes,
-   * so `batchSize` is read and ignored. The dashboard then omits the control
-   * rather than offering a switch whose "no effect" an operator cannot tell
-   * apart from "it worked".
+   * so `batchSize` is read and ignored. That card then omits the control rather
+   * than offering a switch whose "no effect" an operator cannot tell apart from
+   * "it worked".
    *
    * Core cannot infer this — it does not know what an entity type does with the
    * values it is handed. The adapter does, and this is the channel for saying
    * so.
+   *
+   * SCOPE: the "Run once now" card only. It does NOT gate the recurring-schedule
+   * switch on the same page, nor the per-entity-type "Full" switch on the
+   * integration settings tab — whose row-level run posts that schedule's own
+   * `fullSync` to the same run API. An adapter that declares `fullSync`
+   * inapplicable still sees those, and `buildDefaultScheduleState` may pre-set
+   * them to `true`. Harmless by construction, since the adapter has said the
+   * value does not matter, but do not read this predicate as covering every
+   * place a run can be started.
    *
    * This governs what the dashboard OFFERS, not what the API accepts:
    * `POST /api/data_sync/run` keeps honouring both fields, so a client that

--- a/packages/core/src/modules/data_sync/lib/adapter.ts
+++ b/packages/core/src/modules/data_sync/lib/adapter.ts
@@ -207,6 +207,14 @@ export interface RunParameter {
   entityType?: string | string[]
 }
 
+/**
+ * A control the `data_sync` dashboard renders on its "Run once now" card.
+ *
+ * - `fullSync` asks the run API for a `null` start cursor instead of a resolved one.
+ * - `batchSize` sets `StreamImportInput.batchSize` / `StreamExportInput.batchSize`.
+ */
+export type DataSyncStartControl = 'fullSync' | 'batchSize'
+
 export interface DataSyncAdapter {
   readonly providerKey: string
   readonly direction: 'import' | 'export' | 'bidirectional'
@@ -266,6 +274,33 @@ export interface DataSyncAdapter {
    * kinds — an incremental feed and a whole-table backfill.
    */
   persistsSharedCursor?(entityType: string): boolean
+  /**
+   * Whether a manual-start control is meaningful for this entity type. Only an
+   * explicit `false` removes a control, so an adapter that declares nothing —
+   * or returns nothing — keeps today's form exactly.
+   *
+   * Return `false` for an entity type where the operator's choice reaches the
+   * adapter and changes nothing observable: an entity type whose cursor carries
+   * identity, so an inherited cursor is discarded and the run starts from the
+   * top whichever way `fullSync` is set; or one whose paging the source fixes,
+   * so `batchSize` is read and ignored. The dashboard then omits the control
+   * rather than offering a switch whose "no effect" an operator cannot tell
+   * apart from "it worked".
+   *
+   * Core cannot infer this — it does not know what an entity type does with the
+   * values it is handed. The adapter does, and this is the channel for saying
+   * so.
+   *
+   * This governs what the dashboard OFFERS, not what the API accepts:
+   * `POST /api/data_sync/run` keeps honouring both fields, so a client that
+   * posts `fullSync: true` still gets a `null` cursor whatever this returns.
+   *
+   * The predicate is per entity type for the same reason
+   * {@link DataSyncAdapter.persistsSharedCursor} is — one adapter commonly
+   * serves both an incremental feed and a whole-table backfill, and only one of
+   * them has a beginning to restart from.
+   */
+  supportsStartControl?(control: DataSyncStartControl, entityType: string): boolean
   getInitialCursor?(input: { entityType: string; scope: TenantScope }): Promise<string | null>
   getMapping(input: { entityType: string; scope: TenantScope }): Promise<DataMapping>
   validateConnection?(input: {

--- a/packages/core/src/modules/data_sync/lib/start-controls.ts
+++ b/packages/core/src/modules/data_sync/lib/start-controls.ts
@@ -1,0 +1,75 @@
+import type { DataSyncAdapter, DataSyncStartControl } from './adapter'
+
+export const DATA_SYNC_START_CONTROLS: readonly DataSyncStartControl[] = ['fullSync', 'batchSize']
+
+export type StartControlApplicability = Record<DataSyncStartControl, boolean>
+
+/**
+ * Which manual-start controls apply, per entity type, as resolved by
+ * `api/options.ts` and read by the dashboard.
+ *
+ * The map is sparse: an entity type whose controls all apply is omitted, so an
+ * adapter that declares nothing serializes to `{}` and adds nothing to the
+ * wire. "Not declared" and "nothing restricted" therefore share one default.
+ */
+export type StartControlMap = Record<string, StartControlApplicability>
+
+function allApplicable(): StartControlApplicability {
+  return { fullSync: true, batchSize: true }
+}
+
+/**
+ * A predicate that throws is treated as "applies". `api/options.ts` evaluates
+ * every registered adapter in one response, so an adapter with a broken
+ * predicate would otherwise take the options list — and with it the whole
+ * dashboard — down for every other integration.
+ */
+function isApplicable(
+  adapter: DataSyncAdapter,
+  control: DataSyncStartControl,
+  entityType: string,
+): boolean {
+  try {
+    return adapter.supportsStartControl?.(control, entityType) !== false
+  } catch {
+    return true
+  }
+}
+
+/** Evaluates an adapter's declaration across the entity types it supports. */
+export function resolveStartControlMap(adapter: DataSyncAdapter | null | undefined): StartControlMap {
+  if (!adapter || typeof adapter.supportsStartControl !== 'function') return {}
+  const map: StartControlMap = {}
+  for (const entityType of adapter.supportedEntities ?? []) {
+    const applicability = allApplicable()
+    let restricted = false
+    for (const control of DATA_SYNC_START_CONTROLS) {
+      if (isApplicable(adapter, control, entityType)) continue
+      applicability[control] = false
+      restricted = true
+    }
+    if (restricted) map[entityType] = applicability
+  }
+  return map
+}
+
+/**
+ * Reads the resolved map for the selected entity type, defaulting to "every
+ * control applies" for an entity type the map does not restrict.
+ *
+ * The lookup is own-property only: an entity type named after something on
+ * `Object.prototype` would otherwise read back an inherited value whose
+ * `fullSync` is `undefined`, hiding a control the adapter never restricted.
+ */
+export function applicableStartControls(
+  map: StartControlMap | null | undefined,
+  entityType: string,
+): StartControlApplicability {
+  if (!map || !Object.prototype.hasOwnProperty.call(map, entityType)) return allApplicable()
+  const declared = map[entityType]
+  const applicability = allApplicable()
+  for (const control of DATA_SYNC_START_CONTROLS) {
+    if (declared?.[control] === false) applicability[control] = false
+  }
+  return applicability
+}

--- a/packages/core/src/modules/data_sync/lib/start-controls.ts
+++ b/packages/core/src/modules/data_sync/lib/start-controls.ts
@@ -1,6 +1,13 @@
 import type { DataSyncAdapter, DataSyncStartControl } from './adapter'
 
-export const DATA_SYNC_START_CONTROLS: readonly DataSyncStartControl[] = ['fullSync', 'batchSize']
+/**
+ * Keyed by the union rather than listed, so adding a control to
+ * {@link DataSyncStartControl} fails to compile here instead of silently
+ * dropping out of the resolution loop and the client-side read.
+ */
+const START_CONTROL_KEYS: Record<DataSyncStartControl, true> = { fullSync: true, batchSize: true }
+
+export const DATA_SYNC_START_CONTROLS = Object.keys(START_CONTROL_KEYS) as readonly DataSyncStartControl[]
 
 export type StartControlApplicability = Record<DataSyncStartControl, boolean>
 

--- a/packages/core/src/modules/data_sync/lib/start-controls.ts
+++ b/packages/core/src/modules/data_sync/lib/start-controls.ts
@@ -36,10 +36,17 @@ function isApplicable(
   }
 }
 
-/** Evaluates an adapter's declaration across the entity types it supports. */
+/**
+ * Evaluates an adapter's declaration across the entity types it supports.
+ *
+ * The accumulator has a null prototype: assigning `__proto__` on a plain object
+ * literal sets that object's prototype instead of creating an own property, so
+ * an entity type under that name would serialize away and silently lose the
+ * restriction the adapter declared.
+ */
 export function resolveStartControlMap(adapter: DataSyncAdapter | null | undefined): StartControlMap {
   if (!adapter || typeof adapter.supportsStartControl !== 'function') return {}
-  const map: StartControlMap = {}
+  const map: StartControlMap = Object.create(null)
   for (const entityType of adapter.supportedEntities ?? []) {
     const applicability = allApplicable()
     let restricted = false


### PR DESCRIPTION
## Summary

The Data Sync dashboard's **Run once now** card renders the same two controls — *Run as full sync* and *Batch size* — for every adapter and every entity type. Whether either one means anything for the selected entity type is adapter knowledge, and the adapter has no way to say so.

`api/run.ts` resolves the start cursor as `fullSync ? null : resolveStartCursor(...)`, and `lib/start-cursor.ts` branches on the existing per-entity-type predicate `persistsSharedCursor`. For an entity type that opted out of the shared row, the switch's own help text — *"Ignore the saved cursor"* — describes a row that is never written.

**The switch is not dead for those entity types, and this PR does not claim it is.** The two settings still hand the adapter different values:

| `fullSync` | cursor passed to the adapter |
|---|---|
| `true` | `null` |
| `false` | `resolveResumeCursor(...)` — the most recent run's position |

What is unknowable to core is whether that difference is *observable*. An adapter whose cursor is a plain watermark honours the distinction. An adapter whose cursor carries identity — one that checks whether an arriving cursor is its own and mints a fresh position when it is not — collapses both settings into the same outcome; on that entity type, ticking the switch changes the payload and changes nothing else. `batchSize` has the same shape one step milder: an adapter whose paging the source fixes reads it and ignores it.

Core cannot infer which kind it has. The adapter knows exactly. There is no channel for it to say so — that is the defect. The result is a control on the primary operator path that may silently do nothing, and an operator who cannot tell *"it had no effect"* from *"it worked"*.

At the framework level:

> The dashboard renders a fixed set of start controls regardless of whether they are meaningful for the selected adapter and entity type. Applicability is adapter knowledge; the adapter cannot declare it.

**The dashboard already believes this judgement is entity-type-dependent** — it just has no way to ask, so it guesses. `buildDefaultScheduleState` in the same file:

```ts
const normalized = entityType.trim().toLowerCase()
const longerInterval = normalized === 'categories' || normalized === 'attributes'
return { scheduleValue: longerInterval ? '6h' : '1h', fullSync: normalized !== 'products', ... }
```

Generic dashboard code branching on hardcoded entity-type *name strings* to decide whether full sync is appropriate. It works only for entity types core happens to know by name, misfires silently for any adapter that names things differently, and breaks the module's own rule (*"Keep declarations provider-agnostic — never special-case a provider in `data_sync`"*). Raised here as evidence; **deliberately out of scope** — that is the schedule-level control, with its own back-compat surface.

### The solution

Let the adapter declare, per entity type, which manual-start controls apply. The dashboard renders only those.

```ts
supportsStartControl?(control: 'fullSync' | 'batchSize', entityType: string): boolean
```

Only an explicit `false` removes a control, so an adapter that declares nothing — or returns nothing — keeps today's form exactly.

Both halves of this shape are already merged in this module, which is the pitch: **do for the framework's own start controls what #5374 already does for adapter-declared ones.**

- **The mechanism** — #5250, *"let adapters opt out of the shared cursor row per entity type"*: `persistsSharedCursor?(entityType)`, optional, defaulting to prior behaviour, keyed by entity type.
- **The end-to-end path** — #5374, *"generic, adapter-declared run parameters"*: `RunParameter.entityType` scoping, filtered by `getApplicableRunParameters(...)`, shipped to the client by `api/options.ts`, and the dashboard renders only the applicable ones. Exactly the UI behaviour wanted here.

Today `runParameters` get entity-type scoping and the framework's own knobs do not.

### Why per entity type, not per adapter

Per-adapter is simpler and cannot express the case. The argument is core's own, already accepted on the `persistsSharedCursor` docstring:

> The predicate is per entity type because one adapter commonly serves both kinds — an incremental feed and a whole-table backfill.

Change-feed entity types have a durable log position, so *re-drain from the beginning* is a real request. Backfill entity types have one run's scan state, so a fresh start already begins from the top. Same adapter, same dashboard, opposite answers.

### The serialization boundary

`runParameters` is data; `persistsSharedCursor` is a function and therefore server-side only. `api/options.ts` cannot ship a predicate, so **the options route resolves it**: it evaluates the predicate across `supportedEntities` and sends a resolved map. This keeps the adapter-facing API consistent with `persistsSharedCursor` — an adapter author writes one kind of thing for both.

The map is **sparse**: an entity type with no restriction is omitted, so an adapter that declares nothing serializes to `{}` and adds nothing to the wire, and "not declared" and "nothing restricted" share one client-side default.

```jsonc
"startControls": { "orders.backfill": { "fullSync": false, "batchSize": true } }
```

The data-shaped alternative (`startControls?: { control; entityType? }[]`, serializable as-is like `runParameters`) stays available additively if something ever needs a declaration the server cannot evaluate.

### Rejected: deriving it from `persistsSharedCursor`

Hiding the switch whenever `persistsSharedCursor(entityType) === false` conflates *where the cursor is stored* with *whether restarting from scratch is meaningful*, and it would silently change the UI for every existing adapter that opted out of the shared cursor row. The two facts are independent and both belong to the adapter to state.

## Changes

- `lib/adapter.ts` — new exported `DataSyncStartControl` union and the optional `supportsStartControl?(control, entityType)` method on `DataSyncAdapter`.
- `lib/start-controls.ts` (new) — `resolveStartControlMap` (server) and `applicableStartControls` (client), both pure. A throwing predicate counts as *applies*, because `api/options.ts` resolves every registered adapter in one response and one broken predicate must not blank the dashboard for the rest. The accumulator has a null prototype and the client lookup is own-property only, so an entity type named after something on `Object.prototype` cannot silently lose its declaration.
- `api/options.ts` — one additive `startControls` field per item.
- `backend/data-sync/page.tsx` — renders each control only when it applies, drops the row when neither does. A hidden control is **omitted from the request body** (so `runSyncSchema`'s own defaults supply the value the rendered form would have sent) and its state resets when it stops applying, so switching entity types cannot carry a stale value forward. The batch-size range check runs only when that input is on screen.
- One new locale key across all five locale files — the card's description enumerates *"Batch size and full-sync mode"*, which stops being true once a control is hidden. The original string is untouched on the default path.
- `BACKWARD_COMPATIBILITY.md`, module `AGENTS.md`, and `apps/docs/.../integrations-data-sync.mdx`.

**`POST /api/data_sync/run` is untouched and keeps honouring `fullSync` and `batchSize` whatever an adapter declares.** This is a UI-applicability change, not a behaviour change: a script, an API client or a stale browser tab posting `fullSync: true` still gets a `null` start cursor. There is a test pinning exactly that against an adapter that declares the control inapplicable.

**Scope, stated explicitly in the docstring:** the predicate gates the *Run once now* card only. It does not gate the recurring-schedule switch, nor the integration settings tab's per-entity-type "Full" switch — whose row-level run posts that schedule's own `fullSync` to the same run API. Harmless by construction (the adapter has said the value does not matter), but not to be read as covering every place a run can be started.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/2026-09-02-data-sync-adapter-start-controls.md`

It is the first commit, so the design can be ruled on before the diff is read.

## Testing

`yarn typecheck`, `yarn generate` (no diff), `yarn agents:check-budget`, `yarn i18n:check-sync`, `yarn build:packages`, `eslint` and the DS lint config over `data_sync` — all clean, run locally.

`data_sync` suites: **35 passed, 248 tests** (from 32 / 226 on `develop`). New coverage:

- `lib/__tests__/start-controls.test.ts` — sparse-map construction, per-control and per-entity-type resolution, undeclared adapter → `{}`, non-boolean and throwing predicates, own-property lookup, and a prototype-named entity type surviving serialization as an own entry.
- `api/__tests__/options.test.ts` — the resolved map on the wire, `{}` for an adapter that declares nothing, and a still-`200` response when a predicate throws. **The options route had no unit test at all before this**, so this covers pre-existing behaviour too.
- `backend/data-sync/__tests__/page.test.tsx` — the control does not render for a restricted entity type, renders for an unrestricted one, and an undeclared adapter renders both. **The dashboard page had no test before this.**
- `api/__tests__/run.test.ts` — extended: `fullSync: true` still yields a `null` cursor against an adapter declaring the control inapplicable.
- `__integration__/TC-DS-011.spec.ts` — the wire contract: every integration advertises a well-formed `startControls` object keyed only by its own `supportedEntities`.

Also exercised against a throwaway instance: `GET /api/data_sync/options` returns `startControls: {}` for both registered integrations (neither declares the predicate, so the form is byte-identical to today), and `POST /api/data_sync/run` accepted all three request shapes the form can now produce — full body, `fullSync`/`batchSize` omitted, and `fullSync: true`.

Pre-existing failures, verified by checking out `develop` in the same workspace and reproducing them identically — none caused by this change:

- 10 `@open-mercato/documents` suites (`Cannot find module '#generated/entities.ids.generated'`) — 10 failed / 143 passed on both.
- 1 `staff` timesheets test (`page.durationEntry.test.tsx`).
- `yarn build:app` fails on `develop` too, with ~530 `module-not-found` errors for `generated/entities.ids.generated.js` — it needs generated artifacts this DB-less workspace never produced. `yarn build:packages` is clean.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- left for a human to tick -->
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests — `packages/core/src/modules/data_sync/__integration__/TC-DS-011.spec.ts`. Placed in the module's `__integration__/` folder per `.ai/qa/AGENTS.md` ("Never put executable `.spec.ts` files under `.ai/qa/tests`"), which reads as superseding this line's wording.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry.
- [ ] Priority set — cannot apply labels here (no `triage` on this repo); intent below.
- [ ] Risk set — same.
- [ ] QA routing set — same. This change touches a `.tsx` outside tests, so the automated-verification exemption does not apply and it should be `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors — the diff adds none (verified by grep over added lines).
- [x] No arbitrary text sizes. The diff does add two arbitrary *grid templates*, `grid-cols-[minmax(0,180px)_1fr]` (pre-existing, moved) and `grid-cols-[minmax(0,180px)]` (new, so the batch-size-only row does not reserve an empty second column). Flagging them for transparency; happy to change the approach if you would rather not grow that pattern.
- [ ] Empty state handled for list/data pages — **not ticked.** The page's DataTable has a pre-existing `om-ds/require-empty-state` warning that this PR neither introduces nor fixes, as it is outside the change's scope.
- [x] Loading state handled for async pages — unchanged; the page's existing loading handling is untouched.
- [x] `aria-label` on all icon-only buttons — no icon-only buttons added.
- [x] Uses existing DS components — `Label`, `Input`, `Switch` only; no custom replacements.

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791014389&installation_model_id=432243&pr_number=5863&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5863&signature=53b128e88b48fa911a126b72ed2537037b6090a041740995ba71e0d99d4ee3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->