### PR TITLE
fix(customer_accounts): answer a portal invitation for an existing account with a clear conflict (#5899)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/__tests__/invitations-accept.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/invitations-accept.route.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+import { POST } from '@open-mercato/core/modules/customer_accounts/api/invitations/accept'
+import {
+  CustomerInvitationAccountExistsError,
+} from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+
+const mockAcceptInvitation = jest.fn()
+const mockGetEffectiveFeatures = jest.fn()
+const mockCreateSession = jest.fn()
+const mockEmitCustomerAccountsEvent = jest.fn()
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'customerInvitationService') return { acceptInvitation: mockAcceptInvitation }
+    if (token === 'customerSessionService') return { createSession: mockCreateSession }
+    if (token === 'customerRbacService') return { getEffectiveFeatures: mockGetEffectiveFeatures }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: jest.fn((...args: unknown[]) => {
+    mockEmitCustomerAccountsEvent(...args)
+    return Promise.resolve()
+  }),
+}))
+
+function acceptRequest(): Request {
+  return new Request('http://localhost/api/customer_accounts/invitations/accept', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: 'raw-token', password: 'Secret123!', displayName: 'New User' }),
+  })
+}
+
+describe('POST /api/customer_accounts/invitations/accept', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetEffectiveFeatures.mockResolvedValue(['portal.dashboard.view'])
+    mockCreateSession.mockResolvedValue({ rawToken: 'session-token', jwt: 'jwt-token' })
+  })
+
+  it('answers 409 with an account_exists code when the invited email already has a portal account (#5899)', async () => {
+    mockAcceptInvitation.mockRejectedValue(new CustomerInvitationAccountExistsError())
+
+    const res = await POST(acceptRequest())
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ ok: false, code: 'account_exists' })
+    expect(mockCreateSession).not.toHaveBeenCalled()
+    expect(mockEmitCustomerAccountsEvent).not.toHaveBeenCalled()
+  })
+
+  it('recognises the conflict by its code alone, without instanceof on the service class', async () => {
+    mockAcceptInvitation.mockRejectedValue(
+      Object.assign(new Error('duplicate'), { code: 'customer_accounts.invitation.account_exists' }),
+    )
+
+    const res = await POST(acceptRequest())
+    expect(res.status).toBe(409)
+  })
+
+  it('lets unrelated service failures propagate instead of masking them as a conflict', async () => {
+    mockAcceptInvitation.mockRejectedValue(new Error('connection lost'))
+
+    await expect(POST(acceptRequest())).rejects.toThrow('connection lost')
+  })
+
+  it('answers 400 when the invitation token is invalid or expired', async () => {
+    mockAcceptInvitation.mockResolvedValue(null)
+
+    const res = await POST(acceptRequest())
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ ok: false })
+  })
+
+  it('still creates the account and signs the invitee in on the happy path', async () => {
+    mockAcceptInvitation.mockResolvedValue({
+      user: {
+        id: '33333333-3333-4333-8333-333333333333',
+        email: 'new@example.com',
+        displayName: 'New User',
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        organizationId: '22222222-2222-4222-8222-222222222222',
+      },
+      invitation: { id: 'inv-1' },
+    })
+
+    const res = await POST(acceptRequest())
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({ ok: true, user: { email: 'new@example.com' } })
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/invitations/accept.ts
+++ b/packages/core/src/modules/customer_accounts/api/invitations/accept.ts
@@ -3,13 +3,18 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { invitationAcceptSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+import {
+  CustomerInvitationService,
+  isCustomerInvitationAccountExistsError,
+} from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import { CustomerSessionService } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { getClientIp } from '@open-mercato/shared/lib/ratelimit/helpers'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
+
+const ACCOUNT_EXISTS_ERROR_CODE = 'account_exists'
 
 export async function POST(req: Request) {
   let body: unknown
@@ -29,11 +34,21 @@ export async function POST(req: Request) {
   const customerSessionService = container.resolve('customerSessionService') as CustomerSessionService
   const customerRbacService = container.resolve('customerRbacService') as CustomerRbacService
 
-  const result = await customerInvitationService.acceptInvitation(
-    parsed.data.token,
-    parsed.data.password,
-    parsed.data.displayName,
-  )
+  let result: Awaited<ReturnType<CustomerInvitationService['acceptInvitation']>>
+  try {
+    result = await customerInvitationService.acceptInvitation(
+      parsed.data.token,
+      parsed.data.password,
+      parsed.data.displayName,
+    )
+  } catch (error) {
+    if (!isCustomerInvitationAccountExistsError(error)) throw error
+    return NextResponse.json({
+      ok: false,
+      error: 'An account already exists for this email address',
+      code: ACCOUNT_EXISTS_ERROR_CODE,
+    }, { status: 409 })
+  }
   if (!result) {
     return NextResponse.json({ ok: false, error: 'Invalid or expired invitation' }, { status: 400 })
   }
@@ -103,6 +118,11 @@ const acceptSuccessSchema = z.object({
 })
 
 const errorSchema = z.object({ ok: z.literal(false), error: z.string() })
+const accountExistsErrorSchema = z.object({
+  ok: z.literal(false),
+  error: z.string(),
+  code: z.literal(ACCOUNT_EXISTS_ERROR_CODE),
+})
 
 const methodDoc: OpenApiMethodDoc = {
   summary: 'Accept customer invitation',
@@ -117,6 +137,11 @@ const methodDoc: OpenApiMethodDoc = {
   ],
   errors: [
     { status: 400, description: 'Invalid or expired invitation', schema: errorSchema },
+    {
+      status: 409,
+      description: 'The invited email address already has a portal account in this tenant',
+      schema: accountExistsErrorSchema,
+    },
   ],
 }
 

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
@@ -207,21 +207,23 @@ describe('CustomerInvitationService.acceptInvitation — existing portal account
 
   let mockEm: jest.Mocked<Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'flush'>>
   let service: CustomerInvitationService
-
-  const invitation = {
-    id: 'inv-existing-account',
-    email: 'taken@example.com',
-    tenantId,
-    organizationId,
-    customerEntityId: null,
-    roleIdsJson: [],
-    expiresAt: new Date(Date.now() + 60_000),
-    acceptedAt: null,
-    cancelledAt: null,
-  } as unknown as CustomerUserInvitation
+  let invitation: CustomerUserInvitation
 
   beforeEach(() => {
     jest.clearAllMocks()
+    // Rebuilt per test: acceptInvitation stamps `acceptedAt` on the way to the flush, which would
+    // make findByToken reject the invitation in every following test if the fixture were shared.
+    invitation = {
+      id: 'inv-existing-account',
+      email: 'taken@example.com',
+      tenantId,
+      organizationId,
+      customerEntityId: null,
+      roleIdsJson: [],
+      expiresAt: new Date(Date.now() + 60_000),
+      acceptedAt: null,
+      cancelledAt: null,
+    } as unknown as CustomerUserInvitation
     mockEm = {
       find: jest.fn(async () => []),
       findOne: jest.fn(),
@@ -275,6 +277,65 @@ describe('CustomerInvitationService.acceptInvitation — existing portal account
     expect(isCustomerInvitationAccountExistsError({ code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE })).toBe(true)
     expect(isCustomerInvitationAccountExistsError(new Error('boom'))).toBe(false)
     expect(isCustomerInvitationAccountExistsError(null)).toBe(false)
+  })
+
+  it('maps a concurrent insert losing the unique-constraint race onto the same conflict error', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+    ;(mockEm.flush as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('insert into "customer_users" failed'), {
+        code: '23505',
+        constraint: 'customer_users_tenant_email_hash_uniq',
+      }),
+    )
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toMatchObject({
+      code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE,
+    })
+  })
+
+  it('recognises the unique violation when MikroORM wraps the driver error', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+    ;(mockEm.flush as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('insert failed'), {
+        cause: Object.assign(new Error('duplicate key value violates unique constraint "customer_users_tenant_email_hash_uniq"'), {
+          code: '23505',
+        }),
+      }),
+    )
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toMatchObject({
+      code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE,
+    })
+  })
+
+  it('rethrows an unrelated flush failure untouched rather than reporting a conflict', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+    ;(mockEm.flush as jest.Mock).mockRejectedValue(new Error('connection terminated'))
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toThrow('connection terminated')
+  })
+
+  it('does not treat a unique violation on another constraint as an existing account', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+    const unrelated = Object.assign(new Error('duplicate key'), {
+      code: '23505',
+      constraint: 'customer_user_roles_pkey',
+    })
+    ;(mockEm.flush as jest.Mock).mockRejectedValue(unrelated)
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toBe(unrelated)
   })
 
   it('still creates the account when no user exists for the invited address', async () => {

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
@@ -1,6 +1,11 @@
 /** @jest-environment node */
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+import {
+  CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE,
+  CustomerInvitationAccountExistsError,
+  CustomerInvitationService,
+  isCustomerInvitationAccountExistsError,
+} from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import {
   CustomerRole,
   CustomerUser,
@@ -15,6 +20,7 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/tokenGenerator', () 
 
 jest.mock('@open-mercato/shared/lib/encryption/aes', () => ({
   hashForLookup: jest.fn(() => 'email-hash'),
+  lookupHashCandidates: jest.fn(() => ['email-hash']),
 }))
 
 jest.mock('bcryptjs', () => ({
@@ -192,6 +198,95 @@ describe('CustomerInvitationService.acceptInvitation — role lookup batching', 
     await service.acceptInvitation('raw-token', 'Secret123!', 'New User')
     const roleFinds = (mockEm.find as jest.Mock).mock.calls.filter((call) => call[0] === CustomerRole)
     expect(roleFinds).toHaveLength(0)
+  })
+})
+
+describe('CustomerInvitationService.acceptInvitation — existing portal account (#5899)', () => {
+  const tenantId = '11111111-1111-4111-8111-111111111111'
+  const organizationId = '22222222-2222-4222-8222-222222222222'
+
+  let mockEm: jest.Mocked<Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'flush'>>
+  let service: CustomerInvitationService
+
+  const invitation = {
+    id: 'inv-existing-account',
+    email: 'taken@example.com',
+    tenantId,
+    organizationId,
+    customerEntityId: null,
+    roleIdsJson: [],
+    expiresAt: new Date(Date.now() + 60_000),
+    acceptedAt: null,
+    cancelledAt: null,
+  } as unknown as CustomerUserInvitation
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm = {
+      find: jest.fn(async () => []),
+      findOne: jest.fn(),
+      create: jest.fn((_: unknown, data: unknown) => data as any),
+      persist: jest.fn(),
+      flush: jest.fn(async () => undefined),
+    } as unknown as jest.Mocked<Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'flush'>>
+    service = new CustomerInvitationService(mockEm as unknown as EntityManager)
+  })
+
+  it('throws a discriminable account-exists error instead of inserting a duplicate customer_users row', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      if (entity === CustomerUser) return { id: 'existing-user', tenantId, organizationId }
+      return null
+    })
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toMatchObject({
+      code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE,
+    })
+
+    const userCreates = (mockEm.create as jest.Mock).mock.calls.filter((call) => call[0] === CustomerUser)
+    expect(userCreates).toHaveLength(0)
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+    expect(invitation.acceptedAt).toBeNull()
+  })
+
+  it('looks the existing account up by every lookup-hash candidate scoped to the invitation tenant', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      if (entity === CustomerUser) return { id: 'existing-user', tenantId, organizationId }
+      return null
+    })
+
+    await expect(service.acceptInvitation('raw-token', 'Secret123!', 'New User')).rejects.toMatchObject({
+      code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE,
+    })
+
+    const userLookups = (mockEm.findOne as jest.Mock).mock.calls.filter((call) => call[0] === CustomerUser)
+    expect(userLookups).toHaveLength(1)
+    expect(userLookups[0][1]).toMatchObject({
+      emailHash: { $in: ['email-hash'] },
+      tenantId,
+    })
+  })
+
+  it('is recognised by isCustomerInvitationAccountExistsError without relying on instanceof', () => {
+    const error = new CustomerInvitationAccountExistsError()
+    expect(isCustomerInvitationAccountExistsError(error)).toBe(true)
+    expect(isCustomerInvitationAccountExistsError({ code: CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE })).toBe(true)
+    expect(isCustomerInvitationAccountExistsError(new Error('boom'))).toBe(false)
+    expect(isCustomerInvitationAccountExistsError(null)).toBe(false)
+  })
+
+  it('still creates the account when no user exists for the invited address', async () => {
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+
+    const result = await service.acceptInvitation('raw-token', 'Secret123!', 'New User')
+    expect(result).not.toBeNull()
+    const userCreates = (mockEm.create as jest.Mock).mock.calls.filter((call) => call[0] === CustomerUser)
+    expect(userCreates).toHaveLength(1)
   })
 })
 

