### PR TITLE
refactor(ui): give ViewChip a semantic active-state hook and cover the New-view control layout (#5846)

### DIFF
--- a/.ai/specs/SPEC-070-2026-04-04-perspectives-views-panel.md
+++ b/.ai/specs/SPEC-070-2026-04-04-perspectives-views-panel.md
@@ -188,6 +188,8 @@ Deferred — the current `RolePerspective` model covers sharing via roles. A tru
 4. **Migration path** — Should old `ui.perspectives.*` i18n keys be removed immediately or deprecated gradually?
 
 ## Changelog
+### 2026-09-08 (update)
+- Active view state is now exposed semantically, not just visually: `data-active="true|false"` on the `ViewChip` root and `aria-current="true"` on its activate button, so tests, browser QA and assistive technology read it without depending on the chip styling. Covered by `ViewChip.activeState.test.tsx` and `TC-PERSP-NEWVIEW-LAYOUT-001` (issue #5846, PR #5932).
 ### 2026-04-04 (update)
 - Updated dependencies section: @dnd-kit provided by PR #1144 (M.D.)
 ### 2026-04-04

--- a/.ai/specs/SPEC-070-2026-04-04-perspectives-views-panel.md
+++ b/.ai/specs/SPEC-070-2026-04-04-perspectives-views-panel.md
@@ -74,7 +74,7 @@ Each view card shows:
 - "Default" badge if `isDefault`
 - Last updated date (relative: "2 hours ago", "yesterday")
 - Delete button (private only)
-- Active indicator (highlighted border when selected)
+- Active indicator (highlighted border when selected). The highlight is presentation only; the state itself is exposed as `data-active="true|false"` on the chip root and `aria-current="true"` on the chip's activate button, so tests, browser QA, and assistive technology read the active view without depending on the styling (issue #5846).
 
 ### 4. Quick View Switcher
 

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-NEWVIEW-LAYOUT-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-NEWVIEW-LAYOUT-001.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+import type { Locator } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { isStandaloneIntegration } from '@open-mercato/core/helpers/integration/standaloneEnv'
+
+/**
+ * TC-PERSP-NEWVIEW-LAYOUT-001: the Views panel's "New view" control keeps its
+ * confirm/cancel buttons vertically centred inside the name input — while the
+ * name is still blank, and after the first character is typed (issue #5846,
+ * deferred out of PR #5821).
+ *
+ * `NewViewForm` centres those buttons with `absolute right-1 top-1/2
+ * -translate-y-1/2` inside a `relative` wrapper that also holds the input. Any
+ * extra element added as a sibling *inside* that positioning context — #5821's
+ * blank-name hint was exactly that — grows the wrapper and drags the buttons out
+ * of the input, then lets them snap back on the first keystroke once the hint
+ * unmounts. jsdom cannot see this: it has no layout engine, so
+ * `getBoundingClientRect()` returns zeroes and the offset is invisible to the
+ * unit tests. This browser case is the durable guard.
+ *
+ * It asserts geometry rather than DOM structure, so it stays valid across
+ * restyles and across whatever the hint's final markup turns out to be: the only
+ * contract is that the confirm button stays centred in the input and does not
+ * jump when typing starts.
+ */
+
+const PEOPLE_LIST_PATH = '/backend/customers/people'
+
+// Sub-pixel rounding and fractional line-height metrics can shift a centred box
+// by a fraction of a pixel; the defect this guards against was a 10px offset.
+const CENTRE_TOLERANCE_PX = 1.5
+
+async function centreOffset(input: Locator, button: Locator): Promise<number> {
+  const inputBox = await input.boundingBox()
+  const buttonBox = await button.boundingBox()
+  expect(inputBox, 'the view-name input should have a layout box').toBeTruthy()
+  expect(buttonBox, 'the confirm button should have a layout box').toBeTruthy()
+  const inputCentre = inputBox!.y + inputBox!.height / 2
+  const buttonCentre = buttonBox!.y + buttonBox!.height / 2
+  return Math.abs(buttonCentre - inputCentre)
+}
+
+test.describe('TC-PERSP-NEWVIEW-LAYOUT-001: New-view control keeps its buttons centred', () => {
+  test('confirm button stays vertically centred in the name input, blank and after the first keystroke', async ({ page }) => {
+    test.skip(isStandaloneIntegration(), 'Standalone smoke runs omit this monorepo-only Views panel layout check.')
+
+    await login(page, 'admin')
+    await page.goto(PEOPLE_LIST_PATH, { waitUntil: 'domcontentloaded' })
+    await page
+      .getByText('Loading table', { exact: false })
+      .waitFor({ state: 'hidden', timeout: 10_000 })
+      .catch(() => {})
+
+    // Open the Views panel and enter "New view" mode.
+    const openViews = page.getByTestId('data-table-open-views-sidebar').first()
+    await expect(openViews).toBeVisible()
+    await openViews.click()
+    await expect(page.getByRole('button', { name: 'Close', exact: true })).toBeVisible()
+    await page.getByRole('button', { name: 'New', exact: true }).click()
+
+    const nameInput = page.getByPlaceholder('View name...')
+    const confirmButton = page.getByRole('button', { name: 'Create view' })
+    await expect(nameInput).toBeVisible()
+    await expect(confirmButton).toBeVisible()
+
+    // Let the panel settle so the measurement is not taken mid-transition.
+    await page.waitForTimeout(250)
+
+    const blankOffset = await centreOffset(nameInput, confirmButton)
+    expect(
+      blankOffset,
+      'with a blank name the confirm button must sit centred in the input, not pushed below it',
+    ).toBeLessThanOrEqual(CENTRE_TOLERANCE_PX)
+
+    const blankButtonBox = await confirmButton.boundingBox()
+
+    // Typing the first character is what used to make the buttons jump back into
+    // place, because the blank-name hint unmounted and the wrapper shrank.
+    await nameInput.pressSequentially('Q', { delay: 50 })
+    await expect(nameInput).toHaveValue('Q')
+    await page.waitForTimeout(250)
+
+    const typedOffset = await centreOffset(nameInput, confirmButton)
+    expect(
+      typedOffset,
+      'after the first keystroke the confirm button must still be centred in the input',
+    ).toBeLessThanOrEqual(CENTRE_TOLERANCE_PX)
+
+    const typedButtonBox = await confirmButton.boundingBox()
+    expect(
+      Math.abs(typedButtonBox!.y - blankButtonBox!.y),
+      'the confirm button must not move vertically when the first character is typed',
+    ).toBeLessThanOrEqual(CENTRE_TOLERANCE_PX)
+
+    // The view was never submitted, so nothing was persisted and there is no
+    // fixture to clean up.
+  })
+})

--- a/packages/core/src/modules/perspectives/__integration__/TC-PERSP-NEWVIEW-LAYOUT-001.spec.ts
+++ b/packages/core/src/modules/perspectives/__integration__/TC-PERSP-NEWVIEW-LAYOUT-001.spec.ts
@@ -3,6 +3,10 @@ import type { Locator } from '@playwright/test'
 import { login } from '@open-mercato/core/helpers/integration/auth'
 import { isStandaloneIntegration } from '@open-mercato/core/helpers/integration/standaloneEnv'
 
+export const integrationMeta = {
+  dependsOnModules: ['perspectives', 'customers'],
+}
+
 /**
  * TC-PERSP-NEWVIEW-LAYOUT-001: the Views panel's "New view" control keeps its
  * confirm/cancel buttons vertically centred inside the name input — while the

--- a/packages/ui/src/backend/__tests__/ViewChip.activeState.test.tsx
+++ b/packages/ui/src/backend/__tests__/ViewChip.activeState.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { screen } from '@testing-library/react'
+import { ViewChip } from '../views/ViewChip'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+// Coverage for issue #5846: the chip's "this view is active" state used to live
+// only in its Tailwind classes (`bg-brand-violet/10 border-brand-violet/30 ...`),
+// so the only way to assert it was to string-match `className` on `.parentElement`.
+// That broke on any restyle and left the state invisible to assistive technology.
+// The chip now carries `data-active` on its root and `aria-current` on the button
+// the user actually activates, mirroring how `pagination.tsx` marks the current page.
+
+type ChipProps = React.ComponentProps<typeof ViewChip>
+
+function renderChip(overrides: Partial<ChipProps> = {}) {
+  const props: ChipProps = {
+    id: 'view-1',
+    label: 'My view',
+    kind: 'personal',
+    isActive: false,
+    disabled: false,
+    isShared: false,
+    isRenaming: false,
+    renameValue: '',
+    canApplyToRoles: false,
+    deleting: false,
+    onActivate: jest.fn(),
+    onRenameValueChange: jest.fn(),
+    onRenameConfirm: jest.fn(),
+    onRenameCancel: jest.fn(),
+    onClone: jest.fn(),
+    onDelete: jest.fn(),
+    ...overrides,
+  }
+  return renderWithProviders(<ViewChip {...props} />, { dict: {} })
+}
+
+describe('ViewChip active-state hook', () => {
+  it('marks the active chip with data-active="true" and aria-current on its activate button', () => {
+    const { container } = renderChip({ isActive: true, label: 'Active view' })
+
+    expect(container.querySelector('[data-active="true"]')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Active view' })).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('marks an inactive chip with data-active="false" and omits aria-current entirely', () => {
+    const { container } = renderChip({ isActive: false, label: 'Inactive view' })
+
+    expect(container.querySelector('[data-active="false"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-active="true"]')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Inactive view' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('exposes the active state without depending on the chip styling', () => {
+    const { container } = renderChip({ isActive: true, label: 'Styled view' })
+
+    const chip = container.querySelector('[data-active]') as HTMLElement
+    expect(chip).toBeInTheDocument()
+
+    // Strip every class off the chip: the semantic hook must survive a restyle
+    // that drops or renames the `border-brand-violet/30` marker the old assertion read.
+    chip.className = ''
+    expect(chip.getAttribute('data-active')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Styled view' })).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('keeps the hook on the chip root while the view is being renamed', () => {
+    const { container } = renderChip({ isActive: true, isRenaming: true, renameValue: 'Draft name' })
+
+    expect(container.querySelector('[data-active="true"]')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/backend/views/ViewChip.tsx
+++ b/packages/ui/src/backend/views/ViewChip.tsx
@@ -52,7 +52,10 @@ export function ViewChip({
   if (isRenaming) {
     const renameTrimmed = renameValue.trim()
     return (
-      <div className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary/5 px-3 h-8">
+      <div
+        data-active={isActive ? 'true' : 'false'}
+        className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary/5 px-3 h-8"
+      >
         <input
           value={renameValue}
           onChange={(e) => onRenameValueChange(e.target.value)}
@@ -92,6 +95,7 @@ export function ViewChip({
 
   return (
     <div
+      data-active={isActive ? 'true' : 'false'}
       className={`inline-flex items-center gap-0.5 rounded-md border h-8 text-sm ${
         isActive
           ? 'bg-brand-violet/10 border-brand-violet/30 font-medium text-brand-violet'
@@ -105,6 +109,7 @@ export function ViewChip({
         className="h-auto px-3 py-0 text-sm hover:bg-transparent"
         onClick={onActivate}
         disabled={disabled}
+        aria-current={isActive ? 'true' : undefined}
       >
         {showUsersIcon ? <Users className="size-3 mr-1 opacity-50" /> : null}
         {label}


### PR DESCRIPTION
Closes #5846

## 🎯 What this does

Two follow-up cleanups deferred out of #5821, which carried `risk-high` and deliberately did not absorb either of them.

### 1. `ViewChip` gets a stable active-state hook

`ViewChip` expressed "this view is active" purely through Tailwind classes (`bg-brand-violet/10 border-brand-violet/30 font-medium text-brand-violet`). That made the state assertable only by reaching for `.parentElement` and string-matching `className`, which breaks on any restyle, and it left the state invisible to assistive technology and to browser QA alike.

The chip root now carries `data-active="true|false"` and the activate button carries `aria-current="true"` when the view is active. Splitting the two follows precedent already in this repo rather than inventing a convention:

- `packages/ui/src/primitives/pagination.tsx` puts `aria-current` on the **interactive element the user reaches**, which is what assistive technology actually announces. A wrapper `div` carrying `aria-current` would not be announced, so the attribute goes on the button.
- `packages/ui/src/backend/AppShell.tsx` and `packages/ui/src/primitives/rich-editor.tsx` use `data-active` as the **scoping and test hook**. That belongs on the chip root so a test or a QA script can select the whole chip, not just its label button.

`data-active` is set in the renaming branch too, so the hook does not silently disappear while a view is being renamed.

### 2. Browser-level coverage for the New-view control's layout

`NewViewForm` centres its confirm/cancel buttons with `absolute right-1 top-1/2 -translate-y-1/2` inside a `relative` wrapper that also holds the input. Any element added as a sibling **inside that positioning context** grows the wrapper and drags the buttons out of the input, then lets them snap back on the first keystroke once it unmounts. jsdom cannot see this at all: it has no layout engine, so `getBoundingClientRect()` returns zeroes.

`TC-PERSP-NEWVIEW-LAYOUT-001` opens the Views sidebar, clicks **+ New**, and asserts the confirm button's bounding box stays vertically centred within the name input's — while the name is blank, after the first character is typed, and that the button does not move between the two. It asserts **geometry rather than DOM structure**, so it stays valid across restyles and across whatever the hint's final markup turns out to be.

## ⚠️ Scope correction — two things the issue assumed that are not true on `develop`

Both items were filed from #5821, and parts of their stated context live only on that PR's branch:

- **`packages/ui/src/backend/__tests__/PerspectiveSidebar.roleAutosave.test.tsx` does not exist on `develop`.** #5821 introduces it. So the issue's "switch the test to assert on that instead of the class string" is not actionable here — this PR adds its own unit coverage for the new hook instead. **Whichever of the two PRs merges second should repoint that `border-brand-violet/30` assertion at `data-active` / `aria-current`.**
- **The blank-name hint that caused the 10px offset is also introduced by #5821.** On `develop` the New-view control is already centred, so the new Playwright case is not currently reproducing a live defect. It is still the durable guard the issue asked for: it passes on `develop` today, keeps passing once #5821 lands with its fix, and fails if a future restyle reintroduces the offset.

## 🧪 Tests

**Added**

- `packages/ui/src/backend/__tests__/ViewChip.activeState.test.tsx` — 4 cases: active chip exposes both attributes; inactive chip exposes `data-active="false"` and omits `aria-current` entirely; the hook survives having **every class stripped off the chip** (the point of the change — it must not depend on styling); the hook stays present while renaming.
- `packages/core/src/modules/perspectives/__integration__/TC-PERSP-NEWVIEW-LAYOUT-001.spec.ts` — the browser guard described above.

**Executed**

The Playwright case was not just written but **run against a real browser**: a disposable Postgres database was initialized with `mercato init`, the production build served on port 3111, and the spec executed headless — `1 passed`. It is not a spec that has only ever been type-checked.

**Validation gate** (`.ai/agentic.config.json`), all run locally:

| Command | Result |
|---|---|
| `yarn build:packages` (x2) | ✅ |
| `yarn generate` | ✅ |
| `yarn i18n:check-sync` / `yarn i18n:check-usage` | ✅ |
| `yarn typecheck` | ✅ |
| `yarn test` — `@open-mercato/ui` | ✅ 238 suites / 1970 tests |
| `yarn test` — `@open-mercato/core` | ✅ 1478 suites / 12031 tests |
| `yarn test` — `@open-mercato/ai-assistant` | ✅ 111 suites / 1482 tests |
| `yarn test` — `@open-mercato/cli` | ❌ 5 pre-existing failures, see below |
| `yarn build:app` | ✅ |

The `@open-mercato/cli` failures are in `src/lib/__tests__/resolve-environment.test.ts` and `src/lib/__tests__/resolver.enterprise.test.ts` (`Expected: "standalone"`, `Received: "monorepo"`). They are location-dependent — `resolveEnvironment` walks up from a temp dir and finds the enclosing monorepo — and reproduce with a default `TMPDIR` as well. **This diff touches no CLI file and nothing the CLI imports** (one UI component, two test files, one spec markdown line), so it cannot be the cause. They are expected to be green on CI, which runs from a different location.

## 💥 Breaking changes

None. Both attributes are additive; no existing selector, class, or contract surface changes.

## 📸 QA

`needs-qa`: the change is user-facing in the accessibility sense (the active view is now announced to screen readers as the current item), even though nothing changes visually. Manual QA is still pending — this PR does not carry `qa-approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791386022&installation_model_id=432243&pr_number=5932&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5932&signature=51c8f8f45a0f3f4e4702a2092ad8d1ae6943a611d721dffe5534263f36412337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->