### PR TITLE
fix(auth): cascade sidebar rows when deleting a user

### DIFF
--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -354,6 +354,22 @@ Files in `apps/mercato/.mercato/generated/` are produced by the CLI generators. 
 
 ---
 
+## CRUD Foreign-Key Violations Answer 409 (2026-09-07)
+
+Deleting a user who had customised their sidebar failed on the `user_sidebar_preferences` / `sidebar_variants` foreign keys and surfaced as a generic `500`. The fix clears those rows in `auth.users.delete`, gives both FKs `ON DELETE CASCADE`, and teaches `makeCrudRoute` to recognise a Postgres foreign-key violation (SQLSTATE 23503). **All changes are additive** and pass the contract-surface checks above:
+
+| Surface | Change | Classification |
+|---------|--------|----------------|
+| Import path / exports (`@open-mercato/shared/lib/db/pg-errors`) | New exports `isForeignKeyViolation(err)` and `getForeignKeyViolationConstraint(err)` | ✓ ADDITIVE (new exports, nothing removed or renamed) |
+| HTTP response shapes (`makeCrudRoute` handlers) | A handler that throws a Postgres foreign-key violation now answers `409 { error, code: 'FOREIGN_KEY_VIOLATION', requestId }` with an `x-request-id` header, where it previously answered the generic `500 { error, message, requestId }`. The constraint name is logged and reported to telemetry but never returned to the client. Every other error class keeps its byte-identical historical answer | ⚠️ Behaviour change for one error class only. No retained response loses a field, but a client that treated the old `500` as retryable now receives a non-retryable `409`. Regression-tested in `crud-factory.test.ts` |
+| Database schema (`user_sidebar_preferences_user_id_foreign`, `sidebar_variants_user_id_foreign`) | Both constraints are dropped and recreated with `on update cascade on delete cascade` (`Migration20260907120000_auth`). No table or column is added, renamed, removed or retyped, and `down()` restores each constraint to its original definition | ✓ ADDITIVE-ONLY compatible (delete behaviour widened, nothing narrowed) |
+| Command behaviour (`auth.users.delete`, `auth.users.create` undo) | The dependent-row cascade also clears `user_sidebar_preferences` and `sidebar_variants`. Those rows are not captured by `UserUndoSnapshot`, so undoing a user delete restores the user, roles, ACLs and custom fields but not the sidebar customisation. `user_consents` is deliberately left untouched | ✓ Behaviour-preserving for every delete that succeeded before; deletes that previously failed with `500` now succeed |
+| Event IDs, ACL features, DI names, CLI commands | No change | ✓ n/a |
+
+**Migration path for existing modules**: no action required. A client that branched on `5xx` for foreign-key failures should treat `409` with `code: 'FOREIGN_KEY_VIOLATION'` as the same condition; it was never retryable.
+
+---
+
 ## Module Registry Registration Listeners (2026-08-12)
 
 [`.ai/specs/2026-08-12-module-registry-registration-listeners.md`](.ai/specs/2026-08-12-module-registry-registration-listeners.md) adds a public subscription to the module registry so a cache derived from the module list can drop what it built from an incomplete one ([#5103](https://github.com/open-mercato/open-mercato/issues/5103)). **All changes are additive** and pass the contract-surface checks above:

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-064-user-delete-sidebar-cascade.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-064-user-delete-sidebar-cascade.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, clearAuthTokenCache, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-AUTH-064: Deleting a user with sidebar rows succeeds
+ *
+ * `user_sidebar_preferences` and `sidebar_variants` both hold a foreign key to
+ * `users`. The delete cascade in auth.users.delete never cleared them, so any
+ * user who had customised their sidebar could not be deleted: Postgres rejected
+ * the hard delete and the API answered with a bare 500. This spec writes both
+ * kinds of sidebar rows as the target user, deletes the user as a superadmin,
+ * and expects the delete to commit.
+ */
+test.describe('TC-AUTH-064: user delete sidebar cascade', () => {
+  test('deletes a user who has a sidebar preference and a sidebar variant', async ({ request }) => {
+    let adminToken: string | null = null;
+    let roleId: string | null = null;
+    let userId: string | null = null;
+    const stamp = Date.now();
+    const email = `qa-tc-auth-064-${stamp}@example.com`;
+    const password = 'Sup3rSecret!pw';
+
+    try {
+      adminToken = await getAuthToken(request, 'superadmin');
+      const { organizationId } = getTokenContext(adminToken);
+
+      roleId = await createRoleFixture(request, adminToken, { name: `qa-tc-auth-064-${stamp}` });
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId,
+        roles: [roleId],
+        name: 'QA TC-AUTH-064',
+      });
+      await setUserAclVisibility(request, adminToken, {
+        userId,
+        organizations: null,
+        features: ['auth.sidebar.manage'],
+      });
+
+      // Sidebar routes are self-scoped, so the rows must be written as the target user.
+      const userToken = await getAuthToken(request, email, password);
+
+      const prefRes = await apiRequest(request, 'PUT', '/api/auth/sidebar/preferences', {
+        token: userToken,
+        data: { groupLabels: { 'qa-tc-auth-064': `Group ${stamp}` } },
+      });
+      expect(prefRes.status(), 'PUT sidebar preferences should return 200').toBe(200);
+
+      const variantRes = await apiRequest(request, 'POST', '/api/auth/sidebar/variants', {
+        token: userToken,
+        data: { name: `QA TC-AUTH-064 ${stamp}`, isActive: false, settings: { groupLabels: { 'qa-tc-auth-064': `Variant ${stamp}` } } },
+      });
+      expect(variantRes.status(), 'POST sidebar variant should return 200').toBe(200);
+      const variantBody = await readJsonSafe<{ variant?: { id?: string } }>(variantRes);
+      expect(typeof variantBody?.variant?.id, 'variant creation should return an id').toBe('string');
+
+      const deleteRes = await apiRequest(request, 'DELETE', `/api/auth/users?id=${encodeURIComponent(userId)}`, { token: adminToken });
+      expect(deleteRes.status(), 'DELETE user with sidebar rows should return 200').toBe(200);
+      const deletedUserId = userId;
+      userId = null;
+
+      const listRes = await apiRequest(request, 'GET', `/api/auth/users?id=${encodeURIComponent(deletedUserId)}`, { token: adminToken });
+      expect(listRes.status(), 'GET users should return 200').toBe(200);
+      const listBody = await readJsonSafe<{ items?: Array<{ id?: string }> }>(listRes);
+      expect((listBody?.items ?? []).some((user) => user.id === deletedUserId), 'the user should be gone').toBe(false);
+
+      // The deleted user's sessions are gone, so the cached token is no longer valid.
+      clearAuthTokenCache();
+      const staleRes = await apiRequest(request, 'GET', '/api/auth/sidebar/variants', { token: userToken });
+      expect(staleRes.status(), 'the deleted user token should be rejected').toBe(401);
+    } finally {
+      clearAuthTokenCache();
+      await deleteUserIfExists(request, adminToken, userId);
+      await deleteRoleIfExists(request, adminToken, roleId);
+    }
+  });
+});