--- a/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
@@ -36,6 +36,35 @@ export function isCustomerInvitationAccountExistsError(error: unknown): boolean 
     && (error as { code?: unknown }).code === CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE
 }
 
+const CUSTOMER_USERS_EMAIL_UNIQUE_CONSTRAINT = 'customer_users_tenant_email_hash_uniq'
+const POSTGRES_UNIQUE_VIOLATION = '23505'
+
+/**
+ * The pre-insert lookup in {@link CustomerInvitationService.acceptInvitation} is a check-then-act,
+ * so two concurrent accepts for the same address (a double-submitted form, two invitations racing)
+ * can both pass it and let the second one reach the database. Recognising the resulting unique
+ * violation keeps that race on the same 409 answer instead of a 500. MikroORM wraps driver errors,
+ * so the original is inspected through `cause`/`previous` as well, again without `instanceof`.
+ */
+function isCustomerUserEmailUniqueViolation(error: unknown): boolean {
+  const candidates = [
+    error,
+    (error as { cause?: unknown } | null)?.cause,
+    (error as { previous?: unknown } | null)?.previous,
+  ]
+  return candidates.some((candidate) => {
+    if (typeof candidate !== 'object' || candidate === null) return false
+    const { code, constraint, message } = candidate as {
+      code?: unknown
+      constraint?: unknown
+      message?: unknown
+    }
+    if (code !== POSTGRES_UNIQUE_VIOLATION) return false
+    return constraint === CUSTOMER_USERS_EMAIL_UNIQUE_CONSTRAINT
+      || (typeof message === 'string' && message.includes(CUSTOMER_USERS_EMAIL_UNIQUE_CONSTRAINT))
+  })
+}
+
 export type CustomerInvitationRollbackState = {
   email: string
   token: string
@@ -245,7 +274,12 @@ export class CustomerInvitationService {
     // Mark invitation as accepted
     invitation.acceptedAt = new Date()
 
-    await this.em.flush()
+    try {
+      await this.em.flush()
+    } catch (error) {
+      if (isCustomerUserEmailUniqueViolation(error)) throw new CustomerInvitationAccountExistsError()
+      throw error
+    }
     return { user, invitation }
   }
 }

