### PR TITLE
fix(planner): anchor availability DTSTART to the declared timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,65 @@ jobs:
         # scans — the whole set is ~10 s, so it stays on the common PR path.
         run: yarn test:repo-wide-guards
 
+  # ── Core suite under a non-UTC timezone ────────────────────────────────────
+  # Runners default to UTC, where wall-clock/timezone defects are invisible: the
+  # planner DTSTART bug (#5862) was built from the host clock, yet every suite
+  # passed at TZ=UTC with it fully present, because the fixtures only ever used
+  # `...Z` values. This job re-runs @open-mercato/core under a positive-offset
+  # zone whose local date differs from UTC for part of the day, so host-clock
+  # leakage fails the build instead of shipping. Kept as its own job rather than
+  # a step in `test`, which is sharded and would repeat the run per shard.
+  core-timezone:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [prepare, audit-scope, audit, lint]
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.audit-scope.result == 'success' &&
+      (needs.audit.result == 'success' || needs.audit.result == 'skipped') &&
+      needs.lint.result == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Yarn packages
+        uses: actions/cache@v6
+        with:
+          path: .yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+
+      - name: Cache node_modules
+        id: nm-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifacts
+
+      - name: Run core suite at TZ=Pacific/Auckland
+        run: yarn workspace @open-mercato/core test:tz
+
   # ── Documents multi-instance durability ────────────────────────────────────
   # The standard Documents Jest suite intentionally skips this infrastructure
   # regression. Run it as a dedicated required job on GitHub's Docker-capable

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "build": "node build.mjs",
     "watch": "node watch.mjs",
     "test": "jest --config jest.config.cjs",
