### PR TITLE
fix(entities): stop coercing select values like "no" into booleans on custom-entity reads (#5791)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/records.get.boolean-tokens.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.get.boolean-tokens.test.ts
@@ -1,0 +1,112 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/entities/api/records'
+import { CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
+
+// Regression coverage for #5791: a `select` option whose value happens to read as a
+// boolean token ("no", "yes", "on", "off", "1", "0", ...) came back from the records
+// API as a real boolean, and the edit form then wrote that boolean back over the
+// stored option. Only fields DECLARED boolean may be parsed as booleans.
+
+const storedRow: Record<string, unknown> = {
+  id: 'rec-1',
+  cf_computed_verdict: 'no',
+  cf_tags: ['no', 'maybe'],
+  cf_is_archived: 'true',
+  cf_notes: 'off',
+  created_at: '2024-10-03T00:00:00Z',
+}
+
+const mockQE = {
+  query: jest.fn(async () => ({ items: [{ ...storedRow }], total: 1, page: 1, pageSize: 50 })),
+}
+
+function defRow(key: string, kind: string) {
+  return {
+    key,
+    kind,
+    isActive: true,
+    deletedAt: null,
+    organizationId: 'org',
+    tenantId: 't1',
+    updatedAt: new Date('2024-10-01T00:00:00Z'),
+  }
+}
+
+const fieldDefs = [
+  defRow('computed_verdict', 'select'),
+  defRow('tags', 'select'),
+  defRow('is_archived', 'boolean'),
+  defRow('notes', 'text'),
+]
+
+const mockEm = {
+  find: jest.fn(async (entityClass: unknown) => (entityClass === CustomFieldDef ? fieldDefs : [])),
+  findOne: jest.fn(async () => ({ id: 'ce-1', entityId: 'outreach:icp_evaluation' })),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({ resolve: (k: string) => (k === 'queryEngine' ? mockQE : mockEm) }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] }) }))
+
+const baseUrl = 'http://x/api/entities/records?entityId=outreach:icp_evaluation&page=1&pageSize=50'
+
+async function getItems(url = baseUrl) {
+  const res = await GET(new Request(url))
+  expect(res.status).toBe(200)
+  const json = await res.json()
+  return json.items as Array<Record<string, unknown>>
+}
+
+async function getFilters(url: string) {
+  await GET(new Request(url))
+  const call = mockQE.query.mock.calls[0] as unknown as [string, { filters?: Record<string, unknown> }]
+  return call[1]?.filters ?? {}
+}
+
+describe('GET /api/entities/records boolean-token handling', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('returns a select value of "no" as the string it was stored as', async () => {
+    const items = await getItems()
+    expect(items[0].computed_verdict).toBe('no')
+  })
+
+  it('preserves boolean-looking entries inside a multi-select array', async () => {
+    const items = await getItems()
+    expect(items[0].tags).toEqual(['no', 'maybe'])
+  })
+
+  it('still parses a field declared boolean into a real boolean', async () => {
+    const items = await getItems()
+    expect(items[0].is_archived).toBe(true)
+  })
+
+  it('leaves text values that read as boolean tokens untouched', async () => {
+    const items = await getItems()
+    expect(items[0].notes).toBe('off')
+  })
+
+  it('filters a select field by its literal string value', async () => {
+    const filters = await getFilters(`${baseUrl}&computed_verdict=no`)
+    expect(filters.computed_verdict).toBe('no')
+  })
+
+  it('filters a cf_-prefixed select field by its literal string value', async () => {
+    const filters = await getFilters(`${baseUrl}&cf_computed_verdict=no`)
+    expect(filters.cf_computed_verdict).toBe('no')
+  })
+
+  it('still coerces a filter on a field declared boolean', async () => {
+    const filters = await getFilters(`${baseUrl}&is_archived=true`)
+    expect(filters.is_archived).toBe(true)
+  })
+
+  it('leaves values as stored when field definitions cannot be loaded', async () => {
+    mockEm.find.mockRejectedValueOnce(new Error('[internal] definitions unavailable'))
+    const items = await getItems()
+    expect(items[0].computed_verdict).toBe('no')
+    expect(items[0].is_archived).toBe('true')
+  })
+})