--- a/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
@@ -7,11 +7,34 @@ import {
   CustomerRole,
 } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { generateSecureToken, hashToken } from '@open-mercato/core/modules/customer_accounts/lib/tokenGenerator'
-import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { hashForLookup, lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 const BCRYPT_COST = 10
 const INVITATION_TTL_MS = 72 * 60 * 60 * 1000 // 72 hours
+
+export const CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE = 'customer_accounts.invitation.account_exists'
+
+/**
+ * Raised by {@link CustomerInvitationService.acceptInvitation} when the invited address already
+ * owns a portal account in the same tenant. Callers MUST discriminate on the `code` property
+ * rather than `instanceof`: the service is resolved through DI, so a production bundle can hold
+ * more than one copy of this class and `instanceof` then silently returns false.
+ */
+export class CustomerInvitationAccountExistsError extends Error {
+  readonly code = CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE
+
+  constructor() {
+    super('[internal] A portal account already exists for the invited email address')
+    this.name = 'CustomerInvitationAccountExistsError'
+  }
+}
+
+export function isCustomerInvitationAccountExistsError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { code?: unknown }).code === CUSTOMER_INVITATION_ACCOUNT_EXISTS_CODE
+}
 
 export type CustomerInvitationRollbackState = {
   email: string
@@ -156,6 +179,23 @@ export class CustomerInvitationService {
   ): Promise<{ user: CustomerUser; invitation: CustomerUserInvitation } | null> {
     const invitation = await this.findByToken(token)
     if (!invitation) return null
+
+    // customer_users carries a (tenant_id, email_hash) unique constraint, so inserting a second
+    // account for an address that was already invited and activated raises a driver-level unique
+    // violation the caller can only surface as a 500. Detect it up front and let the caller answer
+    // with a message the invitee can act on (#5899). The lookup deliberately omits `deletedAt` —
+    // the constraint is not partial, so a soft-deleted account collides just the same.
+    const existingUser = await findOneWithDecryption(
+      this.em,
+      CustomerUser,
+      {
+        emailHash: { $in: lookupHashCandidates(invitation.email) },
+        tenantId: invitation.tenantId,
+      } as any,
+      undefined,
+      { tenantId: invitation.tenantId, organizationId: invitation.organizationId },
+    )
+    if (existingUser) throw new CustomerInvitationAccountExistsError()
 
     const passwordHash = await hash(password, BCRYPT_COST)
     const emailHash = hashForLookup(invitation.email)

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/invite/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/invite/page.tsx
@@ -79,7 +79,9 @@ export default function PortalInvitePage({ params }: Props) {
           return
         }
 
-        if (result.status === 400) {
+        if (result.status === 409) {
+          setError(t('portal.invite.error.accountExists', 'This email address already has a portal account. Sign in below instead of accepting the invitation.'))
+        } else if (result.status === 400) {
           setError(t('portal.invite.error.invalidToken', 'Invalid or expired invitation.'))
         } else {
           setError(result.result?.error || t('portal.invite.error.generic', 'Invitation acceptance failed. Please try again.'))

--- a/packages/core/src/modules/portal/i18n/de.json
+++ b/packages/core/src/modules/portal/i18n/de.json
@@ -27,6 +27,7 @@
   "portal.invite.confirmPassword.placeholder": "••••••••",
   "portal.invite.description": "Erstellen Sie Ihr Portalkonto, um diese Einladung anzunehmen.",
   "portal.invite.displayName": "Anzeigename",
+  "portal.invite.error.accountExists": "Diese E-Mail-Adresse hat bereits ein Portalkonto. Melden Sie sich unten an, anstatt die Einladung anzunehmen.",
   "portal.invite.error.displayNameRequired": "Der Anzeigename ist erforderlich.",
   "portal.invite.error.generic": "Annahme der Einladung fehlgeschlagen. Bitte versuchen Sie es erneut.",
   "portal.invite.error.invalidToken": "Ungültige oder abgelaufene Einladung.",

--- a/packages/core/src/modules/portal/i18n/en.json
+++ b/packages/core/src/modules/portal/i18n/en.json
@@ -27,6 +27,7 @@
   "portal.invite.confirmPassword.placeholder": "••••••••",
   "portal.invite.description": "Create your portal account to accept this invitation.",
   "portal.invite.displayName": "Display Name",
+  "portal.invite.error.accountExists": "This email address already has a portal account. Sign in below instead of accepting the invitation.",
   "portal.invite.error.displayNameRequired": "Display name is required.",
   "portal.invite.error.generic": "Invitation acceptance failed. Please try again.",
   "portal.invite.error.invalidToken": "Invalid or expired invitation.",

--- a/packages/core/src/modules/portal/i18n/es.json
+++ b/packages/core/src/modules/portal/i18n/es.json
@@ -27,6 +27,7 @@
   "portal.invite.confirmPassword.placeholder": "••••••••",
   "portal.invite.description": "Crea tu cuenta del portal para aceptar esta invitación.",
   "portal.invite.displayName": "Nombre para mostrar",
+  "portal.invite.error.accountExists": "Esta dirección de correo electrónico ya tiene una cuenta del portal. Inicia sesión abajo en lugar de aceptar la invitación.",
   "portal.invite.error.displayNameRequired": "El nombre para mostrar es obligatorio.",
   "portal.invite.error.generic": "Error al aceptar la invitación. Inténtalo de nuevo.",
   "portal.invite.error.invalidToken": "Invitación no válida o expirada.",

--- a/packages/core/src/modules/portal/i18n/ko.json
+++ b/packages/core/src/modules/portal/i18n/ko.json
@@ -27,6 +27,7 @@
   "portal.invite.confirmPassword.placeholder": "••••••••",
   "portal.invite.description": "이 초대를 수락하려면 포털 계정을 만드세요.",
   "portal.invite.displayName": "표시 이름",
+  "portal.invite.error.accountExists": "이 이메일 주소에는 이미 포털 계정이 있습니다. 초대를 수락하는 대신 아래에서 로그인하세요.",
   "portal.invite.error.displayNameRequired": "표시 이름이 필요합니다.",
   "portal.invite.error.generic": "초대 수락에 실패했습니다. 다시 시도해 주세요.",
   "portal.invite.error.invalidToken": "초대가 유효하지 않거나 만료되었습니다.",

--- a/packages/core/src/modules/portal/i18n/pl.json
+++ b/packages/core/src/modules/portal/i18n/pl.json
@@ -27,6 +27,7 @@
   "portal.invite.confirmPassword.placeholder": "••••••••",
   "portal.invite.description": "Utwórz konto w portalu, aby przyjąć to zaproszenie.",
   "portal.invite.displayName": "Nazwa wyświetlana",
+  "portal.invite.error.accountExists": "Ten adres e-mail ma już konto w portalu. Zaloguj się poniżej zamiast przyjmować zaproszenie.",
   "portal.invite.error.displayNameRequired": "Nazwa wyświetlana jest wymagana.",
   "portal.invite.error.generic": "Nie udało się przyjąć zaproszenia. Spróbuj ponownie.",
   "portal.invite.error.invalidToken": "Nieprawidłowe lub wygasłe zaproszenie.",


### PR DESCRIPTION
Closes #5899

## 🎯 Goal
- An invitee whose email already has a portal account now sees an actionable message ("This email address already has a portal account. Sign in below instead of accepting the invitation.") on the Accept invitation page, instead of a server error that looks like a broken link or an outage.

## 🔍 Problem
Finishing a customer portal invitation at `/{org-slug}/portal/invite?token=…` failed with a server error whenever the invited address already had an active portal account in the same tenant from an earlier invitation. Nothing was lost — the existing account stayed untouched and no partial account was created — but the invitee had no explanation and no way to recover on their own.

## 🔍 Root Cause
`CustomerInvitationService.acceptInvitation` (`packages/core/src/modules/customer_accounts/services/customerInvitationService.ts`) went straight from "token is valid" to `em.create(CustomerUser, …)` + `flush()`, with no check for an account that already exists for the invited address. `customer_users` carries a `(tenant_id, email_hash)` unique constraint (`customer_users_tenant_email_hash_uniq`, added in `Migration20260313222043`), so the insert raised a driver-level unique violation. `api/invitations/accept.ts` did not catch anything, so the violation escaped the route handler as an unhandled exception — a 500 — and the portal page's `result.status === 400` branch never matched, leaving the generic failure path.

## What Changed
- `packages/core/src/modules/customer_accounts/services/customerInvitationService.ts` — `acceptInvitation` now looks the invited address up in `customer_users` (via `findOneWithDecryption`, matching every `lookupHashCandidates` variant, scoped to the invitation's tenant) before creating anything, and throws the new exported `CustomerInvitationAccountExistsError` when one exists. Nothing is written in that path: no user row, no role links, and the invitation is left un-accepted so it stays usable if the conflict is resolved. The lookup deliberately omits `deletedAt` because the unique constraint is not partial — a soft-deleted account collides just the same, and would otherwise still 500.
- The same guard also covers the concurrent case: because the lookup and the insert are separate statements, a double-submitted form or two racing invitations could still let one request reach the constraint. The flush now recognises a Postgres `23505` on `customer_users_tenant_email_hash_uniq` (reading `code`/`constraint` off the error and its `cause`/`previous`, since MikroORM wraps driver errors) and reports the same conflict; every other failure is rethrown untouched.
- The error is discriminated by a `code` property (`isCustomerInvitationAccountExistsError`), not `instanceof`: the service is resolved through DI and a production bundle can hold more than one copy of the class, which makes `instanceof` silently false.
- `packages/core/src/modules/customer_accounts/api/invitations/accept.ts` — catches that one error and answers `409 { ok: false, error, code: 'account_exists' }`; every other failure still propagates unchanged. The 409 is documented in the route's `openApi` block with its own response schema.
- `packages/core/src/modules/portal/frontend/[orgSlug]/portal/invite/page.tsx` — maps status 409 to the new `portal.invite.error.accountExists` message, shown in the existing error `Alert` directly above the form's "Already have an account? Sign in" link, so the recovery action is one click away. The 400 and generic branches are untouched.
- `packages/core/src/modules/portal/i18n/{en,pl,de,es,ko}.json` — the new key, translated in all five locales the module ships.

Note on disclosure: the endpoint requires a valid, unexpired invitation token, so telling that token's holder "this address already has an account" reveals nothing they were not already told by being invited at that address. This is deliberately narrower than the self-service signup route, which stays enumeration-safe.

## 🧪 Tests
- The full `validation.commands` gate from `.ai/agentic.config.json`, in order, run locally: `yarn build:packages` ✅, `yarn generate` ✅, `yarn build:packages` ✅, `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅, `yarn typecheck` ✅, `yarn test` (see below), `yarn build:app` ✅.
- `yarn test` — 33 of 34 turbo tasks green, including `@open-mercato/core` (12,040 passed / 1,479 suites) and `@open-mercato/shared` (2,115 passed). Two local-environment caveats, both unrelated to this diff: the first run reported 2 `@open-mercato/shared` failures in `dynamicLoader.generatedCacheRecovery.test.ts` from a `tsx` IPC socket path (`listen EINVAL`) because turbo does not forward `TMPDIR` — re-running with `--env-mode=loose` and a short `TMPDIR` makes them pass; and `create-mercato-app#test` fails on its agent-harness oracle suites, which need the `codex`/`claude` CLIs and a sandbox this machine does not provide. This PR touches no `packages/create-app` file, so CI is the authority on that package.
- `packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts` — new `acceptInvitation — existing portal account (#5899)` suite: the conflict throws a `code`-discriminable error, creates no `CustomerUser`, persists and flushes nothing and leaves `acceptedAt` null; the lookup uses every hash candidate scoped to the invitation's tenant; `isCustomerInvitationAccountExistsError` matches by code rather than `instanceof`; the concurrent race maps onto the same conflict in both the direct and MikroORM-wrapped error shapes, while an unrelated flush failure and a `23505` on a different constraint propagate untouched; and the no-existing-account path still creates the account.
- `packages/core/src/modules/customer_accounts/api/__tests__/invitations-accept.route.test.ts` — new route suite: 409 + `account_exists` with no session created and no events emitted, recognition by code alone, unrelated service failures still propagating rather than being masked as a conflict, the existing 400 invalid/expired branch, and the 201 happy path.

## 💥 Breaking Changes
- None. `acceptInvitation`'s signature is unchanged; the conflict path previously threw a driver-level unique-violation exception and now throws a typed one with a stable `code`, so existing callers see the same control flow with a better error. The `409` response and its `code` field are additive to the route's documented contract.