+    "test:tz": "cross-env TZ=Pacific/Auckland jest --config jest.config.cjs",
     "typecheck": "tsc --noEmit"
   },
   "imports": {
@@ -270,6 +271,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "chance": "^1.1.13",
+    "cross-env": "^10.1.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "react": "19.2.8",

--- a/packages/core/src/modules/planner/__tests__/availabilityTimezone.test.ts
+++ b/packages/core/src/modules/planner/__tests__/availabilityTimezone.test.ts
@@ -1,0 +1,149 @@
+/** @jest-environment node */
+
+/**
+ * Unit coverage for the planner timezone primitives (issue #5862).
+ *
+ * Every expectation here is an absolute instant or a zone-relative calendar
+ * field, so none of them may depend on the host process's `TZ`. The suite runs
+ * on both CI legs (`test` at UTC and `test:tz` at a positive offset).
+ */
+
+import {
+  nextWeekdayDateKey,
+  resolveTimeZone,
+  zonedDateKey,
+  zonedWallTimeToInstant,
+  zonedWeekday,
+} from '../lib/availabilityTimezone'
+import {
+  plannerAvailabilityDateSpecificReplaceSchema,
+  plannerAvailabilityWeeklyReplaceSchema,
+} from '../data/validators'
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const SUBJECT_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+describe('resolveTimeZone', () => {
+  it('passes through a resolvable IANA zone', () => {
+    expect(resolveTimeZone('Europe/Warsaw')).toBe('Europe/Warsaw')
+    expect(resolveTimeZone('  Pacific/Auckland  ')).toBe('Pacific/Auckland')
+  })
+
+  it('degrades an unresolvable or empty zone to UTC rather than throwing', () => {
+    // Legacy rows store `timezone` as free-form text, so a malformed value must
+    // not turn a read into a 500. Writes reject it at the schema instead.
+    expect(resolveTimeZone('Europe/Warszawa')).toBe('UTC')
+    expect(resolveTimeZone('')).toBe('UTC')
+    expect(resolveTimeZone('   ')).toBe('UTC')
+    expect(resolveTimeZone(null)).toBe('UTC')
+    expect(resolveTimeZone(undefined)).toBe('UTC')
+  })
+})
+
+describe('zonedWallTimeToInstant', () => {
+  it('resolves wall time against the given zone', () => {
+    expect(zonedWallTimeToInstant('2026-06-15', '09:00', 'UTC')?.toISOString())
+      .toBe('2026-06-15T09:00:00.000Z')
+    // CEST (+2) in June.
+    expect(zonedWallTimeToInstant('2026-06-15', '09:00', 'Europe/Warsaw')?.toISOString())
+      .toBe('2026-06-15T07:00:00.000Z')
+    // NZST (+12) — lands on the previous UTC day.
+    expect(zonedWallTimeToInstant('2026-06-15', '09:00', 'Pacific/Auckland')?.toISOString())
+      .toBe('2026-06-14T21:00:00.000Z')
+    // EDT (-4) — lands later the same UTC day.
+    expect(zonedWallTimeToInstant('2026-06-15', '09:00', 'America/New_York')?.toISOString())
+      .toBe('2026-06-15T13:00:00.000Z')
+  })
+
+  it('tracks the zone offset across a DST transition', () => {
+    // Warsaw is +2 before 2026-10-25 and +1 after, so the same wall time maps
+    // to different instants either side of the boundary.
+    expect(zonedWallTimeToInstant('2026-10-24', '09:00', 'Europe/Warsaw')?.toISOString())
+      .toBe('2026-10-24T07:00:00.000Z')
+    expect(zonedWallTimeToInstant('2026-10-26', '09:00', 'Europe/Warsaw')?.toISOString())
+      .toBe('2026-10-26T08:00:00.000Z')
+  })
+
+  it('rejects malformed date keys and times', () => {
+    expect(zonedWallTimeToInstant('15-06-2026', '09:00', 'UTC')).toBeNull()
+    expect(zonedWallTimeToInstant('', '09:00', 'UTC')).toBeNull()
+    expect(zonedWallTimeToInstant('2026-06-15', '25:00', 'UTC')).toBeNull()
+    expect(zonedWallTimeToInstant('2026-06-15', '09:61', 'UTC')).toBeNull()
+    expect(zonedWallTimeToInstant('2026-06-15', 'nope', 'UTC')).toBeNull()
+  })
+})
+
+describe('zonedDateKey', () => {
+  it('reports the calendar day as seen from the zone', () => {
+    const instant = new Date('2026-06-14T21:00:00Z')
+    expect(zonedDateKey(instant, 'UTC')).toBe('2026-06-14')
+    // The same instant is already the 15th in Auckland.
+    expect(zonedDateKey(instant, 'Pacific/Auckland')).toBe('2026-06-15')
+    expect(zonedDateKey(instant, 'America/New_York')).toBe('2026-06-14')
+  })
+
+  it('falls back to UTC for an unresolvable zone', () => {
+    expect(zonedDateKey(new Date('2026-06-14T21:00:00Z'), 'Not/AZone')).toBe('2026-06-14')
+  })
+})
+
+describe('zonedWeekday', () => {
+  it('reports the weekday as seen from the zone', () => {
+    // 2026-06-14T21:00Z is a Sunday in UTC, Monday in Auckland.
+    const instant = new Date('2026-06-14T21:00:00Z')
+    expect(zonedWeekday(instant, 'UTC')).toBe(0)
+    expect(zonedWeekday(instant, 'Pacific/Auckland')).toBe(1)
+  })
+})
+
+describe('nextWeekdayDateKey', () => {
+  const from = new Date('2026-06-15T12:00:00Z') // Monday in UTC
+
+  it('returns today when the requested weekday is today in that zone', () => {
+    expect(nextWeekdayDateKey(1, 'UTC', from)).toBe('2026-06-15')
+  })
+
+  it('rolls forward a full week when the zone is already past that weekday', () => {
+    // 12:00Z Monday is Tuesday in Auckland, so the next Monday is the 22nd.
+    // Reading the weekday from the host clock shifted the whole series.
+    expect(nextWeekdayDateKey(1, 'Pacific/Auckland', from)).toBe('2026-06-22')
+  })
+
+  it('finds the next occurrence later in the same week', () => {
+    expect(nextWeekdayDateKey(3, 'UTC', from)).toBe('2026-06-17')
+    expect(nextWeekdayDateKey(0, 'UTC', from)).toBe('2026-06-21')
+  })
+})
+
+describe('replace schemas reject an unresolvable timezone at the boundary', () => {
+  const weeklyBase = {
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    subjectType: 'member' as const,
+    subjectId: SUBJECT_ID,
+    windows: [{ weekday: 1, start: '09:00', end: '17:00' }],
+  }
+  const dateSpecificBase = {
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    subjectType: 'member' as const,
+    subjectId: SUBJECT_ID,
+    dates: ['2026-06-15'],
+    windows: [{ start: '09:00', end: '17:00' }],
+  }
+
+  it('accepts resolvable zones', () => {
+    expect(plannerAvailabilityWeeklyReplaceSchema.safeParse({ ...weeklyBase, timezone: 'Europe/Warsaw' }).success).toBe(true)
+    expect(plannerAvailabilityDateSpecificReplaceSchema.safeParse({ ...dateSpecificBase, timezone: 'UTC' }).success).toBe(true)
+  })
+
+  it('rejects a plausible-looking but unknown zone instead of silently anchoring it to UTC', () => {
+    // Pre-fix the field was inert so a typo cost nothing; it is load-bearing
+    // now, and a bad value would persist a permanently mis-anchored DTSTART
+    // indistinguishable from a correct row.
+    expect(plannerAvailabilityWeeklyReplaceSchema.safeParse({ ...weeklyBase, timezone: 'Europe/Warszawa' }).success).toBe(false)
+    expect(plannerAvailabilityDateSpecificReplaceSchema.safeParse({ ...dateSpecificBase, timezone: 'Mars/Olympus_Mons' }).success).toBe(false)
+    expect(plannerAvailabilityWeeklyReplaceSchema.safeParse({ ...weeklyBase, timezone: '' }).success).toBe(false)
+  })
+})

--- a/packages/core/src/modules/planner/api/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/api/availability-date-specific.ts
@@ -10,6 +10,7 @@ import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/er
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { plannerAvailabilityDateSpecificReplaceSchema } from '../data/validators'
+import { zonedDateKey } from '../lib/availabilityTimezone'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -93,7 +94,10 @@ export async function POST(req: Request) {
         const blocked = rules.some((rule) => {
           const window = parseAvailabilityRuleWindow(rule)
           if (window.repeat !== 'once') return false
-          return dateSet.has(formatDateKey(window.startAt))
+          // Resolved in the rule's own zone so this gate agrees with
+          // `planner.availability.date-specific.replace` and does not depend
+          // on the host clock.
+          return dateSet.has(zonedDateKey(window.startAt, rule.timezone))
         })
         if (blocked) {
           throw new CrudHttpError(403, { error: translate('planner.availability.errors.unauthorized', 'Unauthorized') })
@@ -215,9 +219,3 @@ function resolveDateSet(input: { date?: string; dates?: string[] }): Set<string>
   return dates
 }
 
-function formatDateKey(value: Date): string {
-  const year = value.getFullYear()
-  const month = String(value.getMonth() + 1).padStart(2, '0')
-  const day = String(value.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}

--- a/packages/core/src/modules/planner/commands/__tests__/availability-timezone-invariance.test.ts
+++ b/packages/core/src/modules/planner/commands/__tests__/availability-timezone-invariance.test.ts
@@ -1,0 +1,234 @@
+/** @jest-environment node */
+
+/**
+ * Timezone handling for the planner availability write commands (issue #5862).
+ *
+ * The structured replace endpoints receive the author's wall-clock time
+ * (`windows: [{ start: 'HH:MM', … }]`) together with the intended IANA zone
+ * (`timezone`) in the same payload. `DTSTART` must be a function of those two
+ * inputs ONLY — never of the host process's `TZ`.
+ *
+ * Before the fix it was a function of the host clock: the builders constructed
+ * the instant with the local `Date` constructor and labelled the result `Z`, so
+ * the same request persisted a different absolute instant depending on which
+ * machine served it.
+ *
+ * TWO KINDS OF ASSERTION HERE, AND BOTH ARE NEEDED
+ *
+ * 1. `timezone: 'UTC'` cases pin host-`TZ` invariance. Every helper in
+ *    `availabilityTimezone.ts` is the identity transform at UTC, so these stay
+ *    correct under either resolution of the semantic fork in #5862 and will not
+ *    need rewriting when it is settled.
+ * 2. Non-UTC cases pin the behaviour this change actually introduces — that the
+ *    DECLARED zone is what anchors the instant. Without these, discarding the
+ *    caller's zone entirely (returning UTC unconditionally from
+ *    `resolveTimeZone`) leaves group 1 green at every host `TZ`, so the suite
+ *    would not detect a regression to zone-blind writes.
+ *
+ * HOW TO RUN
+ *
+ * `process.env.TZ` cannot be reassigned mid-run: inside a jest worker the
+ * mutation is silently ignored, though the same reassignment does take effect
+ * in plain node — which makes this an easy trap. The zone must come from the
+ * runner, so this suite is executed twice:
+ *
+ *     yarn workspace @open-mercato/core test availability-timezone   # TZ=UTC
+ *     yarn workspace @open-mercato/core test:tz                      # non-UTC
+ *
+ * Both legs run in CI. A suite that only ever ran at `TZ=UTC` passed with this
+ * bug fully present, which is precisely why it shipped.
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const SUBJECT_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+const DATE = '2026-06-15'
+// 2026-06-15 is a Monday in UTC. Pinned so the weekly weekday anchor, which the
+// command derives from "now", is deterministic.
+const NOW = '2026-06-15T12:00:00Z'
+const MONDAY = 1
+
+const DATE_SPECIFIC = 'planner.availability.date-specific.replace'
+const WEEKLY = 'planner.availability.weekly.replace'
+
+function makeEm() {
+  const created: Record<string, unknown>[] = []
+  const em: Record<string, unknown> = {
+    find: jest.fn(async () => []),
+    findOne: jest.fn(async () => null),
+    create: jest.fn((_cls: unknown, data: Record<string, unknown>) => {
+      created.push(data)
+      return { ...data }
+    }),
+    persist: jest.fn(() => undefined),
+    flush: jest.fn(async () => undefined),
+    transactional: jest.fn(async (cb: (trx: unknown) => Promise<unknown>) => cb(em)),
+    fork() {
+      return this
+    },
+  }
+  return { em, created }
+}
+
+function makeCtx(em: unknown) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({ em: asValue(em) })
+  return {
+    container,
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: new Request('https://example.test/api/planner/availability', { method: 'POST' }),
+  }
+}
+
+async function persistedRrules(commandId: string, input: Record<string, unknown>): Promise<string[]> {
+  const { em, created } = makeEm()
+  const handler = commandRegistry.get(commandId)
+  expect(handler).toBeTruthy()
+  await handler!.execute(input as never, makeCtx(em) as never)
+  return created.map((row) => String(row.rrule))
+}
+
+function dtStartOf(rrule: string): string {
+  const match = rrule.match(/DTSTART[:=](\d{8}T\d{6}Z?)/)
+  if (!match?.[1]) throw new Error(`[internal] no DTSTART in rrule: ${rrule}`)
+  return match[1]
+}
+
+function bydayOf(rrule: string): string | null {
+  return rrule.match(/BYDAY=([A-Z]{2})/)?.[1] ?? null
+}
+
+function dateSpecificInput(timezone: string, windows: { start: string; end: string }[]) {
+  return {
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    // `member` avoids the rule-set optimistic-lock branch; the DTSTART builder
+    // under test is shared by every subject type.
+    subjectType: 'member',
+    subjectId: SUBJECT_ID,
+    timezone,
+    dates: [DATE],
+    windows,
+    kind: 'availability',
+  }
+}
+
+function weeklyInput(timezone: string) {
+  return {
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    subjectType: 'member',
+    subjectId: SUBJECT_ID,
+    timezone,
+    windows: [{ weekday: MONDAY, start: '09:00', end: '17:00' }],
+  }
+}
+
+describe(`planner availability writes (host TZ=${process.env.TZ ?? 'unset'})`, () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../availability-date-specific')
+    await import('../availability-weekly')
+  })
+
+  describe('host-TZ invariance — holds under either resolution of #5862', () => {
+    it('date-specific replace anchors the window to the declared zone', async () => {
+      const rrules = await persistedRrules(DATE_SPECIFIC, dateSpecificInput('UTC', [{ start: '09:00', end: '17:00' }]))
+      expect(rrules.map(dtStartOf)).toEqual(['20260615T090000Z'])
+    })
+
+    it('date-specific full-day unavailability starts at midnight in the declared zone', async () => {
+      const rrules = await persistedRrules(DATE_SPECIFIC, {
+        ...dateSpecificInput('UTC', []),
+        isAvailable: false,
+        kind: 'unavailability',
+      })
+      expect(rrules.map(dtStartOf)).toEqual(['20260615T000000Z'])
+    })
+
+    it('weekly replace derives the weekday anchor in the declared zone', async () => {
+      jest.useFakeTimers({ now: new Date(NOW), doNotFake: ['queueMicrotask', 'nextTick'] })
+      try {
+        const rrules = await persistedRrules(WEEKLY, weeklyInput('UTC'))
+        expect(rrules.map(dtStartOf)).toEqual(['20260615T090000Z'])
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+  })
+
+  describe('the declared zone is what anchors the instant', () => {
+    it('anchors a Europe/Warsaw window at that zone offset, not UTC and not the host', async () => {
+      const rrules = await persistedRrules(
+        DATE_SPECIFIC,
+        dateSpecificInput('Europe/Warsaw', [{ start: '09:00', end: '17:00' }]),
+      )
+      // 09:00 CEST (+2) === 07:00Z. Discarding the zone would yield 09:00Z.
+      expect(rrules.map(dtStartOf)).toEqual(['20260615T070000Z'])
+    })
+
+    it('anchors a Pacific/Auckland window onto the previous UTC day', async () => {
+      const rrules = await persistedRrules(
+        DATE_SPECIFIC,
+        dateSpecificInput('Pacific/Auckland', [{ start: '09:00', end: '17:00' }]),
+      )
+      // 09:00 NZST (+12) on the 15th is 21:00Z on the 14th — a different
+      // calendar date, which no same-day assertion can catch.
+      expect(rrules.map(dtStartOf)).toEqual(['20260614T210000Z'])
+    })
+
+    it('anchors a full-day Europe/Warsaw block to that zone midnight', async () => {
+      const rrules = await persistedRrules(DATE_SPECIFIC, {
+        ...dateSpecificInput('Europe/Warsaw', []),
+        isAvailable: false,
+        kind: 'unavailability',
+      })
+      // Midnight in Warsaw is 22:00Z the previous day. The UTC-only expander
+      // therefore reads this row as the 14th — a known layer-2 consequence
+      // tracked in #5862, pinned here so the shift is visible rather than
+      // rediscovered as a fresh defect.
+      expect(rrules.map(dtStartOf)).toEqual(['20260614T220000Z'])
+    })
+
+    it('resolves the weekly anchor and BYDAY in the declared zone, across a UTC day boundary', async () => {
+      jest.useFakeTimers({ now: new Date(NOW), doNotFake: ['queueMicrotask', 'nextTick'] })
+      try {
+        const rrules = await persistedRrules(WEEKLY, weeklyInput('Pacific/Auckland'))
+        expect(rrules).toHaveLength(1)
+        // At 12:00Z Monday it is already Tuesday in Auckland, so the next
+        // Monday is the 22nd — 09:00 there is 21:00Z on Sunday the 21st.
+        // Host-clock arithmetic picked a different week entirely.
+        expect(dtStartOf(rrules[0])).toBe('20260621T210000Z')
+        // BYDAY is zone-relative by design: a UTC Sunday DTSTART carrying
+        // BYDAY=MO. See the note in `buildWeeklyRrule`.
+        expect(bydayOf(rrules[0])).toBe('MO')
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('keeps the window duration intact when the zone shifts the anchor', async () => {
+      const rrules = await persistedRrules(
+        DATE_SPECIFIC,
+        dateSpecificInput('Pacific/Auckland', [{ start: '09:00', end: '17:00' }]),
+      )
+      expect(rrules[0]).toContain('DURATION:PT8H')
+    })
+  })
+})

--- a/packages/core/src/modules/planner/commands/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/commands/availability-date-specific.ts
@@ -3,6 +3,7 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseAvailabilityRuleWindow } from '@open-mercato/core/modules/planner/lib/availabilitySchedule'
+import { zonedDateKey, zonedWallTimeToInstant } from '@open-mercato/core/modules/planner/lib/availabilityTimezone'
 import { PlannerAvailabilityRule } from '../data/entities'
 import {
   plannerAvailabilityDateSpecificReplaceSchema,
@@ -52,22 +53,9 @@ type DateSpecificUndoPayload = {
   after: AvailabilityRuleSnapshot[]
 }
 
-function parseTimeInput(value: string): { hours: number; minutes: number } | null {
-  const [hours, minutes] = value.split(':').map((part) => Number(part))
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null
-  return { hours, minutes }
-}
-
-function toDateForDay(value: string, time: string): Date | null {
-  if (!value) return null
-  const parsed = parseTimeInput(time)
-  if (!parsed) return null
-  const parts = value.split('-').map((part) => Number(part))
-  if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) return null
-  const [year, month, day] = parts
-  const date = new Date(year, month - 1, day, parsed.hours, parsed.minutes, 0, 0)
-  return Number.isNaN(date.getTime()) ? null : date
+function toDateForDay(dateKey: string, time: string, timeZone: string): Date | null {
+  if (!dateKey) return null
+  return zonedWallTimeToInstant(dateKey, time, timeZone)
 }
 
 function formatDuration(minutes: number): string {
@@ -86,18 +74,11 @@ function buildAvailabilityRrule(start: Date, end: Date): string {
   return `DTSTART:${dtStart}\nDURATION:${duration}\nRRULE:FREQ=DAILY;COUNT=1`
 }
 
-function buildFullDayRrule(date: string): string | null {
-  const start = toDateForDay(date, '00:00')
+function buildFullDayRrule(date: string, timeZone: string): string | null {
+  const start = toDateForDay(date, '00:00', timeZone)
   if (!start) return null
   const end = new Date(start.getTime() + 24 * 60 * 60 * 1000)
   return buildAvailabilityRrule(start, end)
-}
-
-function formatDateKey(value: Date): string {
-  const year = value.getFullYear()
-  const month = String(value.getMonth() + 1).padStart(2, '0')
-  const day = String(value.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
 }
 
 function toAvailabilityRuleSnapshot(record: PlannerAvailabilityRule): AvailabilityRuleSnapshot {
@@ -140,7 +121,7 @@ async function loadDateSpecificSnapshots(
     .filter((rule) => {
       const window = parseAvailabilityRuleWindow(rule)
       if (window.repeat !== 'once') return false
-      return params.dates.has(formatDateKey(window.startAt))
+      return params.dates.has(zonedDateKey(window.startAt, rule.timezone))
     })
     .map(toAvailabilityRuleSnapshot)
 }
@@ -223,7 +204,7 @@ const replaceDateSpecificAvailabilityCommand: CommandHandler<PlannerAvailability
         const toDelete = existing.filter((rule) => {
           const window = parseAvailabilityRuleWindow(rule)
           if (window.repeat !== 'once') return false
-          return dates.has(formatDateKey(window.startAt))
+          return dates.has(zonedDateKey(window.startAt, rule.timezone))
         })
         enforceCommandOptimisticLock({
           resourceKind: AVAILABILITY_RULE_RESOURCE_KIND,
@@ -244,7 +225,7 @@ const replaceDateSpecificAvailabilityCommand: CommandHandler<PlannerAvailability
 
       if (!isAvailable) {
         dates.forEach((date) => {
-          const rrule = buildFullDayRrule(date)
+          const rrule = buildFullDayRrule(date, parsed.timezone)
           if (!rrule) return
           const record = trx.create(PlannerAvailabilityRule, {
             tenantId: parsed.tenantId,
@@ -266,8 +247,8 @@ const replaceDateSpecificAvailabilityCommand: CommandHandler<PlannerAvailability
       } else {
         dates.forEach((date) => {
           windows.forEach((window) => {
-            const start = toDateForDay(date, window.start)
-            const end = toDateForDay(date, window.end)
+            const start = toDateForDay(date, window.start, parsed.timezone)
+            const end = toDateForDay(date, window.end, parsed.timezone)
             if (!start || !end || start >= end) return
             const rrule = buildAvailabilityRrule(start, end)
             const record = trx.create(PlannerAvailabilityRule, {

--- a/packages/core/src/modules/planner/commands/availability-weekly.ts
+++ b/packages/core/src/modules/planner/commands/availability-weekly.ts
@@ -2,6 +2,7 @@ import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { parseAvailabilityRuleWindow } from '@open-mercato/core/modules/planner/lib/availabilitySchedule'
+import { nextWeekdayDateKey, zonedWallTimeToInstant, zonedWeekday } from '@open-mercato/core/modules/planner/lib/availabilityTimezone'
 import { PlannerAvailabilityRule, PlannerAvailabilityRuleSet } from '../data/entities'
 import {
   plannerAvailabilityWeeklyReplaceSchema,
@@ -54,22 +55,14 @@ type WeeklyUndoPayload = {
   after: AvailabilityRuleSnapshot[]
 }
 
-function parseTimeInput(value: string): { hours: number; minutes: number } | null {
-  const [hours, minutes] = value.split(':').map((part) => Number(part))
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null
-  return { hours, minutes }
-}
-
-function toDateForWeekday(weekday: number, time: string): Date | null {
-  const parsed = parseTimeInput(time)
-  if (!parsed) return null
-  const now = new Date()
-  const base = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const diff = (weekday - base.getDay() + 7) % 7
-  const target = new Date(base.getTime() + diff * 24 * 60 * 60 * 1000)
-  target.setHours(parsed.hours, parsed.minutes, 0, 0)
-  return target
+/**
+ * `from` is threaded in rather than defaulted per call: resolving a window's
+ * start and end against two separate `new Date()` reads can straddle midnight
+ * in the declared zone, which lands the anchors seven days apart and silently
+ * drops the window at the `start >= end` guard below.
+ */
+function toDateForWeekday(weekday: number, time: string, timeZone: string, from: Date): Date | null {
+  return zonedWallTimeToInstant(nextWeekdayDateKey(weekday, timeZone, from), time, timeZone)
 }
 
 function formatDuration(minutes: number): string {
@@ -81,11 +74,18 @@ function formatDuration(minutes: number): string {
   return `PT${mins}M`
 }
 
-function buildWeeklyRrule(start: Date, end: Date): string {
+function buildWeeklyRrule(start: Date, end: Date, timeZone: string): string {
   const dtStart = start.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
   const durationMinutes = Math.max(1, Math.round((end.getTime() - start.getTime()) / 60000))
   const duration = formatDuration(durationMinutes)
-  const dayCode = DAY_CODES[start.getDay()] ?? 'MO'
+  // `BYDAY` names the weekday the window falls on in its DECLARED zone, which
+  // is the meaningful label for a recurring local-time window. It is therefore
+  // deliberately not consistent with the `Z`-suffixed `DTSTART` beside it: a
+  // Pacific/Auckland Monday 09:00 ships DTSTART:...T210000Z, a Sunday in UTC,
+  // with BYDAY=MO. Nothing in the planner reads BYDAY today (neither the
+  // expander nor `parseAvailabilityRuleWindow`); a future iCal export must
+  // re-derive it from the zone rather than trust it against DTSTART.
+  const dayCode = DAY_CODES[zonedWeekday(start, timeZone)] ?? 'MO'
   return `DTSTART:${dtStart}\nDURATION:${duration}\nRRULE:FREQ=WEEKLY;BYDAY=${dayCode}`
 }
 
@@ -247,10 +247,10 @@ const replaceWeeklyAvailabilityCommand: CommandHandler<PlannerAvailabilityWeekly
       }
 
       parsed.windows.forEach((window) => {
-        const start = toDateForWeekday(window.weekday, window.start)
-        const end = toDateForWeekday(window.weekday, window.end)
+        const start = toDateForWeekday(window.weekday, window.start, parsed.timezone, now)
+        const end = toDateForWeekday(window.weekday, window.end, parsed.timezone, now)
         if (!start || !end || start >= end) return
-        const rrule = buildWeeklyRrule(start, end)
+        const rrule = buildWeeklyRrule(start, end, parsed.timezone)
         const record = trx.create(PlannerAvailabilityRule, {
           tenantId: parsed.tenantId,
           organizationId: parsed.organizationId,

--- a/packages/core/src/modules/planner/data/validators.ts
+++ b/packages/core/src/modules/planner/data/validators.ts
@@ -69,11 +69,27 @@ const dateSpecificWindowSchema = z.object({
 
 const dateSpecificDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
 
+/**
+ * The replace endpoints anchor `DTSTART` in this zone, so an unresolvable value
+ * would persist a UTC-anchored instant under a label nothing can resolve —
+ * permanently mis-anchored and indistinguishable from a correctly written row.
+ * Reject at the boundary; the read path still degrades unknown stored zones to
+ * UTC so legacy rows cannot turn a read into a 500.
+ */
+const resolvableTimeZoneSchema = z.string().min(1).refine((value) => {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value })
+    return true
+  } catch {
+    return false
+  }
+}, { message: 'Unknown IANA time zone' })
+
 export const plannerAvailabilityWeeklyReplaceSchema = z.object({
   ...scopedCreateFields,
   subjectType: availabilitySubjectSchema,
   subjectId: z.string().uuid(),
-  timezone: z.string().min(1),
+  timezone: resolvableTimeZoneSchema,
   windows: z.array(weeklyWindowSchema).default([]),
 })
 
@@ -83,7 +99,7 @@ export const plannerAvailabilityDateSpecificReplaceSchema = z.object({
   ...scopedCreateFields,
   subjectType: availabilitySubjectSchema,
   subjectId: z.string().uuid(),
-  timezone: z.string().min(1),
+  timezone: resolvableTimeZoneSchema,
   date: dateSpecificDateSchema.optional(),
   dates: z.array(dateSpecificDateSchema).optional(),
   windows: z.array(dateSpecificWindowSchema).default([]),

--- a/packages/core/src/modules/planner/lib/availabilityTimezone.ts
+++ b/packages/core/src/modules/planner/lib/availabilityTimezone.ts
@@ -1,0 +1,73 @@
+import { addDays, format } from 'date-fns'
+import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz'
+
+const FALLBACK_TIME_ZONE = 'UTC'
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Availability rows store `timezone` as free-form `text`, so a malformed value
+ * must not turn a read or a write into a 500. Unknown zones degrade to UTC,
+ * which is already how the expander interprets every stored instant.
+ */
+export function resolveTimeZone(value: string | null | undefined): string {
+  if (typeof value !== 'string' || !value.trim().length) return FALLBACK_TIME_ZONE
+  const candidate = value.trim()
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: candidate })
+    return candidate
+  } catch {
+    return FALLBACK_TIME_ZONE
+  }
+}
+
+function parseTimeOfDay(value: string): { hours: number; minutes: number } | null {
+  const [hours, minutes] = String(value).split(':').map((part) => Number(part))
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null
+  return { hours, minutes }
+}
+
+/**
+ * `2026-06-15` + `09:00` + `Europe/Warsaw` → the absolute instant that wall
+ * time denotes. Replaces `new Date(y, m, d, h, min)`, whose result depended on
+ * the host process's `TZ` rather than on the zone the caller declared (#5862).
+ */
+export function zonedWallTimeToInstant(dateKey: string, time: string, timeZone: string): Date | null {
+  if (!DATE_KEY_PATTERN.test(String(dateKey))) return null
+  const parsed = parseTimeOfDay(time)
+  if (!parsed) return null
+  const hours = String(parsed.hours).padStart(2, '0')
+  const minutes = String(parsed.minutes).padStart(2, '0')
+  const instant = fromZonedTime(`${dateKey}T${hours}:${minutes}:00`, resolveTimeZone(timeZone))
+  return Number.isNaN(instant.getTime()) ? null : instant
+}
+
+/**
+ * The calendar date an instant falls on, as seen from `timeZone`.
+ *
+ * Which day an existing rule belongs to has to be read in that rule's own zone,
+ * the same zone its `DTSTART` was anchored in. Derived from the host clock
+ * instead, replace-by-date selected a different set of rows — and the 403 gate
+ * in `api/availability-date-specific.ts` admitted or refused the same request —
+ * depending on which machine served it.
+ */
+export function zonedDateKey(instant: Date, timeZone: string): string {
+  return formatInTimeZone(instant, resolveTimeZone(timeZone), 'yyyy-MM-dd')
+}
+
+/** `Date.getDay()` index (0 = Sunday) of an instant, as seen from `timeZone`. */
+export function zonedWeekday(instant: Date, timeZone: string): number {
+  return toZonedTime(instant, resolveTimeZone(timeZone)).getDay()
+}
+
+/**
+ * The next occurrence of `weekday` (0 = Sunday) at or after `from`, as a
+ * calendar date key in `timeZone`. The zone matters: at 12:00 UTC on a Monday
+ * it is already Tuesday in `Pacific/Auckland`, which shifted the whole series
+ * by a week before this was zone-aware.
+ */
+export function nextWeekdayDateKey(weekday: number, timeZone: string, from: Date = new Date()): string {
+  const local = toZonedTime(from, resolveTimeZone(timeZone))
+  const diff = (weekday - local.getDay() + 7) % 7
+  return format(addDays(local, diff), 'yyyy-MM-dd')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8566,6 +8566,7 @@ __metadata:
     "@xyflow/react": "npm:^12.11.2"
     ai: "npm:^7.0.4"
     chance: "npm:^1.1.13"
+    cross-env: "npm:^10.1.0"
     date-fns: "npm:4.4.0"
     date-fns-tz: "npm:^3.2.0"
     jest: "npm:^30.4.2"


### PR DESCRIPTION
Fixes the write-path layer of #5862.

## Problem

The structured availability replace endpoints receive the author's wall-clock time and the intended IANA zone **in the same payload** (`timezone` is required alongside `windows: [{ start: 'HH:MM', … }]`), then discarded the zone. `DTSTART` was assembled with the local `Date` constructor and labelled `Z`:

```js
// commands/availability-date-specific.ts (before)
const date = new Date(year, month - 1, day, parsed.hours, parsed.minutes, 0, 0)  // local ctor
const dtStart = start.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'      // → UTC, labelled Z
```

So the persisted instant was a function of the host process's `TZ` rather than of the zone the caller declared. Same request, four machines:

| writer `TZ` | stored `DTSTART` |
|---|---|
| `UTC` | `20260601T090000Z` |
| `Europe/Warsaw` | `20260601T070000Z` |
| `America/New_York` | `20260601T130000Z` |
| `Pacific/Auckland` | `20260531T210000Z` ← previous calendar date |

This is user-visible, not just a data-hygiene issue. The editor reads windows back through browser-local formatters (`AvailabilityRulesEditor.tsx:220-231` uses `getHours()`), so on the dominant server-written path a Warsaw author enters **09:00**, the server stores `09:00Z`, and the form shows **11:00** back.

## What changed

**New — `planner/lib/availabilityTimezone.ts`:** `resolveTimeZone`, `zonedWallTimeToInstant`, `zonedDateKey`, `zonedWeekday`, `nextWeekdayDateKey`, built on `date-fns-tz`. No new production dependency: `date-fns-tz@^3.2.0` is already in `packages/core`, and `fromZonedTime` is already the established pattern in `currencies/services/providers/{nbp,raiffeisen}.ts`.

**Write path:**
- `commands/availability-date-specific.ts` — wall clock resolved in the declared zone
- `commands/availability-weekly.ts` — weekday anchor derived in-zone rather than from `new Date()` + host `getDay()`; `BYDAY` names the weekday the window falls on in its declared zone

**Day resolution, which had to move in lockstep:**
- The two day-key call sites in the date-specific command drive replace-selection. Left on the host clock while `DTSTART` moved to the declared zone, replace-by-date would have missed rows and duplicated rules.
- `api/availability-date-specific.ts` feeds a **403 gate** and read the day from the host clock — so it admitted or refused the same request depending on which machine served it. It also has to agree with the command about which rules fall on a date.

**Boundary validation:** an unresolvable `timezone` is now rejected by the replace schemas. The field was inert before this change, so a typo cost nothing; it is load-bearing now, and `Europe/Warszawa` would otherwise persist a UTC-anchored `DTSTART` under a label nothing can resolve, indistinguishable from a correct row. `resolveTimeZone`'s UTC fallback stays for the read path, where a malformed legacy value must not turn a read into a 500.

Also removes two duplicated `parseTimeInput` copies and two pass-through `formatDateKey` wrappers, and threads a single `now` through both weekly anchor resolutions so a window whose start and end straddle midnight in the declared zone is no longer silently dropped by the `start >= end` guard.

## Verification

`process.env.TZ` **cannot be reassigned inside a jest worker** — the mutation is silently ignored, though the same reassignment does take effect in plain node, which makes this an easy trap. The zone must therefore come from the runner. This PR adds:

- `test:tz` in `packages/core`, plus the `cross-env` devDependency it needs (and the `yarn.lock` entry, without which `yarn install --immutable` fails with `YN0028`)
- a dedicated **`core-timezone` CI job** running the core suite at `TZ=Pacific/Auckland`. Its own job rather than a step in `test`, which is sharded and would repeat the run per shard.

| Gate | Result |
|---|---|
| Full `@open-mercato/core` suite, `TZ=UTC` (`yarn test`) | 1480 suites / 12052 tests pass |
| Full `@open-mercato/core` suite, non-UTC (`yarn test:tz`) | 1480 suites / 12052 tests pass |
| `typecheck` | clean |
| `eslint` on changed files | clean |
| `yarn install --immutable` against the committed tree | clean |

The suite now pins **two** distinct things, because either alone is insufficient:

1. **Host-`TZ` invariance** — cases with `timezone: 'UTC'`, where every helper is the identity transform. Correct under either resolution of the semantic fork in #5862, so they will not need rewriting once it is settled.
2. **That the declared zone is what anchors the instant** — `Europe/Warsaw` 09:00 → `20260615T070000Z`; `Pacific/Auckland` 09:00 → `20260614T210000Z` (previous UTC day); a weekly `Pacific/Auckland` Monday window landing on `20260621T210000Z`, a UTC **Sunday**, carrying `BYDAY=MO`.

Group 2 exists because group 1 alone did not pin the behaviour this PR introduces. Mutating `resolveTimeZone` to be zone-blind (returning UTC unconditionally — the same defect class, landing on UTC instead of the host clock) previously left everything green; it now **fails 10 tests at both zones**. `availabilityTimezone.ts` also has direct unit tests covering the UTC fallback, a DST transition, and the weekday anchor.

Confirmed red-then-green: before the fix, under Auckland the date-specific case produced `20260614T210000Z` and weekly produced `20260621T210000Z` — the latter a **full week off**, because 12:00 UTC on a Monday is already Tuesday in NZ.

## Two things reviewers should weigh

**1. This commits to honouring the declared `timezone` on write.** #5862 leaves open a fork between "planner windows are UTC instants, per-rule timezone stored but unused" and "honour the per-rule timezone". This PR takes the latter for the write path, on the grounds that these endpoints already *require* `timezone`, so consuming it is the faithful reading of the existing contract. It does pre-empt part of that decision; if maintainers prefer the UTC-only reading, group-1 tests still hold and only `availabilityTimezone.ts` changes.

**2. This actively changes what the expander computes for newly written rows** — not merely leaves it wrong. Because `DTSTART` moves, and `getMergedAvailabilityWindows` resolves a `once` rule's day purely in UTC (`startOfDay` at `availabilityMerge.ts:91-93`, `toDayKey` at `:87-89`), the effective day shifts for positive-offset zones:

| declared zone | full-day `DTSTART` | expander's UTC day |
|---|---|---|
| `UTC` | `20260615T000000Z` | 2026-06-15 |
| `Europe/Warsaw` | `20260614T220000Z` | **2026-06-14** |
| `Pacific/Auckland` | `20260614T120000Z` | **2026-06-14** |
| `America/New_York` | `20260615T040000Z` | 2026-06-15 |

A Warsaw tenant marking June 15 unavailable now writes a row the expander reads as June 14. **Impact today is nil** — nothing in the repository calls `getMergedAvailabilityWindows`; `plannerAvailabilityService` is registered in `planner/di.ts` but has no caller outside its own tests. It is still a real change to a DI-registered service's output, so it is pinned by an explicit test rather than left to be rediscovered, and tracked as layer 2 of #5862. Fixing it means making the expander zone-aware, which needs the semantic decision above settled first.

Existing rows are otherwise untouched: no migration, no schema change. A non-UTC tenant's pre-fix and post-fix rows for the same wall time will sit apart by the zone offset until re-saved. Re-anchoring automatically is not safely possible — two write paths baked in two different clocks (server `TZ` for the structured endpoints, browser clock for `createCrud('planner/availability', { rrule })`) and nothing in the row records which one wrote it.

## Deliberately out of scope

- **Client-side builders and read-back display** — `AvailabilityRulesEditor.tsx:295` and `AvailabilitySchedule.tsx:82` still build `DTSTART` from the browser clock, and the read-back formatters still render browser-local rather than in the rule's zone. Needs UI QA and a different review surface. Narrower than before this PR, since the timezone picker defaults to the browser zone and the two usually coincide.
- **The expander** (`lib/availabilityMerge.ts`) — UTC-only day boundaries, UTC `EXDATE` day keys, and DST-drifting `+DAY_MS` / `+7*DAY_MS` stepping. Layers 2–3 in #5862.
- **The `once`-branch duration drop** (`availabilityMerge.ts:97-103` discards `DURATION` and always emits a 24h window) — an expander change that would reinterpret existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
