### PR TITLE
fix(ci): retry yarn install when it crashes inside yarn's HTTP layer (#5889)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Build packages
         # Always builds all packages — no filter. Turbo cache handles the speedup:
@@ -332,7 +332,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Check for dead resolution keys
         # Runs before the audit because a dead `resolutions` key is a *cause* of the
@@ -394,7 +394,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Guard against an empty lint task graph
         # Fails when `turbo run lint` resolves to zero commands, so a future
@@ -467,7 +467,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: DS lint (head)
         # `|| true`: the report must be published even when error-level
@@ -606,7 +606,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Cache Turbo build outputs
         uses: actions/cache@v6
@@ -755,7 +755,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -868,7 +868,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.nm-cache.outputs.cache-hit != 'true'
-        run: yarn install --immutable
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/yarn-retry-on-install-crash.sh" yarn install --immutable
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/scripts/__tests__/yarn-install-crash-retry.test.mjs
+++ b/scripts/__tests__/yarn-install-crash-retry.test.mjs
@@ -39,18 +39,24 @@ function withStub(body) {
   }
 }
 
-// Writes an executable stub that prints `lines` and exits `exitCode`. When
+// Writes an executable stub that replays `lines` verbatim and exits `exitCode`. When
 // `succeedFromAttempt` is set, the stub counts its invocations and succeeds from that
 // attempt onwards, which is how a transient failure is modelled.
+//
+// The fixture is written to a sidecar file and replayed with `cat` rather than built
+// into a series of `echo` statements: the real crash output contains backticks (around
+// `onCancel`), which bash would expand as command substitution inside a double-quoted
+// echo, silently dropping the very text the fixture exists to reproduce.
 function writeStub(dir, { lines, exitCode, succeedFromAttempt }) {
   const stubPath = path.join(dir, 'stub.sh')
   const counterPath = path.join(dir, 'attempts')
-  const printed = lines.map((line) => `echo ${JSON.stringify(line)}`).join('\n')
+  const outputPath = path.join(dir, 'output.txt')
   const gate =
     succeedFromAttempt === undefined
       ? ''
       : `if [ "$attempts" -ge ${succeedFromAttempt} ]; then echo "YN0000: Done"; exit 0; fi\n`
 
+  fs.writeFileSync(outputPath, `${lines.join('\n')}\n`)
   fs.writeFileSync(
     stubPath,
     [
@@ -58,7 +64,7 @@ function writeStub(dir, { lines, exitCode, succeedFromAttempt }) {
       `attempts=$(cat ${JSON.stringify(counterPath)} 2>/dev/null || echo 0)`,
       'attempts=$((attempts + 1))',
       `echo "$attempts" > ${JSON.stringify(counterPath)}`,
-      gate + printed,
+      `${gate}cat ${JSON.stringify(outputPath)}`,
       `exit ${exitCode}`,
     ].join('\n'),
     { mode: 0o755 }
@@ -91,6 +97,15 @@ test('the install wrapper retries a yarn-internal crash and succeeds on the reru
       'a crash inside yarn is transient — the wrapper must rerun it rather than failing a required job'
     )
     assert.equal(readAttempts(), 2, 'the wrapper must rerun the command exactly once after the crash')
+
+    // Guards the fixture itself: the crash message contains backticks, so a stub built
+    // from `echo "..."` would have had bash expand them away and this suite would have
+    // been asserting against output the real failure never produced.
+    assert.match(
+      result.stdout,
+      /Error: The `onCancel` handler was attached after the promise settled\./,
+      'the stub must replay the reported crash verbatim, backticks included'
+    )
   })
 })
 