--- a/packages/core/src/modules/entities/api/__tests__/records.get.custom-entity.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.get.custom-entity.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import { GET } from '@open-mercato/core/modules/entities/api/records'
+import { CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
 
 const mockQE = {
   query: jest.fn(async (_entityId: string, _options: { filters?: Record<string, unknown> }) => ({
@@ -12,7 +13,22 @@ const mockQE = {
   })),
 }
 
+function defRow(key: string, kind: string) {
+  return {
+    key,
+    kind,
+    isActive: true,
+    deletedAt: null,
+    organizationId: 'org',
+    tenantId: 't1',
+    updatedAt: new Date('2024-10-01T00:00:00Z'),
+  }
+}
+
 const mockEm = {
+  find: jest.fn(async (entityClass: unknown) => (
+    entityClass === CustomFieldDef ? [defRow('date', 'boolean'), defRow('how_long', 'integer')] : []
+  )),
   findOne: jest.fn(async () => ({ id: 'ce-1', entityId: 'example:custom' })),
 }
 

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -15,6 +15,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { enforceCommandOptimisticLockWithGuards } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { assertEntityAclForRequest, getDeclaredCustomEntityRestriction } from '../lib/entityAcl'
+import { loadCustomFieldKinds } from '../lib/scoped-field-defs'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('entities').child({ component: 'records' })
@@ -197,24 +198,34 @@ export async function GET(req: Request) {
     if (organizationIds && organizationIds.length === 0) {
       return NextResponse.json({ items: [], total: 0, page, pageSize, totalPages: 0 })
     }
-    const normalizeCustomEntityValue = (value: unknown) => {
-      if (Array.isArray(value)) {
-        return value.map((entry) => {
-          if (typeof entry !== 'string') return entry
-          const parsed = parseBooleanToken(entry)
-          return parsed === null ? entry : parsed
-        })
-      }
-      if (typeof value !== 'string') return value
+    // Doc storage keeps custom-field values as JSON, so a checkbox can arrive as the
+    // string "true"/"1" and must be handed back to the form as a real boolean. That
+    // parse is only ever correct for fields DECLARED boolean: applied blind it also
+    // rewrites legitimate string values whose text happens to be a boolean token —
+    // a `select` option `no` came back as `false`, and the edit form then wrote that
+    // boolean back over the stored option (#5791). Consult the declared kind instead.
+    const needsFieldKinds = isCustomEntity || qpEntries.some(([key]) => key.startsWith('cf_'))
+    const fieldKinds = needsFieldKinds
+      ? await loadCustomFieldKinds(em, { entityId, organizationId: scope.selectedId ?? auth.orgId ?? null, tenantId: auth.tenantId ?? null })
+      : new Map<string, string>()
+    const isBooleanField = (key: string) => fieldKinds.get(key) === 'boolean'
+    const parseBooleanField = (key: string, value: unknown) => {
+      if (typeof value !== 'string' || !isBooleanField(key)) return value
       const parsed = parseBooleanToken(value)
       return parsed === null ? value : parsed
+    }
+    const normalizeCustomEntityValue = (key: string, value: unknown) => {
+      if (Array.isArray(value)) return value.map((entry) => parseBooleanField(key, entry))
+      return parseBooleanField(key, value)
     }
     const mapRow = (row: any) => {
       if (!isCustomEntity || !row || typeof row !== 'object') return row
       const out: Record<string, unknown> = {}
       for (const [k, v] of Object.entries(row)) {
-        if (k.startsWith('cf_')) out[k.replace(/^cf_/, '')] = normalizeCustomEntityValue(v)
-        else out[k] = v
+        if (k.startsWith('cf_')) {
+          const bare = k.replace(/^cf_/, '')
+          out[bare] = normalizeCustomEntityValue(bare, v)
+        } else out[k] = v
       }
       return out
     }
@@ -235,8 +246,7 @@ export async function GET(req: Request) {
             const values = parseCommaSeparatedList(val)
             ;(filtersObj as any)[key] = { $in: values }
           } else {
-            const parsed = parseBooleanToken(val)
-            ;(filtersObj as any)[key] = parsed === null ? val : parsed
+            ;(filtersObj as any)[key] = parseBooleanField(key.replace(/^cf_/, ''), val)
           }
         }
       } else if (allowAnyKey) {
@@ -244,8 +254,7 @@ export async function GET(req: Request) {
           const values = parseCommaSeparatedList(val)
           ;(filtersObj as any)[key] = { $in: values }
         } else {
-          const parsed = parseBooleanToken(val)
-          ;(filtersObj as any)[key] = parsed === null ? val : parsed
+          ;(filtersObj as any)[key] = parseBooleanField(key, val)
         }
       } else {
         if (['id', 'created_at', 'updated_at', 'deleted_at', 'name', 'title', 'email'].includes(key)) {

--- a/packages/core/src/modules/entities/lib/scoped-field-defs.ts
+++ b/packages/core/src/modules/entities/lib/scoped-field-defs.ts
@@ -1,0 +1,76 @@
+import type { EntityManager } from '@mikro-orm/core'
+import { CustomFieldDef } from '../data/entities'
+
+export type ScopedCustomFieldDefsOptions = {
+  entityId: string
+  organizationId?: string | null
+  tenantId?: string | null
+}
+
+// Definitions overlay by scope: an org+tenant row shadows a tenant-global row,
+// which shadows an instance-global one. Duplicate keys within the same scope are
+// resolved by recency so the newest definition wins.
+const scopeScore = (def: CustomFieldDef) => (def.tenantId ? 2 : 0) + (def.organizationId ? 1 : 0)
+
+const definitionTime = (def: CustomFieldDef) =>
+  def.updatedAt instanceof Date ? def.updatedAt.getTime() : new Date(def.updatedAt).getTime()
+
+export async function loadScopedCustomFieldDefs(
+  em: EntityManager,
+  opts: ScopedCustomFieldDefsOptions,
+): Promise<Map<string, CustomFieldDef>> {
+  const organizationId = opts.organizationId ?? null
+  const tenantId = opts.tenantId ?? null
+  const defs = await em.find(CustomFieldDef, {
+    entityId: opts.entityId,
+    isActive: true,
+    deletedAt: null,
+    $and: [
+      {
+        $or: organizationId === null
+          ? [{ organizationId: null }]
+          : [{ organizationId }, { organizationId: null }],
+      },
+      {
+        $or: tenantId === null
+          ? [{ tenantId: null }]
+          : [{ tenantId }, { tenantId: null }],
+      },
+    ],
+  } as any)
+
+  const byKey = new Map<string, CustomFieldDef>()
+  for (const def of defs) {
+    const existing = byKey.get(def.key)
+    if (!existing) {
+      byKey.set(def.key, def)
+      continue
+    }
+    const nextScore = scopeScore(def)
+    const existingScore = scopeScore(existing)
+    if (nextScore > existingScore) {
+      byKey.set(def.key, def)
+      continue
+    }
+    if (nextScore < existingScore) continue
+    if (definitionTime(def) >= definitionTime(existing)) byKey.set(def.key, def)
+  }
+  return byKey
+}
+
+// Kind lookup used by read paths that must not reinterpret a stored value against
+// the wrong type. Failures degrade to an empty map: callers then leave values as
+// stored, which is always safer than coercing them blind.
+export async function loadCustomFieldKinds(
+  em: EntityManager,
+  opts: ScopedCustomFieldDefsOptions,
+): Promise<Map<string, string>> {
+  try {
+    const defs = await loadScopedCustomFieldDefs(em, opts)
+    const kinds = new Map<string, string>()
+    for (const [key, def] of defs) kinds.set(key, String(def.kind || ''))
+    return kinds
+  } catch {
+    return new Map<string, string>()
+  }
+}

--- a/packages/core/src/modules/entities/lib/validation.ts
+++ b/packages/core/src/modules/entities/lib/validation.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/core'
-import { CustomFieldDef } from '../data/entities'
 import { validateValuesAgainstDefs } from '@open-mercato/shared/modules/entities/validation'
+import { loadScopedCustomFieldDefs } from './scoped-field-defs'
 
 export async function validateCustomFieldValuesServer(
   em: EntityManager,
@@ -12,51 +12,11 @@ export async function validateCustomFieldValuesServer(
     rejectUndeclaredKeys?: boolean
   },
 ): Promise<{ ok: boolean; fieldErrors: Record<string, string> }> {
-  const organizationId = opts.organizationId ?? null
-  const tenantId = opts.tenantId ?? null
-  const defs = await em.find(CustomFieldDef, {
+  const byKey = await loadScopedCustomFieldDefs(em, {
     entityId: opts.entityId,
-    isActive: true,
-    deletedAt: null,
-    $and: [
-      {
-        $or: organizationId === null
-          ? [{ organizationId: null }]
-          : [{ organizationId }, { organizationId: null }],
-      },
-      {
-        $or: tenantId === null
-          ? [{ tenantId: null }]
-          : [{ tenantId }, { tenantId: null }],
-      },
-    ],
-  } as any)
-
-  // Prefer the most specific scope and newest definition for duplicate keys.
-  const scopeScore = (def: CustomFieldDef) => (def.tenantId ? 2 : 0) + (def.organizationId ? 1 : 0)
-  const byKey = new Map<string, CustomFieldDef>()
-  for (const d of defs) {
-    const existing = byKey.get(d.key)
-    if (!existing) {
-      byKey.set(d.key, d)
-      continue
-    }
-    const nextScore = scopeScore(d)
-    const existingScore = scopeScore(existing)
-    if (nextScore > existingScore) {
-      byKey.set(d.key, d)
-      continue
-    }
-    if (nextScore < existingScore) continue
-
-    const nextUpdatedAt = d.updatedAt instanceof Date ? d.updatedAt.getTime() : new Date(d.updatedAt).getTime()
-    const existingUpdatedAt = existing.updatedAt instanceof Date
-      ? existing.updatedAt.getTime()
-      : new Date(existing.updatedAt).getTime()
-    if (nextUpdatedAt >= existingUpdatedAt) {
-      byKey.set(d.key, d)
-    }
-  }
+    organizationId: opts.organizationId,
+    tenantId: opts.tenantId,
+  })
   return validateValuesAgainstDefs(opts.values, Array.from(byKey.values()) as any, {
     rejectUndeclaredKeys: opts.rejectUndeclaredKeys === true,
   })


### PR DESCRIPTION
Closes #5791
Status: complete

## 🎯 Goal

A `select` custom field on a custom entity keeps the value it was written with. Writing `no` into `outreach:icp_evaluation.computed_verdict` and reading the record back now returns `"no"` instead of `false`, and filtering that field by `no` returns the matching records instead of nothing.

## 🔍 Problem

`POST /api/entities/records` accepted `"no"` for a `select` field, but reading the record back returned the boolean `false` — with nothing in the request or the response signalling the change. The reporter hit this at scale: of 19 972 migrated evaluation records, 1 844 read back as `false`, exactly matching the number of `no` verdicts in the source export. Any query filtering by `verdict = "no"` returned nothing, and any UI rendering the verdict printed `false` where a label belonged.

The three controls in the issue placed it precisely: another option of the same field (`maybe`) survived, the same string survived in a `text` field, and the same string survived in a `select` custom field on a native entity.

## 🔍 Root Cause

The defect is on the **read** path, not the write path — `packages/core/src/modules/entities/api/records.ts`.

`normalizeCustomEntityValue` ran `parseBooleanToken` over **every** string custom-field value of a custom entity, consulting only the runtime value type and never the field's declared `kind`. Any value in the boolean-token sets from `packages/shared/src/lib/boolean.ts` — `no`, `yes`, `n`, `y`, `on`, `off`, `0`, `1`, `true`, `false`, `enable`/`enabled`, `disable`/`disabled`, case-insensitively and after trimming — came back as a boolean regardless of the field it belonged to. The helper exists for a real reason: doc storage keeps custom-field values as JSON, so a checkbox can arrive as the string `"true"` and has to reach the form as a real boolean. Applied blind, it also rewrote legitimate string values.

That explains all three controls. `maybe` is not a boolean token. A `text` field on a *native* entity never reaches this helper — `mapRow` is gated on `isCustomEntity`. And native-entity reads go through the kind-aware paths in `packages/shared/src/lib/query/engine.ts` and `packages/shared/src/lib/crud/custom-fields.ts`, which switch on `cfd.kind`, which is why 777 person records hold `no` correctly.

The write path is clean: `normalizeDocValues` in `packages/shared/src/lib/data/engine.ts` only renames `cf_x` → `cf:x`, so **storage still holds the string `"no"`**. The write only looked implicated because of a round trip — the API returned `false`, the edit form posted `false` back, and `validateCustomFieldValuesServer` does not enforce select options, so the boolean was persisted over the option. Records that were never re-saved through the UI are corrected by this fix alone, with no data migration.

The same kind-blind parse sat in `buildFilter`, so `?computed_verdict=no` sent boolean `false` to the query engine — the "filtering by `verdict = no` returns nothing" half of the report.

## What Changed

- **`packages/core/src/modules/entities/api/records.ts`** — the boolean parse in both `normalizeCustomEntityValue` (response rows and exports) and `buildFilter` (`cf_`-prefixed and bare-key filters) now runs only for fields whose declared `kind` is `boolean`. Every other kind is returned and queried exactly as stored. Definitions are loaded once per request and only when they can matter (a custom entity, or a request carrying `cf_` filters), so no non-custom-entity read gains a query.
- **`packages/core/src/modules/entities/lib/scoped-field-defs.ts`** (new) — `loadScopedCustomFieldDefs` holds the scope-overlay resolution (org+tenant shadows tenant-global shadows instance-global, ties broken by recency) that `validation.ts` already implemented, plus `loadCustomFieldKinds`, the kind-map lookup for read paths. A definition-load failure returns an empty map, so the route degrades to *no coercion* — values as stored — rather than to a blind parse.
- **`packages/core/src/modules/entities/lib/validation.ts`** — now calls the extracted loader instead of carrying its own copy of that resolution. Pure extraction, no behavior change; covered by the existing `records.validation.test.ts`.

Deliberately left alone: the write path does not gain select-option validation. Rejecting a boolean written into a `select` is a separate, behavior-changing decision, and installs already holding a coerced `false` would start failing writes on it. The read fix is what the issue asks for and what restores the 1 844 records.

## 🧪 Tests

- `yarn build:packages` · `yarn generate` · `yarn build:packages` · `yarn i18n:check-sync` · `yarn i18n:check-usage` · `yarn typecheck` — all green.
- `yarn build:app` — green.
- `yarn workspace @open-mercato/core test` — 12 039 passed / 1 479 suites. `@open-mercato/ui` — 1 966 passed / 237 suites. `@open-mercato/shared` — 2 115 passed / 189 suites.
- `yarn test` (full gate) — every package green except 5 pre-existing failures in `@open-mercato/cli` (`resolve-environment.test.ts`, `resolver.enterprise.test.ts`). Those suites are location-dependent and fail on a clean checkout; they are unrelated to this diff, which touches `packages/core` only. Note that turbo aborts the remaining packages on that failure, which is why `core`/`ui`/`shared` were run explicitly above.
- **New — `packages/core/src/modules/entities/api/__tests__/records.get.boolean-tokens.test.ts`** locks in the reported behavior: a `select` value of `"no"` returns as `"no"`; boolean-looking entries inside a multi-select array are preserved; a field declared `boolean` still parses to a real boolean; a `text` value of `"off"` is untouched; both `?computed_verdict=no` and `?cf_computed_verdict=no` filter by the literal string; a filter on a boolean-declared field still coerces; and when definitions cannot be loaded, values come back exactly as stored. 6 of its 8 cases fail against the pre-fix route.
- **Updated — `records.get.custom-entity.test.ts`** now declares its `date` field as `kind: 'boolean'` and keeps its original assertions, so the checkbox behavior the helper was written for is still proven.

## 💥 Breaking Changes

None to any contract surface — no API shape, schema, event, or import path changes.

One intentional behavioral change, which is the fix: a custom-entity custom field that is **not** declared `boolean` and whose stored value reads as a boolean token now comes back as that string rather than as a boolean. Any consumer that was reading the coerced boolean out of a non-boolean field was reading corrupted data. Fields declared `boolean` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791122851&installation_model_id=432243&pr_number=5883&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5883&signature=c9b975e48e5bcfb5f7f7543f94c9ca23eeda48511664be5b601a5a87bbbe7b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->