### PR TITLE
fix(data_sync): unregister the scheduled job when the schedule write fails (#5871)

### DIFF
--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -11,7 +11,18 @@ const mockEm = {
 const mockScheduler = {
   register: jest.fn(),
   unregister: jest.fn(),
+  exists: jest.fn(),
 }
+
+const mockLoggerError = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    child: jest.fn(() => ({
+      error: (...args: unknown[]) => mockLoggerError(...args),
+    })),
+  })),
+}))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
@@ -63,6 +74,21 @@ function request(scheduleValue = '3600') {
   })
 }
 
+const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+
+function saveInput() {
+  return {
+    integrationId: 'sync_excel',
+    entityType: 'customers.person',
+    direction: 'import' as const,
+    scheduleType: 'interval' as const,
+    scheduleValue: '1h',
+    timezone: 'UTC',
+    fullSync: false,
+    isEnabled: true,
+  }
+}
+
 function existingRow(scheduledJobId: string | null) {
   return {
     id: 'schedule-1',
@@ -96,6 +122,7 @@ describe('data_sync schedule save write ordering', () => {
     mockEm.flush.mockImplementation(async () => undefined)
     mockScheduler.register.mockImplementation(async () => undefined)
     mockScheduler.unregister.mockImplementation(async () => undefined)
+    mockScheduler.exists.mockImplementation(async () => false)
   })
 
   it('does not persist the schedule when the scheduler rejects an unparseable value', async () => {
@@ -166,9 +193,54 @@ describe('data_sync schedule save write ordering', () => {
     const res = await POST(request('1h'))
 
     expect(res.status).toBe(422)
+    expect(mockScheduler.exists).toHaveBeenCalledWith('schedule-1')
     expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'schedule-1' }))
     expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
     expect(mockScheduler.unregister).toHaveBeenCalledWith('schedule-1')
+  })
+
+  it('leaves a job that already lived at the row id alone when the update write fails', async () => {
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow(null))
+    mockScheduler.exists.mockImplementation(async () => true)
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.exists).toHaveBeenCalledWith('schedule-1')
+    expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'schedule-1' }))
+    expect(mockScheduler.unregister).not.toHaveBeenCalled()
+  })
+
+  it('does not query the scheduler for a freshly minted id on the create path', async () => {
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.exists).not.toHaveBeenCalled()
+    expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('compensates as before when the scheduler cannot answer whether the job exists', async () => {
+    const schedulerWithoutExists = {
+      register: jest.fn(async () => undefined),
+      unregister: jest.fn(async () => undefined),
+    }
+    const service = createSyncScheduleService(mockEm, schedulerWithoutExists)
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow(null))
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    await expect(service.saveSchedule(saveInput(), scope)).rejects.toThrow('connection terminated unexpectedly')
+
+    expect(schedulerWithoutExists.unregister).toHaveBeenCalledTimes(1)
+    expect(schedulerWithoutExists.unregister).toHaveBeenCalledWith('schedule-1')
   })
 
   it('still surfaces the original write failure when the compensating unregister also fails', async () => {
@@ -186,5 +258,30 @@ describe('data_sync schedule save write ordering', () => {
     const body = await res.json()
     expect(body.error).toBe(flushError.message)
     expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the orphaned scheduled job when the compensating unregister fails', async () => {
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+    const compensationError = new Error('scheduler unavailable')
+    mockScheduler.unregister.mockImplementation(async () => {
+      throw compensationError
+    })
+
+    await POST(request('1h'))
+
+    const registeredJobId = mockScheduler.register.mock.calls[0][0].id
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to unregister the scheduled job'),
+      expect.objectContaining({
+        scheduledJobId: registeredJobId,
+        scheduleId: registeredJobId,
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        err: compensationError,
+      }),
+    )
   })
 })

--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -56,6 +56,17 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 }))
 
 import { POST } from '../route'