--- a/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
@@ -112,8 +112,10 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
 
   const userId = '44444444-4444-4444-4444-444444444444'
 
-  // Every table with a foreign key to `users` (plus `user_consents`, which has a
-  // bare user_id column) must be cleared before the user row goes, in this order.
+  // Every table with a foreign key to `users` must be cleared before the user row
+  // goes, in this order. `user_consents` is deliberately NOT here: it has no FK, so
+  // it never blocks the delete, and it is compliance evidence that the command's
+  // undo cannot restore. Consent erasure belongs to a dedicated GDPR path.
   function expectedCascade(id: string): Array<[unknown, Record<string, unknown>]> {
     return [
       [UserAcl, { user: id }],
@@ -122,7 +124,6 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
       [PasswordReset, { user: id }],
       [UserSidebarPreference, { user: id }],
       [SidebarVariant, { user: id }],
-      [UserConsent, { userId: id }],
     ]
   }
 
@@ -139,8 +140,9 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.begin).toBe(1)
     expect(calls.commit).toBe(1)
     expect(calls.rollback).toBe(0)
-    expect(calls.nativeDelete).toBe(7)
+    expect(calls.nativeDelete).toBe(6)
     expect(calls.nativeDeleteArgs).toEqual(expectedCascade(userId))
+    expect(calls.nativeDeleteArgs.map(([entity]) => entity)).not.toContain(UserConsent)
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
   })
 
@@ -164,6 +166,7 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.commit).toBe(1)
     expect(calls.rollback).toBe(0)
     expect(calls.nativeDeleteArgs).toEqual(expectedCascade(userId))
+    expect(calls.nativeDeleteArgs.map(([entity]) => entity)).not.toContain(UserConsent)
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledWith(expect.objectContaining({ entity: User, soft: false }))
   })
@@ -185,8 +188,8 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.begin).toBe(1)
     expect(calls.commit).toBe(0)
     expect(calls.rollback).toBe(1)
-    // All seven dependent-row deletes were attempted inside the transaction
+    // All six dependent-row deletes were attempted inside the transaction
     // before the failing user delete, and are rolled back together.
-    expect(calls.nativeDelete).toBe(7)
+    expect(calls.nativeDelete).toBe(6)
   })
 })

