### PR TITLE
fix(create-app): enable attachments in the empty starter preset (#5897)

### DIFF
--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -18,10 +18,10 @@ test('resolvePreset: classic returns isClassic=true and empty modules', () => {
   assert.deepEqual(result.filesToRemove, [])
 })
 
-test('resolvePreset: empty returns 11-module list', () => {
+test('resolvePreset: empty returns 12-module list', () => {
   const result = resolvePreset('empty')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 11)
+  assert.equal(result.modules.length, 12)
   const ids = result.modules.map((m) => m.id)
   assert.deepEqual(ids, [
     'auth',
@@ -35,10 +35,14 @@ test('resolvePreset: empty returns 11-module list', () => {
     'dashboards',
     'events',
     'search',
+    'attachments',
   ])
   assert.equal(result.modules.find((m) => m.id === 'events')?.from, '@open-mercato/events')
   // search backs the Cmd+K palette the app shell renders unconditionally (issue #5164)
   assert.equal(result.modules.find((m) => m.id === 'search')?.from, '@open-mercato/search')
+  // attachments owns POST /api/attachments, which the baseline directory branding page
+  // uploads the organization logo through (issue #5897)
+  assert.equal(result.modules.find((m) => m.id === 'attachments')?.from, '@open-mercato/core')
   assert.ok(
     result.modules
       .filter((m) => m.id !== 'events' && m.id !== 'search')
@@ -95,7 +99,7 @@ test('resolvePreset: crm returns 19-module list extending empty (includes attach
 test('resolvePreset: wms returns empty plus the WMS dependency chain', () => {
   const result = resolvePreset('wms')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 18)
+  assert.equal(result.modules.length, 19)
   const ids = result.modules.map((m) => m.id)
   assert.deepEqual(ids, [
     'auth',
@@ -109,6 +113,7 @@ test('resolvePreset: wms returns empty plus the WMS dependency chain', () => {
     'dashboards',
     'events',
     'search',
+    'attachments',
     'customers',
     'dictionaries',
     'feature_toggles',
@@ -208,7 +213,7 @@ test('applyStarterPreset: classic is a no-op', () => {
   }
 })
 
-test('applyStarterPreset: empty writes 11-module modules.ts and keeps example source present', () => {
+test('applyStarterPreset: empty writes 12-module modules.ts and keeps example source present', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('empty', dir)
@@ -221,6 +226,9 @@ test('applyStarterPreset: empty writes 11-module modules.ts and keeps example so
     assert.ok(content.includes("id: 'events'"))
     assert.ok(content.includes("id: 'search'"))
     assert.ok(content.includes("from: '@open-mercato/search'"))
+    // attachments must register so the branding logo upload has a route to POST to
+    // (regression coverage for issue #5897)
+    assert.ok(content.includes("id: 'attachments'"))
     assert.ok(!content.includes("id: 'customers'"))
     assert.ok(!content.includes('example_customers_sync'))
     assert.ok(existsSync(join(dir, 'src', 'modules', 'example')))
@@ -274,6 +282,9 @@ test('applyStarterPreset: wms writes the WMS dependency chain and keeps example 
     for (const moduleId of ['customers', 'dictionaries', 'feature_toggles', 'catalog', 'sales', 'wms', 'currencies']) {
       assert.ok(content.includes(`id: '${moduleId}'`))
     }
+    // catalog's product media manager uploads through POST /api/attachments, which only
+    // the inherited attachments module registers (issue #5897)
+    assert.ok(content.includes("id: 'attachments'"))
     assert.ok(!content.includes("id: 'ai_assistant'"))
     assert.ok(existsSync(join(dir, 'src', 'modules', 'example')))
     const marker = JSON.parse(readFileSync(join(dir, '.mercato', 'starter-preset.json'), 'utf-8'))
@@ -320,6 +331,66 @@ test('every non-classic preset enables the modules the template topbar gates on'
         `preset "${presetId}" must enable module "${moduleId}" — the topbar gates an affordance on one of its features`,
       )
     }
+  }
+})
+
+// Drift guard: a preset that enables a module whose UI uploads through
+// `POST /api/attachments` without also enabling `attachments` ships an app where the
+// route is simply not registered, so the upload answers 404 while the rest of the page
+// keeps working. That silent failure is how issue #5897 escaped review — the baseline
+// `directory` branding page has always uploaded the organization logo that way.
+
+const CORE_MODULES_DIR = join(__dirname, '..', '..', '..', 'core', 'src', 'modules')
+
+function collectSourceFiles(dir: string): string[] {
+  const skipped = new Set(['__tests__', '__integration__', 'migrations', 'node_modules'])
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (skipped.has(entry.name)) continue
+      files.push(...collectSourceFiles(join(dir, entry.name)))
+      continue
+    }
+    if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) files.push(join(dir, entry.name))
+  }
+  return files
+}
+
+const attachmentUploaderCache = new Map<string, boolean>()
+
+function moduleUploadsToAttachments(moduleId: string): boolean {
+  const cached = attachmentUploaderCache.get(moduleId)
+  if (cached !== undefined) return cached
+  const moduleDir = join(CORE_MODULES_DIR, moduleId)
+  const uploads =
+    existsSync(moduleDir) &&
+    collectSourceFiles(moduleDir).some((file) =>
+      readFileSync(file, 'utf-8').includes("'/api/attachments'"),
+    )
+  attachmentUploaderCache.set(moduleId, uploads)
+  return uploads
+}
+
+test('every non-classic preset enabling an attachment uploader also enables attachments', () => {
+  // The guard is only meaningful while a baseline module really does upload; assert that
+  // premise so a future refactor turns this test red rather than vacuously green.
+  assert.ok(
+    moduleUploadsToAttachments('directory'),
+    'expected the directory branding page to upload the organization logo to /api/attachments',
+  )
+
+  for (const presetId of ['empty', 'crm', 'wms']) {
+    const modules = resolvePreset(presetId).modules
+    const enabledIds = new Set(modules.map((m) => m.id))
+    const uploaders = modules
+      .filter((m) => m.from === '@open-mercato/core' && m.id !== 'attachments')
+      .map((m) => m.id)
+      .filter(moduleUploadsToAttachments)
+    if (uploaders.length === 0) continue
+    assert.ok(
+      enabledIds.has('attachments'),
+      `preset "${presetId}" enables ${uploaders.join(', ')} — module(s) uploading through POST /api/attachments — but not the attachments module that registers the route`,
+    )
   }
 })
 

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { resolvePreset, generateModulesTs, applyStarterPreset } from './apply-starter-preset.js'
+import type { ModuleEntry } from './starter-presets.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -340,7 +341,15 @@ test('every non-classic preset enables the modules the template topbar gates on'
 // keeps working. That silent failure is how issue #5897 escaped review — the baseline
 // `directory` branding page has always uploaded the organization logo that way.
 
-const CORE_MODULES_DIR = join(__dirname, '..', '..', '..', 'core', 'src', 'modules')
+const PACKAGES_DIR = join(__dirname, '..', '..', '..')
+
+// Every module a preset can enable lives at `packages/<pkg>/src/modules/<id>`, so the
+// owning package is derivable from the entry's `from` — scanning only `@open-mercato/core`
+// would leave a preset that enables an uploader from `search`, `events` or `ai-assistant`
+// unguarded.
+function moduleSourceDir(entry: ModuleEntry): string {
+  return join(PACKAGES_DIR, entry.from.replace('@open-mercato/', ''), 'src', 'modules', entry.id)
+}
 
 function collectSourceFiles(dir: string): string[] {
   const skipped = new Set(['__tests__', '__integration__', 'migrations', 'node_modules'])
@@ -358,16 +367,16 @@ function collectSourceFiles(dir: string): string[] {
 
 const attachmentUploaderCache = new Map<string, boolean>()
 
-function moduleUploadsToAttachments(moduleId: string): boolean {
-  const cached = attachmentUploaderCache.get(moduleId)
+function moduleUploadsToAttachments(entry: ModuleEntry): boolean {
+  const cached = attachmentUploaderCache.get(entry.id)
   if (cached !== undefined) return cached
-  const moduleDir = join(CORE_MODULES_DIR, moduleId)
+  const moduleDir = moduleSourceDir(entry)
   const uploads =
     existsSync(moduleDir) &&
     collectSourceFiles(moduleDir).some((file) =>
       readFileSync(file, 'utf-8').includes("'/api/attachments'"),
     )
-  attachmentUploaderCache.set(moduleId, uploads)
+  attachmentUploaderCache.set(entry.id, uploads)
   return uploads
 }
 
@@ -375,7 +384,7 @@ test('every non-classic preset enabling an attachment uploader also enables atta
   // The guard is only meaningful while a baseline module really does upload; assert that
   // premise so a future refactor turns this test red rather than vacuously green.
   assert.ok(
-    moduleUploadsToAttachments('directory'),
+    moduleUploadsToAttachments({ id: 'directory', from: '@open-mercato/core' }),
     'expected the directory branding page to upload the organization logo to /api/attachments',
   )
 
@@ -383,9 +392,9 @@ test('every non-classic preset enabling an attachment uploader also enables atta
     const modules = resolvePreset(presetId).modules
     const enabledIds = new Set(modules.map((m) => m.id))
     const uploaders = modules
-      .filter((m) => m.from === '@open-mercato/core' && m.id !== 'attachments')
-      .map((m) => m.id)
+      .filter((m) => m.id !== 'attachments')
       .filter(moduleUploadsToAttachments)
+      .map((m) => m.id)
     if (uploaders.length === 0) continue
     assert.ok(
       enabledIds.has('attachments'),

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -41,6 +41,14 @@ const EMPTY_MODULES: ModuleEntry[] = [
   // table the token strategy reads, so the palette works with no Meilisearch and no
   // embedding provider configured.
   { id: 'search', from: SEARCH },
+  // `directory` above ships the organization branding page, whose logo picker uploads
+  // through `POST /api/attachments` — a route only the `attachments` module registers.
+  // Without it the upload 404s silently instead of failing visibly, so `attachments`
+  // belongs in the baseline rather than in a single preset's extras (issue #5897).
+  // It costs nothing to enable: it lives in `@open-mercato/core`, already pinned in the
+  // template's package.json, and every `OM_ATTACHMENT_*` / OCR / S3 setting defaults to
+  // a working local-filestore configuration.
+  { id: 'attachments', from: CORE },
 ]
 
 export const STARTER_PRESETS: Record<string, StarterPreset> = {
@@ -73,7 +81,8 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
       mode: 'patch',
       add: [
         { id: 'customers', from: CORE },
-        { id: 'attachments', from: CORE },
+        // `attachments` is inherited from EMPTY_MODULES; re-adding it here would make
+        // `resolvePreset` throw on duplicate module ids.
         { id: 'messages', from: CORE },
         { id: 'dictionaries', from: CORE },
         { id: 'feature_toggles', from: CORE },


### PR DESCRIPTION
Closes #5897

## 🎯 Goal

A `--preset empty` (or `--preset wms`) app scaffolded with `create-mercato-app` can actually upload files: the organization branding logo saves instead of silently failing, and no `/api/attachments` request answers 404 any more.

## 🔍 Problem

`EMPTY_MODULES` in `packages/create-app/src/lib/starter-presets.ts` listed eleven modules, and `attachments` was not one of them — it appeared only in the `crm` preset's extras. Every other preset therefore shipped an app with UI that uploads through a route no enabled module registers. The failure is silent: the page renders, the picker opens, the request 404s in the background, and the app keeps working, so it is only noticed when someone actually tries to attach a file.

## 🔍 Root Cause

API routes are auto-discovered per enabled module, so `POST /api/attachments` exists only when the `attachments` module is enabled. `directory` **is** in the baseline, and its organization branding page uploads the logo to exactly that endpoint (`packages/core/src/modules/directory/backend/directory/branding/page.tsx:89`, `uploadLogo`). The `wms` preset inherits the same gap and adds a second victim, since it enables `catalog`, whose product media manager (`packages/core/src/modules/catalog/components/products/ProductMediaManager.tsx`) uploads the same way. This is the same drift class as #5164, where `search` was missing from the baseline while the app shell rendered the Cmd+K palette unconditionally.

## What Changed

- `packages/create-app/src/lib/starter-presets.ts` — `{ id: 'attachments', from: CORE }` **moves** from the `crm` preset's `add` list into `EMPTY_MODULES`, so `empty`, `crm` and `wms` all inherit it from a single place, mirroring how #5164 handled `search`. Moving rather than duplicating is load-bearing, not cosmetic: `resolvePreset` throws `Preset "crm" has duplicate module IDs` when a patch preset re-adds a baseline module, so leaving the `crm` line in place would have replaced a silent 404 with a hard scaffold failure. A comment at each site records why the entry sits where it does.
- Nothing else needed wiring. `attachments` ships inside `@open-mercato/core`, which the template's `package.json.template` already pins and the classic template's `src/modules.ts` already registers, and every `OM_ATTACHMENT_*` / OCR / S3 setting defaults to a working local filestore — so template dependencies, `next.config.ts`, `.env.example` and the generated standalone AGENTS.md byte budget are all untouched.
- `packages/create-app/src/lib/apply-starter-preset.test.ts` — the pinned preset expectations follow the new baseline (`empty` 11 → 12 modules, `wms` 18 → 19, `crm` unchanged at 19 because the module moved from its extras into the inherited baseline), plus the generated `modules.ts` content assertions for `empty` and `wms`, and the new drift guard described below.

## 🧪 Tests

- New guard `every non-classic preset enabling an attachment uploader also enables attachments`, modelled on the existing topbar drift guard in the same file. It walks the source of every core-backed module each non-classic preset enables (skipping `__tests__`, `__integration__` and `migrations`), finds the ones that post to `'/api/attachments'`, and requires `attachments` to be enabled alongside them — closing the drift class rather than this single instance. It first asserts that `directory` really is such an uploader, so a future refactor that moves the upload elsewhere turns the test red instead of leaving it vacuously green.
- Verified in both directions: with `starter-presets.ts` reverted the guard fails with `preset "empty" enables directory — module(s) uploading through POST /api/attachments — but not the attachments module that registers the route`; with the fix applied it passes.
- Full validation gate run locally in the configured order — `yarn build:packages` ✅, `yarn generate` ✅ (no generated-file drift), `yarn build:packages` ✅, `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅, `yarn typecheck` ✅, `yarn test` ❌, `yarn build:app` ✅.
- The `yarn test` failure is 5 pre-existing `@open-mercato/cli` failures in `resolve-environment.test.ts` and `resolver.enterprise.test.ts` — the known location-dependent class where a temp root nested inside the monorepo resolves as `monorepo` rather than `standalone`. They touch no create-app code.
- Turbo aborts the remaining packages after that failure, so the changed package's suite was run standalone: `yarn workspace create-mercato-app test` → **799 passed, 80 failed**, with every preset, scaffold and design-system-inventory test green (including `CLI bare scaffold applies explicit crm preset without prompting` and its `wms` counterpart). All 80 failures live in `agent-harness-evaluator.test.ts`, `agent-harness-release.test.ts`, `writable-ast-oracles.test.ts` and `business-writable-oracles.test.ts`, which drive the codex/claude CLIs. Re-running exactly those four files with this change stashed produced the identical 80 failures, confirming they are environmental and pre-existing rather than a regression from this PR.

## 💥 Breaking Changes

None. The change is scaffold-time only — no runtime contract, HTTP route, event id, DB schema or published type changes, so it is additive under `BACKWARD_COMPATIBILITY.md`. Fresh `empty` and `wms` apps now apply six extra `attachments` migrations on their first `mercato db migrate`, which is the cost the issue explicitly accepts. Already-scaffolded apps are untouched; backfilling them is out of scope per the issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791381201&installation_model_id=432243&pr_number=5917&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5917&signature=c476814cd75d519ad34379003103e911bfbd6af7388fb993f64171ba4c8ce1a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->