+import { PUT } from '../[id]/route'
+
+const updateRouteScheduleId = '3f8b1f1e-2c3d-4a5b-8c7d-9e0f1a2b3c4d'
+
+function updateRequest(scheduleValue = '1h') {
+  return new Request(`http://localhost/api/data_sync/schedules/${updateRouteScheduleId}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ scheduleValue }),
+  })
+}
 
 function request(scheduleValue = '3600') {
   return new Request('http://localhost/api/data_sync/schedules', {
@@ -283,5 +294,33 @@ describe('data_sync schedule save write ordering', () => {
         err: compensationError,
       }),
     )
+  })
+
+  it('unregisters the registration it minted when the update route fails to flush', async () => {
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow(null))
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const res = await PUT(updateRequest(), { params: { id: updateRouteScheduleId } })
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.exists).toHaveBeenCalledWith('schedule-1')
+    expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'schedule-1' }))
+    expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
+    expect(mockScheduler.unregister).toHaveBeenCalledWith('schedule-1')
+  })
+
+  it('leaves an inherited registration alone when the update route fails to flush', async () => {
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow('job-1'))
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const res = await PUT(updateRequest(), { params: { id: updateRouteScheduleId } })
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-1' }))
+    expect(mockScheduler.unregister).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -17,8 +17,10 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
 }))
 
+const mockFindOneWithDecryption = jest.fn()
+
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
-  findOneWithDecryption: jest.fn(async () => null),
+  findOneWithDecryption: jest.fn(async (...args: unknown[]) => mockFindOneWithDecryption(...args)),
   findAndCountWithDecryption: jest.fn(async () => [[], 0]),
 }))
 
@@ -61,9 +63,29 @@ function request(scheduleValue = '3600') {
   })
 }
 
+function existingRow(scheduledJobId: string | null) {
+  return {
+    id: 'schedule-1',
+    integrationId: 'sync_excel',
+    entityType: 'customers.person',
+    direction: 'import' as const,
+    scheduleType: 'interval' as const,
+    scheduleValue: '30m',
+    timezone: 'UTC',
+    fullSync: false,
+    isEnabled: true,
+    scheduledJobId,
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  }
+}
+
 describe('data_sync schedule save write ordering', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockFindOneWithDecryption.mockImplementation(async () => null)
     mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
     mockEm.create.mockImplementation((_entityClass: unknown, data: Record<string, unknown>) => ({
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
@@ -120,6 +142,33 @@ describe('data_sync schedule save write ordering', () => {
     const registeredJobId = mockScheduler.register.mock.calls[0][0].id
     expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
     expect(mockScheduler.unregister).toHaveBeenCalledWith(registeredJobId)
+  })
+
+  it('leaves an inherited registration alone when the update write fails', async () => {
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow('job-1'))
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('could not serialize access due to concurrent update')
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-1' }))
+    expect(mockScheduler.unregister).not.toHaveBeenCalled()
+  })
+
+  it('unregisters the registration it minted for a row that had no scheduled job yet', async () => {
+    mockFindOneWithDecryption.mockImplementation(async () => existingRow(null))
+    mockEm.flush.mockImplementation(async () => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    expect(mockScheduler.register).toHaveBeenCalledWith(expect.objectContaining({ id: 'schedule-1' }))
+    expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
+    expect(mockScheduler.unregister).toHaveBeenCalledWith('schedule-1')
   })
 
   it('still surfaces the original write failure when the compensating unregister also fails', async () => {

--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -3,16 +3,14 @@
 const mockGetAuthFromRequest = jest.fn()
 
 const mockEm = {
-  create: jest.fn((_entityClass: unknown, data: Record<string, unknown>) => ({ ...data })),
+  create: jest.fn(),
   persist: jest.fn(),
-  flush: jest.fn(async () => undefined),
+  flush: jest.fn(),
 }
 
 const mockScheduler = {
-  register: jest.fn(async () => {
-    throw new Error('Failed to calculate next run time for schedule: some-id')
-  }),
-  unregister: jest.fn(async () => undefined),
+  register: jest.fn(),
+  unregister: jest.fn(),
 }
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
@@ -46,7 +44,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 import { POST } from '../route'
 
-function request() {
+function request(scheduleValue = '3600') {
   return new Request('http://localhost/api/data_sync/schedules', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -55,7 +53,7 @@ function request() {
       entityType: 'customers.person',
       direction: 'import',
       scheduleType: 'interval',
-      scheduleValue: '3600',
+      scheduleValue,
       timezone: 'UTC',
       fullSync: false,
       isEnabled: true,
@@ -67,9 +65,22 @@ describe('data_sync schedule save write ordering', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    mockEm.create.mockImplementation((_entityClass: unknown, data: Record<string, unknown>) => ({
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      ...data,
+    }))
+    mockEm.persist.mockImplementation(() => undefined)
+    mockEm.flush.mockImplementation(async () => undefined)
+    mockScheduler.register.mockImplementation(async () => undefined)
+    mockScheduler.unregister.mockImplementation(async () => undefined)
   })
 
   it('does not persist the schedule when the scheduler rejects an unparseable value', async () => {
+    mockScheduler.register.mockImplementation(async () => {
+      throw new Error('Failed to calculate next run time for schedule: some-id')
+    })
+
     const res = await POST(request())
 
     expect(res.status).toBe(422)
@@ -80,5 +91,51 @@ describe('data_sync schedule save write ordering', () => {
     expect(mockEm.create).not.toHaveBeenCalled()
     expect(mockEm.persist).not.toHaveBeenCalled()
     expect(mockEm.flush).not.toHaveBeenCalled()
+    expect(mockScheduler.unregister).not.toHaveBeenCalled()
+  })
+
+  it('registers the scheduled job before flushing the schedule row on the success path', async () => {
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(201)
+    expect(mockScheduler.register).toHaveBeenCalledTimes(1)
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+    expect(mockScheduler.register.mock.invocationCallOrder[0])
+      .toBeLessThan(mockEm.flush.mock.invocationCallOrder[0])
+    expect(mockScheduler.unregister).not.toHaveBeenCalled()
+  })
+
+  it('unregisters the scheduled job it just created when the schedule row fails to flush', async () => {
+    const flushError = new Error('could not serialize access due to concurrent update')
+    mockEm.flush.mockImplementation(async () => {
+      throw flushError
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toBe(flushError.message)
+
+    const registeredJobId = mockScheduler.register.mock.calls[0][0].id
+    expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
+    expect(mockScheduler.unregister).toHaveBeenCalledWith(registeredJobId)
+  })
+
+  it('still surfaces the original write failure when the compensating unregister also fails', async () => {
+    const flushError = new Error('connection terminated unexpectedly')
+    mockEm.flush.mockImplementation(async () => {
+      throw flushError
+    })
+    mockScheduler.unregister.mockImplementation(async () => {
+      throw new Error('scheduler unavailable')
+    })
+
+    const res = await POST(request('1h'))
+
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toBe(flushError.message)
+    expect(mockScheduler.unregister).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/modules/data_sync/di.ts
+++ b/packages/core/src/modules/data_sync/di.ts
@@ -20,6 +20,7 @@ type Cradle = {
   schedulerService?: {
     register: (registration: Record<string, unknown>) => Promise<void>
     unregister: (scheduleId: string) => Promise<void>
+    exists?: (scheduleId: string) => Promise<boolean>
   }
 }
 

--- a/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
@@ -220,15 +220,13 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
 
         return row
       } catch (error: unknown) {
-        // The registration above is already durable, so a failing write would
-        // otherwise leave a live ScheduledJob pointing at a SyncSchedule row
-        // that was never persisted. Only a create can be compensated: it minted
-        // `scheduledJobId` in this call, so unregistering it cannot destroy a
-        // registration someone else owns. An update reuses an existing job the
-        // scheduler has already overwritten, and SchedulerServiceLike exposes no
-        // way to restore the previous registration — that asymmetry is
-        // deliberate and stays until the scheduler contract can roll an update
-        // back.
+        // The registration above is already durable, so a failed write would
+        // otherwise strand a live ScheduledJob pointing at a row that was never
+        // persisted. Only a create can be compensated: it minted scheduledJobId
+        // in this call, so unregistering it cannot destroy someone else's
+        // registration. An update reuses a job the scheduler has already
+        // overwritten and SchedulerServiceLike offers no way to restore the
+        // previous one, so it deliberately stays uncompensated.
         if (!existing) {
           try {
             await requireScheduler().unregister(scheduledJobId)

--- a/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
@@ -33,6 +33,15 @@ type SchedulerServiceLike = {
     isEnabled?: boolean
   }) => Promise<void>
   unregister: (scheduleId: string) => Promise<void>
+  exists?: (scheduleId: string) => Promise<boolean>
+}
+
+async function scheduledJobExists(scheduler: SchedulerServiceLike, scheduledJobId: string): Promise<boolean> {
+  // A scheduler substitute that cannot answer keeps the pre-existing behaviour:
+  // treat the registration as minted, which compensates rather than stranding an
+  // orphan on the create path where this is by far the likelier outcome.
+  if (!scheduler.exists) return false
+  return scheduler.exists(scheduledJobId)
 }
 
 export function createSyncScheduleService(em: EntityManager, schedulerService?: SchedulerServiceLike) {
@@ -161,12 +170,21 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
 
       const id = existing?.id ?? randomUUID()
       const scheduledJobId = existing?.scheduledJobId ?? id
-      const mintsRegistration = !existing?.scheduledJobId
+      const scheduler = requireScheduler()
+      // Only a registration this call mints may be compensated below. A create
+      // mints a fresh id, so no job can already live at it. An update of a row
+      // whose scheduledJobId is null is the ambiguous case — deleteSchedule reads
+      // that null as "the job lives at row.id", and register() upserts on id — so
+      // ask the scheduler instead of assuming, otherwise compensation would
+      // delete a job this call merely overwrote.
+      const mintsRegistration = existing
+        ? !existing.scheduledJobId && !(await scheduledJobExists(scheduler, scheduledJobId))
+        : true
 
       // Validate the schedule (and register it with the scheduler) before writing
       // the SyncSchedule row — an unparseable scheduleValue must not leave a
       // persisted row with no working schedule behind it.
-      await requireScheduler().register({
+      await scheduler.register({
         id: scheduledJobId,
         name: buildScheduleName(input),
         description: buildScheduleDescription(input),
@@ -223,14 +241,13 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
       } catch (error: unknown) {
         // The registration above is already durable, so a failed write would
         // otherwise strand a live ScheduledJob the data-sync page cannot explain
-        // or delete. Only a registration this call minted can be compensated —
-        // unregistering it cannot destroy one the row already owned. When the
-        // row arrived with a scheduledJobId the scheduler has just overwritten a
-        // job we inherited, and SchedulerServiceLike offers no way to restore
-        // the previous one, so that case deliberately stays uncompensated.
+        // or delete. Only a registration this call minted is compensated: when a
+        // job was already there, register() overwrote one we inherited, and
+        // SchedulerServiceLike offers no way to restore the previous definition,
+        // so unregistering would destroy that job rather than roll anything back.
         if (mintsRegistration) {
           try {
-            await requireScheduler().unregister(scheduledJobId)
+            await scheduler.unregister(scheduledJobId)
           } catch (compensationError: unknown) {
             logger.error('Failed to unregister the scheduled job after a schedule write failure', {
               scheduledJobId,

--- a/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
@@ -161,6 +161,7 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
 
       const id = existing?.id ?? randomUUID()
       const scheduledJobId = existing?.scheduledJobId ?? id
+      const mintsRegistration = !existing?.scheduledJobId
 
       // Validate the schedule (and register it with the scheduler) before writing
       // the SyncSchedule row — an unparseable scheduleValue must not leave a
@@ -221,13 +222,13 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
         return row
       } catch (error: unknown) {
         // The registration above is already durable, so a failed write would
-        // otherwise strand a live ScheduledJob pointing at a row that was never
-        // persisted. Only a create can be compensated: it minted scheduledJobId
-        // in this call, so unregistering it cannot destroy someone else's
-        // registration. An update reuses a job the scheduler has already
-        // overwritten and SchedulerServiceLike offers no way to restore the
-        // previous one, so it deliberately stays uncompensated.
-        if (!existing) {
+        // otherwise strand a live ScheduledJob the data-sync page cannot explain
+        // or delete. Only a registration this call minted can be compensated —
+        // unregistering it cannot destroy one the row already owned. When the
+        // row arrived with a scheduledJobId the scheduler has just overwritten a
+        // job we inherited, and SchedulerServiceLike offers no way to restore
+        // the previous one, so that case deliberately stays uncompensated.
+        if (mintsRegistration) {
           try {
             await requireScheduler().unregister(scheduledJobId)
           } catch (compensationError: unknown) {

--- a/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-schedule-service.ts
@@ -3,7 +3,10 @@ import type { AwilixContainer } from 'awilix'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { enforceCommandOptimisticLockWithGuards, enforceRecordGoneIsConflict } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { SyncSchedule } from '../data/entities'
+
+const logger = createLogger('data_sync').child({ component: 'sync-schedule-service' })
 
 type SyncScope = {
   organizationId: string
@@ -184,37 +187,63 @@ export function createSyncScheduleService(em: EntityManager, schedulerService?: 
         isEnabled: input.isEnabled,
       })
 
-      const row = existing ?? em.create(SyncSchedule, {
-        id,
-        integrationId: input.integrationId,
-        entityType: input.entityType,
-        direction: input.direction,
-        scheduleType: input.scheduleType,
-        scheduleValue: input.scheduleValue,
-        timezone: input.timezone,
-        fullSync: input.fullSync,
-        isEnabled: input.isEnabled,
-        organizationId: scope.organizationId,
-        tenantId: scope.tenantId,
-      })
+      try {
+        const row = existing ?? em.create(SyncSchedule, {
+          id,
+          integrationId: input.integrationId,
+          entityType: input.entityType,
+          direction: input.direction,
+          scheduleType: input.scheduleType,
+          scheduleValue: input.scheduleValue,
+          timezone: input.timezone,
+          fullSync: input.fullSync,
+          isEnabled: input.isEnabled,
+          organizationId: scope.organizationId,
+          tenantId: scope.tenantId,
+        })
 
-      row.integrationId = input.integrationId
-      row.entityType = input.entityType
-      row.direction = input.direction
-      row.scheduleType = input.scheduleType
-      row.scheduleValue = input.scheduleValue
-      row.timezone = input.timezone
-      row.fullSync = input.fullSync
-      row.isEnabled = input.isEnabled
-      row.scheduledJobId = scheduledJobId
+        row.integrationId = input.integrationId
+        row.entityType = input.entityType
+        row.direction = input.direction
+        row.scheduleType = input.scheduleType
+        row.scheduleValue = input.scheduleValue
+        row.timezone = input.timezone
+        row.fullSync = input.fullSync
+        row.isEnabled = input.isEnabled
+        row.scheduledJobId = scheduledJobId
 
-      if (!existing) {
-        em.persist(row)
+        if (!existing) {
+          em.persist(row)
+        }
+
+        await em.flush()
+
+        return row
+      } catch (error: unknown) {
+        // The registration above is already durable, so a failing write would
+        // otherwise leave a live ScheduledJob pointing at a SyncSchedule row
+        // that was never persisted. Only a create can be compensated: it minted
+        // `scheduledJobId` in this call, so unregistering it cannot destroy a
+        // registration someone else owns. An update reuses an existing job the
+        // scheduler has already overwritten, and SchedulerServiceLike exposes no
+        // way to restore the previous registration — that asymmetry is
+        // deliberate and stays until the scheduler contract can roll an update
+        // back.
+        if (!existing) {
+          try {
+            await requireScheduler().unregister(scheduledJobId)
+          } catch (compensationError: unknown) {
+            logger.error('Failed to unregister the scheduled job after a schedule write failure', {
+              scheduledJobId,
+              scheduleId: id,
+              organizationId: scope.organizationId,
+              tenantId: scope.tenantId,
+              err: compensationError,
+            })
+          }
+        }
+        throw error
       }
-
-      await em.flush()
-
-      return row
     },
 
     async deleteSchedule(


### PR DESCRIPTION
Fixes #5871.

> **Stacked on #5661.** The window this PR closes only exists *after* #5661's reorder — `develop`
> still writes the `SyncSchedule` row before calling `schedulerService.register(...)`, so there is
> nothing to compensate there yet. This PR is therefore based on
> `fix/issue-5506-data-sync-schedule-saved-on-422`; GitHub will retarget it to `develop` once #5661
> merges. **Merge #5661 first.**
>
> ### ⚠ Merge precondition: this PR has never run CI, and three things hide that
>
> `.github/workflows/ci.yml` triggers on `pull_request` against `main`, `develop` and `feat/wms`
> only, so no CI run exists for any commit on this branch. Per @pkarw's review that is riskier than
> "CI is deferred", because nothing downstream catches it:
>
> 1. `develop` has **no required status checks** (`required_status_checks: null`); the single
>    approving review is the only gate.
> 2. The PR **reads as green** — the only two checks present are `license/cla` (pass) and
>    `[code]smith` (skipped), which is visually indistinguishable from a full CI pass.
> 3. **Retargeting alone will not fire CI.** The automatic retarget on #5661's merge raises the
>    `edited` activity type, and `ci.yml` uses the default set (`opened`, `synchronize`, `reopened`).
>
> **So before merging:** after #5661 lands and GitHub retargets this PR to `develop`, push a commit
> (a rebase onto the new `develop` is the natural one) so `synchronize` fires, then confirm a
> `CI for Develop&Main` run exists **for the new head SHA**. Closing and reopening also works.
> Retargeting to `develop` *now* is not the answer — it would pull #5661's commit into this diff and
> make this PR supersede it.

## 🎯 Goal

A failing `SyncSchedule` write can no longer strand a live `ScheduledJob` behind it.

## 🔍 Problem

#5661 reorders `saveSchedule()` so `schedulerService.register(...)` runs before the `SyncSchedule`
row is flushed. That closes #5506's defect but inverts the window: `SchedulerService.register()`
forks its own `EntityManager`, commits the `ScheduledJob` row, and registers the BullMQ repeatable
job — all durable — *before* `em.flush()` writes the `SyncSchedule`.

If that flush throws — a transient database error or a lost connection — the scheduler keeps a live
job whose `targetPayload.scheduleId` points at a row that was never written.

The damage is bounded but real: the worker degrades safely (`workers/sync-scheduled.ts` returns
early on a schedule-lookup miss), but the phantom job stays visible in the scheduler admin UI as a
`Data sync: …` entry the data-sync page cannot explain or delete, keeps firing no-op queue jobs on
its cadence indefinitely, and counts against the tenant's active-schedule quota via
`enforceTenantActiveScheduleLimit`. Because a create mints a fresh `randomUUID()` per attempt, an
operator retrying through a run of flush failures accumulates a *distinct* orphan each time.

> **Correction (from review).** Earlier revisions of this description, and #5871 itself, also listed
> *"the losing side of a concurrent keyed create"* as a way the flush can throw, on the grounds that
> `SyncSchedule` has no unique constraint on the logical key. The premise is right and the conclusion
> was backwards: because there genuinely is no unique constraint, a concurrent keyed create cannot
> fail the flush at all — **both** writers succeed, and the result is duplicate `SyncSchedule` and
> `ScheduledJob` rows. That is an unguarded duplication hazard, not a compensable failure, and it is
> now tracked separately in #6000. The fix here remains fully justified by the other two causes.

## What Changed

`packages/core/src/modules/data_sync/lib/sync-schedule-service.ts` — the row build and `em.flush()`
in `saveSchedule()` are wrapped in a `try`. On failure, when this call minted the registration, it
calls `unregister(scheduledJobId)` inside its own `try/catch`, logs a compensation failure through
`createLogger('data_sync')` rather than masking the original error, and rethrows. This mirrors the
best-effort pattern the scheduler already uses for its own BullMQ sync.

### The compensation condition is "did this call mint the registration", not "is this a create"

#5871 proposes compensating when `existing` is falsy. That is one case short. An **update of a row
whose `scheduledJobId` is still null** — a legacy row, or one left behind by an earlier partial
write — reuses the row's own id as `scheduledJobId`, so `register()` creates a job on that path too.
A failing flush there left exactly the same defect: a live job the data-sync page cannot see (the
row's `scheduledJobId` never got persisted), explain, or delete.

### The guard asks the scheduler rather than assuming (review follow-up)

An earlier revision widened the condition to `!existing?.scheduledJobId` and justified it with the
claim that *a registration this call minted cannot be one the row already owned*. @pkarw's review
showed that claim is asserted, not enforced — and that the sibling `deleteSchedule` twelve lines down
encodes its **negation**, computing `row.scheduledJobId ?? row.id` and unregistering that, i.e.
treating a null column as "the job lives at `row.id`".

Concretely, for a row with `scheduledJobId: null` that *does* own a job at its id: `register()` is an
upsert keyed on `id`, so it **overwrites** that job rather than creating one; a later flush failure
then made `mintsRegistration` true and the compensation **deleted** it — precisely the "destroy
someone else's job" outcome the comment said could not happen. No current writer persists a null
`scheduled_job_id`, so this was latent rather than exploitable, but it was a stated invariant nothing
enforced, sitting next to code assuming the opposite.

So the guard now asks instead of assuming, via the `exists(scheduleId)` the scheduler already
exposes:

- **create** → the id is a freshly minted `randomUUID()`, so nothing can already live at it.
  `mintsRegistration` is true with **no** query — the common path pays nothing.
- **update, row carries a `scheduledJobId`** → inherited, unchanged: not compensated.
- **update, row's `scheduledJobId` is null** → the ambiguous case, and the only one that queries.
  A pre-existing job means `register()` overwrote one we inherited, so it is left alone.

`exists` is **optional** on the module-local `SchedulerServiceLike`: a substitute scheduler that
cannot answer falls back to the previous behaviour (compensate), which strands no orphan on the far
likelier create path.

### Why an inherited registration is deliberately not compensated

When a job was already there, the scheduler has overwritten one this call did not mint, and
`SchedulerServiceLike` exposes only `register` and `unregister` — there is no way to restore the
previous definition. `unregister` would *destroy* a legitimate job rather than roll one back, so
leaving the overwritten job in place is strictly the lesser harm. Closing that symmetrically means
widening the scheduler contract with a restore/rollback API — a public-contract change worth its own
issue, not something to smuggle in here.

## 🧪 Tests

`packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts` — nine
cases (23 across the three schedule suites), and the pre-existing case now asserts that a rejecting
`register()` does **not** trigger compensation:

- **success-path ordering** — pins `register()` resolving before `em.flush()` via
  `invocationCallOrder`, so a future refactor cannot reintroduce the #5506 ordering in a form the
  suite still passes.
- **create-path compensation** — scheduler resolves, `em.flush` rejects → `unregister` is called once
  with exactly the `scheduledJobId` that `register` received, and the original flush error still
  propagates to the caller.
- **compensation failure does not mask the cause** — `unregister` also throws → the caller still sees
  the original flush error.
- **the compensation failure is logged** — asserts `logger.error` fires with `scheduledJobId`,
  `scheduleId`, `organizationId`, `tenantId` and the cause. That log is the only signal an operator
  ever gets that a compensation failed and an orphan really does exist.
- **an inherited registration is left alone** — existing row with `scheduledJobId: 'job-1'`, flush
  rejects → `unregister` is never called.
- **a minted registration on the update path is compensated** — existing row with
  `scheduledJobId: null`, `exists` false, flush rejects → `unregister` is called with the row's own id.
- **a job that already lived at the row id is left alone** — same row, `exists` **true** → `unregister`
  is never called. This is the case the previous revision got wrong.
- **the create path does not query the scheduler** — `exists` is never called for a freshly minted id.
- **an `exists`-less scheduler still compensates** — pins the optional-capability fallback.

Mutation-tested rather than read: reverting the guard to `!existing?.scheduledJobId` fails 2 cases;
flipping the `exists`-absent fallback fails 1; removing the compensation-failure log fails 1. Every
new branch is pinned by its own case.

## ✅ Validation

CI cannot run on this base (see the precondition at the top), so this is local evidence only and
carries no weight at merge time:

- `data_sync` module — **33 suites / 236 tests, all green** (was 232 before this revision).
- `packages/core` full suite — 11 484 passed. The 28 suites that fail to load and the 2 failing
  `catalog` enricher-config tests are `#generated/…` resolution errors from an unbuilt local
  checkout; they reproduce identically without this branch's changes and none is in `data_sync`.
- Regression proof by mutation, above.
- `typecheck` reports no error in any of the three changed files. The remaining gate commands
  (`build:packages`, `generate`, `i18n:check-*`, `build:app`) were **not** run to completion on this
  revision — the checkout has no built package artifacts, so they produce environment noise rather
  than signal. They need CI, which is the reason to settle the base-branch question before merge.
  `packages/core` has no `lint` script, and the diff touches no `.tsx`, no locale file, no entity and
  no migration.

## 🔗 Follow-ups filed from the review

Non-blocking findings, tracked rather than folded in:

- **#5999** — `deleteSchedule` has the mirror-image window (unregister-then-flush): a failing flush
  destroys the job but leaves the row live and enabled. Pre-existing; this PR establishes the
  compensation pattern that fixes it.
- **#6000** — no unique constraint on the `SyncSchedule` logical key, so concurrent keyed creates
  duplicate the row and the scheduled job. This is the corrected version of the claim struck from
  the Problem section above.
- **#6001** — both schedule write routes return raw driver messages as `422`, classifying
  infrastructure failures as client errors. Pre-existing; this PR's tests now pin it, so that issue
  notes the assertions must be updated alongside the fix.

## 💥 Breaking Changes

None. Request/response shapes, DI wiring, and upsert semantics are unchanged. `SchedulerServiceLike`
is a module-local type and the added `exists` is optional, so an existing scheduler substitute stays
assignable. The only new behavior is on an error path that previously leaked a registration.