--- a/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
@@ -29,7 +29,16 @@ import '@open-mercato/core/modules/auth/commands/users'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { User } from '../../data/entities'
+import {
+  User,
+  UserAcl,
+  UserRole,
+  Session,
+  PasswordReset,
+  UserSidebarPreference,
+  SidebarVariant,
+  UserConsent,
+} from '../../data/entities'
 
 /**
  * Regression coverage for issue #2339 — the auth.users.delete cascade deleted
@@ -48,6 +57,7 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     rollback: number
     flush: number
     nativeDelete: number
+    nativeDeleteArgs: Array<[unknown, Record<string, unknown>]>
   }
 
   function makeEm(calls: TxnCalls): EntityManager {
@@ -65,8 +75,9 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
       flush: async () => {
         calls.flush += 1
       },
-      nativeDelete: async () => {
+      nativeDelete: async (entity: unknown, where: Record<string, unknown>) => {
         calls.nativeDelete += 1
+        calls.nativeDeleteArgs.push([entity, where])
         return 0
       },
       find: async () => [],
@@ -101,9 +112,23 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
 
   const userId = '44444444-4444-4444-4444-444444444444'
 
+  // Every table with a foreign key to `users` (plus `user_consents`, which has a
+  // bare user_id column) must be cleared before the user row goes, in this order.
+  function expectedCascade(id: string): Array<[unknown, Record<string, unknown>]> {
+    return [
+      [UserAcl, { user: id }],
+      [UserRole, { user: id }],
+      [Session, { user: id }],
+      [PasswordReset, { user: id }],
+      [UserSidebarPreference, { user: id }],
+      [SidebarVariant, { user: id }],
+      [UserConsent, { userId: id }],
+    ]
+  }
+
   it('commits after every cascade delete succeeds', async () => {
     const handler = commandRegistry.get('auth.users.delete') as CommandHandler<{ query?: Record<string, unknown> }, unknown>
-    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0 }
+    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0, nativeDeleteArgs: [] }
     const em = makeEm(calls)
     const dataEngine = {
       deleteOrmEntity: jest.fn(async () => ({ id: userId, organizationId: 'org-1', tenantId: 'tenant-1' })),
@@ -115,12 +140,37 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.commit).toBe(1)
     expect(calls.rollback).toBe(0)
     expect(calls.nativeDelete).toBe(7)
+    expect(calls.nativeDeleteArgs).toEqual(expectedCascade(userId))
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('undoing a create clears the same dependent rows before hard-deleting the user', async () => {
+    const handler = commandRegistry.get('auth.users.create') as CommandHandler<unknown, unknown>
+    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0, nativeDeleteArgs: [] }
+    const em = makeEm(calls)
+    const dataEngine = {
+      deleteOrmEntity: jest.fn(async () => ({ id: userId, organizationId: 'org-1', tenantId: 'tenant-1' })),
+    }
+
+    await handler.undo!({
+      logEntry: {
+        resourceId: userId,
+        snapshotAfter: { id: userId, tenantId: 'tenant-1', organizationId: 'org-1', custom: {} },
+      } as any,
+      ctx: makeCtx(em, dataEngine),
+    })
+
+    expect(calls.begin).toBe(1)
+    expect(calls.commit).toBe(1)
+    expect(calls.rollback).toBe(0)
+    expect(calls.nativeDeleteArgs).toEqual(expectedCascade(userId))
+    expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
+    expect(dataEngine.deleteOrmEntity).toHaveBeenCalledWith(expect.objectContaining({ entity: User, soft: false }))
   })
 
   it('rolls back the whole cascade when the user delete fails', async () => {
     const handler = commandRegistry.get('auth.users.delete') as CommandHandler<{ query?: Record<string, unknown> }, unknown>
-    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0 }
+    const calls: TxnCalls = { begin: 0, commit: 0, rollback: 0, flush: 0, nativeDelete: 0, nativeDeleteArgs: [] }
     const em = makeEm(calls)
     const dataEngine = {
       deleteOrmEntity: jest.fn(async () => {

--- a/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts
@@ -34,7 +34,9 @@ import { User } from '../../data/entities'
 /**
  * Regression coverage for issue #2339 — the auth.users.delete cascade deleted
  * UserAcl/UserRole/Session/PasswordReset rows and then the user across five
- * sequential statements with no enclosing transaction. A failure mid-cascade
+ * sequential statements with no enclosing transaction. The cascade later grew
+ * UserSidebarPreference/SidebarVariant/UserConsent so a customised sidebar no
+ * longer trips the `users` FK and turns the delete into a 500. A failure mid-cascade
  * left orphaned ACL/role rows committed. The cascade now runs inside a single
  * `withAtomicFlush(..., { transaction: true })`, so a later failure rolls the
  * whole thing back.
@@ -112,7 +114,7 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.begin).toBe(1)
     expect(calls.commit).toBe(1)
     expect(calls.rollback).toBe(0)
-    expect(calls.nativeDelete).toBe(4)
+    expect(calls.nativeDelete).toBe(7)
     expect(dataEngine.deleteOrmEntity).toHaveBeenCalledTimes(1)
   })
 
@@ -133,8 +135,8 @@ describe('auth.users.delete atomic cascade (issue #2339)', () => {
     expect(calls.begin).toBe(1)
     expect(calls.commit).toBe(0)
     expect(calls.rollback).toBe(1)
-    // All four dependent-row deletes were attempted inside the transaction
+    // All seven dependent-row deletes were attempted inside the transaction
     // before the failing user delete, and are rolled back together.
-    expect(calls.nativeDelete).toBe(4)
+    expect(calls.nativeDelete).toBe(7)
   })
 })

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -24,7 +24,6 @@ import {
   PasswordReset,
   UserSidebarPreference,
   SidebarVariant,
-  UserConsent,
 } from '@open-mercato/core/modules/auth/data/entities'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { resolveOrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -370,7 +369,6 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
         await em.nativeDelete(PasswordReset, { user: userId })
         await em.nativeDelete(UserSidebarPreference, { user: userId })
         await em.nativeDelete(SidebarVariant, { user: userId })
-        await em.nativeDelete(UserConsent, { userId })
 
         if (snapshot?.custom && Object.keys(snapshot.custom).length) {
           const reset = buildCustomFieldResetMap(undefined, snapshot.custom)
@@ -946,7 +944,6 @@ const deleteUserCommand: CommandHandler<{ body?: Record<string, unknown>; query?
         await em.nativeDelete(PasswordReset, { user: id })
         await em.nativeDelete(UserSidebarPreference, { user: id })
         await em.nativeDelete(SidebarVariant, { user: id })
-        await em.nativeDelete(UserConsent, { userId: id })
         const removed = await de.deleteOrmEntity({
           entity: User,
           where: deleteWhere as FilterQuery<User>,

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -15,7 +15,17 @@ import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { UniqueConstraintViolationException, LockMode } from '@mikro-orm/core'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
-import { User, UserRole, Role, UserAcl, Session, PasswordReset } from '@open-mercato/core/modules/auth/data/entities'
+import {
+  User,
+  UserRole,
+  Role,
+  UserAcl,
+  Session,
+  PasswordReset,
+  UserSidebarPreference,
+  SidebarVariant,
+  UserConsent,
+} from '@open-mercato/core/modules/auth/data/entities'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { resolveOrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { E } from '#generated/entities.ids.generated'
@@ -358,6 +368,9 @@ const createUserCommand: CommandHandler<Record<string, unknown>, CreateUserResul
         await em.nativeDelete(UserRole, { user: userId })
         await em.nativeDelete(Session, { user: userId })
         await em.nativeDelete(PasswordReset, { user: userId })
+        await em.nativeDelete(UserSidebarPreference, { user: userId })
+        await em.nativeDelete(SidebarVariant, { user: userId })
+        await em.nativeDelete(UserConsent, { userId })
 
         if (snapshot?.custom && Object.keys(snapshot.custom).length) {
           const reset = buildCustomFieldResetMap(undefined, snapshot.custom)
@@ -931,6 +944,9 @@ const deleteUserCommand: CommandHandler<{ body?: Record<string, unknown>; query?
         await em.nativeDelete(UserRole, { user: id })
         await em.nativeDelete(Session, { user: id })
         await em.nativeDelete(PasswordReset, { user: id })
+        await em.nativeDelete(UserSidebarPreference, { user: id })
+        await em.nativeDelete(SidebarVariant, { user: id })
+        await em.nativeDelete(UserConsent, { userId: id })
         const removed = await de.deleteOrmEntity({
           entity: User,
           where: deleteWhere as FilterQuery<User>,

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -84,7 +84,7 @@ export class UserSidebarPreference {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { deleteRule: 'cascade' })
   user!: User
 
   @Property({ name: 'tenant_id', type: 'uuid', nullable: true })
@@ -149,7 +149,7 @@ export class SidebarVariant {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { deleteRule: 'cascade' })
   user!: User
 
   @Property({ name: 'tenant_id', type: 'uuid', nullable: true })

--- a/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/auth/migrations/.snapshot-open-mercato.json
@@ -913,7 +913,8 @@
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.users"
+          "referencedTableName": "public.users",
+          "deleteRule": "cascade"
         }
       },
       "nativeEnums": {}
@@ -1978,7 +1979,8 @@
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.users"
+          "referencedTableName": "public.users",
+          "deleteRule": "cascade"
         }
       },
       "nativeEnums": {}

--- a/packages/core/src/modules/auth/migrations/Migration20260907120000_auth.ts
+++ b/packages/core/src/modules/auth/migrations/Migration20260907120000_auth.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260907120000_auth extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`alter table "user_sidebar_preferences" drop constraint "user_sidebar_preferences_user_id_foreign";`);
+    this.addSql(`alter table "user_sidebar_preferences" add constraint "user_sidebar_preferences_user_id_foreign" foreign key ("user_id") references "users" ("id") on update cascade on delete cascade;`);
+
+    this.addSql(`alter table "sidebar_variants" drop constraint "sidebar_variants_user_id_foreign";`);
+    this.addSql(`alter table "sidebar_variants" add constraint "sidebar_variants_user_id_foreign" foreign key ("user_id") references "users" ("id") on update cascade on delete cascade;`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`alter table "user_sidebar_preferences" drop constraint "user_sidebar_preferences_user_id_foreign";`);
+    this.addSql(`alter table "user_sidebar_preferences" add constraint "user_sidebar_preferences_user_id_foreign" foreign key ("user_id") references "users" ("id") on update cascade;`);
+
+    this.addSql(`alter table "sidebar_variants" drop constraint "sidebar_variants_user_id_foreign";`);
+    this.addSql(`alter table "sidebar_variants" add constraint "sidebar_variants_user_id_foreign" foreign key ("user_id") references "users" ("id");`);
+  }
+
+}

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -903,6 +903,22 @@ describe('CRUD Factory', () => {
     expect(mockDataEngine.emitOrmEntityEvent).not.toHaveBeenCalled()
   })
 
+  it('returns a 409 with the constraint name when a handler hits a foreign key violation', async () => {
+    setRecordCustomFields.mockImplementationOnce(async () => {
+      throw Object.assign(
+        new Error('update or delete on table "users" violates foreign key constraint "sidebar_variants_user_id_foreign" on table "sidebar_variants"'),
+        { code: '23503', constraint: 'sidebar_variants_user_id_foreign' },
+      )
+    })
+    const res = await route.POST(new Request('http://x/api/example/todos', { method: 'POST', body: JSON.stringify({ title: 'Referenced', is_done: true, cf_priority: 3 }), headers: { 'content-type': 'application/json' } }))
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('FOREIGN_KEY_VIOLATION')
+    expect(body.constraint).toBe('sidebar_variants_user_id_foreign')
+    expect(Object.values(db)).toHaveLength(0)
+    expect(mockDataEngine.emitOrmEntityEvent).not.toHaveBeenCalled()
+  })
+
   it('POST surfaces CRUD side-effect failures after custom field writes', async () => {
     mockDataEngine.emitOrmEntityEvent.mockImplementationOnce(async () => {
       throw new Error('index write failed')

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -905,9 +905,11 @@ describe('CRUD Factory', () => {
 
   it('returns a 409 with the constraint name when a handler hits a foreign key violation', async () => {
     setRecordCustomFields.mockImplementationOnce(async () => {
+      // Mirror MikroORM's wrapping: the pg error sits behind `previous`, and the
+      // wrapper only carries the message.
       throw Object.assign(
         new Error('update or delete on table "users" violates foreign key constraint "sidebar_variants_user_id_foreign" on table "sidebar_variants"'),
-        { code: '23503', constraint: 'sidebar_variants_user_id_foreign' },
+        { previous: { code: '23503', constraint: 'sidebar_variants_user_id_foreign' } },
       )
     })
     const res = await route.POST(new Request('http://x/api/example/todos', { method: 'POST', body: JSON.stringify({ title: 'Referenced', is_done: true, cf_priority: 3 }), headers: { 'content-type': 'application/json' } }))

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -903,7 +903,7 @@ describe('CRUD Factory', () => {
     expect(mockDataEngine.emitOrmEntityEvent).not.toHaveBeenCalled()
   })
 
-  it('returns a 409 with the constraint name when a handler hits a foreign key violation', async () => {
+  it('returns a correlated 409 without leaking the constraint name when a handler hits a foreign key violation', async () => {
     setRecordCustomFields.mockImplementationOnce(async () => {
       // Mirror MikroORM's wrapping: the pg error sits behind `previous`, and the
       // wrapper only carries the message.
@@ -916,7 +916,12 @@ describe('CRUD Factory', () => {
     expect(res.status).toBe(409)
     const body = await res.json()
     expect(body.code).toBe('FOREIGN_KEY_VIOLATION')
-    expect(body.constraint).toBe('sidebar_variants_user_id_foreign')
+    // Internal schema names stay in the server log, never in the client body.
+    expect(body.constraint).toBeUndefined()
+    expect(JSON.stringify(body)).not.toContain('sidebar_variants_user_id_foreign')
+    // Same correlation contract as the generic 500 path.
+    expect(typeof body.requestId).toBe('string')
+    expect(res.headers.get('x-request-id')).toBe(body.requestId)
     expect(Object.values(db)).toHaveLength(0)
     expect(mockDataEngine.emitOrmEntityEvent).not.toHaveBeenCalled()
   })

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -75,7 +75,7 @@ import { parseExtensionHeaders } from '../umes/extension-headers'
 import { createGenericOptimisticLockReader } from './optimistic-lock'
 import { registerOptimisticLockReaderIfAbsent } from './optimistic-lock-store'
 import { createLogger } from '../logger'
-import { isForeignKeyViolation, isTransientDbError } from '../db/pg-errors'
+import { getForeignKeyViolationConstraint, isForeignKeyViolation, isTransientDbError } from '../db/pg-errors'
 import { getTelemetryRuntime } from '../telemetry/runtime'
 import { randomUUID } from 'node:crypto'
 
@@ -634,17 +634,18 @@ function handleError(err: unknown, request?: Request): Response {
   }
 
   if (isForeignKeyViolation(err)) {
-    // A dependent row still references the record (or the payload points at a
-    // missing parent). That is a data-state conflict the caller can act on, not
-    // a server fault, so surface it as a 409 with the constraint for diagnosis.
-    const constraint = (err as { constraint?: string }).constraint
+    // SQLSTATE 23503 covers both directions: a DELETE blocked by a dependent row
+    // and an INSERT/UPDATE pointing at a missing parent. Either way it is a
+    // data-state conflict the caller can act on, not a server fault, so surface
+    // it as a 409 with the constraint for diagnosis.
+    const constraint = getForeignKeyViolationConstraint(err)
     logger.warn('Foreign key violation during CRUD handler', {
       message: err instanceof Error ? err.message : undefined,
       constraint,
     })
     return json(
       {
-        error: 'Record is still referenced by other data',
+        error: 'The record is still referenced by other data, or references a record that does not exist',
         code: 'FOREIGN_KEY_VIOLATION',
         ...(constraint ? { constraint } : {}),
       },

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -75,7 +75,7 @@ import { parseExtensionHeaders } from '../umes/extension-headers'
 import { createGenericOptimisticLockReader } from './optimistic-lock'
 import { registerOptimisticLockReaderIfAbsent } from './optimistic-lock-store'
 import { createLogger } from '../logger'
-import { isTransientDbError } from '../db/pg-errors'
+import { isForeignKeyViolation, isTransientDbError } from '../db/pg-errors'
 import { getTelemetryRuntime } from '../telemetry/runtime'
 import { randomUUID } from 'node:crypto'
 
@@ -630,6 +630,25 @@ function handleError(err: unknown, request?: Request): Response {
     return json(
       { error: 'Service temporarily unavailable' },
       { status: 503, headers: { 'Retry-After': '2' } },
+    )
+  }
+
+  if (isForeignKeyViolation(err)) {
+    // A dependent row still references the record (or the payload points at a
+    // missing parent). That is a data-state conflict the caller can act on, not
+    // a server fault, so surface it as a 409 with the constraint for diagnosis.
+    const constraint = (err as { constraint?: string }).constraint
+    logger.warn('Foreign key violation during CRUD handler', {
+      message: err instanceof Error ? err.message : undefined,
+      constraint,
+    })
+    return json(
+      {
+        error: 'Record is still referenced by other data',
+        code: 'FOREIGN_KEY_VIOLATION',
+        ...(constraint ? { constraint } : {}),
+      },
+      { status: 409 },
     )
   }
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -636,20 +636,29 @@ function handleError(err: unknown, request?: Request): Response {
   if (isForeignKeyViolation(err)) {
     // SQLSTATE 23503 covers both directions: a DELETE blocked by a dependent row
     // and an INSERT/UPDATE pointing at a missing parent. Either way it is a
-    // data-state conflict the caller can act on, not a server fault, so surface
-    // it as a 409 with the constraint for diagnosis.
+    // data-state conflict the caller can act on, so answer 409 instead of 500.
+    // The constraint name stays in the log only: it maps internal table/column
+    // names and has no business in a client-facing body. The missing-parent
+    // direction is often a server-side defect, so the error is still reported to
+    // telemetry and carries a requestId exactly like the generic 500 below.
+    const requestId = resolveRequestId(request)
     const constraint = getForeignKeyViolationConstraint(err)
     logger.warn('Foreign key violation during CRUD handler', {
       message: err instanceof Error ? err.message : undefined,
       constraint,
+      requestId,
+    })
+    getTelemetryRuntime()?.reportError(err, {
+      module: 'crud',
+      attributes: { requestId, errorName: 'ForeignKeyViolation', constraint: constraint ?? undefined },
     })
     return json(
       {
         error: 'The record is still referenced by other data, or references a record that does not exist',
         code: 'FOREIGN_KEY_VIOLATION',
-        ...(constraint ? { constraint } : {}),
+        requestId,
       },
-      { status: 409 },
+      { status: 409, headers: { 'x-request-id': requestId } },
     )
   }
 

--- a/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
@@ -1,4 +1,4 @@
-import { isForeignKeyViolation, isTransientDbError, isUniqueViolation } from '../pg-errors'
+import { getForeignKeyViolationConstraint, isForeignKeyViolation, isTransientDbError, isUniqueViolation } from '../pg-errors'
 
 describe('isTransientDbError', () => {
   it('is true for the max_connections SQLSTATE', () => {
@@ -60,10 +60,38 @@ describe('isForeignKeyViolation', () => {
     ).toBe(true)
   })
 
+  it('looks through MikroORM wrapper chains (cause / previous)', () => {
+    expect(isForeignKeyViolation({ message: 'wrapped', cause: { code: '23503' } })).toBe(true)
+    expect(isForeignKeyViolation({ message: 'wrapped', previous: { code: '23503' } })).toBe(true)
+  })
+
   it('is false for unique violations, transient errors and non-DB errors', () => {
     expect(isForeignKeyViolation({ code: '23505' })).toBe(false)
     expect(isForeignKeyViolation({ code: '53300' })).toBe(false)
     expect(isForeignKeyViolation(new Error('something unrelated broke'))).toBe(false)
     expect(isForeignKeyViolation(null)).toBe(false)
+  })
+})
+
+describe('getForeignKeyViolationConstraint', () => {
+  const driverMessage = 'update or delete on table "users" violates foreign key constraint "sidebar_variants_user_id_foreign" on table "sidebar_variants"'
+
+  it('reads the pg constraint field from the top-level error', () => {
+    expect(getForeignKeyViolationConstraint({ code: '23503', constraint: 'user_roles_user_id_foreign' })).toBe('user_roles_user_id_foreign')
+  })
+
+  it('reads the constraint from a wrapped driver error', () => {
+    expect(getForeignKeyViolationConstraint({ message: 'wrapped', previous: { code: '23503', constraint: 'sessions_user_id_foreign' } })).toBe('sessions_user_id_foreign')
+    expect(getForeignKeyViolationConstraint({ message: 'wrapped', cause: { code: '23503', constraint: 'user_acls_user_id_foreign' } })).toBe('user_acls_user_id_foreign')
+  })
+
+  it('falls back to the quoted constraint in the driver message', () => {
+    expect(getForeignKeyViolationConstraint(new Error(driverMessage))).toBe('sidebar_variants_user_id_foreign')
+  })
+
+  it('is null when nothing identifies the constraint', () => {
+    expect(getForeignKeyViolationConstraint({ code: '23503' })).toBeNull()
+    expect(getForeignKeyViolationConstraint(new Error('something unrelated broke'))).toBeNull()
+    expect(getForeignKeyViolationConstraint(null)).toBeNull()
   })
 })

--- a/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
@@ -60,9 +60,18 @@ describe('isForeignKeyViolation', () => {
     ).toBe(true)
   })
 
-  it('looks through MikroORM wrapper chains (cause / previous)', () => {
+  it('looks through MikroORM wrapper chains (cause / previous), including re-wrapped errors', () => {
     expect(isForeignKeyViolation({ message: 'wrapped', cause: { code: '23503' } })).toBe(true)
     expect(isForeignKeyViolation({ message: 'wrapped', previous: { code: '23503' } })).toBe(true)
+    expect(isForeignKeyViolation({ message: 'outer', cause: { message: 'inner', previous: { code: '23503' } } })).toBe(true)
+  })
+
+  it('stops on cyclic or very deep wrapper chains', () => {
+    const cyclic: Record<string, unknown> = { message: 'loop' }
+    cyclic.cause = cyclic
+    expect(isForeignKeyViolation(cyclic)).toBe(false)
+    const deep = { cause: { cause: { cause: { cause: { cause: { code: '23503' } } } } } }
+    expect(isForeignKeyViolation(deep)).toBe(false)
   })
 
   it('is false for unique violations, transient errors and non-DB errors', () => {

--- a/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
+++ b/packages/shared/src/lib/db/__tests__/pg-errors.test.ts
@@ -1,4 +1,4 @@
-import { isTransientDbError, isUniqueViolation } from '../pg-errors'
+import { isForeignKeyViolation, isTransientDbError, isUniqueViolation } from '../pg-errors'
 
 describe('isTransientDbError', () => {
   it('is true for the max_connections SQLSTATE', () => {
@@ -44,5 +44,26 @@ describe('isTransientDbError', () => {
     const uniqueErr = { code: '23505', message: 'duplicate key value violates unique constraint' }
     expect(isUniqueViolation(uniqueErr)).toBe(true)
     expect(isTransientDbError(uniqueErr)).toBe(false)
+  })
+})
+
+describe('isForeignKeyViolation', () => {
+  it('is true for the foreign_key_violation SQLSTATE', () => {
+    expect(isForeignKeyViolation({ code: '23503' })).toBe(true)
+  })
+
+  it('is true for ORM-wrapped messages that drop the SQLSTATE', () => {
+    expect(
+      isForeignKeyViolation(
+        new Error('update or delete on table "users" violates foreign key constraint "sidebar_variants_user_id_foreign" on table "sidebar_variants"'),
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for unique violations, transient errors and non-DB errors', () => {
+    expect(isForeignKeyViolation({ code: '23505' })).toBe(false)
+    expect(isForeignKeyViolation({ code: '53300' })).toBe(false)
+    expect(isForeignKeyViolation(new Error('something unrelated broke'))).toBe(false)
+    expect(isForeignKeyViolation(null)).toBe(false)
   })
 })

--- a/packages/shared/src/lib/db/pg-errors.ts
+++ b/packages/shared/src/lib/db/pg-errors.ts
@@ -11,18 +11,46 @@ export function isUniqueViolation(err: unknown): boolean {
   return typeof message === 'string' && /duplicate key value|unique constraint/i.test(message)
 }
 
+const FOREIGN_KEY_VIOLATION_MESSAGE = /violates foreign key constraint(?: "([^"]+)")?/i
+
+/**
+ * MikroORM wraps driver errors and copies the pg fields onto the wrapper, but
+ * the original error may also sit behind `cause` (Node) or `previous`
+ * (MikroORM). Walk that short chain so a check works on any layer.
+ */
+function pgErrorCandidates(err: unknown): Array<Record<string, unknown>> {
+  if (!err || typeof err !== 'object') return []
+  const chain = [err, (err as { cause?: unknown }).cause, (err as { previous?: unknown }).previous]
+  return chain.filter((candidate): candidate is Record<string, unknown> => !!candidate && typeof candidate === 'object')
+}
+
 /**
  * Detect a Postgres foreign-key violation (SQLSTATE 23503): the row is still
- * referenced by a dependent table, or references a parent that does not exist.
- * MikroORM copies `code` from the driver error onto its wrapper exception, so a
- * single check covers raw pg errors and ORM-wrapped ones alike.
+ * referenced by a dependent table, or the payload references a parent that
+ * does not exist. Looks through MikroORM's driver-error wrapping.
  */
 export function isForeignKeyViolation(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false
-  const code = (err as { code?: string }).code
-  if (code === '23503') return true // Postgres foreign_key_violation
-  const message = (err as { message?: string }).message
-  return typeof message === 'string' && /violates foreign key constraint/i.test(message)
+  return pgErrorCandidates(err).some((candidate) => {
+    if (candidate.code === '23503') return true // Postgres foreign_key_violation
+    return typeof candidate.message === 'string' && FOREIGN_KEY_VIOLATION_MESSAGE.test(candidate.message)
+  })
+}
+
+/**
+ * Name of the constraint behind a foreign-key violation, read from the pg
+ * `constraint` field on any layer of the wrapper chain, or parsed out of the
+ * quoted constraint in the driver message when the field is missing.
+ */
+export function getForeignKeyViolationConstraint(err: unknown): string | null {
+  for (const candidate of pgErrorCandidates(err)) {
+    if (typeof candidate.constraint === 'string' && candidate.constraint.length > 0) return candidate.constraint
+  }
+  for (const candidate of pgErrorCandidates(err)) {
+    if (typeof candidate.message !== 'string') continue
+    const match = FOREIGN_KEY_VIOLATION_MESSAGE.exec(candidate.message)
+    if (match?.[1]) return match[1]
+  }
+  return null
 }
 
 /**

--- a/packages/shared/src/lib/db/pg-errors.ts
+++ b/packages/shared/src/lib/db/pg-errors.ts
@@ -12,6 +12,20 @@ export function isUniqueViolation(err: unknown): boolean {
 }
 
 /**
+ * Detect a Postgres foreign-key violation (SQLSTATE 23503): the row is still
+ * referenced by a dependent table, or references a parent that does not exist.
+ * MikroORM copies `code` from the driver error onto its wrapper exception, so a
+ * single check covers raw pg errors and ORM-wrapped ones alike.
+ */
+export function isForeignKeyViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const code = (err as { code?: string }).code
+  if (code === '23503') return true // Postgres foreign_key_violation
+  const message = (err as { message?: string }).message
+  return typeof message === 'string' && /violates foreign key constraint/i.test(message)
+}
+
+/**
  * Postgres SQLSTATEs for transient connection / availability failures — the
  * database (or its connection pool) is temporarily unreachable and the request
  * can succeed on retry. Deliberately scoped to connection/availability codes;

--- a/packages/shared/src/lib/db/pg-errors.ts
+++ b/packages/shared/src/lib/db/pg-errors.ts
@@ -13,15 +13,30 @@ export function isUniqueViolation(err: unknown): boolean {
 
 const FOREIGN_KEY_VIOLATION_MESSAGE = /violates foreign key constraint(?: "([^"]+)")?/i
 
+const MAX_ERROR_CHAIN_DEPTH = 4
+
 /**
  * MikroORM wraps driver errors and copies the pg fields onto the wrapper, but
  * the original error may also sit behind `cause` (Node) or `previous`
- * (MikroORM). Walk that short chain so a check works on any layer.
+ * (MikroORM), possibly re-wrapped by a transaction helper. Walk that chain,
+ * breadth-first with a small depth cap, so a check works on any layer.
  */
 function pgErrorCandidates(err: unknown): Array<Record<string, unknown>> {
-  if (!err || typeof err !== 'object') return []
-  const chain = [err, (err as { cause?: unknown }).cause, (err as { previous?: unknown }).previous]
-  return chain.filter((candidate): candidate is Record<string, unknown> => !!candidate && typeof candidate === 'object')
+  const found: Array<Record<string, unknown>> = []
+  const seen = new Set<unknown>()
+  let layer: unknown[] = [err]
+  for (let depth = 0; depth < MAX_ERROR_CHAIN_DEPTH && layer.length > 0; depth += 1) {
+    const next: unknown[] = []
+    for (const candidate of layer) {
+      if (!candidate || typeof candidate !== 'object' || seen.has(candidate)) continue
+      seen.add(candidate)
+      const record = candidate as Record<string, unknown>
+      found.push(record)
+      next.push(record.cause, record.previous)
+    }
+    layer = next
+  }
+  return found
 }
 
 /**


### PR DESCRIPTION
## Summary

Deleting a user from the backend (`DELETE /api/auth/users?id=...`) returns a bare 500 for any user who has customised their sidebar.

`user_sidebar_preferences` and `sidebar_variants` both hold a foreign key to `users` with no `ON DELETE` rule. `auth.users.delete` clears four child tables (`user_acls`, `user_roles`, `sessions`, `password_resets`) but never these two, which were added later by the sidebar customisation feature (#1730). Postgres rejects the hard delete and `makeCrudRoute` turns the exception into a generic 500, so callers only see `API 500: DELETE /auth/users` and the real cause is on stdout only.

The fix works on three levels: the command clears the missing child rows inside its existing transaction, the two FKs gain `ON DELETE CASCADE` so any other path that removes a user stays safe, and the CRUD factory maps a Postgres foreign-key violation to a 409 with a readable code instead of a blank 500.

Consent rows are deliberately left alone. `user_consents` has no FK, so it never blocked the delete, and its rows are proof-of-consent evidence that the command's undo cannot restore. Consent erasure belongs to a dedicated GDPR path. A unit test asserts the consent entity is not part of the cascade. The sidebar rows are also not restored by undo; that is accepted because they are cosmetic and must go for the FK fix to work.

## Changes

- `auth.users.delete` and the `auth.users.create` undo cascade also clear `user_sidebar_preferences` and `sidebar_variants` before the user row, inside the same `withAtomicFlush` transaction.
- `UserSidebarPreference.user` and `SidebarVariant.user` declare `deleteRule: 'cascade'`. `Migration20260907120000_auth` drops and recreates both FKs with `on update cascade on delete cascade`; `down()` restores each constraint to its original definition. The auth snapshot carries the matching `deleteRule` keys.
- New `isForeignKeyViolation(err)` and `getForeignKeyViolationConstraint(err)` in `packages/shared/src/lib/db/pg-errors.ts`. Both walk MikroORM's `cause` / `previous` wrapper chain (depth-capped, cycle-safe) and fall back to the driver message.
- `makeCrudRoute` answers a foreign-key violation with `409 { error, code: 'FOREIGN_KEY_VIOLATION', requestId }` plus an `x-request-id` header, reports it to telemetry, and keeps the constraint name in the server log only. Every other error class keeps its historical response.
- `BACKWARD_COMPATIBILITY.md` gains a dated section for the 500 to 409 change and the FK rewrite.

Known follow-up, not in this PR: `role_sidebar_preferences` references `roles` with no `on delete` rule and `auth.roles.delete` clears only `RoleAcl`, so deleting a role with a customised sidebar fails the same way (now as a 409). Same remedy applies.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
n/a — bug fix; the contract change is recorded in `BACKWARD_COMPATIBILITY.md`.

## Testing

- `packages/core/src/modules/auth/commands/__tests__/users.delete-atomic.test.ts`: asserts the exact `nativeDelete` cascade order for the delete command and for a successful create undo, on both the commit and rollback paths, and that `UserConsent` is never touched.
- `packages/shared/src/lib/db/__tests__/pg-errors.test.ts`: SQLSTATE, ORM-wrapped message, `cause` / `previous` chains, re-wrapped and cyclic chains, constraint extraction.
- `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts`: 409 status, code, requestId body/header match, constraint name absent from the body, write still rolled back.
- New integration spec `packages/core/src/modules/auth/__integration__/TC-AUTH-064-user-delete-sidebar-cascade.spec.ts`: creates a user, grants `auth.sidebar.manage`, logs in as that user, writes a sidebar preference and a sidebar variant, deletes the user as superadmin, expects 200 and a rejected stale token.

Commands run on this branch rebased onto `develop`:

```
yarn test:integration:ephemeral --filter TC-AUTH-064   1 passed (real Postgres, migration applied)
packages/core   jest auth/commands/__tests__            106 passed
packages/shared jest pg-errors + crud-factory           87 passed
eslint on changed files                                 clean
tsc (packages/shared)                                   clean
```

Not covered: a direct test of the database-level `ON DELETE CASCADE` on its own. The explicit `nativeDelete` calls always fire first, so the migration's cascade is only exercised indirectly.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

Priority, risk and QA labels cannot be set from this account; the intended values are in a comment below.

### Design System Compliance
No UI files change in this PR.
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

No upstream issue exists for this. Closest precedent is #1713 (company delete returned a bare 500 on an FK violation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791372953&installation_model_id=432243&pr_number=5913&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5913&signature=48cc5e54b5339e1e97ddd9d5f4f15d0c09de9b27e25e1b5092922d531f43c992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->