### PR TITLE
perf(events): coalesce clientBroadcast SSE fan-out for bulk writers

### DIFF
--- a/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
+++ b/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
@@ -1,0 +1,70 @@
+# Execution plan — client-broadcast SSE coalescing
+
+Source doc: `.ai/specs/2026-09-04-client-broadcast-sse-coalescing.md` (spec PR #5895)
+Issue: #5733
+Engine: om-auto-create-pr (steps: 10, --loop: no)
+
+## Goal
+
+Give the event bus opt-in coalescing of **browser** deliveries for `clientBroadcast` / `portalBroadcast` events, so a bulk writer stops paying one `pg_notify` roundtrip and one tenant-wide SSE fan-out per record, while inline subscribers, webhooks and the queue keep firing once per record.
+
+## Scope
+
+- `packages/shared/src/modules/events/types.ts` — one additive optional `EventDefinition` field.
+- `packages/shared/src/modules/events/factory.ts` — the `isCoalescedBroadcastEvent` reader plus a declaration-time guard rejecting `crossProcessBroadcast` + coalescing.
+- `packages/events/src/broadcast-coalescer.ts` — new, self-contained scheduler.
+- `packages/events/src/bus.ts` — extract the two browser-facing sinks into one closure and route it through the coalescer when eligible.
+- `packages/core/src/modules/catalog/events.ts` — opt the three product broadcast events in.
+- Docs: `packages/events/AGENTS.md`, `apps/mercato/.env.example` (+ create-app template sync).
+
+## Non-goals
+
+- Migrating `progress.job.updated` off `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS`.
+- Lossless batching of distinct records into a single SSE frame (would change the browser wire format).
+- Re-coalescing envelopes received from other processes.
+- Opting in any event outside catalog.
+
+## Risks
+
+- **Cross-tenant leakage via the coalescing key.** A key missing scope would let one tenant's payload be delivered in place of another's. Mitigated by building the key from trusted scope and a dedicated regression test (Step 1.5).
+- **Delaying private cross-process coordination.** Coalescing a `crossProcessBroadcast` event would let another process serve stale cache. Mitigated by a declaration-time rejection (Step 1.2) and an eligibility guard.
+- **Losing the tail of a burst on process exit.** Mitigated by flushing pending entries from the existing SIGTERM/SIGINT hook (Step 1.6); a hard SIGKILL still loses at most one interval.
+- **Behavior drift for events that did not opt in.** Mitigated by Phase 1 shipping with zero opted-in events and a test asserting the non-opted-in emit sequence is unchanged.
+
+## Implementation Plan
+
+### Phase 1 — Coalescing mechanism (behavior-neutral)
+
+- 1.1 Declare `broadcastCoalescing?: boolean` on `EventDefinition` and add the `isCoalescedBroadcastEvent` reader.
+- 1.2 Reject `crossProcessBroadcast: true` + `broadcastCoalescing: true` at declaration time in `createModuleEvents`.
+- 1.3 Add `packages/events/src/broadcast-coalescer.ts` (leading-edge dispatch, unconditional trailing flush, per-key isolation, deferred-error containment).
+- 1.4 Wire it into `bus.emit`: extract the tap fan-out + `publishCrossProcessEvent` into one closure, route through the coalescer when eligible.
+- 1.5 Build the coalescing key from trusted scope, with cross-tenant/cross-org isolation tests.
+- 1.6 Flush pending broadcasts from the existing SIGTERM/SIGINT shutdown hook.
+- 1.7 Resolve `OM_BROADCAST_COALESCE_INTERVAL_MS` via `parseNumberWithDefault` and document it in `.env.example` + the create-app template.
+
+### Phase 2 — First consumers and documentation
+
+- 2.1 Opt `catalog.product.{created,updated,deleted}` in; run `yarn generate`.
+- 2.2 Bulk-writer guard test: N domain deliveries, ≪N browser dispatches, last payload wins.
+- 2.3 Document the mechanism in `packages/events/AGENTS.md` and note the progress-local knob stays.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Coalescing mechanism
+
+- [ ] 1.1 Declare the field and the reader
+- [ ] 1.2 Reject the unsafe declaration combination
+- [ ] 1.3 Add the coalescer module
+- [ ] 1.4 Wire the coalescer into bus.emit
+- [ ] 1.5 Scope isolation in the coalescing key
+- [ ] 1.6 Shutdown flush
+- [ ] 1.7 Env knob and .env.example
+
+### Phase 2: First consumers and documentation
+
+- [ ] 2.1 Opt the catalog product events in
+- [ ] 2.2 Bulk-writer guard test
+- [ ] 2.3 Documentation

--- a/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
+++ b/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
@@ -55,16 +55,16 @@ Give the event bus opt-in coalescing of **browser** deliveries for `clientBroadc
 
 ### Phase 1: Coalescing mechanism
 
-- [ ] 1.1 Declare the field and the reader
-- [ ] 1.2 Reject the unsafe declaration combination
-- [ ] 1.3 Add the coalescer module
-- [ ] 1.4 Wire the coalescer into bus.emit
-- [ ] 1.5 Scope isolation in the coalescing key
-- [ ] 1.6 Shutdown flush
-- [ ] 1.7 Env knob and .env.example
+- [x] 1.1 Declare the field and the reader — e3b0e3754
+- [x] 1.2 Reject the unsafe declaration combination — e3b0e3754
+- [x] 1.3 Add the coalescer module — e3b0e3754
+- [x] 1.4 Wire the coalescer into bus.emit — e3b0e3754
+- [x] 1.5 Scope isolation in the coalescing key — e3b0e3754
+- [x] 1.6 Shutdown flush — e3b0e3754
+- [x] 1.7 Env knob and .env.example — e3b0e3754
 
 ### Phase 2: First consumers and documentation
 
-- [ ] 2.1 Opt the catalog product events in
-- [ ] 2.2 Bulk-writer guard test
-- [ ] 2.3 Documentation
+- [x] 2.1 Opt the catalog product events in — d15ce68dd
+- [x] 2.2 Bulk-writer guard test — d15ce68dd
+- [x] 2.3 Documentation — d15ce68dd

--- a/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
+++ b/.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md
@@ -51,6 +51,8 @@ Give the event bus opt-in coalescing of **browser** deliveries for `clientBroadc
 
 ## Progress
 
+PR: #5896
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Coalescing mechanism

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -187,6 +187,15 @@ OM_AUTO_SPAWN_WORKERS_LAZY_MODE=shared
 # Custom entrypoints (a bare `next start`, a custom server) never run that
 # bootstrap, so neither variable is rewritten for them.
 # OM_EVENTS_EXTERNAL_WORKER=true
+#
+# Minimum milliseconds between coalesced BROWSER deliveries of one event within
+# one tenant/organization, for events declared with `broadcastCoalescing: true`.
+# A bulk writer emitting such an event per record then pays one pg_notify
+# roundtrip and one SSE fan-out per window instead of per record; the last emit
+# of a burst is always delivered. Subscribers, webhooks and the queue are never
+# coalesced. Set to 0 to disable coalescing process-wide and restore per-record
+# browser delivery.
+# OM_BROADCAST_COALESCE_INTERVAL_MS=250
 
 # Auto-spawn scheduler polling when QUEUE_STRATEGY=local (default: true)
 # Set to false to run scheduler in a separate process

--- a/packages/core/src/modules/catalog/__tests__/product-broadcast-coalescing.test.ts
+++ b/packages/core/src/modules/catalog/__tests__/product-broadcast-coalescing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guards the #5733 contract for the catalog product broadcast events: a bulk
+ * writer emitting one event per record must keep per-record domain delivery
+ * while its browser deliveries collapse, and the burst must end on the final
+ * record so an open DataTable is not left stale.
+ */
+
+const publishCrossProcessEventMock = jest.fn(async () => undefined)
+
+jest.mock('@open-mercato/events/bridge', () => ({
+  publishCrossProcessEvent: (...args: unknown[]) => publishCrossProcessEventMock(...args),
+  registerCrossProcessEventListener: jest.fn(),
+  CROSS_PROCESS_EVENT_INSTANCE_ID: 'test-instance',
+}))
+
+import { isBroadcastEvent, isCoalescedBroadcastEvent, setGlobalEventBus } from '@open-mercato/shared/modules/events'
+import { createEventBus, registerGlobalEventTap } from '@open-mercato/events/bus'
+import { resetBroadcastCoalescerForTests } from '@open-mercato/events/broadcast-coalescer'
+import catalogEventsConfig from '../events'
+
+const INTERVAL_MS = 50
+const BULK_SIZE = 200
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('catalog product broadcast coalescing', () => {
+  const resolve = ((name: string) => name) as never
+  const originalInterval = process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+  let unregisterTap: (() => void) | null = null
+
+  beforeEach(() => {
+    publishCrossProcessEventMock.mockClear()
+    process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = String(INTERVAL_MS)
+  })
+
+  afterEach(() => {
+    unregisterTap?.()
+    unregisterTap = null
+    resetBroadcastCoalescerForTests()
+    setGlobalEventBus(null as never)
+    if (originalInterval === undefined) delete process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+    else process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = originalInterval
+  })
+
+  it('declares coalescing on exactly the three product events that reach the browser', () => {
+    for (const eventId of ['catalog.product.created', 'catalog.product.updated', 'catalog.product.deleted']) {
+      expect(isBroadcastEvent(eventId)).toBe(true)
+      expect(isCoalescedBroadcastEvent(eventId)).toBe(true)
+    }
+
+    for (const eventId of [
+      'catalog.category.created',
+      'catalog.variant.created',
+      'catalog.price.created',
+      'catalog.product.stock_low',
+    ]) {
+      expect(isCoalescedBroadcastEvent(eventId)).toBe(false)
+    }
+  })
+
+  it('keeps one domain delivery per record while the browser sees a handful', async () => {
+    const bus = createEventBus({ resolve, queueStrategy: 'local' })
+    setGlobalEventBus(bus)
+
+    const subscriberIds: string[] = []
+    const browserIds: string[] = []
+    bus.on('catalog.product.created', async (payload) => {
+      subscriberIds.push(String((payload as { id: string }).id))
+    })
+    unregisterTap = registerGlobalEventTap((_event, payload) => {
+      browserIds.push(String((payload as { id: string }).id))
+    })
+
+    for (let index = 0; index < BULK_SIZE; index += 1) {
+      await catalogEventsConfig.emit(
+        'catalog.product.created',
+        { id: `product-${index}`, tenantId: 'tenant-1', organizationId: 'org-1' },
+      )
+    }
+    await wait(INTERVAL_MS * 2)
+
+    // Webhooks, notification handlers, workflow triggers and the indexer all hang
+    // off this path: it must stay one delivery per row.
+    expect(subscriberIds).toHaveLength(BULK_SIZE)
+
+    // The browser half is what the issue asked to bound.
+    expect(browserIds.length).toBeLessThan(BULK_SIZE / 2)
+    expect(publishCrossProcessEventMock.mock.calls.length).toBe(browserIds.length)
+
+    // And the burst ends on the last row, so a DataTable refetching on the final
+    // frame sees the finished import.
+    expect(browserIds[browserIds.length - 1]).toBe(`product-${BULK_SIZE - 1}`)
+  })
+})

--- a/packages/core/src/modules/catalog/__tests__/product-broadcast-coalescing.test.ts
+++ b/packages/core/src/modules/catalog/__tests__/product-broadcast-coalescing.test.ts
@@ -13,7 +13,7 @@ jest.mock('@open-mercato/events/bridge', () => ({
   CROSS_PROCESS_EVENT_INSTANCE_ID: 'test-instance',
 }))
 
-import { isBroadcastEvent, isCoalescedBroadcastEvent, setGlobalEventBus } from '@open-mercato/shared/modules/events'
+import { getGlobalEventBus, isBroadcastEvent, isCoalescedBroadcastEvent, setGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { createEventBus, registerGlobalEventTap } from '@open-mercato/events/bus'
 import { resetBroadcastCoalescerForTests } from '@open-mercato/events/broadcast-coalescer'
 import catalogEventsConfig from '../events'
@@ -28,6 +28,7 @@ function wait(ms: number): Promise<void> {
 describe('catalog product broadcast coalescing', () => {
   const resolve = ((name: string) => name) as never
   const originalInterval = process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+  const originalBus = getGlobalEventBus()
   let unregisterTap: (() => void) | null = null
 
   beforeEach(() => {
@@ -39,7 +40,9 @@ describe('catalog product broadcast coalescing', () => {
     unregisterTap?.()
     unregisterTap = null
     resetBroadcastCoalescerForTests()
-    setGlobalEventBus(null as never)
+    // Restore whatever the worker had rather than nulling the global: another
+    // suite sharing this worker would otherwise emit into a bus that is gone.
+    if (originalBus) setGlobalEventBus(originalBus)
     if (originalInterval === undefined) delete process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
     else process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = originalInterval
   })

--- a/packages/core/src/modules/catalog/events.ts
+++ b/packages/core/src/modules/catalog/events.ts
@@ -10,9 +10,15 @@ const events = [
   // bridge to the DataTable on /backend/catalog/catalog/products via the
   // DOM event bridge so confirmed mutations (AI or otherwise) auto-refresh
   // the list without a round-trip.
-  { id: 'catalog.product.created', label: 'Product Created', entity: 'product', category: 'crud', clientBroadcast: true },
-  { id: 'catalog.product.updated', label: 'Product Updated', entity: 'product', category: 'crud', clientBroadcast: true },
-  { id: 'catalog.product.deleted', label: 'Product Deleted', entity: 'product', category: 'crud', clientBroadcast: true },
+  //
+  // They coalesce their browser delivery (#5733): the consumer is a list that
+  // refetches, so it needs to know that products changed and to be correct when
+  // a burst ends — not to be told 2,000 times during a bulk import, which would
+  // cost a pg_notify roundtrip and a tenant-wide SSE fan-out per row. Subscribers,
+  // webhooks and the queue still see one event per record.
+  { id: 'catalog.product.created', label: 'Product Created', entity: 'product', category: 'crud', clientBroadcast: true, broadcastCoalescing: true },
+  { id: 'catalog.product.updated', label: 'Product Updated', entity: 'product', category: 'crud', clientBroadcast: true, broadcastCoalescing: true },
+  { id: 'catalog.product.deleted', label: 'Product Deleted', entity: 'product', category: 'crud', clientBroadcast: true, broadcastCoalescing: true },
   { id: 'catalog.product.stock_low', label: 'Product Stock Low', entity: 'product', category: 'lifecycle' },
   { id: 'catalog.product_unit_conversion.created', label: 'Product Unit Conversion Created', entity: 'product_unit_conversion', category: 'crud' },
   { id: 'catalog.product_unit_conversion.updated', label: 'Product Unit Conversion Updated', entity: 'product_unit_conversion', category: 'crud' },

--- a/packages/core/src/modules/progress/AGENTS.md
+++ b/packages/core/src/modules/progress/AGENTS.md
@@ -88,6 +88,8 @@ Use stable, grep-friendly ids:
 |----------|--------|---------|
 | `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS` | Coalesces intermediate `progress.job.updated` broadcasts per job: the service emits only when this many ms elapsed since the last broadcast **or** `progressPercent` advanced by ≥1; sub-threshold updates buffer in memory. Keeps bulk workers from firing one serialized `pg_notify` roundtrip + tenant-wide SSE fan-out per record. Persistence is throttled independently: heartbeats reach the database at least every `HEARTBEAT_INTERVAL_MS` (5s) regardless of this knob, so no value can starve the 60s `STALE_JOB_TIMEOUT_SECONDS` sweep. Terminal events (`created`/`started`/`completed`/`failed`/`cancelled`) are never throttled. Set to `0` to restore per-record emission (tests/debugging). | `250` |
 
+This knob stays service-local: it buffers persistence alongside the broadcast, which the generic mechanism does not. For any OTHER bulk-written browser event, declare `broadcastCoalescing: true` instead — see `packages/events/AGENTS.md` → Coalescing browser deliveries.
+
 ## Concurrency Semantics (multi-instance safe)
 
 `progressService` is safe to run across many app/worker instances. Do not reintroduce read-modify-write transitions:

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -228,6 +228,15 @@ AUTO_SPAWN_WORKERS=true
 # Custom entrypoints (a bare `next start`, a custom server) never run that
 # bootstrap, so neither variable is rewritten for them.
 # OM_EVENTS_EXTERNAL_WORKER=true
+#
+# Minimum milliseconds between coalesced BROWSER deliveries of one event within
+# one tenant/organization, for events declared with `broadcastCoalescing: true`.
+# A bulk writer emitting such an event per record then pays one pg_notify
+# roundtrip and one SSE fan-out per window instead of per record; the last emit
+# of a burst is always delivered. Subscribers, webhooks and the queue are never
+# coalesced. Set to 0 to disable coalescing process-wide and restore per-record
+# browser delivery.
+# OM_BROADCAST_COALESCE_INTERVAL_MS=250
 
 # Dev-mode memory optimization: which workspace packages the `yarn dev`
 # package watcher tracks. The watcher's memory footprint scales with the

--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -185,6 +185,20 @@ useAppEvent('mymod.entity.created', (event) => {
 - `isBroadcastEvent(eventId)` checks if an event has `clientBroadcast: true`
 - The `useEventBridge()` hook must be mounted once in the app shell to start receiving events
 
+### Coalescing browser deliveries (bulk writers)
+
+Every emit of a `clientBroadcast: true` event costs a serialized `pg_notify` roundtrip plus a tenant-wide SSE fan-out, so a bulk writer pays both once per record. Declare `broadcastCoalescing: true` to bound that:
+
+```typescript
+{ id: 'mymod.entity.created', label: 'Created', clientBroadcast: true, broadcastCoalescing: true },
+```
+
+- Only the **browser** half coalesces. Inline subscribers, webhooks, workflow triggers and the queue still receive one event per record — the domain event is untouched.
+- Within `OM_BROADCAST_COALESCE_INTERVAL_MS` (default 250, `0` disables process-wide) only the newest payload per `(event, tenant, organization)` reaches the SSE bridges. The first emit of a burst goes out immediately, and a trailing flush is **always** armed, so the last emit is delivered and a DataTable never ends a burst stale.
+- **When to declare it:** only when browser consumers react to the fact that something changed (a list refetch), never to each occurrence. A consumer that must see every record — a per-record toast, a running tally — MUST NOT have its event opted in; suppressed payloads are dropped, not merged.
+- MUST NOT combine with `crossProcessBroadcast` — delaying private coordination would let another process serve stale data. `createModuleEvents` throws on that declaration, and on `broadcastCoalescing` without a browser sink.
+- `isCoalescedBroadcastEvent(eventId)` reports the resolved decision. `progress.job.updated` keeps its own service-local throttle (`OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS`) and is not affected.
+
 ### Private cross-process coordination
 
 Use `crossProcessBroadcast: true` for server-to-server invalidation or coordination that must cross process boundaries but must not be exposed through browser SSE. The event bus publishes both `clientBroadcast` and `crossProcessBroadcast` events to the cross-process bridge, while the DOM Event Bridge delivers only `clientBroadcast` events. Do not use `clientBroadcast` merely to reach another server process when the payload contains record-scoped identifiers or activity that the organization-level SSE audience cannot authorize.

--- a/packages/events/src/__tests__/broadcast-coalescer.test.ts
+++ b/packages/events/src/__tests__/broadcast-coalescer.test.ts
@@ -1,0 +1,126 @@
+import {
+  flushPendingBroadcasts,
+  resetBroadcastCoalescerForTests,
+  resolveBroadcastCoalesceIntervalMs,
+  submitBroadcast,
+} from '../broadcast-coalescer'
+
+const INTERVAL_MS = 50
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('broadcast coalescer', () => {
+  const originalInterval = process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+
+  afterEach(() => {
+    resetBroadcastCoalescerForTests()
+    if (originalInterval === undefined) delete process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+    else process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = originalInterval
+  })
+
+  it('collapses a burst to a leading dispatch plus a trailing flush carrying the newest payload', async () => {
+    const delivered: number[] = []
+
+    for (let index = 0; index < 50; index += 1) {
+      await submitBroadcast('key', async () => { delivered.push(index) }, { intervalMs: INTERVAL_MS })
+    }
+
+    // Leading edge only, so far: the other 49 were superseded, not delivered.
+    expect(delivered).toEqual([0])
+
+    await wait(INTERVAL_MS * 2)
+
+    // The trailing flush is unconditional, and the survivor is the LAST emit —
+    // the property that keeps a DataTable from ending a burst stale.
+    expect(delivered).toEqual([0, 49])
+  })
+
+  it('never lets one key suppress or impersonate another', async () => {
+    const tenantA: string[] = []
+    const tenantB: string[] = []
+
+    await submitBroadcast('event::tenant-a::', async () => { tenantA.push('a1') }, { intervalMs: INTERVAL_MS })
+    await submitBroadcast('event::tenant-b::', async () => { tenantB.push('b1') }, { intervalMs: INTERVAL_MS })
+    await submitBroadcast('event::tenant-a::', async () => { tenantA.push('a2') }, { intervalMs: INTERVAL_MS })
+    await submitBroadcast('event::tenant-b::', async () => { tenantB.push('b2') }, { intervalMs: INTERVAL_MS })
+
+    expect(tenantA).toEqual(['a1'])
+    expect(tenantB).toEqual(['b1'])
+
+    await wait(INTERVAL_MS * 2)
+
+    expect(tenantA).toEqual(['a1', 'a2'])
+    expect(tenantB).toEqual(['b1', 'b2'])
+  })
+
+  it('dispatches every submission synchronously when the interval is zero', async () => {
+    const delivered: number[] = []
+
+    for (let index = 0; index < 5; index += 1) {
+      await submitBroadcast('key', async () => { delivered.push(index) }, { intervalMs: 0 })
+    }
+
+    expect(delivered).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('contains a failing deferred dispatch so the next window still delivers', async () => {
+    const delivered: string[] = []
+
+    await submitBroadcast('key', async () => { delivered.push('leading') }, { intervalMs: INTERVAL_MS })
+    await submitBroadcast('key', async () => { throw new Error('[internal] pg_notify unavailable') }, { intervalMs: INTERVAL_MS })
+
+    await wait(INTERVAL_MS * 2)
+
+    await submitBroadcast('key', async () => { delivered.push('after-failure') }, { intervalMs: INTERVAL_MS })
+    await wait(INTERVAL_MS * 2)
+
+    expect(delivered).toContain('leading')
+    expect(delivered).toContain('after-failure')
+  })
+
+  it('flushes pending survivors on shutdown instead of dropping the tail', async () => {
+    const delivered: string[] = []
+
+    await submitBroadcast('key', async () => { delivered.push('leading') }, { intervalMs: 10_000 })
+    await submitBroadcast('key', async () => { delivered.push('tail') }, { intervalMs: 10_000 })
+
+    expect(delivered).toEqual(['leading'])
+
+    await flushPendingBroadcasts()
+
+    expect(delivered).toEqual(['leading', 'tail'])
+  })
+
+  it('forgets a key once its burst ends, so pending state stays bounded', async () => {
+    const delivered: string[] = []
+    await submitBroadcast('key', async () => { delivered.push('first') }, { intervalMs: INTERVAL_MS })
+    await wait(INTERVAL_MS * 2)
+
+    // The window closed with nothing superseded, so the next submit is a fresh
+    // leading edge rather than a queued survivor.
+    await submitBroadcast('key', async () => { delivered.push('second') }, { intervalMs: INTERVAL_MS })
+
+    expect(delivered).toEqual(['first', 'second'])
+  })
+
+  describe('interval resolution', () => {
+    it('defaults to 250ms and rejects unusable values', () => {
+      delete process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+      expect(resolveBroadcastCoalesceIntervalMs()).toBe(250)
+
+      process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = '0'
+      expect(resolveBroadcastCoalesceIntervalMs()).toBe(0)
+
+      process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = '1000'
+      expect(resolveBroadcastCoalesceIntervalMs()).toBe(1000)
+
+      process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = '-5'
+      expect(resolveBroadcastCoalesceIntervalMs()).toBe(250)
+
+      process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = 'soon'
+      expect(resolveBroadcastCoalesceIntervalMs()).toBe(250)
+    })
+  })
+})

--- a/packages/events/src/__tests__/broadcast-coalescer.test.ts
+++ b/packages/events/src/__tests__/broadcast-coalescer.test.ts
@@ -93,6 +93,30 @@ describe('broadcast coalescer', () => {
     expect(delivered).toEqual(['leading', 'tail'])
   })
 
+  it('never runs two deliveries of one key concurrently, so an older payload cannot land last', async () => {
+    const started: string[] = []
+    const finished: string[] = []
+
+    const slowDispatch = (label: string, durationMs: number) => async () => {
+      started.push(label)
+      await wait(durationMs)
+      finished.push(label)
+    }
+
+    // Leading edge takes far longer than one window, so a naive re-arm would fire
+    // the next flush while it is still in flight.
+    await submitBroadcast('key', slowDispatch('first', INTERVAL_MS * 3), { intervalMs: INTERVAL_MS })
+    await submitBroadcast('key', slowDispatch('second', 0), { intervalMs: INTERVAL_MS })
+
+    await wait(INTERVAL_MS * 6)
+
+    expect(started).toEqual(['first', 'second'])
+    expect(finished).toEqual(['first', 'second'])
+    // 'second' must not have started before 'first' completed.
+    expect(started.indexOf('second')).toBeGreaterThanOrEqual(0)
+    expect(finished.indexOf('first')).toBeLessThan(finished.indexOf('second'))
+  })
+
   it('forgets a key once its burst ends, so pending state stays bounded', async () => {
     const delivered: string[] = []
     await submitBroadcast('key', async () => { delivered.push('first') }, { intervalMs: INTERVAL_MS })

--- a/packages/events/src/__tests__/broadcast-coalescing-bus.test.ts
+++ b/packages/events/src/__tests__/broadcast-coalescing-bus.test.ts
@@ -134,6 +134,25 @@ describe('event bus browser-delivery coalescing', () => {
     }
   })
 
+  it('flushes the tail on a natural exit as well as on a signal', async () => {
+    const registered: string[] = []
+    const onceSpy = jest.spyOn(process, 'once').mockImplementation(function (this: NodeJS.Process, event: string) {
+      registered.push(event)
+      return this
+    } as never)
+
+    try {
+      delete (globalThis as Record<string, unknown>).__openMercatoBroadcastCoalescerShutdown__
+      createEventBus({ resolve, queueStrategy: 'local' })
+    } finally {
+      onceSpy.mockRestore()
+    }
+
+    // The trailing timer is unref'd, so a CLI that emits and exits normally never
+    // sees a signal — beforeExit is the hook that saves its tail.
+    expect(registered).toEqual(expect.arrayContaining(['SIGTERM', 'SIGINT', 'beforeExit']))
+  })
+
   it('restores per-record browser delivery when the interval is disabled', async () => {
     process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = '0'
     const bus = createEventBus({ resolve, queueStrategy: 'local' })

--- a/packages/events/src/__tests__/broadcast-coalescing-bus.test.ts
+++ b/packages/events/src/__tests__/broadcast-coalescing-bus.test.ts
@@ -1,0 +1,156 @@
+const publishCrossProcessEventMock = jest.fn(async () => undefined)
+
+jest.mock('../bridge', () => ({
+  publishCrossProcessEvent: (...args: unknown[]) => publishCrossProcessEventMock(...args),
+  registerCrossProcessEventListener: jest.fn(),
+  CROSS_PROCESS_EVENT_INSTANCE_ID: 'test-instance',
+}))
+
+import { createModuleEvents } from '@open-mercato/shared/modules/events'
+import { createEventBus, registerGlobalEventTap } from '@open-mercato/events/bus'
+import { resetBroadcastCoalescerForTests } from '@open-mercato/events/broadcast-coalescer'
+
+const INTERVAL_MS = 50
+
+createModuleEvents({
+  moduleId: 'coalesce_test',
+  events: [
+    { id: 'coalesce_test.bulk.created', label: 'Bulk Created', clientBroadcast: true, broadcastCoalescing: true },
+    { id: 'coalesce_test.plain.created', label: 'Plain Created', clientBroadcast: true },
+  ] as const,
+})
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('event bus browser-delivery coalescing', () => {
+  const resolve = ((name: string) => name) as never
+  const originalInterval = process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+  let unregisterTap: (() => void) | null = null
+
+  beforeEach(() => {
+    publishCrossProcessEventMock.mockClear()
+    process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = String(INTERVAL_MS)
+  })
+
+  afterEach(() => {
+    unregisterTap?.()
+    unregisterTap = null
+    resetBroadcastCoalescerForTests()
+    if (originalInterval === undefined) delete process.env.OM_BROADCAST_COALESCE_INTERVAL_MS
+    else process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = originalInterval
+  })
+
+  it('keeps domain delivery per record while collapsing the browser dispatch', async () => {
+    const bus = createEventBus({ resolve, queueStrategy: 'local' })
+    const subscriberCalls: string[] = []
+    const tappedIds: string[] = []
+
+    bus.on('coalesce_test.bulk.created', async (payload) => {
+      subscriberCalls.push(String((payload as { id: string }).id))
+    })
+    unregisterTap = registerGlobalEventTap((_event, payload) => {
+      tappedIds.push(String((payload as { id: string }).id))
+    })
+
+    for (let index = 0; index < 100; index += 1) {
+      await bus.emit(
+        'coalesce_test.bulk.created',
+        { id: `product-${index}`, tenantId: 'tenant-1', organizationId: 'org-1' },
+        { tenantId: 'tenant-1', organizationId: 'org-1' },
+      )
+    }
+    await wait(INTERVAL_MS * 2)
+
+    // The hard requirement from the issue: the domain event still fires once per
+    // record, so webhooks, notification handlers and indexers are untouched.
+    expect(subscriberCalls).toHaveLength(100)
+    expect(subscriberCalls[0]).toBe('product-0')
+    expect(subscriberCalls[99]).toBe('product-99')
+
+    // The browser half collapses, and the burst still ends on the final record.
+    expect(tappedIds.length).toBeLessThan(100)
+    expect(tappedIds[0]).toBe('product-0')
+    expect(tappedIds[tappedIds.length - 1]).toBe('product-99')
+
+    // The pg_notify roundtrip collapses with it — half the cost the issue names.
+    expect(publishCrossProcessEventMock.mock.calls.length).toBe(tappedIds.length)
+  })
+
+  it('leaves an event that did not opt in on the per-record path', async () => {
+    const bus = createEventBus({ resolve, queueStrategy: 'local' })
+    const tappedIds: string[] = []
+    unregisterTap = registerGlobalEventTap((_event, payload) => {
+      tappedIds.push(String((payload as { id: string }).id))
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      await bus.emit(
+        'coalesce_test.plain.created',
+        { id: `product-${index}`, tenantId: 'tenant-1', organizationId: 'org-1' },
+        { tenantId: 'tenant-1', organizationId: 'org-1' },
+      )
+    }
+
+    expect(tappedIds).toHaveLength(10)
+    expect(publishCrossProcessEventMock).toHaveBeenCalledTimes(10)
+  })
+
+  it('never delivers one tenant or organization payload under another scope', async () => {
+    const bus = createEventBus({ resolve, queueStrategy: 'local' })
+    const seen: Array<{ tenantId: string; organizationId: string; id: string }> = []
+    unregisterTap = registerGlobalEventTap((_event, payload) => {
+      const data = payload as { id: string; tenantId: string; organizationId: string }
+      seen.push({ tenantId: data.tenantId, organizationId: data.organizationId, id: data.id })
+    })
+
+    const scopes = [
+      { tenantId: 'tenant-a', organizationId: 'org-1' },
+      { tenantId: 'tenant-b', organizationId: 'org-1' },
+      { tenantId: 'tenant-a', organizationId: 'org-2' },
+    ]
+
+    for (let round = 0; round < 5; round += 1) {
+      for (const scope of scopes) {
+        await bus.emit(
+          'coalesce_test.bulk.created',
+          { id: `${scope.tenantId}-${scope.organizationId}-${round}`, ...scope },
+          scope,
+        )
+      }
+    }
+    await wait(INTERVAL_MS * 2)
+
+    // Every scope gets its own leading edge and its own trailing flush, and no
+    // delivered payload ever carries a scope other than the one it was keyed by.
+    for (const scope of scopes) {
+      const forScope = seen.filter((entry) => entry.tenantId === scope.tenantId && entry.organizationId === scope.organizationId)
+      expect(forScope.length).toBeGreaterThanOrEqual(2)
+      expect(forScope[forScope.length - 1].id).toBe(`${scope.tenantId}-${scope.organizationId}-4`)
+      for (const entry of forScope) {
+        expect(entry.id.startsWith(`${scope.tenantId}-${scope.organizationId}-`)).toBe(true)
+      }
+    }
+  })
+
+  it('restores per-record browser delivery when the interval is disabled', async () => {
+    process.env.OM_BROADCAST_COALESCE_INTERVAL_MS = '0'
+    const bus = createEventBus({ resolve, queueStrategy: 'local' })
+    const tappedIds: string[] = []
+    unregisterTap = registerGlobalEventTap((_event, payload) => {
+      tappedIds.push(String((payload as { id: string }).id))
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      await bus.emit(
+        'coalesce_test.bulk.created',
+        { id: `product-${index}`, tenantId: 'tenant-1', organizationId: 'org-1' },
+        { tenantId: 'tenant-1', organizationId: 'org-1' },
+      )
+    }
+
+    expect(tappedIds).toHaveLength(10)
+    expect(publishCrossProcessEventMock).toHaveBeenCalledTimes(10)
+  })
+})

--- a/packages/events/src/broadcast-coalescer.ts
+++ b/packages/events/src/broadcast-coalescer.ts
@@ -1,0 +1,166 @@
+import { parseNumberWithDefault } from '@open-mercato/shared/lib/number'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+
+/**
+ * Coalesces the BROWSER half of an event emit.
+ *
+ * A `clientBroadcast: true` event costs a serialized `pg_notify` roundtrip plus a
+ * tenant-wide SSE fan-out on every emit, so a bulk writer pays both once per
+ * record even though its browser consumers only refresh a list. Events that opt
+ * in with `broadcastCoalescing: true` route their browser dispatch through here:
+ * the first emit of a burst goes out immediately (leading edge) and later emits
+ * sharing a key replace the pending payload instead of being delivered.
+ *
+ * A trailing flush is ALWAYS armed, so the last emit of a burst is delivered and
+ * a DataTable never ends the burst stale. This is where the mechanism goes past
+ * the progress service's private throttle, which can drop its tail only because
+ * its terminal transitions emit through a separate unthrottled path.
+ *
+ * Inline subscribers, webhooks and the queue never reach this module — the domain
+ * event still fires once per record.
+ */
+
+const DEFAULT_COALESCE_INTERVAL_MS = 250
+const PENDING_BROADCASTS_KEY = '__openMercatoPendingBroadcasts__'
+
+const logger = createLogger('events').child({ component: 'broadcast-coalescer' })
+
+type BroadcastDispatch = () => Promise<void>
+
+type PendingBroadcast = {
+  /** The newest superseding dispatch awaiting the trailing flush, if any. */
+  pending: BroadcastDispatch | null
+  timer: ReturnType<typeof setTimeout> | null
+  suppressed: number
+}
+
+/**
+ * Held on `globalThis` for the same reason as the bus's global taps and producer
+ * queue: a fresh event bus is built per request, so per-bus state would coalesce
+ * nothing across the emits of a single bulk job.
+ */
+function getPendingBroadcasts(): Map<string, PendingBroadcast> {
+  const existing = (globalThis as Record<string, unknown>)[PENDING_BROADCASTS_KEY]
+  if (existing instanceof Map) {
+    return existing as Map<string, PendingBroadcast>
+  }
+  const created = new Map<string, PendingBroadcast>()
+  ;(globalThis as Record<string, unknown>)[PENDING_BROADCASTS_KEY] = created
+  return created
+}
+
+/**
+ * Minimum elapsed time between coalesced browser deliveries of one key. `0`
+ * disables coalescing process-wide, restoring per-record delivery — the runtime
+ * escape hatch, mirroring `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS=0`.
+ */
+export function resolveBroadcastCoalesceIntervalMs(): number {
+  return parseNumberWithDefault(
+    process.env.OM_BROADCAST_COALESCE_INTERVAL_MS,
+    DEFAULT_COALESCE_INTERVAL_MS,
+    { min: 0, integer: true },
+  )
+}
+
+function armTimer(key: string, intervalMs: number): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(() => {
+    void onWindowClosed(key, intervalMs)
+  }, intervalMs)
+  // Never keep a CLI or worker process alive just to flush a browser delivery.
+  // The shutdown hook flushes what is still pending on the way out.
+  if (typeof (timer as { unref?: () => void }).unref === 'function') {
+    ;(timer as { unref: () => void }).unref()
+  }
+  return timer
+}
+
+async function onWindowClosed(key: string, intervalMs: number): Promise<void> {
+  const entries = getPendingBroadcasts()
+  const entry = entries.get(key)
+  if (!entry) return
+
+  const pending = entry.pending
+  if (!pending) {
+    // The window closed with nothing superseded: the burst is over.
+    entry.timer = null
+    entries.delete(key)
+    return
+  }
+
+  const suppressed = entry.suppressed
+  entry.pending = null
+  entry.suppressed = 0
+  // Re-arm before dispatching so a burst still in flight keeps its window.
+  entry.timer = armTimer(key, intervalMs)
+
+  await runDispatch(pending, key)
+  if (suppressed > 0) {
+    logger.debug('Coalesced browser deliveries', { key, suppressed })
+  }
+}
+
+/**
+ * A deferred dispatch has no caller awaiting it, so its failure must be
+ * contained here — `bus.emit` already logs-and-continues on a synchronous
+ * publish failure, and one failed flush must not stop the next window.
+ */
+async function runDispatch(dispatch: BroadcastDispatch, key: string): Promise<void> {
+  try {
+    await dispatch()
+  } catch (error) {
+    logger.error('Coalesced broadcast dispatch failed', { key, err: error })
+  }
+}
+
+/**
+ * Submit a browser dispatch for `key`. Resolves once the caller's obligation is
+ * discharged: immediately-dispatched submissions resolve after delivery,
+ * superseded ones resolve as soon as they are queued.
+ */
+export async function submitBroadcast(
+  key: string,
+  dispatch: BroadcastDispatch,
+  options?: { intervalMs?: number },
+): Promise<void> {
+  const intervalMs = options?.intervalMs ?? resolveBroadcastCoalesceIntervalMs()
+  if (intervalMs <= 0) {
+    await dispatch()
+    return
+  }
+
+  const entries = getPendingBroadcasts()
+  const entry = entries.get(key)
+  if (!entry) {
+    entries.set(key, { pending: null, timer: armTimer(key, intervalMs), suppressed: 0 })
+    await dispatch()
+    return
+  }
+
+  if (entry.pending) entry.suppressed += 1
+  entry.pending = dispatch
+}
+
+/**
+ * Deliver every survivor still awaiting its trailing flush. Wired into the
+ * process shutdown hook so a graceful stop does not swallow the tail of a burst.
+ */
+export async function flushPendingBroadcasts(): Promise<void> {
+  const entries = getPendingBroadcasts()
+  const drained: Array<Promise<void>> = []
+  for (const [key, entry] of entries) {
+    if (entry.timer) clearTimeout(entry.timer)
+    const pending = entry.pending
+    entries.delete(key)
+    if (pending) drained.push(runDispatch(pending, key))
+  }
+  await Promise.all(drained)
+}
+
+/** Drop all pending state without dispatching. Tests only. */
+export function resetBroadcastCoalescerForTests(): void {
+  const entries = getPendingBroadcasts()
+  for (const entry of entries.values()) {
+    if (entry.timer) clearTimeout(entry.timer)
+  }
+  entries.clear()
+}

--- a/packages/events/src/broadcast-coalescer.ts
+++ b/packages/events/src/broadcast-coalescer.ts
@@ -90,13 +90,23 @@ async function onWindowClosed(key: string, intervalMs: number): Promise<void> {
   const suppressed = entry.suppressed
   entry.pending = null
   entry.suppressed = 0
-  // Re-arm before dispatching so a burst still in flight keeps its window.
-  entry.timer = armTimer(key, intervalMs)
+  entry.timer = null
 
   await runDispatch(pending, key)
   if (suppressed > 0) {
     logger.debug('Coalesced browser deliveries', { key, suppressed })
   }
+
+  // Re-arm only AFTER the dispatch settles, so one key never has two deliveries
+  // in flight. Re-arming first would let a slow pg_notify roundtrip overlap the
+  // next window and land an older payload last — the exact staleness coalescing
+  // exists to prevent. As a side effect the window self-extends under load,
+  // which is the right behavior for a throttle. Submissions arriving during the
+  // dispatch still queue on the entry, which is still in the map.
+  const current = entries.get(key)
+  if (!current) return
+  if (current.pending) current.timer = armTimer(key, intervalMs)
+  else entries.delete(key)
 }
 
 /**

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -117,7 +117,10 @@ function buildBroadcastCoalesceKey(event: string, options?: EmitOptions): string
       if (trimmed) organizationScopes.add(trimmed)
     }
   }
-  return `${event}::${tenantId}::${Array.from(organizationScopes).sort().join(',')}`
+  // Sorted so a multi-organization audience keys identically however the caller
+  // ordered it, and explicitly comparator-ed per the #3620 guard.
+  const sortedScopes = Array.from(organizationScopes).sort((left, right) => left.localeCompare(right))
+  return `${event}::${tenantId}::${sortedScopes.join(',')}`
 }
 
 function getGlobalEventTaps(): Set<GlobalEventTap> {

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -195,10 +195,16 @@ function registerProducerShutdownHook(): void {
 }
 
 /**
- * Deliver the tail of any in-flight coalesced burst on a graceful stop, so
- * shutting a worker down mid-import does not leave browsers a window behind.
- * Registered independently of the producer hook: coalescing is in play whether
- * or not this process ever opened an async producer queue.
+ * Deliver the tail of any in-flight coalesced burst on the way out, so stopping
+ * a worker mid-import does not leave browsers a window behind. Registered
+ * independently of the producer hook: coalescing is in play whether or not this
+ * process ever opened an async producer queue.
+ *
+ * `beforeExit` matters as much as the signals here. The trailing timer is
+ * unref'd so a pending browser delivery never holds a process open, which means
+ * a short-lived emitter — a CLI import, a one-shot script — reaches a natural
+ * exit with the tail still queued and no signal ever fired. `beforeExit` runs
+ * exactly when the loop has drained, which is precisely that case.
  */
 function registerBroadcastCoalescerShutdownHook(): void {
   if ((globalThis as Record<string, unknown>)[BROADCAST_COALESCER_SHUTDOWN_KEY]) return
@@ -207,6 +213,7 @@ function registerBroadcastCoalescerShutdownHook(): void {
   }
   process.once('SIGTERM', shutdown)
   process.once('SIGINT', shutdown)
+  process.once('beforeExit', shutdown)
   ;(globalThis as Record<string, unknown>)[BROADCAST_COALESCER_SHUTDOWN_KEY] = true
 }
 

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -7,9 +7,11 @@ import { matchEventPattern } from '@open-mercato/shared/lib/events/patterns'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import {
   isBroadcastEvent,
+  isCoalescedBroadcastEvent,
   isCrossProcessBroadcastEvent,
   isPrivateCrossProcessEventEmitter,
 } from '@open-mercato/shared/modules/events'
+import { flushPendingBroadcasts, submitBroadcast } from './broadcast-coalescer'
 import {
   inferModuleIdFromResourceId,
   withModuleResourceUsage,
@@ -95,6 +97,29 @@ function resolveCrossProcessEmitOptions(
   }
 }
 
+/**
+ * Coalescing key for the browser dispatch of one event.
+ *
+ * Scope is part of the key by necessity, not for granularity: a key of event id
+ * alone would let a burst in one tenant suppress another tenant's delivery and
+ * then deliver the first tenant's payload in its place.
+ */
+function buildBroadcastCoalesceKey(event: string, options?: EmitOptions): string {
+  const tenantId = typeof options?.tenantId === 'string' ? options.tenantId.trim() : ''
+  const organizationScopes = new Set<string>()
+  if (typeof options?.organizationId === 'string' && options.organizationId.trim().length > 0) {
+    organizationScopes.add(options.organizationId.trim())
+  }
+  if (Array.isArray(options?.organizationIds)) {
+    for (const organizationId of options.organizationIds) {
+      if (typeof organizationId !== 'string') continue
+      const trimmed = organizationId.trim()
+      if (trimmed) organizationScopes.add(trimmed)
+    }
+  }
+  return `${event}::${tenantId}::${Array.from(organizationScopes).sort().join(',')}`
+}
+
 function getGlobalEventTaps(): Set<GlobalEventTap> {
   const existing = (globalThis as Record<string, unknown>)[GLOBAL_EVENT_TAPS_KEY]
   if (existing instanceof Set) {
@@ -139,6 +164,7 @@ type EventJobData = {
 // base dir is cwd-relative, so it stays per-bus.
 const EVENTS_PRODUCER_QUEUE_KEY = '__openMercatoEventsProducerQueues__'
 const EVENTS_PRODUCER_SHUTDOWN_KEY = '__openMercatoEventsProducerShutdown__'
+const BROADCAST_COALESCER_SHUTDOWN_KEY = '__openMercatoBroadcastCoalescerShutdown__'
 
 function isSharedProducerEnabled(): boolean {
   return parseBooleanWithDefault(process.env.OM_EVENTS_SHARED_PRODUCER, true)
@@ -166,6 +192,22 @@ function registerProducerShutdownHook(): void {
   process.once('SIGTERM', shutdown)
   process.once('SIGINT', shutdown)
   ;(globalThis as Record<string, unknown>)[EVENTS_PRODUCER_SHUTDOWN_KEY] = true
+}
+
+/**
+ * Deliver the tail of any in-flight coalesced burst on a graceful stop, so
+ * shutting a worker down mid-import does not leave browsers a window behind.
+ * Registered independently of the producer hook: coalescing is in play whether
+ * or not this process ever opened an async producer queue.
+ */
+function registerBroadcastCoalescerShutdownHook(): void {
+  if ((globalThis as Record<string, unknown>)[BROADCAST_COALESCER_SHUTDOWN_KEY]) return
+  const shutdown = () => {
+    void flushPendingBroadcasts().catch(() => {})
+  }
+  process.once('SIGTERM', shutdown)
+  process.once('SIGINT', shutdown)
+  ;(globalThis as Record<string, unknown>)[BROADCAST_COALESCER_SHUTDOWN_KEY] = true
 }
 
 /**
@@ -199,6 +241,8 @@ function registerProducerShutdownHook(): void {
  * ```
  */
 export function createEventBus(opts: CreateBusOptions): EventBus {
+  registerBroadcastCoalescerShutdownHook()
+
   // In-memory listeners for immediate event delivery
   const listeners = new Map<string, Set<RegisteredSubscriber>>()
   // Subscribers registered as persistent (worker-dispatched). Used by the
@@ -439,13 +483,52 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     payload: EventPayload,
     options?: EmitOptions
   ): Promise<void> {
-    const taps = getGlobalEventTaps()
-    for (const tap of taps) {
-      try {
-        await Promise.resolve(tap(event, payload, options))
-      } catch (error) {
-        logger.error('Global tap error', { event, err: error })
+    // Private coordination always requires trusted envelope scope and module
+    // provenance. Legacy declared browser events may promote their typed scope
+    // for raw EventBus compatibility; tenant-managed workflow adapters pass
+    // authoritative scope in options, which always wins over payload values.
+    const crossProcessOptions = resolveCrossProcessEmitOptions(event, payload, options)
+
+    const runGlobalTaps = async (): Promise<void> => {
+      const taps = getGlobalEventTaps()
+      for (const tap of taps) {
+        try {
+          await Promise.resolve(tap(event, payload, options))
+        } catch (error) {
+          logger.error('Global tap error', { event, err: error })
+        }
       }
+    }
+
+    const publishToOtherProcesses = async (): Promise<void> => {
+      if (
+        !isCrossProcessBroadcastEvent(event)
+        || !hasTrustedTenantScope(crossProcessOptions)
+        || !isPrivateCrossProcessEventEmitter(event, crossProcessOptions?.emitterModuleId)
+      ) return
+      try {
+        await publishCrossProcessEvent(event, payload, crossProcessOptions)
+      } catch (error) {
+        logger.error('Cross-process publish error', { event, err: error })
+      }
+    }
+
+    // The two sinks that exist only so browsers see the change: the global taps
+    // (which both SSE endpoints subscribe through) and the pg_notify publish that
+    // reaches connections held by other processes. Neither carries domain meaning,
+    // so an opted-in event may coalesce them without touching subscriber, webhook
+    // or queue semantics below.
+    const coalesceBrowserDelivery = isCoalescedBroadcastEvent(event)
+    if (coalesceBrowserDelivery) {
+      await submitBroadcast(
+        buildBroadcastCoalesceKey(event, crossProcessOptions ?? options),
+        async () => {
+          await runGlobalTaps()
+          await publishToOtherProcesses()
+        },
+      )
+    } else {
+      await runGlobalTaps()
     }
 
     // Deliver to in-memory handlers first. Under single-delivery, persistent
@@ -468,21 +551,10 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
       inlinePersistentFailed = delivered.persistentFailures > 0
     }
 
-    // Private coordination always requires trusted envelope scope and module
-    // provenance. Legacy declared browser events may promote their typed scope
-    // for raw EventBus compatibility; tenant-managed workflow adapters pass
-    // authoritative scope in options, which always wins over payload values.
-    const crossProcessOptions = resolveCrossProcessEmitOptions(event, payload, options)
-    if (
-      isCrossProcessBroadcastEvent(event)
-      && hasTrustedTenantScope(crossProcessOptions)
-      && isPrivateCrossProcessEventEmitter(event, crossProcessOptions?.emitterModuleId)
-    ) {
-      try {
-        await publishCrossProcessEvent(event, payload, crossProcessOptions)
-      } catch (error) {
-        logger.error('Cross-process publish error', { event, err: error })
-      }
+    // Already dispatched with the taps when this event coalesces its browser
+    // delivery; otherwise it publishes here, exactly where it always has.
+    if (!coalesceBrowserDelivery) {
+      await publishToOtherProcesses()
     }
 
     // If persistent, also enqueue for async processing

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -493,12 +493,6 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     payload: EventPayload,
     options?: EmitOptions
   ): Promise<void> {
-    // Private coordination always requires trusted envelope scope and module
-    // provenance. Legacy declared browser events may promote their typed scope
-    // for raw EventBus compatibility; tenant-managed workflow adapters pass
-    // authoritative scope in options, which always wins over payload values.
-    const crossProcessOptions = resolveCrossProcessEmitOptions(event, payload, options)
-
     const runGlobalTaps = async (): Promise<void> => {
       const taps = getGlobalEventTaps()
       for (const tap of taps) {
@@ -510,7 +504,15 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
       }
     }
 
+    // Resolved at call time, never hoisted. Private coordination always requires
+    // trusted envelope scope and module provenance. Legacy declared browser events
+    // may promote their typed scope for raw EventBus compatibility; tenant-managed
+    // workflow adapters pass authoritative scope in options, which always wins over
+    // payload values. Computing it lazily keeps the non-coalesced path resolving
+    // scope at exactly the point it always did — after inline delivery — so an
+    // event that did not opt in cannot observe this change at all.
     const publishToOtherProcesses = async (): Promise<void> => {
+      const crossProcessOptions = resolveCrossProcessEmitOptions(event, payload, options)
       if (
         !isCrossProcessBroadcastEvent(event)
         || !hasTrustedTenantScope(crossProcessOptions)
@@ -531,7 +533,7 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     const coalesceBrowserDelivery = isCoalescedBroadcastEvent(event)
     if (coalesceBrowserDelivery) {
       await submitBroadcast(
-        buildBroadcastCoalesceKey(event, crossProcessOptions ?? options),
+        buildBroadcastCoalesceKey(event, resolveCrossProcessEmitOptions(event, payload, options) ?? options),
         async () => {
           await runGlobalTaps()
           await publishToOtherProcesses()

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './bus'
+export * from './broadcast-coalescer'

--- a/packages/shared/src/modules/events/__tests__/broadcast-coalescing-declaration.test.ts
+++ b/packages/shared/src/modules/events/__tests__/broadcast-coalescing-declaration.test.ts
@@ -1,0 +1,53 @@
+import { createModuleEvents, isCoalescedBroadcastEvent } from '../factory'
+
+const GLOBAL_EVENT_REGISTRY_KEY = '__openMercatoEventDefinitionRegistry__'
+
+describe('broadcastCoalescing declarations', () => {
+  const globalScope = globalThis as Record<string, unknown>
+  const originalRegistry = globalScope[GLOBAL_EVENT_REGISTRY_KEY]
+
+  beforeEach(() => {
+    delete globalScope[GLOBAL_EVENT_REGISTRY_KEY]
+  })
+
+  afterAll(() => {
+    if (originalRegistry === undefined) delete globalScope[GLOBAL_EVENT_REGISTRY_KEY]
+    else globalScope[GLOBAL_EVENT_REGISTRY_KEY] = originalRegistry
+  })
+
+  it('recognizes an opted-in browser event and nothing else', () => {
+    createModuleEvents({
+      moduleId: 'coalesce_decl_test',
+      events: [
+        { id: 'coalesce_decl_test.bulk', label: 'Bulk', clientBroadcast: true, broadcastCoalescing: true },
+        { id: 'coalesce_decl_test.portal', label: 'Portal', portalBroadcast: true, broadcastCoalescing: true },
+        { id: 'coalesce_decl_test.plain_browser', label: 'Plain Browser', clientBroadcast: true },
+        { id: 'coalesce_decl_test.local', label: 'Local' },
+      ] as const,
+    })
+
+    expect(isCoalescedBroadcastEvent('coalesce_decl_test.bulk')).toBe(true)
+    expect(isCoalescedBroadcastEvent('coalesce_decl_test.portal')).toBe(true)
+    expect(isCoalescedBroadcastEvent('coalesce_decl_test.plain_browser')).toBe(false)
+    expect(isCoalescedBroadcastEvent('coalesce_decl_test.local')).toBe(false)
+    expect(isCoalescedBroadcastEvent('coalesce_decl_test.never_declared')).toBe(false)
+  })
+
+  it('rejects coalescing private cross-process coordination', () => {
+    expect(() => createModuleEvents({
+      moduleId: 'coalesce_decl_test',
+      events: [
+        { id: 'coalesce_decl_test.private', label: 'Private', crossProcessBroadcast: true, broadcastCoalescing: true },
+      ] as const,
+    })).toThrow(/crossProcessBroadcast/)
+  })
+
+  it('rejects coalescing an event with no browser delivery to coalesce', () => {
+    expect(() => createModuleEvents({
+      moduleId: 'coalesce_decl_test',
+      events: [
+        { id: 'coalesce_decl_test.orphan', label: 'Orphan', broadcastCoalescing: true },
+      ] as const,
+    })).toThrow(/clientBroadcast or portalBroadcast/)
+  })
+})

--- a/packages/shared/src/modules/events/factory.ts
+++ b/packages/shared/src/modules/events/factory.ts
@@ -186,6 +186,20 @@ export function isPrivateCrossProcessEventEmitter(
 }
 
 /**
+ * Check whether an event opted into coalesced browser delivery.
+ * Read by the event bus before it hands a browser dispatch to the coalescer.
+ */
+export function isCoalescedBroadcastEvent(eventId: string): boolean {
+  const event = getEventRegistryState().declaredEvents.find(e => e.id === eventId)
+  if (event?.broadcastCoalescing !== true) return false
+  // Private cross-process coordination must never be delayed, and an event with
+  // no browser sink has nothing to coalesce. Both are rejected at declaration
+  // time, so this is defence in depth for events registered by other paths.
+  if (event.crossProcessBroadcast === true) return false
+  return event.clientBroadcast === true || event.portalBroadcast === true
+}
+
+/**
  * Check if an event has portalBroadcast enabled.
  * Used by the portal SSE endpoint to filter events for the Portal Event Bridge.
  */
@@ -276,6 +290,23 @@ export function createModuleEvents<
     ...e,
     module: moduleId,
   }))
+
+  for (const event of fullEvents) {
+    if (event.broadcastCoalescing !== true) continue
+    if (event.crossProcessBroadcast === true) {
+      throw new Error(
+        `[internal] Event "${event.id}" declared by module "${moduleId}" combines crossProcessBroadcast with ` +
+        'broadcastCoalescing. Private cross-process coordination must be delivered immediately — delaying it ' +
+        'would let another process serve stale data. Drop one of the two flags.',
+      )
+    }
+    if (event.clientBroadcast !== true && event.portalBroadcast !== true) {
+      throw new Error(
+        `[internal] Event "${event.id}" declared by module "${moduleId}" sets broadcastCoalescing without ` +
+        'clientBroadcast or portalBroadcast. There is no browser delivery to coalesce.',
+      )
+    }
+  }
 
   // Register all event IDs and definitions in the global registry.
   for (const event of fullEvents) {

--- a/packages/shared/src/modules/events/types.ts
+++ b/packages/shared/src/modules/events/types.ts
@@ -38,6 +38,19 @@ export interface EventDefinition {
   crossProcessBroadcast?: boolean
   /** When true, this event is bridged to the customer portal via SSE (Portal Event Bridge). Default: false */
   portalBroadcast?: boolean
+  /**
+   * When true, browser deliveries of this event coalesce: within
+   * OM_BROADCAST_COALESCE_INTERVAL_MS only the newest payload per
+   * (event, tenant, organization) reaches the SSE bridges, and a trailing flush
+   * guarantees the last one is delivered. Subscribers, webhooks and the queue are
+   * unaffected — the domain event still fires once per record.
+   *
+   * Declare it only on events whose browser consumers react to the fact that
+   * something changed (a list refresh), never to each occurrence. Cannot be
+   * combined with crossProcessBroadcast: delaying private coordination would let
+   * another process serve stale data. Default: false
+   */
+  broadcastCoalescing?: boolean
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #5733
Refs #5895
Source doc: `.ai/specs/2026-09-04-client-broadcast-sse-coalescing.md`
Tracking plan: `.ai/runs/2026-09-04-client-broadcast-sse-coalescing.md`
Status: complete

## 🎯 Goal

Give the event bus opt-in coalescing of **browser** deliveries for `clientBroadcast` events, so a bulk writer stops paying one `pg_notify` roundtrip and one tenant-wide SSE fan-out per record — while inline subscribers, webhooks, workflows and the queue keep firing once per record.

## 📋 Plan

- **Phase 1** — the mechanism: the `broadcastCoalescing` declaration field, the coalescer module, the wiring into `bus.emit`, scope-isolated keys, shutdown flush, env knob. No event opts in, so this phase is behavior-neutral.
- **Phase 2** — the first consumers: opt `catalog.product.{created,updated,deleted}` in, add the bulk-writer guard test, document the mechanism.

## 💥 Breaking Changes

- None. One additive optional `EventDefinition` field (permitted by `BACKWARD_COMPATIBILITY.md:42`), new exports, one new optional env var. The SSE frame shape, `useAppEvent`, every event id, the audience filter and the queue contract are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791135424&installation_model_id=432243&pr_number=5896&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5896&signature=0ad94409dec0c0c3073772cd4fd4b8e2685b00a1edbe3df8b7821f7e06697005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