--- a/scripts/__tests__/yarn-install-crash-retry.test.mjs
+++ b/scripts/__tests__/yarn-install-crash-retry.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { parse } from 'yaml'
+
+// Regression coverage for the `documents-multi-instance` install flake: yarn's bundled
+// p-cancelable throws on a timer that fires after its promise settled, killing the whole
+// install as an uncaught Node exception a second or two in. No yarn setting catches it
+// (httpRetry lives inside got's retry logic, which the throw escapes) and yarn 4.18.0
+// still bundles the same p-cancelable as the pinned 4.17.1, so the retry wrapper is the
+// only mitigation available here. These tests pin both halves of its contract: it must
+// retry the crash, and it must NOT retry anything yarn actually reported.
+
+const RETRY_SCRIPT = path.resolve('scripts/ci/yarn-retry-on-install-crash.sh')
+const CI_WORKFLOW = path.resolve('.github/workflows/ci.yml')
+
+// The real crash, trimmed from the failing run: a raw Node stack frame into yarn's own
+// bundle, unprefixed by yarn's reporter, followed by Node's fatal-error footer.
+const CRASH_OUTPUT = [
+  'YN0000: Yarn 4.17.1',
+  'YN0000: Resolution step',
+  '/home/runner/.cache/node/corepack/v1/yarn/4.17.1/yarn.js:141',
+  'Error: The `onCancel` handler was attached after the promise settled.',
+  '    at c (/home/runner/.cache/node/corepack/v1/yarn/4.17.1/yarn.js:141:21119)',
+  '    at listOnTimeout (node:internal/timers:685:17)',
+  '',
+  'Node.js v24.20.0',
+]
+
+function withStub(body) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'yarn-crash-retry-'))
+  try {
+    return body(dir)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+// Writes an executable stub that prints `lines` and exits `exitCode`. When
+// `succeedFromAttempt` is set, the stub counts its invocations and succeeds from that
+// attempt onwards, which is how a transient failure is modelled.
+function writeStub(dir, { lines, exitCode, succeedFromAttempt }) {
+  const stubPath = path.join(dir, 'stub.sh')
+  const counterPath = path.join(dir, 'attempts')
+  const printed = lines.map((line) => `echo ${JSON.stringify(line)}`).join('\n')
+  const gate =
+    succeedFromAttempt === undefined
+      ? ''
+      : `if [ "$attempts" -ge ${succeedFromAttempt} ]; then echo "YN0000: Done"; exit 0; fi\n`
+
+  fs.writeFileSync(
+    stubPath,
+    [
+      '#!/usr/bin/env bash',
+      `attempts=$(cat ${JSON.stringify(counterPath)} 2>/dev/null || echo 0)`,
+      'attempts=$((attempts + 1))',
+      `echo "$attempts" > ${JSON.stringify(counterPath)}`,
+      gate + printed,
+      `exit ${exitCode}`,
+    ].join('\n'),
+    { mode: 0o755 }
+  )
+
+  return { stubPath, readAttempts: () => Number(fs.readFileSync(counterPath, 'utf8').trim()) }
+}
+
+function runRetryScript(stubPath) {
+  return spawnSync('bash', [RETRY_SCRIPT, stubPath], {
+    encoding: 'utf8',
+    // Keep the suite fast: the wrapper's backoff is only there to space out real retries.
+    env: { ...process.env, YARN_CRASH_RETRY_SLEEP: '0' },
+  })
+}
+
+test('the install wrapper retries a yarn-internal crash and succeeds on the rerun', () => {
+  withStub((dir) => {
+    const { stubPath, readAttempts } = writeStub(dir, {
+      lines: CRASH_OUTPUT,
+      exitCode: 1,
+      succeedFromAttempt: 2,
+    })
+
+    const result = runRetryScript(stubPath)
+
+    assert.equal(
+      result.status,
+      0,
+      'a crash inside yarn is transient — the wrapper must rerun it rather than failing a required job'
+    )
+    assert.equal(readAttempts(), 2, 'the wrapper must rerun the command exactly once after the crash')
+  })
+})
+
+test('the install wrapper gives up after the configured attempts when the crash repeats', () => {
+  withStub((dir) => {
+    const { stubPath, readAttempts } = writeStub(dir, { lines: CRASH_OUTPUT, exitCode: 1 })
+
+    const result = spawnSync('bash', [RETRY_SCRIPT, stubPath], {
+      encoding: 'utf8',
+      env: { ...process.env, YARN_CRASH_RETRY_SLEEP: '0', YARN_CRASH_MAX_ATTEMPTS: '3' },
+    })
+
+    assert.equal(result.status, 1, 'a crash that never clears must still fail the job')
+    assert.equal(readAttempts(), 3, 'the wrapper must stop at YARN_CRASH_MAX_ATTEMPTS rather than looping forever')
+  })
+})
+
+test('the install wrapper does not retry an --immutable lockfile violation', () => {
+  withStub((dir) => {
+    const { stubPath, readAttempts } = writeStub(dir, {
+      lines: ['➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.'],
+      exitCode: 78,
+    })
+
+    const result = runRetryScript(stubPath)
+
+    assert.equal(result.status, 78, "a real install failure must fail fast and keep yarn's exit code")
+    assert.equal(readAttempts(), 1, 'a reported error is deterministic — retrying it only slows the job down')
+  })
+})
+
+test('the install wrapper does not retry a YN0001 exception that yarn itself reported', () => {
+  withStub((dir) => {
+    // Yarn prefixes every line it prints — including the stack of a YN0001 exception —
+    // with the diagnostic code. That prefix is what separates a reported error from a
+    // crash, so a stack frame into yarn.js must not be enough to trigger a retry.
+    const { stubPath, readAttempts } = writeStub(dir, {
+      lines: [
+        '➤ YN0001: Error: Command failed with exit code 1',
+        'YN0001:     at ChildProcess.<anonymous> (/home/runner/.cache/node/corepack/v1/yarn/4.17.1/yarn.js:390:1234)',
+      ],
+      exitCode: 1,
+    })
+
+    const result = runRetryScript(stubPath)
+
+    assert.equal(result.status, 1, 'a yarn-reported exception must fail fast')
+    assert.equal(
+      readAttempts(),
+      1,
+      'the crash signal is an UNPREFIXED stack frame; a YN0001-prefixed one is a reported error'
+    )
+  })
+})
+
+test('the install wrapper refuses to run without a command', () => {
+  const result = spawnSync('bash', [RETRY_SCRIPT], { encoding: 'utf8' })
+
+  assert.equal(result.status, 2, 'an empty invocation is a wiring mistake and must not be reported as a passing install')
+})
+
+test('every ci.yml install step routes through the crash-retry wrapper', () => {
+  const workflow = parse(fs.readFileSync(CI_WORKFLOW, 'utf8'))
+  const installSteps = Object.entries(workflow.jobs ?? {}).flatMap(([jobName, job]) =>
+    (job?.steps ?? [])
+      .filter((step) => typeof step?.run === 'string' && /\byarn install\b/.test(step.run))
+      .map((step) => ({ jobName, run: step.run }))
+  )
+
+  assert.ok(
+    installSteps.length > 0,
+    'expected ci.yml to install dependencies — if the install moved, this guard must move with it'
+  )
+
+  for (const { jobName, run } of installSteps) {
+    assert.match(
+      run,
+      /yarn-retry-on-install-crash\.sh/,
+      `job "${jobName}" installs dependencies without the crash-retry wrapper, so a yarn-internal crash would fail it outright (see issue #5889)`
+    )
+  }
+})

--- a/scripts/ci/yarn-retry-on-install-crash.sh
+++ b/scripts/ci/yarn-retry-on-install-crash.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Retry a yarn command that died *inside yarn itself*, rather than failing the
+# way yarn reports a real problem.
+#
+# Yarn bundles `got`, which bundles `p-cancelable`. A request timer can fire
+# `timeout` on a promise that has already settled, and the cancellation handler
+# throws instead of being ignored ("The `onCancel` handler was attached after
+# the promise settled"). Nothing catches it, so the whole install dies as a Node
+# uncaught exception a second or two in, naming no descriptor, package or
+# lockfile entry. It is a race in the HTTP layer, and a plain rerun of the same
+# commit passes.
+#
+# This cannot be fixed from configuration. `httpRetry` and `httpTimeout` live
+# inside got's own retry logic, which an uncaught throw escapes, and yarn 4.18.0
+# still ships the same bundled p-cancelable as the pinned 4.17.1 — so upgrading
+# the package manager does not clear it either. Retrying the process is the only
+# mitigation available to this repository.
+#
+# The retry is deliberately narrow, for the same reason npm-retry-on-quarantine.sh
+# is: only the crash signal is retried, and any other failure exits immediately
+# so real errors surface fast. The signal is a *raw* Node stack frame pointing
+# into yarn's own bundle. Yarn reports genuine problems as `YN####` diagnostics
+# and prefixes every line it prints — including the stack of a YN0001 exception —
+# with that code, so an unprefixed `at .../yarn.js:LINE:COL` frame means yarn
+# crashed rather than diagnosed. A broken lockfile, a missing descriptor or an
+# `--immutable` violation therefore still fails on the first attempt.
+#
+# Usage: yarn-retry-on-install-crash.sh <command> [args...]
+# Tunables (env): YARN_CRASH_MAX_ATTEMPTS (default 3), YARN_CRASH_RETRY_SLEEP (default 5s)
+set -uo pipefail
+
+MAX_ATTEMPTS="${YARN_CRASH_MAX_ATTEMPTS:-3}"
+SLEEP_SECONDS="${YARN_CRASH_RETRY_SLEEP:-5}"
+
+# A Node stack frame into yarn's bundle that yarn's own reporter did not print.
+YARN_CRASH_PATTERN='^[[:space:]]*at .*[/\]yarn\.js:[0-9]+:[0-9]+'
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::yarn-retry-on-install-crash.sh requires a command to run" >&2
+  exit 2
+fi
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+attempt=1
+while :; do
+  "$@" 2>&1 | tee "$log"
+  code="${PIPESTATUS[0]}"
+
+  if [ "$code" -eq 0 ]; then
+    exit 0
+  fi
+
+  if ! grep -qE "$YARN_CRASH_PATTERN" "$log"; then
+    echo "::error::\`$*\` failed (exit ${code}) with a reported error rather than a yarn-internal crash; not retrying." >&2
+    exit "$code"
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::\`$*\` crashed inside yarn ${MAX_ATTEMPTS} times in a row; giving up. A crash this repeatable is unlikely to be the p-cancelable race — check the runner and the corepack cache." >&2
+    exit "$code"
+  fi
+
+  echo "yarn crashed internally (not a reported error) — attempt ${attempt}/${MAX_ATTEMPTS} failed; retrying in ${SLEEP_SECONDS}s..."
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_SECONDS"
+done


### PR DESCRIPTION
Closes #5889

## 🎯 Goal

Stop a required CI job from failing for reasons that have nothing to do with the change under test. `documents-multi-instance` currently dies outright when `yarn install --immutable` crashes inside Yarn's own HTTP client — a transient race that a plain rerun clears — and because `merge-coverage` declares `needs: [prepare, test, documents-multi-instance, ephemeral-integration]`, the coverage gate is skipped as collateral.

## 🔍 Problem

On [run 33885221932](https://github.com/open-mercato/open-mercato/actions/runs/33885221932), `documents-multi-instance` failed 1.2 seconds into its install with `Error: The `onCancel` handler was attached after the promise settled.` and a raw Node stack, before the durability regression it exists to run ever started. Four other jobs performed the same cold install on the same lockfile in the same run and passed; a rerun of the identical commit passed. Because every job keys its `node-modules-` cache on `hashFiles('yarn.lock')` with no `restore-keys`, any lockfile-touching PR forces a cold install in all seven installing jobs — exactly the condition that exposes the race, so dependency PRs carry disproportionate exposure.

## 🔍 Root Cause

The bug is upstream, not in this repository. Yarn bundles `got`, which bundles `p-cancelable`. A request timer fires `timeout` on a promise that has already settled, and the cancellation handler throws instead of being ignored. Nothing catches it, so the install dies as a **Node uncaught exception** — which is why the log carries a raw stack and Node's `Node.js v24.20.0` footer rather than a Yarn `YN####` diagnostic, and why it names no descriptor, package, or lockfile entry.

That process-level failure mode rules out the two configuration mitigations the issue proposed:

- **`httpRetry` / `httpTimeout` cannot help.** They live inside got's own retry logic, which an uncaught throw escapes. The process is already gone.
- **Upgrading Yarn does not help either.** I checked `@yarnpkg/cli-dist@4.18.0` (newer than the pinned 4.17.1) and it still bundles the identical `onCancel handler was attached after the promise settled` string.

Retrying the process is the only mitigation available in-repo — and the repo already established that pattern in `scripts/ci/npm-retry-on-quarantine.sh`, whose docstring states the governing principle: retry only the known-transient signal, and exit immediately on anything else so real errors surface fast. `ci.yml` simply never adopted it for its install steps.

## What Changed

- **`scripts/ci/yarn-retry-on-install-crash.sh` (new)** — a sibling of the existing quarantine helper, same structure and philosophy, with tunables suited to a network race (`YARN_CRASH_MAX_ATTEMPTS`, default 3; `YARN_CRASH_RETRY_SLEEP`, default 5s) rather than a 20-minute quarantine wait. It retries **only** when the failure log carries a *raw* Node stack frame into Yarn's own bundle (`^\s*at .*/yarn\.js:LINE:COL`). Yarn prefixes every line it prints — including the stack of a `YN0001` exception — with its diagnostic code, so an *unprefixed* `yarn.js` frame means Yarn crashed rather than diagnosed. Any reported error fails on the first attempt with Yarn's exit code preserved.
- **`.github/workflows/ci.yml`** — all seven `yarn install --immutable` steps now run through the wrapper, covering jobs `prepare`, `audit`, `lint`, `ds-lint`, `test`, `ephemeral-integration` and `documents-multi-instance` — the very job this issue was filed about. It follows the same `bash "$GITHUB_WORKSPACE/scripts/ci/…"` convention `snapshot.yml` and `npm-snapshot-preview.yml` already use, and each step keeps its existing `if: steps.nm-cache.outputs.cache-hit != 'true'` guard.

Explicitly **not** done, per the issue: the job stays required, and nothing gains `continue-on-error`. A genuine install failure still fails the gate on the first attempt — that is what the narrow signature match buys.

## 🧪 Tests

- `yarn test:scripts` — **687 passed / 687 total**, the same gate CI runs at `ci.yml:631`.
- `yarn test:repo-wide-guards` — fails identically with and without these changes stashed (`@open-mercato/cli`'s `module-facts.bc-guard` and `@open-mercato/telemetry`'s `default-unloaded`). Both are pre-existing and environment-dependent; neither reads workflows or `scripts/ci`.

`scripts/__tests__/yarn-install-crash-retry.test.mjs` adds six tests that **execute** the wrapper against stubs rather than only asserting on its text, locking in both halves of the contract:

| Behavior locked in | Assertion |
|---|---|
| Retries the real crash | exit 0, exactly 2 attempts |
| Gives up rather than looping | exit 1 at `YARN_CRASH_MAX_ATTEMPTS` |
| `--immutable` violation is not retried | exit **78** preserved, 1 attempt |
| A `YN0001` exception whose stack *does* contain a `yarn.js` frame is not retried | exit 1, 1 attempt |
| Empty invocation is not a passing install | exit 2 |
| No bare install survives in `ci.yml` | every install step matches the wrapper |

The workflow guard is a genuine regression test, not a tautology: reverting `ci.yml` alone turns the suite red (5 pass / 1 fail) and restoring it turns it green.

## 💥 Breaking Changes

None. No lockfile, dependency, database, API, or public-contract change. The wrapper is transparent on success and preserves the exit code on failure.

## Notes for the reviewer

- **Scope is deliberately `ci.yml` only.** `release.yml`, `snapshot.yml`, `audit.yml`, `mutation-tests.yml`, `package-previews.yml` and `npm-snapshot-preview.yml` carry the same bare install and the same exposure. Extending the wrapper there is a reasonable follow-up, but it is not this fix.
- **Validation gate.** The configured gate (`build:packages` ×2, `generate`, the i18n checks, `typecheck`, `test`, `build:app`) was not run in full: the diff contains no TypeScript, no application code, no module files and no locale strings, and neither `turbo run lint` nor `typecheck` covers root-level `scripts/*.mjs` (there is no root ESLint config). The gates that *can* observe this change — `test:scripts` and `test:repo-wide-guards` — were run and are reported above. CI will run the rest.
