### PR TITLE
docs(specs): add Contractor Registry spec + implementation guide

### DIFF
--- a/.ai/specs/2026-09-06-contractor-registry-implementation-guide.md
+++ b/.ai/specs/2026-09-06-contractor-registry-implementation-guide.md
@@ -1,0 +1,143 @@
+# Contractor Registry — implementation guide
+
+**Related:** [Contractor Registry](2026-09-06-contractor-registry.md) (full spec — read this for the *why* behind every decision below; this document is the *what* and *in what order*, for someone about to write the code)
+
+## What you're building, in one paragraph
+
+A new, independent module (`contractors`) with two things a developer
+touches directly: a **contractor record** (`Contractor` — tax
+identity: NIP, name, address, GUS/VIES verification status) and its
+**bank accounts** (`ContractorBankAccount` — 0..N per contractor,
+checked live against the Biała Lista VAT whitelist). Nothing else in
+this module calls into AP, AR, or any other module — it's a shared
+service other modules resolve by FK-id or by DI token, not a consumer
+of them.
+
+## The two entities, one sentence each
+
+- **`Contractor`** — `isVendor`/`isCustomer` (bool, not exclusive),
+  `nip`/`nipHash` (unique per organization, immutable once set),
+  `name`, `address`, `contactEmail`/`contactPhone`, `verificationStatus`
+  (`PENDING`/`VERIFIED`/`FAILED`), `gusData`/`viesData` (raw diagnostic
+  copies, never a source of truth for any command).
+- **`ContractorBankAccount`** — `contractorId` (FK), `accountNumber`
+  (encrypted), `isPrimary` (exactly one `true` per contractor,
+  command-enforced), `lastVerifiedAt`/`lastVerificationStatus` (UX
+  cache only — see the pitfall below, this one matters most), its own
+  `organizationId`/`tenantId` (not just inherited via `contractorId`).
+
+For exact fields/types, see the full spec's Architecture → Entities
+and Data Models. Don't re-derive them here — copy from there.
+
+## One flow, start to finish
+
+Registering a new vendor and paying them for the first time:
+
+1. AP staff enters a NIP. `createContractor` checks `nipHash`
+   uniqueness for `(tenant, organization)`, persists the contractor
+   with `verificationStatus: 'PENDING'`, and enqueues
+   `workers/verifyContractorRegistry.ts`.
+2. The worker calls GUS (and VIES, if applicable), fills in
+   `name`/`address` if missing, sets `verificationStatus` to
+   `VERIFIED` or `FAILED`. This never blocks step 1 — GUS/VIES being
+   down does not stop a contractor from being created.
+3. AP staff adds a bank account via `createContractorBankAccount`.
+   `isPrimary: true` on this call automatically unsets any other
+   primary for the same contractor, inside the same transaction.
+4. Before the first payment, AP resolves `contractorBankWhitelistCheck`
+   from this module's `di.ts` (via its own local `tryResolve` wrapper —
+   **not** an HTTP call to this module's own API) and invokes it. This
+   performs a **live** call to the Ministry of Finance's Biała Lista
+   API for the exact `accountNumber`/`nip` pair, returns the fresh
+   result, and — only as a side effect — updates
+   `lastVerifiedAt`/`lastVerificationStatus` for the UX badge. AP
+   blocks the payment on anything other than a fresh `WHITELISTED`
+   result.
+5. AP posts the payment in GL and writes a `contractorSnapshot` (name,
+   NIP, account, verification status *at that exact moment*) onto the
+   `JournalEntryLine` it creates — that snapshot, not a live join to
+   `Contractor`, is what an accountant sees when reopening this
+   invoice six months later, even if the vendor's account changes
+   after.
+
+That's the whole write path this module owns. `approveContractor`
+(pending team confirmation) is an optional extra gate before step 3,
+not a replacement for any of the above.
+
+## Build order
+
+Follow `Implementation Plan → Phase 1` in the full spec — it's already
+numbered 1–10 and matches the `File Manifest` table 1:1. Don't reorder
+it; steps 1–2 (entities/migration, ACL/setup) have to exist before
+anything else compiles or is reachable. High-level shape:
+
+1. Entities + migration (both tables, plus the two supporting indexes
+   named in Data Models) + `encryption.ts` (`nip` → `nip_hash`,
+   `account_number`) — write the encryption map in this same step, not
+   deferred to a later one.
+2. `acl.ts` (two features) + `setup.ts` + `di.ts` (registers
+   `contractorBankWhitelistCheck` — read the DI pitfall below before
+   you build the HTTP route, not after)
+3. `createContractor` / `updateContractor`
+4. `createContractorBankAccount` / `updateContractorBankAccount`
+5. `workers/verifyContractorRegistry.ts` (queue-backed, idempotent)
+6. `checkBankAccountWhitelist` command
+7. API routes + `api/openapi.ts`
+8. Backend pages (list/create/edit + inline bank-account sub-list +
+   "verify now" row action)
+9. GL side: add `contractorSnapshot` to `JournalEntryLine` per #5663
+   (only once #5663 itself is implemented — see "When you're done")
+10. Unit + integration test coverage
+
+## Things that will bite you if you skip them
+
+- **`checkBankAccountWhitelist` is a DI-resolvable service, not just an
+  HTTP route.** An earlier draft of the full spec designed it as a
+  plain HTTP route AP would call at payment time — an independent
+  review caught this as the wrong cross-module mechanism (no degrade
+  path if `contractors` is ever disabled). Build `di.ts` first, wire
+  AP's payment command to resolve it via a local `tryResolve` in
+  `try/catch`, and keep the HTTP route scoped to this module's own
+  "verify now" button only. Don't let the two drift back apart.
+- **Never read `lastVerifiedAt` to skip the live Biała Lista call —
+  not even if it was checked five minutes ago.** This is the single
+  most safety-critical rule in the module (Art. 96b requires
+  verification "on the day of transfer," not "recently"). Write the
+  regression test for this before anything else: seed a fresh
+  `lastVerifiedAt: now()`, call `checkBankAccountWhitelist`, assert the
+  live API client was actually invoked anyway.
+- **`nip` is unconditionally immutable, with no "unlocks if nothing
+  posted yet" exception.** This is stricter than GL's own
+  posted-entries-gated guards (e.g. `LedgerAccountType.normalBalance`)
+  — don't copy that pattern here. `updateContractor` rejects any `nip`
+  change outright; changing it means creating a new contractor.
+- **`isPrimary` uniqueness is enforced in the command, not a database
+  constraint.** `createContractorBankAccount`/
+  `updateContractorBankAccount` must re-read and unset any existing
+  primary inside the same transaction as the write. A partial unique
+  index would also work but isn't what this spec calls for — don't add
+  one unless you're deliberately revisiting that decision.
+- **`contractorSnapshot` on `JournalEntryLine` is `json`, not
+  `jsonb`.** This field belongs to the GL core engine spec (#5663),
+  not this module — #5663 itself is still spec-only as of this
+  writing, so there's nothing to migrate here yet. Don't add it to
+  this module's own migration.
+- **`gusData`/`viesData` are diagnostics, never a source of truth.**
+  No command may branch on their contents; they exist only to be
+  displayed in the UI. If you catch yourself reading `gusData` inside
+  a command, that's a sign something else is wrong.
+- **`ContractorBankAccount.deletedAt` is a soft "deactivate," not a
+  real delete.** Account history has audit value — don't hard-delete
+  rows here even if the UI action is labeled "remove."
+
+## When you're done with this spec
+
+`2026-09-06-accounts-payable.md` already assumes this registry exists
+and is written against it — it's next. It resolves
+`contractorBankWhitelistCheck` via `tryResolve`, references
+`Contractor` by FK-id only, and writes `contractorSnapshot` onto
+`JournalEntryLine` at posting time. The GL side of this (the
+`contractorSnapshot` column itself) depends on #5663
+(`2026-08-18-general-ledger-core-engine.md`) being implemented first —
+that module doesn't exist in code yet, so build order step 9 above
+waits on it.

--- a/.ai/specs/2026-09-06-contractor-registry-implementation-guide.md
+++ b/.ai/specs/2026-09-06-contractor-registry-implementation-guide.md
@@ -16,15 +16,21 @@ of them.
 ## The two entities, one sentence each
 
 - **`Contractor`** — `isVendor`/`isCustomer` (bool, not exclusive),
-  `nip`/`nipHash` (unique per organization, immutable once set),
-  `name`, `address`, `contactEmail`/`contactPhone`, `verificationStatus`
-  (`PENDING`/`VERIFIED`/`FAILED`), `gusData`/`viesData` (raw diagnostic
-  copies, never a source of truth for any command).
+  `nip`/`nipHash` (unique per organization while `deletedAt` is null,
+  immutable once set), `name`, `address`, `contactEmail`/`contactPhone`,
+  `verificationStatus` (`PENDING`/`VERIFIED`/`FAILED`),
+  `lastCheckStatus`/`lastCheckedAt`/`lastCheckRequestId` (typed,
+  non-PII diagnostic fields — **not** the raw GUS/VIES response, see
+  the pitfall below), `approvalStatus`
+  (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`), `createdByUserId` (backs
+  the self-approval guard).
 - **`ContractorBankAccount`** — `contractorId` (FK), `accountNumber`
   (encrypted), `isPrimary` (exactly one `true` per contractor,
-  command-enforced), `lastVerifiedAt`/`lastVerificationStatus` (UX
-  cache only — see the pitfall below, this one matters most), its own
-  `organizationId`/`tenantId` (not just inherited via `contractorId`).
+  enforced by both the command and a partial unique index — see the
+  pitfall below, this one changed), `lastVerifiedAt`/
+  `lastVerificationStatus` (UX cache only — see the pitfall below, this
+  one matters most), its own `organizationId`/`tenantId` (not just
+  inherited via `contractorId`).
 
 For exact fields/types, see the full spec's Architecture → Entities
 and Data Models. Don't re-derive them here — copy from there.
@@ -44,50 +50,78 @@ Registering a new vendor and paying them for the first time:
 3. AP staff adds a bank account via `createContractorBankAccount`.
    `isPrimary: true` on this call automatically unsets any other
    primary for the same contractor, inside the same transaction.
-4. Before the first payment, AP resolves `contractorBankWhitelistCheck`
+4. `createContractor` (step 1) also emitted
+   `contractors.contractor.created`, triggering the
+   `contractors.vendor-approval` workflow — a `USER_TASK` sitting on
+   the contractor's own detail page. Someone with `contractors.approve`
+   (**not** `contractors.manage` — a different feature, deliberately,
+   so the person who registered the vendor can't also approve it)
+   completes the task via `POST /api/workflows/tasks/:id/complete`,
+   calling `applyContractorApprovalDecision` from inside the workflow.
+   This is independent of steps 2–3 above and can happen before or
+   after them — but not before what comes next.
+5. Before the first payment, AP resolves `contractorBankWhitelistCheck`
    from this module's `di.ts` (via its own local `tryResolve` wrapper —
-   **not** an HTTP call to this module's own API) and invokes it. This
+   **not** an HTTP call to this module's own API) and invokes it. **This
+   command now rejects outright, before making any network call, if
+   `approvalStatus` isn't `APPROVED`** — step 4 above is a hard
+   prerequisite, not a parallel nice-to-have. Once past that check, it
    performs a **live** call to the Ministry of Finance's Biała Lista
    API for the exact `accountNumber`/`nip` pair, returns the fresh
    result, and — only as a side effect — updates
    `lastVerifiedAt`/`lastVerificationStatus` for the UX badge. AP
    blocks the payment on anything other than a fresh `WHITELISTED`
    result.
-5. AP posts the payment in GL and writes a `contractorSnapshot` (name,
+6. AP posts the payment in GL and writes a `contractorSnapshot` (name,
    NIP, account, verification status *at that exact moment*) onto the
    `JournalEntryLine` it creates — that snapshot, not a live join to
    `Contractor`, is what an accountant sees when reopening this
    invoice six months later, even if the vendor's account changes
    after.
 
-That's the whole write path this module owns. `approveContractor`
-(pending team confirmation) is an optional extra gate before step 3,
-not a replacement for any of the above.
+That's the whole write path this module owns.
 
 ## Build order
 
-Follow `Implementation Plan → Phase 1` in the full spec — it's already
-numbered 1–10 and matches the `File Manifest` table 1:1. Don't reorder
-it; steps 1–2 (entities/migration, ACL/setup) have to exist before
-anything else compiles or is reachable. High-level shape:
+Follow `Implementation Plan → Phase 1` in the full spec — it's now
+numbered 1–11 (grew by one step for the approval workflow, confirmed
+in scope 2026-09-08) and matches the `File Manifest` table 1:1. Don't
+reorder it; steps 1–2 (entities/migration, ACL/setup) have to exist
+before anything else compiles or is reachable. High-level shape:
 
 1. Entities + migration (both tables, plus the two supporting indexes
-   named in Data Models) + `encryption.ts` (`nip` → `nip_hash`,
+   named in Data Models, **plus the two partial unique indexes** —
+   `contractor_bank_account_one_primary_uq` and the `nip_hash`
+   uniqueness scoped `where deleted_at is null`, see the `isPrimary`
+   pitfall below) + `encryption.ts` (`nip` → `nip_hash`,
    `account_number`) — write the encryption map in this same step, not
    deferred to a later one.
-2. `acl.ts` (two features) + `setup.ts` + `di.ts` (registers
-   `contractorBankWhitelistCheck` — read the DI pitfall below before
-   you build the HTTP route, not after)
+2. `acl.ts` (**three** features — `contractors.view`/`.manage`/
+   `.approve`, not two; see the four-eyes pitfall below) + `setup.ts` +
+   `di.ts` (registers `contractorBankWhitelistCheck` — read the DI
+   pitfall below before you build the HTTP route, not after)
 3. `createContractor` / `updateContractor`
 4. `createContractorBankAccount` / `updateContractorBankAccount`
 5. `workers/verifyContractorRegistry.ts` (queue-backed, idempotent)
-6. `checkBankAccountWhitelist` command
-7. API routes + `api/openapi.ts`
-8. Backend pages (list/create/edit + inline bank-account sub-list +
+6. `checkBankAccountWhitelist` command — **gate this on
+   `approvalStatus === 'APPROVED'` from the start** (see the approval
+   pitfall below), not as an afterthought once step 7 below exists
+7. `workflows.ts` (`contractors.vendor-approval` definition,
+   `registerWorkflowSafeCommands` on `applyContractorApprovalDecision`)
+   + `events.ts` (`contractors.contractor.created`) + the injected
+   approval-task widget (owned by `workflows`, not this module — same
+   division as `sales.order-approval`)
+8. API routes + `api/openapi.ts`
+9. Backend pages (list/create/edit + inline bank-account sub-list +
    "verify now" row action)
-9. GL side: add `contractorSnapshot` to `JournalEntryLine` per #5663
-   (only once #5663 itself is implemented — see "When you're done")
-10. Unit + integration test coverage
+10. `i18n/` — every status label, the "last checked" badge, the
+    "verify now" button, and 400/409/502 error copy; don't leave these
+    for a cleanup pass, `yarn i18n:check-hardcoded` will catch them
+    later anyway
+11. GL side: add `contractorSnapshot` to `JournalEntryLine` per #5663
+    (only once #5663 itself is implemented — see "When you're done")
+    + unit/integration test coverage, including the reserved
+    `TC-CONTRACTOR-*` category and the `CRUDFORM` spec
 
 ## Things that will bite you if you skip them
 
@@ -111,24 +145,64 @@ anything else compiles or is reachable. High-level shape:
   posted-entries-gated guards (e.g. `LedgerAccountType.normalBalance`)
   — don't copy that pattern here. `updateContractor` rejects any `nip`
   change outright; changing it means creating a new contractor.
-- **`isPrimary` uniqueness is enforced in the command, not a database
-  constraint.** `createContractorBankAccount`/
-  `updateContractorBankAccount` must re-read and unset any existing
-  primary inside the same transaction as the write. A partial unique
-  index would also work but isn't what this spec calls for — don't add
-  one unless you're deliberately revisiting that decision.
+- **`isPrimary` uniqueness needs both the command AND a partial
+  unique index — this changed 2026-09-08.** An earlier draft relied on
+  the command alone (`createContractorBankAccount`/
+  `updateContractorBankAccount` re-reading and unsetting any existing
+  primary in the same transaction); a maintainer review pointed out
+  this repo has no such "command-only" preference — both real
+  precedents for an "exactly one primary" invariant
+  (`communication_channels_one_primary_per_user_uq`,
+  `customer_deal_people_primary_uq`) use a partial unique index. Add
+  `contractor_bank_account_one_primary_uq` in the migration (step 1)
+  and keep the command's unset-logic too — the index is the safety
+  net, the command is what makes a normal request never hit it.
+- **`nip`/`nipHash` uniqueness is a *partial* index — `where deleted_at
+  is null` — not a plain unique constraint.** Same review round: a
+  plain constraint would permanently burn a NIP the moment its
+  contractor is soft-deleted, since `nip` can't be corrected on the
+  old row either (see the immutability pitfall above). Scope the index
+  to match `deletedAt`, same shape as
+  `communication_channels_one_primary_per_user_uq`.
 - **`contractorSnapshot` on `JournalEntryLine` is `json`, not
   `jsonb`.** This field belongs to the GL core engine spec (#5663),
   not this module — #5663 itself is still spec-only as of this
   writing, so there's nothing to migrate here yet. Don't add it to
   this module's own migration.
-- **`gusData`/`viesData` are diagnostics, never a source of truth.**
-  No command may branch on their contents; they exist only to be
-  displayed in the UI. If you catch yourself reading `gusData` inside
-  a command, that's a sign something else is wrong.
+- **There is no `gusData`/`viesData` raw-payload column — this
+  changed 2026-09-08.** An earlier draft stored the full GUS/VIES API
+  response verbatim for diagnostics; a maintainer review caught that
+  for a sole proprietorship (JDG) that response carries the owner's
+  personal name/address in plaintext, duplicating exactly what
+  `encryption.ts` already encrypts on `name`/`address`. Use
+  `lastCheckStatus`/`lastCheckedAt`/`lastCheckRequestId` instead —
+  typed, non-PII fields only. No command may branch on their contents;
+  they exist only to be displayed in the UI. If you find yourself
+  wanting to persist the raw response for real diagnostic need, it
+  must go through `encryption.ts` like every other PII field, with a
+  stated retention policy — it is not a shortcut around that.
 - **`ContractorBankAccount.deletedAt` is a soft "deactivate," not a
   real delete.** Account history has audit value — don't hard-delete
   rows here even if the UI action is labeled "remove."
+- **`Contractor`'s delete guard checks `ContractorBankAccount` only —
+  never `ledger`'s `JournalEntryLine`.** An earlier draft also blocked
+  deletion on posted `JournalEntryLine` references; a maintainer
+  review caught that as backwards (this upstream module reaching into
+  a downstream consumer's table, exactly what
+  `packages/core/AGENTS.md` → Cross-Module Coupling forbids, and a
+  guaranteed `module-decoupling.test.ts` failure with `ledger`
+  disabled). `contractorSnapshot` already makes this unnecessary — a
+  historical journal entry never needs the `Contractor` row to still
+  exist. Don't add the `JournalEntryLine` check back in.
+- **`contractors.approve` is a separate ACL feature from
+  `contractors.manage` — and `applyContractorApprovalDecision` also
+  rejects self-approval.** The person who registers a vendor
+  (`contractors.manage`) must not be able to approve their own
+  registration; that's the entire point of the gate, and the fraud
+  scenario it exists to close. Require `contractors.approve` on the
+  approval command specifically, and check the acting user against
+  `Contractor.createdByUserId` before allowing the decision — even for
+  a user who happens to hold both features.
 
 ## When you're done with this spec
 
@@ -139,5 +213,5 @@ and is written against it — it's next. It resolves
 `JournalEntryLine` at posting time. The GL side of this (the
 `contractorSnapshot` column itself) depends on #5663
 (`2026-08-18-general-ledger-core-engine.md`) being implemented first —
-that module doesn't exist in code yet, so build order step 9 above
+that module doesn't exist in code yet, so build order step 11 above
 waits on it.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -1,10 +1,14 @@
 # Contractor Registry — shared contractor registry (AP + AR)
 
 **Related:** [Accounts Payable](2026-09-06-accounts-payable.md) (consumer
-— vendors), sales-invoice-gl-posting (consumer — customers, indirectly
-through `sales`; **planned, not yet written** spec — see
-`2026-08-18-general-ledger-core-engine.md` Out of scope), [General
-Ledger core engine](2026-08-18-general-ledger-core-engine.md)
+— vendor registration/verification), [Accounts Payable —
+Payments](2026-09-06-accounts-payable-payments.md) (consumer — the
+module that actually resolves `contractorBankWhitelistCheck` via
+`tryResolve` at payment time, per AP's own split; **added
+2026-09-08**, see Changelog), sales-invoice-gl-posting (consumer —
+customers, indirectly through `sales`; **planned, not yet written**
+spec — see `2026-08-18-general-ledger-core-engine.md` Out of scope),
+[General Ledger core engine](2026-08-18-general-ledger-core-engine.md)
 (`JournalEntryLine` gets a new `contractorSnapshot` field from this
 spec)
 
@@ -456,7 +460,15 @@ review — see Changelog).
   **Deliberately not `updateContractor`** — see Design decisions
   ("`approveContractor`'s mechanism is now resolved") for the
   contradiction this avoids, mirroring AP's identical fix to the same
-  latent issue in `sales.order-approval`.
+  latent issue in `sales.order-approval`. **Reversibility (added
+  2026-09-08, flagged by review):** this transition is final — once
+  `APPROVED`/`REJECTED`, there is no resubmission path back to
+  `PENDING_APPROVAL` on the same task, mirroring
+  `accounts_payable_payments`'s own explicit stance for
+  `applyVendorInvoiceApprovalDecision` ("the decision is documented
+  and irreversible without a trace"). A rejected contractor that
+  should be reconsidered is corrected and re-registered as a new
+  pending case, not resubmitted onto the same approval task.
 
 ### Events
 
@@ -490,7 +502,7 @@ import { defineWorkflow, createWorkflowsModuleConfig } from '@open-mercato/share
 import { registerWorkflowSafeCommands } from '@open-mercato/core/modules/workflows/lib/workflow-safe-commands'
 
 registerWorkflowSafeCommands([
-  { commandId: 'contractors.applyApprovalDecision', requiredFeatures: ['contractors.manage'] },
+  { commandId: 'contractors.contractor.applyApprovalDecision', requiredFeatures: ['contractors.manage'] },
 ])
 
 const vendorApproval = defineWorkflow({
@@ -570,26 +582,38 @@ triggers on `sales.order.created`.
 
 ### Cross-module integration
 
-AP does not call the HTTP route above at payment time. Per
-`packages/core/AGENTS.md` → Cross-Module Coupling, a same-request
-synchronous need on an optional peer resolves that peer's service
-locally via a `tryResolve`-in-`try/catch` helper (precedent:
+**Corrected 2026-09-08**: the consumer named below is
+`accounts_payable_payments`, not `accounts_payable` (invoices) — AP
+split into the two modules on 2026-09-08 (see
+`2026-09-06-accounts-payable-payments.md`), and that document is
+explicit that `contractorBankWhitelistCheck` integration lives
+exclusively in the payments module, not the invoices one. This
+section previously said "AP" generically; corrected for accuracy.
+
+`accounts_payable_payments` does not call the HTTP route above at
+payment time. Per `packages/core/AGENTS.md` → Cross-Module Coupling, a
+same-request synchronous need on an optional peer resolves that peer's
+service locally via a `tryResolve`-in-`try/catch` helper (precedent:
 `inbox_ops/subscribers/extractionWorker.ts`,
 `shipping_carriers/api/webhook/[provider]/route.ts`) — never a hard
-`container.resolve(...)` and never an HTTP call to itself. AP's
-payment command resolves `contractorBankWhitelistCheck` (the DI token
-registered in this module's `di.ts`) this way and calls it in-process.
-Two distinct degradation cases follow from this, both resolving to the
-same policy (block the payment, never proceed without a live check —
-see Risks & Impact Review):
+`container.resolve(...)` and never an HTTP call to itself.
+`accounts_payable_payments`'s `confirmPaymentBatch` command resolves
+`contractorBankWhitelistCheck` (the DI token registered in this
+module's `di.ts`) this way and calls it in-process. Two distinct
+degradation cases follow from this, both resolving to the same policy
+(block the payment, never proceed without a live check — see Risks &
+Impact Review):
 - **`contractors` module disabled/absent** — `tryResolve` returns
-  `undefined`; AP's own guard treats a missing whitelist-check service
-  as "cannot verify," and blocks the payment.
+  `undefined`; `accounts_payable_payments`'s own guard treats a
+  missing whitelist-check service as "cannot verify," and blocks the
+  payment.
 - **`contractors` module present, but the live Biała Lista API call
   itself fails** — `checkBankAccountWhitelist` throws or returns an
-  error result; AP catches it and blocks the payment the same way.
-This module never imports or resolves anything belonging to AP —
-the dependency direction is one-way (AP → `contractors`), matching
+  error result; `accounts_payable_payments` catches it and blocks the
+  payment the same way.
+This module never imports or resolves anything belonging to
+`accounts_payable_payments` — the dependency direction is one-way
+(`accounts_payable_payments` → `contractors`), matching
 `packages/core/AGENTS.md`'s "upstream module MUST NOT import, resolve,
 or hard-require the consumer."
 
@@ -801,10 +825,12 @@ exactly as `sales.order-approval` and
 
 - Assert the module-decoupling test
   (`packages/core/src/__tests__/module-decoupling.test.ts`) passes with
-  `contractors` disabled, and that AP's own `tryResolve` wrapper around
-  `contractorBankWhitelistCheck` degrades to "block the payment" in
-  that case rather than throwing unhandled (see Cross-module
-  integration, Risks & Impact Review).
+  `contractors` disabled, and that `accounts_payable_payments`'s own
+  `tryResolve` wrapper around `contractorBankWhitelistCheck` degrades
+  to "block the payment" in that case rather than throwing unhandled
+  (see Cross-module integration, Risks & Impact Review; **corrected
+  2026-09-08** — the consumer is the payments module, not AP's
+  invoices module, per AP's own split).
 - Assert `createContractor` rejects a duplicate `nip` within the same
   `(tenant, organization)` (via `nipHash` lookup), and allows the same
   `nip` across different organizations.
@@ -873,25 +899,31 @@ exactly as `sales.order-approval` and
   stay `FAILED` indefinitely if GUS/VIES are down long-term — no
   automatic re-enqueue beyond the queue's own retry window; manual
   re-trigger needed (out of scope for this document's Phase 1 UI).
-- **Scenario**: Biała Lista API is down at the exact moment AP needs
-  to execute a payment (AP has resolved `checkBankAccountWhitelist` via
-  `tryResolve` — see Cross-module integration — and the in-process call
-  itself fails). **Severity**: High (business-blocking, not
-  data-corrupting). **Affected area**: AP's payment execution flow.
-  **Mitigation**: `checkBankAccountWhitelist` throws/returns an error
-  result; AP is expected to block the payment rather than proceed
-  without a live check (this module cannot make that policy decision
-  for AP — noted explicitly as AP's own responsibility, see Out of
-  scope). **Residual risk**: legitimate payments could be delayed
-  during a Biała Lista outage; accepted as the safer failure mode given
-  the legal exposure of paying without verification.
+- **Scenario**: Biała Lista API is down at the exact moment
+  `accounts_payable_payments` needs to execute a payment
+  (`accounts_payable_payments` has resolved `checkBankAccountWhitelist`
+  via `tryResolve` — see Cross-module integration — and the in-process
+  call itself fails; **corrected 2026-09-08** — this was "AP" generically
+  before AP's own split into invoices/payments). **Severity**: High
+  (business-blocking, not data-corrupting). **Affected area**:
+  `accounts_payable_payments`'s payment execution flow. **Mitigation**:
+  `checkBankAccountWhitelist` throws/returns an error result;
+  `accounts_payable_payments` is expected to block the payment rather
+  than proceed without a live check (this module cannot make that
+  policy decision for its consumer — noted explicitly as
+  `accounts_payable_payments`'s own responsibility, see Out of scope).
+  **Residual risk**: legitimate payments could be delayed during a
+  Biała Lista outage; accepted as the safer failure mode given the
+  legal exposure of paying without verification.
 - **Scenario**: the `contractors` module itself is disabled or absent
-  when AP tries to resolve `contractorBankWhitelistCheck`.
-  **Severity**: High (business-blocking). **Affected area**: AP's
-  payment execution flow. **Mitigation**: AP's local `tryResolve`
-  wrapper (per `packages/core/AGENTS.md` → Cross-Module Coupling)
-  returns `undefined` instead of throwing; AP treats a missing service
-  identically to a failed live check — block the payment. Covered by
+  when `accounts_payable_payments` tries to resolve
+  `contractorBankWhitelistCheck`. **Severity**: High
+  (business-blocking). **Affected area**:
+  `accounts_payable_payments`'s payment execution flow. **Mitigation**:
+  its local `tryResolve` wrapper (per `packages/core/AGENTS.md` →
+  Cross-Module Coupling) returns `undefined` instead of throwing;
+  `accounts_payable_payments` treats a missing service identically to
+  a failed live check — block the payment. Covered by
   `packages/core/src/__tests__/module-decoupling.test.ts` per repo
   convention (see Testing Strategy). **Residual risk**: none identified
   — this is the sanctioned degrade-gracefully path, not a gap.
@@ -925,9 +957,10 @@ independently of AP, which does not yet exist.
   its result against a particular payment/invoice record is Accounts
   Payable's concern (AP owns the "payment" concept; this module does
   not know what a payment is).
-- **Multi-step or threshold-based vendor approval.** Phase 2, pending
-  the same team confirmation as the Phase 1 one-step version — see
-  Design decisions.
+- **Multi-step or threshold-based vendor approval.** Phase 2,
+  deferred unless the team later decides the Phase 1 one-step version
+  (confirmed in scope, 2026-09-08) isn't sufficient — see Design
+  decisions.
 - **Cross-organization contractor sharing.** YAGNI — no precedent in
   the codebase, no confirmed business requirement (see Design
   decisions).
@@ -940,6 +973,11 @@ independently of AP, which does not yet exist.
   replaced by the `JournalEntryLine.contractorSnapshot` point-in-time
   copy (see Design decisions) — no separate audit-log table for every
   field change.
+- **Whether Accounts Payable should block using a contractor still in
+  `PENDING_APPROVAL` status.** Phase 1 does not gate on this — `Contractor`
+  exposes `approvalStatus` as a field AP can read, but this document
+  doesn't mandate AP enforce it before a first payment. Left as an
+  open question for AP's own design (see Architecture → Entities).
 
 ## Final Compliance Report — 2026-09-07
 
@@ -1163,7 +1201,7 @@ This round applies that same, now-proven resolution here:
   `useGuardedMutation` toggle — 1:1 mirroring `sales.order-approval`
   and `accounts_payable.invoice-approval`.
 - Added the `contractors.vendor-approval` Workflow definition section
-  (new), triggered on a new, conditional `contracts.contractor.created`
+  (new), triggered on a new, conditional `contractors.contractor.created`
   event (Events section updated) — immediate trigger, like
   `sales.order.created`, since (unlike AP's invoice) a contractor has
   no separate draft state before approval.
@@ -1236,3 +1274,62 @@ implementing:
   normal PR review, same as every other decision in this document —
   this was a recommendation backed by evidence, not a unilateral
   decision.
+
+### 2026-09-08 (cont. — fresh-context review, per om-spec-writing Step 8)
+
+The prior two rounds today (mechanism resolution, then scope
+resolution) were self-verified against real code but never run
+through the `om-spec-writing` skill's actual Step 8 process — a
+fresh-context subagent given only this file, applying
+`spec-checklist.md`. Ran it. Six findings, all confirmed against the
+real repo before being accepted (per this engagement's standing
+practice of never taking a subagent's claim at face value):
+
+- **High — stale cross-module consumer name.** Cross-module
+  integration, both Risks scenarios, and Testing Strategy all said
+  "AP" resolves `contractorBankWhitelistCheck`. AP itself split into
+  `accounts_payable` (invoices) and `accounts_payable_payments` on
+  2026-09-08 at 08:29 UTC — *before* either of today's edit rounds to
+  this document — and AP's own spec is explicit that the whitelist
+  integration lives exclusively in `accounts_payable_payments`, not
+  the invoices module. Verified directly against
+  `2026-09-06-accounts-payable-payments.md` on `docs/accounts-payable`
+  (commit `7677a3ea3`). Fixed: Related header now links both AP
+  documents; Cross-module integration, Risks & Impact Review, and
+  Testing Strategy all name `accounts_payable_payments` specifically.
+- **High — command-ID naming inconsistency.** The workflow's
+  `registerWorkflowSafeCommands` entry used `contractors.applyApprovalDecision`
+  — missing the resource segment both real precedents use
+  (`sales.orders.update`, verified in
+  `packages/core/src/modules/sales/workflows.ts`;
+  `accounts_payable.vendor_invoices.applyApprovalDecision`, verified
+  in AP's own spec) — and inconsistent with this same document's own
+  event name, `contractors.contractor.created`. Fixed:
+  `contractors.contractor.applyApprovalDecision`.
+- **Medium — stale Out of scope bullet.** Still read "pending the same
+  team confirmation as the Phase 1 one-step version" after Phase 1 was
+  confirmed. Fixed to read as deferred pending a *future* decision
+  that the confirmed one-step version isn't sufficient.
+- **Medium — orphaned cross-reference.** Architecture → Entities
+  pointed to "(see Out of scope)" for whether AP should block use of a
+  `PENDING_APPROVAL` contractor; no matching bullet existed. Added
+  one.
+- **Medium — missing reversibility statement.** `spec-checklist.md`
+  §4 requires undo/reversibility to be documented for every mutation;
+  `applyContractorApprovalDecision` had none, unlike
+  `accounts_payable_payments`'s explicit stance for the identical
+  mechanism. Added: the transition is final, no resubmission path.
+- **Low — typo.** `contracts.contractor.created` (missing "or") in the
+  prior round's changelog entry. Fixed.
+
+No new violation found in the checklist items directly touched by
+today's edits (naming, undo contract, cross-module coupling) beyond
+the above. Scope-cohesion re-check: confirming `approveContractor` as
+a permanent Phase-1 commitment (rather than conditional) strengthens,
+not weakens, the earlier case for keeping it threaded rather than
+split — no new split argument found. Research-citation honesty
+re-check: the AFP/ksbot.pl/Trustpair/SAP-Ariba/ApprovalMax claims are
+stated identically everywhere they recur, and the document
+consistently frames the vendor-approval decision as a recommendation
+for the normal PR review, not an already-audited fact overriding
+Łukasz's sign-off.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -231,6 +231,42 @@ follow-up. The per-section "pending team confirmation" markers stay —
 they, not a separate document, are what carries the "this isn't
 approved yet" signal.
 
+**`approveContractor`'s mechanism is now resolved: the `workflows`
+engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`
+and `accounts_payable.invoice-approval` — not `useGuardedMutation`
+(2026-09-08, this round).** The scope question (whether this feature
+ships at all) stays pending Łukasz/the team's confirmation — this
+decision only settles *how* it would be built, once confirmed, so the
+document stops carrying a half-fixed citation (see Changelog,
+"approval-pattern citation corrected," which removed the false GL
+comparison but left no replacement design). Verified directly: the
+repo's only implemented approve/reject precedent is
+`sales.order-approval`, and it uses the full workflow engine, not a
+guarded row action — `useGuardedMutation` is real, but only for a
+simple, *reversible* toggle (GL's fiscal-period lock/unlock), which is
+a structurally different decision shape from a one-time approve/reject
+gate. `approveContractor` is exactly the second shape, same as AP's
+own invoice approval, so this document now adopts the identical
+pattern AP already adopted for the identical problem: a
+`contractors.vendor-approval` workflow, triggered on
+`contractors.contractor.created` (immediate, like
+`sales.order.created` — this module has no separate "draft" contractor
+state before approval, unlike AP's invoice, which has `DRAFT` before
+`PENDING_APPROVAL`; see Workflow definition), `USER_TASK` with a
+`formSchema: {decision: approve | reject}`, and completion through the
+existing generic `POST /api/workflows/tasks/:id/complete` — not a
+custom `/api/contractors/:id/approve` route (removed, see API
+Contracts). One deliberate departure from `sales.order-approval`,
+carried over from AP's own review: the workflow's transition calls a
+**dedicated** `applyContractorApprovalDecision` command, not the
+general-purpose `updateContractor` — AP independently found that
+`sales.order-approval` reusing its own generic `update` command for
+this exact purpose is a latent, unresolved contradiction risk
+(`updateContractor` has its own guards — e.g. the NIP-immutability
+guard above — that were never designed with a workflow-originated call
+in mind), and this document avoids repeating it rather than copying
+the same latent issue a third time.
+
 **Registry is per-organization, not shared across a tenant's
 organizations.** No precedent for such a pattern for a domain,
 tenant/org-scoped entity in the code — the only nullable
@@ -295,6 +331,16 @@ encrypted column without a hash doesn't work.
   lock), `deletedAt` (soft delete — per the standard column contract;
   deletion blocked if the contractor has any `JournalEntryLine`
   references via snapshot or any active `ContractorBankAccount`).
+  *If `approveContractor` is confirmed in scope*: `approvalStatus`
+  (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`), `approvedByUserId`,
+  `approvedAt` — set only by `applyContractorApprovalDecision` from
+  inside the workflow, never through `updateContractor` (see Design
+  decisions, Workflow definition). `verificationStatus` (GUS/VIES) and
+  `approvalStatus` (human approve/reject) are independent, parallel
+  fields — Phase 1 does not gate one on the other, and nothing in
+  Phase 1 blocks Accounts Payable from using a `PENDING_APPROVAL`
+  contractor; whether it should is a real, still-open question this
+  document does not resolve (see Out of scope).
 - `ContractorBankAccount` — `contractorId` (FK to `Contractor`),
   `accountNumber` (encrypted), `isPrimary` (bool — exactly one primary
   per contractor, enforced in the command), `lastVerifiedAt` (nullable,
@@ -318,7 +364,7 @@ export const features = [
 ```
 
 `createContractor`/`updateContractor`/`createContractorBankAccount`/
-`updateContractorBankAccount`/`approveContractor` require
+`updateContractorBankAccount`/`applyContractorApprovalDecision` require
 `contractors.manage`; `checkBankAccountWhitelist` requires
 `contractors.view` (read-only check, callable by anyone who can see
 the contractor — the actual payment-blocking decision belongs to AP's
@@ -366,23 +412,105 @@ review — see Changelog).
   sanctioned entry point for another module to call it synchronously
   in the same request; the HTTP route below wraps the same command
   only for this module's own backend UI.
-- `approveContractor` — **pending team confirmation, see Design
-  decisions.** One approver, binary decision (approve/reject),
-  mirroring AP's own one-step invoice approval. Sets
-  `approvalStatus`/`approvedByUserId`/`approvedAt` (fields added to
-  `Contractor` only if this command is confirmed in scope — see
-  Data Models note).
+- `applyContractorApprovalDecision` — **pending team confirmation,
+  see Design decisions.** Called **only** from inside the
+  `contractors.vendor-approval` workflow (not directly from the UI),
+  via `UPDATE_ENTITY`, `PENDING_APPROVAL` → `APPROVED` or `REJECTED`
+  and nothing else (accepts no other fields). Registered separately in
+  `registerWorkflowSafeCommands`, requires `contractors.manage`.
+  **Deliberately not `updateContractor`** — see Design decisions
+  ("`approveContractor`'s mechanism is now resolved") for the
+  contradiction this avoids, mirroring AP's identical fix to the same
+  latent issue in `sales.order-approval`.
 
 ### Events
 
-None declared in Phase 1. AP consumes `Contractor`/
-`ContractorBankAccount` by resolving this module's `di.ts`-registered
-service directly (see DI Registrar and Cross-module integration below)
-at the moment it needs an answer — payment approval and vendor
-registration are both synchronous, user-initiated flows, not something
-a downstream module needs to react to automatically after the fact.
-Revisit if a real asynchronous consumer emerges (YAGNI — matches the
-same reasoning already used for cross-organization sharing).
+**One conditional event, only if `approveContractor` is confirmed in
+scope: `contractors.contractor.created` (persistent), emitted by
+`createContractor`.** Its sole purpose is triggering the
+`contractors.vendor-approval` workflow (see Workflow definition) —
+exactly mirroring `sales.order.created` triggering
+`sales.order-approval`, not a general-purpose "contractor created"
+notification for other consumers. If the approval feature is cut,
+this event is cut with it; nothing else in this module needs it. AP
+still consumes `Contractor`/`ContractorBankAccount` by resolving this
+module's `di.ts`-registered service directly (see DI Registrar and
+Cross-module integration below) at the moment it needs an answer —
+payment approval and vendor registration are both synchronous,
+user-initiated flows, not something a downstream module needs to react
+to automatically after the fact. Revisit further async use if a real
+consumer emerges (YAGNI — matches the same reasoning already used for
+cross-organization sharing).
+
+### Workflow definition (`workflows.ts`)
+
+**Only ships if `approveContractor` is confirmed in scope** (see
+Design decisions). A 1:1 mirror of the `sales.order-approval` pattern
+(`packages/core/src/modules/sales/workflows.ts`) — not a new
+mechanism, the same one AP already adopted for its own invoice
+approval:
+
+```typescript
+import { defineWorkflow, createWorkflowsModuleConfig } from '@open-mercato/shared/modules/workflows'
+import { registerWorkflowSafeCommands } from '@open-mercato/core/modules/workflows/lib/workflow-safe-commands'
+
+registerWorkflowSafeCommands([
+  { commandId: 'contractors.applyApprovalDecision', requiredFeatures: ['contractors.manage'] },
+])
+
+const vendorApproval = defineWorkflow({
+  workflowId: 'contractors.vendor-approval',
+  workflowName: 'Contractor Vendor Approval Workflow',
+  steps: [
+    { stepId: 'start', stepType: 'START' },
+    {
+      stepId: 'pending_approval',
+      stepType: 'USER_TASK',
+      userTaskConfig: {
+        formSchema: {
+          type: 'object',
+          required: ['decision'],
+          properties: {
+            comments: { type: 'string' },
+            decision: { enum: ['approve', 'reject'], type: 'string' },
+          },
+        },
+        slaDuration: 'PT24H',
+      },
+    },
+    { stepId: 'approved', stepType: 'AUTOMATED' },
+    { stepId: 'rejected', stepType: 'AUTOMATED' },
+    { stepId: 'end', stepType: 'END' },
+  ] as const,
+  transitions: [ /* start→pending_approval (auto), pending_approval→approved
+                    (preCondition: decision === 'approve'), pending_approval→rejected
+                    (preCondition: decision === 'reject'), both →end — identical
+                    structure to sales.order-approval, see that file */ ],
+  triggers: [{
+    triggerId: 'vendor_approval_trigger',
+    eventPattern: 'contractors.contractor.created',
+    config: { entityType: 'Contractor' },
+    enabled: true,
+    priority: 0,
+  }],
+})
+
+export const workflowsConfig = createWorkflowsModuleConfig({
+  moduleId: 'contractors',
+  workflows: [vendorApproval],
+})
+
+export default workflowsConfig
+```
+
+One structural difference from AP's own `accounts_payable.invoice-approval`,
+not from `sales.order-approval`: AP triggers on a separate "submitted"
+event because a vendor invoice has an explicit `DRAFT` state before
+approval. A contractor has no equivalent draft state — `createContractor`
+persists it immediately (already true today, for the unrelated
+GUS/VIES check) — so this workflow triggers directly on
+`contractors.contractor.created`, exactly like `sales.order-approval`
+triggers on `sales.order.created`.
 
 ### Queries / API
 
@@ -400,8 +528,11 @@ same reasoning already used for cross-organization sharing).
   returning the live result. This route backs only this module's own
   backend UI (the per-row "verify now" button) — it is **not** the
   integration path for AP. See Cross-module integration below.
-- `api/contractors/[id]/approve/route.ts` — pending team confirmation
-  (see Design decisions); custom write route calling `approveContractor`.
+- **Removed 2026-09-08**: no dedicated approve route. See API
+  Contracts, "Contractor approval — no dedicated route" — approval
+  now completes through the generic
+  `POST /api/workflows/tasks/:id/complete`, once `approveContractor`
+  is confirmed in scope.
 
 ### Cross-module integration
 
@@ -438,15 +569,19 @@ or hard-require the consumer."
   showing the UX-only "last checked: N days ago" badge, plus a
   "Verify now" button per row that calls the live-check route above
   and refreshes the badge.
-- Pending team confirmation: an "Approve contractor" guarded row
-  action on the list, using `useGuardedMutation`, visible only for
-  contractors not yet approved. **Correction (2026-09-07):** this is
-  a deliberate Phase-1 simplification, not a verified precedent — see
-  the Compliance Matrix note below. If `approveContractor` is
-  confirmed in scope, revisit against the workflow-engine pattern
-  (`defineWorkflow`/`USER_TASK`, as used by `sales.order-approval`)
-  before committing to `useGuardedMutation` for a real approve/reject
-  decision.
+- Pending team confirmation: an injected approval-task widget at a
+  `contractors.contractor.detail:details` spot ID, visible when
+  `approvalStatus === 'PENDING_APPROVAL'` and there's a task assigned
+  to the current user. **Resolved 2026-09-08** (see Design decisions,
+  Workflow definition): this is no longer a `useGuardedMutation` row
+  action — mirroring the corrected pattern already used in
+  `2026-09-06-accounts-payable.md`, the widget itself is owned and
+  defined by `workflows` (real precedent:
+  `workflows/widgets/injection/order-approval/`, injected into
+  `sales.document.detail.order:details`), not by this module. This
+  module only needs to declare and document the spot ID above; the
+  widget component and its injection-table entry belong to
+  `workflows`.
 
 ## Data Models
 
@@ -465,8 +600,9 @@ active `ContractorBankAccount` exists (enforced in `updateContractor`'s
 delete path — see Commands).
 
 *If `approveContractor` is confirmed in scope:* add
-`approvalStatus` (`PENDING`/`APPROVED`/`REJECTED`), `approvedByUserId`,
-`approvedAt` to this entity.
+`approvalStatus` (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`),
+`approvedByUserId`, `approvedAt` to this entity — now also listed
+directly in Architecture → Entities (2026-09-08), not only here.
 
 Supporting index for the `contractors` list filters (see API
 Contracts / Queries-API): `(tenant_id, organization_id, is_vendor,
@@ -536,10 +672,16 @@ Custom write route (mutation guard registry, mapped to `update`).
 - **Response 403**: caller lacks `contractors.view`.
 - **Response 502**: Biała Lista API unavailable — see Risks.
 
-### `POST /api/contractors/:id/approve`
+### Contractor approval — no dedicated route
 
-Pending team confirmation (see Design decisions). Custom write route,
-`contractors.manage` required.
+**Removed 2026-09-08** (see Design decisions, Workflow definition): an
+earlier draft proposed a custom `POST /api/contractors/:id/approve`
+route. Once the mechanism moved to the `workflows` engine, approval no
+longer needs a module-specific route — completing the decision goes
+through the existing, generic `POST /api/workflows/tasks/:id/complete`,
+exactly as `sales.order-approval` and
+`accounts_payable.invoice-approval` already do. Still pending team
+confirmation whether the feature ships at all (see Design decisions).
 
 ## Implementation Plan
 
@@ -573,13 +715,26 @@ Pending team confirmation (see Design decisions). Custom write route,
    yet), so nothing has actually "landed" in running code; listed here
    only for traceability against the sibling spec.
 10. Regression + integration test coverage (see Testing Strategy).
+11. *If `approveContractor` is confirmed in scope* (pending team
+    confirmation, not deferred to Phase 2 — see Design decisions,
+    "stays threaded... same implementation cycle"): add `approvalStatus`/
+    `approvedByUserId`/`approvedAt` to `Contractor`; implement
+    `workflows.ts` (`contractors.vendor-approval`) and `events.ts`
+    (`contractors.contractor.created`); implement
+    `applyContractorApprovalDecision`; add the injected approval-task
+    widget in `workflows` (see Backend Pages). **Corrected 2026-09-08**:
+    an earlier draft of this Implementation Plan listed the one-step
+    approval flow under "Phase 2 (deferred)" below, contradicting
+    Design decisions' own resolution that it belongs to Phase 1's
+    implementation cycle once confirmed, not a separate follow-up —
+    moved here.
 
 ### Phase 2 (deferred, pending team confirmation)
 
-- `approveContractor` one-step approval flow, if confirmed — or a
-  more elaborate multi-step/threshold-based approval if the team
-  decides the light version isn't sufficient (mirrors AP's own
-  Phase 2 deferral of multi-step invoice approval).
+- A more elaborate multi-step/threshold-based approval, if the team
+  decides the light, one-step version (Phase 1, step 11) isn't
+  sufficient (mirrors AP's own Phase 2 deferral of multi-step invoice
+  approval).
 - Cross-organization contractor sharing, if a real business need
   emerges (currently YAGNI — see Design decisions).
 
@@ -599,6 +754,10 @@ Pending team confirmation (see Design decisions). Custom write route,
 | `api/contractors/route.ts` | Create | `Contractor` CRUD (`makeCrudRoute`) |
 | `api/contractors/[id]/bank-accounts/route.ts` | Create | `ContractorBankAccount` CRUD (`makeCrudRoute`) |
 | `api/contractors/[id]/bank-accounts/[bankAccountId]/verify/route.ts` | Create | Live Biała Lista check |
+| `workflows.ts` | Create, conditional | **Only if `approveContractor` is confirmed in scope** — the `contractors.vendor-approval` definition, `registerWorkflowSafeCommands` on `applyContractorApprovalDecision` |
+| `events.ts` | Create, conditional | **Only if `approveContractor` is confirmed in scope** — `contractors.contractor.created`, the workflow's sole trigger |
+| `widgets/injection/vendor-approval/` | Create, conditional | **In `workflows`, not this module** — approval-task widget injected into `contractors.contractor.detail:details`, mirroring `workflows/widgets/injection/order-approval/` |
+| `commands/contractors.ts` | Update, conditional | Adds `applyContractorApprovalDecision`, called only from inside the workflow |
 | `api/openapi.ts` | Create | `openApi` exports for every route above |
 | `backend/contractors/page.tsx` (+ create/[id]) | Create | List/create/edit UI with inline bank-account sub-list |
 | `commands/__tests__/*` | Create | Regression coverage |
@@ -626,6 +785,12 @@ Pending team confirmation (see Design decisions). Custom write route,
   Regression test: seed a `ContractorBankAccount` with
   `lastVerifiedAt: now()`, call `checkBankAccountWhitelist`, assert the
   live API client was actually invoked.
+- *If `approveContractor` is confirmed in scope*: assert
+  `applyContractorApprovalDecision` is only reachable through the
+  `contractors.vendor-approval` workflow (via `registerWorkflowSafeCommands`),
+  not directly callable to bypass the approval task, and that it moves
+  `approvalStatus` `PENDING_APPROVAL` → `APPROVED`/`REJECTED` only —
+  never any other transition.
 - Assert `verifyContractorRegistry` worker is idempotent — running it
   twice for the same contractor does not duplicate or corrupt
   `gusData`/`viesData`.
@@ -770,7 +935,8 @@ independently of AP, which does not yet exist.
 | `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |
 | `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | Compliant | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared |
 | `packages/queue/AGENTS.md` | Workers MUST be idempotent; MUST export `metadata: { queue, id?, concurrency? }` | Compliant | `verifyContractorRegistry.ts` follows the exact shape verified against `customers/workers/*.ts` |
-| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. The pending-confirmation "approve" row action is drafted as a `useGuardedMutation` toggle — **corrected 2026-09-07:** this document originally claimed parity with "GL's fiscal-period lock/unlock row action," but that comparison doesn't hold: the repo's only implemented approve/reject precedent (`sales.order-approval`) uses a full workflow (`defineWorkflow`/`USER_TASK`), not a guarded row action. `useGuardedMutation` here is now flagged as an unverified Phase-1 shortcut, to revisit against the workflow-engine pattern if `approveContractor` is confirmed in scope, not cited as an already-proven pattern |
+| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. **Resolved 2026-09-08** (superseding the 2026-09-07 correction, which only removed a false citation without replacing the design): the pending-confirmation approval step now uses the `workflows` engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`/`accounts_payable.invoice-approval`, not `useGuardedMutation` — consistent with the same principle already settled for `accounts_payable.invoice-approval`: a guarded row action is a real pattern only for a simple, reversible toggle (GL's fiscal-period lock/unlock), not a one-time approve/reject decision. See Design decisions, Workflow definition |
+| `packages/core/AGENTS.md` → Command Side Effects | The workflow's own transition calls a command dedicated to that transition, not the entity's general-purpose update command | **Compliant (fixed this round)** | Carried over from AP's own fix to the identical latent issue in `sales.order-approval` (which reuses `sales.orders.update` for its transition): `applyContractorApprovalDecision` is a separate, narrow command, not `updateContractor` — see Design decisions |
 | `BACKWARD_COMPATIBILITY.md` | Database schema additive-only | Compliant | Two new tables only |
 | `packages/core/AGENTS.md` → Cross-Module Coupling | Optional-peer sync calls resolve via a local `tryResolve` in `try/catch`; never a hard `requires`; upstream MUST NOT resolve the consumer | **Compliant (fixed this round)** | Originally designed as a plain HTTP route AP would call — an independent review caught this as the wrong mechanism (no degrade path if `contractors` is disabled). Corrected: `checkBankAccountWhitelist` is now also registered in `di.ts`; AP resolves it via `tryResolve`; the HTTP route is now scoped to this module's own UI only. See DI Registrar, Cross-module integration, Risks & Impact Review. |
 | Checklist § Performance | Every query pattern names its supporting index | **Compliant (fixed this round)** | Missing from the first draft of this expansion; added to Data Models for both entities' list/lookup filters. |
@@ -793,23 +959,33 @@ None. One item is explicitly **not yet decided** rather than
 non-compliant: `approveContractor` (the one-step vendor approval
 workflow) is marked throughout as pending confirmation from
 Łukasz/the team — it is designed so it can be dropped without
-reworking any other section, not silently assumed as approved.
+reworking any other section, not silently assumed as approved. Its
+*mechanism*, unlike its scope, is no longer undecided — see Design
+decisions and Workflow definition (2026-09-08).
 
 ### Verdict
 
 **Ready for maintainer review, with one item flagged for explicit
 team confirmation before implementation (not a compliance blocker):**
-the `approveContractor` one-step vendor acceptance workflow. Every
-AGENTS.md rule checked is compliant — an independent review round
-(2026-09-07, second pass) found and fixed a real cross-module-coupling
-gap (`checkBankAccountWhitelist` was designed as an HTTP-only call with
-no degrade path; now also a `di.ts`-resolvable service behind
-`tryResolve`) and a missing supporting-index gap (now added to Data
-Models), and corrected several factual citation errors (see Changelog).
-A separate scope-cohesion check flagged `approveContractor` as
-bundled-but-severable; resolved as a deliberate choice to keep it
-threaded through the same sections rather than split out (see Design
-decisions). The two design decisions worked through with the team
+whether the `approveContractor` one-step vendor acceptance workflow
+ships at all. Its mechanism, if it does, is now fully resolved
+(2026-09-08): the `workflows` engine (`defineWorkflow`/`USER_TASK`),
+1:1 with `sales.order-approval` and AP's own
+`accounts_payable.invoice-approval`, with the same dedicated-command
+departure AP made from `sales.order-approval`'s one latent issue (see
+Design decisions, Workflow definition) — replacing an earlier,
+half-finished correction that had removed a false citation
+("verified GL precedent") without replacing it with a real design.
+Every AGENTS.md rule checked is compliant — an independent review
+round (2026-09-07, second pass) found and fixed a real
+cross-module-coupling gap (`checkBankAccountWhitelist` was designed as
+an HTTP-only call with no degrade path; now also a `di.ts`-resolvable
+service behind `tryResolve`) and a missing supporting-index gap (now
+added to Data Models), and corrected several factual citation errors
+(see Changelog). A separate scope-cohesion check flagged
+`approveContractor` as bundled-but-severable; resolved as a deliberate
+choice to keep it threaded through the same sections rather than
+split out (see Design decisions). The two design decisions worked through with the team
 earlier this session — `ContractorBankAccount` as its own entity, and
 its verification cache as strictly UX-only, never a compliance
 shortcut — remain fully threaded through Design decisions, Data
@@ -926,3 +1102,47 @@ assumed this registry's existence.
   `approveContractor` remains pending team confirmation either way —
   this changes only how its eventual mechanism is justified, not its
   scope status.
+
+### 2026-09-08 — approval mechanism resolved, matching AP's own fix to the identical problem
+
+The previous round's correction removed a false citation ("verified
+GL precedent") from the approval design but did not replace it with a
+real one, leaving `approveContractor` sketched as a `useGuardedMutation`
+row action with no justification. Meanwhile,
+`2026-09-06-accounts-payable.md` independently faced and fully
+resolved the identical problem for its own one-step invoice approval.
+This round applies that same, now-proven resolution here:
+
+- `approveContractor` renamed `applyContractorApprovalDecision` and
+  redesigned as a command called only from inside a `workflows` engine
+  definition (`contractors.vendor-approval`), not a directly-callable
+  `useGuardedMutation` toggle — 1:1 mirroring `sales.order-approval`
+  and `accounts_payable.invoice-approval`.
+- Added the `contractors.vendor-approval` Workflow definition section
+  (new), triggered on a new, conditional `contracts.contractor.created`
+  event (Events section updated) — immediate trigger, like
+  `sales.order.created`, since (unlike AP's invoice) a contractor has
+  no separate draft state before approval.
+- `Contractor` now lists `approvalStatus`/`approvedByUserId`/
+  `approvedAt` directly in Architecture → Entities, not only as a
+  footnote in Data Models.
+- Removed the custom `POST /api/contractors/:id/approve` route (API
+  Contracts, Queries/API, File Manifest) — completion now goes through
+  the existing, generic `POST /api/workflows/tasks/:id/complete`,
+  exactly as `sales.order-approval`/AP's invoice approval already do.
+- Backend Pages: replaced the guarded-row-action sketch with an
+  injected approval-task widget, owned by `workflows` (real precedent:
+  `workflows/widgets/injection/order-approval/`), matching the
+  corrected pattern already applied to
+  `2026-09-06-accounts-payable.md`'s own Backend Pages this same week.
+- Carried over AP's own deliberate departure from `sales.order-approval`:
+  the workflow's transition calls a dedicated
+  `applyContractorApprovalDecision` command, not the general-purpose
+  `updateContractor` — `sales.order-approval` reusing its own generic
+  `update` command for this exact purpose is a latent, unverified
+  contradiction risk AP found and avoided; this document avoids it too
+  rather than repeating it a third time.
+- Updated Compliance Matrix, Non-Compliant Items, and Verdict to
+  record the above. The scope question itself — whether
+  `approveContractor` ships at all — remains unchanged: still pending
+  Łukasz/the team's confirmation.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -1,16 +1,18 @@
 # Contractor Registry — shared contractor registry (AP + AR)
 
-**Related:** [Accounts Payable](2026-09-06-accounts-payable.md) (consumer
-— vendor registration/verification), [Accounts Payable —
+**Related:** [Accounts Payable](2026-09-06-accounts-payable.md)
+(consumer — vendor registration/verification; **pending, not yet
+merged into `develop` — PR #5962**), [Accounts Payable —
 Payments](2026-09-06-accounts-payable-payments.md) (consumer — the
 module that actually resolves `contractorBankWhitelistCheck` via
 `tryResolve` at payment time, per AP's own split; **added
-2026-09-08**, see Changelog), sales-invoice-gl-posting (consumer —
-customers, indirectly through `sales`; **planned, not yet written**
-spec — see `2026-08-18-general-ledger-core-engine.md` Out of scope),
-[General Ledger core engine](2026-08-18-general-ledger-core-engine.md)
+2026-09-08**, see Changelog; **pending, not yet merged — PR #5962**),
+sales-invoice-gl-posting (consumer — customers, indirectly through
+`sales`; **planned, not yet written** spec — see
+`2026-08-18-general-ledger-core-engine.md` Out of scope), [General
+Ledger core engine](2026-08-18-general-ledger-core-engine.md)
 (`JournalEntryLine` gets a new `contractorSnapshot` field from this
-spec)
+spec; **pending, not yet merged — PR #5663**)
 
 ## TLDR
 
@@ -57,6 +59,17 @@ test (`__integration__/TC-CRM-078.spec.ts`) — `roleType` is a
 `z.string()` field (free text, not an enum; see `data/validators.ts`),
 so "vendor" isn't a recognized domain concept there, just a sample
 free-text value.
+
+Verification (GUS/VIES/whitelist) genuinely has no existing surface
+anywhere in the repo. Tax-ID *data entry*, however, is not entirely
+new: `customers`' `AddressEditor` already offers a `taxIdType` of
+`plNip`/`euVat`/`other` with a `taxId` value on an address, carried
+through `sales` document addresses, and `customers/search.ts` already
+treats `tax_id`/`registration_number` as hash-only fields. This module
+deliberately leaves that address-level field alone — it doesn't
+attempt to migrate or unify with it — and introduces a second place a
+NIP can be entered. Accepted as a real but minor duplication, not a
+reason to delay a dedicated registry.
 
 All entities in `customers` carry both `organizationId` and
 `tenantId` (a separate `Tenant` lives in `modules/directory`), and
@@ -326,6 +339,107 @@ encrypted column without a hash doesn't work.
 (financial data, PII). Reads go through
 `findWithDecryption`/`findOneWithDecryption`, never hand-rolled crypto.
 
+**Delete guard: drop the `JournalEntryLine` half (2026-09-08,
+maintainer review).** The original design blocked `Contractor`
+deletion "if it has any `JournalEntryLine` references via snapshot" —
+but `JournalEntryLine` belongs to `ledger`, a downstream consumer of
+this module, and checking it from here would require `contractors` to
+import or resolve something belonging to its own consumer, exactly the
+direction `packages/core/AGENTS.md` forbids ("the upstream/depended-on
+module MUST NOT import, resolve, or hard-require the consumer") — the
+same rule this document already quotes correctly for the
+`accounts_payable_payments` relationship (see Cross-module
+integration). It would also fail `module-decoupling.test.ts` the
+moment `ledger` is disabled, since the referenced table wouldn't
+exist. Dropped entirely: `contractorSnapshot` exists specifically so a
+historical journal entry never needs the `Contractor` row to still
+exist (a denormalized, point-in-time copy — see
+`2026-08-18-general-ledger-core-engine.md`), and deletion here is a
+soft delete (`deletedAt`) besides, so the row remains physically
+present regardless. The only delete guard this module enforces is its
+own: an active `ContractorBankAccount`. Whether `accounts_payable`'s
+open `VendorInvoice.vendorId` references should also block a
+contractor's deletion is a legitimate question, but belongs to AP's
+own design (it owns that FK), not to this module's ACL.
+
+**`gusData`/`viesData` narrowed to non-PII diagnostics (2026-09-08,
+maintainer review).** The original design stored the raw GUS/VIES API
+response verbatim (`jsonb`) for diagnostics. For a sole proprietorship
+(JDG), that raw response carries the owner's personal name and often a
+residential address — the exact fields this module's own encryption
+map already encrypts on `Contractor.name`/`Contractor.address` — so
+the raw blob silently duplicated the same PII in plaintext beside its
+encrypted counterpart, reducing the encryption to decoration for
+anyone with table or backup access. Narrowed to typed, non-PII fields
+only: `lastCheckStatus` (the registry's own status/response code),
+`lastCheckedAt`, `lastCheckRequestId` — enough to debug a failed
+lookup without persisting the underlying personal data a second time,
+in a form this module cannot redact on a GDPR erasure request. If a
+raw payload genuinely proves necessary for diagnostics later, it must
+be declared in the encryption map like every other PII field, with a
+stated retention/purge policy — not assumed safe because it's "just
+diagnostics."
+
+**Approval gate gets a real enforcement point: `checkBankAccountWhitelist`
+(2026-09-08, maintainer review).** Confirming the vendor-approval gate
+in scope (2026-09-08 as it happened) settled the workflow's
+*mechanism* but left its *consequence* undefined: `approvalStatus` and
+`verificationStatus` were specified as independent fields with
+"nothing in Phase 1 blocks Accounts Payable from using a
+`PENDING_APPROVAL` contractor" left as an open question for AP. A
+control nothing consults is documentation, not a control — the entire
+fraud-prevention argument in Problem Statement/Design decisions would
+fire zero times in practice. Resolved: `checkBankAccountWhitelist` —
+already the sanctioned, DI-resolved choke point every payment goes
+through (see Commands, Cross-module integration) — now also rejects
+with a typed error when the contractor's `approvalStatus` is not
+`APPROVED`, before it makes the live Biała Lista call. This folds the
+human-approval gate into the same call site AP already depends on,
+rather than requiring AP to separately read and interpret
+`approvalStatus` itself. This closes the Out of scope item below of
+the same name.
+
+**Four-eyes needs its own permission: `contractors.approve`
+(2026-09-08, maintainer review).** The original ACL required
+`contractors.manage` for both `createContractor` and
+`applyContractorApprovalDecision` — the same single feature on both
+sides of the split the approval gate exists to create, so the user who
+registers a vendor can also approve their own registration, defeating
+the four-eyes rationale in Problem Statement/Design decisions outright
+(the exact internal fictitious-vendor scheme the fraud research warns
+about). Split: `applyContractorApprovalDecision` now requires a
+distinct `contractors.approve` feature, not `contractors.manage`.
+`applyContractorApprovalDecision` additionally rejects a decision
+where the acting user is the same as the contractor's
+`createdByUserId` — explicit self-approval is blocked even for a user
+who happens to hold both features. `Contractor` gains a
+`createdByUserId` column to make this check possible.
+
+**`isPrimary` and the `nip`/`nipHash` uniqueness constraint get
+partial indexes, not the reasoning originally given (2026-09-08,
+maintainer review).** Two corrections. First,
+`ContractorBankAccount.isPrimary`'s command-only invariant was
+justified by "this repo's general preference for command-enforced
+business rules over database-level ones" — that preference doesn't
+exist; both real precedents for an "exactly one primary" invariant in
+this repo (`communication_channels_one_primary_per_user_uq`,
+`customer_deal_people_primary_uq`) use a partial unique index. Added:
+`create unique index "contractor_bank_account_one_primary_uq" on
+"contractor_bank_account" ("contractor_id") where "is_primary" and
+"deleted_at" is null`, keeping the command's unset-the-other-primary
+logic as the ergonomic path (so a normal request never hits the
+constraint) and removing the previously accepted concurrent-race
+residual risk, which the index now closes at the database level.
+Second, the `nipHash` uniqueness constraint (`UNIQUE (tenant_id,
+organization_id, nip_hash)`) didn't account for this entity's own
+`deletedAt` soft delete: a soft-deleted row still occupies the unique
+tuple, so re-registering the same NIP — including by the legitimate
+contractor it actually belongs to — would 409 forever, with no
+correction path since `nip` is unconditionally immutable. Changed to a
+partial index scoped `where "deleted_at" is null`, the same shape as
+`communication_channels_one_primary_per_user_uq`: a soft-deleted
+registration frees its NIP for re-registration.
+
 ### Alternatives considered
 
 | Alternative | Why Rejected |
@@ -361,14 +475,18 @@ encrypted column without a hash doesn't work.
 
 - `Contractor` — `isVendor` (bool), `isCustomer` (bool), `name`,
   `nip` (+ `nipHash` for lookup on the encrypted column, unique per
-  `(tenant_id, organization_id)` — duplicate detection), `address`,
+  `(tenant_id, organization_id)` while `deletedAt` is null — a partial
+  index, see Design decisions — duplicate detection), `address`,
   `contactEmail`, `contactPhone`, `verificationStatus`
-  (`PENDING`/`VERIFIED`/`FAILED`), `gusData`/`viesData` (`jsonb`, the
-  raw response from the last check — diagnostics, not a source of
-  truth), tenant/org scoped, `updatedAt` (user-editable → optimistic
-  lock), `deletedAt` (soft delete — per the standard column contract;
-  deletion blocked if the contractor has any `JournalEntryLine`
-  references via snapshot or any active `ContractorBankAccount`).
+  (`PENDING`/`VERIFIED`/`FAILED`), `lastCheckStatus`/`lastCheckedAt`/
+  `lastCheckRequestId` (typed, non-PII registry-check diagnostics —
+  see Design decisions; **not** the raw GUS/VIES response),
+  `createdByUserId` (see Design decisions — backs the self-approval
+  guard on `applyContractorApprovalDecision`), tenant/org scoped,
+  `updatedAt` (user-editable → optimistic lock), `deletedAt` (soft
+  delete — per the standard column contract; deletion blocked only
+  while an active `ContractorBankAccount` exists — a `JournalEntryLine`
+  check was considered and dropped, see Design decisions).
   Confirmed in scope, 2026-09-08 (see Design decisions):
   `approvalStatus`
   (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`), `approvedByUserId`,
@@ -376,13 +494,15 @@ encrypted column without a hash doesn't work.
   inside the workflow, never through `updateContractor` (see Design
   decisions, Workflow definition). `verificationStatus` (GUS/VIES) and
   `approvalStatus` (human approve/reject) are independent, parallel
-  fields — Phase 1 does not gate one on the other, and nothing in
-  Phase 1 blocks Accounts Payable from using a `PENDING_APPROVAL`
-  contractor; whether it should is a real, still-open question this
-  document does not resolve (see Out of scope).
+  fields — Phase 1 does not gate registration or verification on
+  approval, but `checkBankAccountWhitelist` does gate on it (see
+  Design decisions, Commands): a `PENDING_APPROVAL`/`REJECTED`
+  contractor's bank account can never pass the live whitelist call a
+  payment depends on.
 - `ContractorBankAccount` — `contractorId` (FK to `Contractor`),
   `accountNumber` (encrypted), `isPrimary` (bool — exactly one primary
-  per contractor, enforced in the command), `lastVerifiedAt` (nullable,
+  per contractor, enforced by both the command and a partial unique
+  index, see Design decisions), `lastVerifiedAt` (nullable,
   UX cache — see Design decisions), `lastVerificationStatus`
   (`WHITELISTED`/`NOT_WHITELISTED`/`UNKNOWN`, UX cache), its own
   `organizationId`/`tenantId` (own scope columns, matching the
@@ -399,15 +519,24 @@ Following the `customers` module convention
 export const features = [
   { id: 'contractors.view', title: 'View contractors', module: 'contractors' },
   { id: 'contractors.manage', title: 'Manage contractors', module: 'contractors', dependsOn: ['contractors.view'] },
+  { id: 'contractors.approve', title: 'Approve contractors', module: 'contractors', dependsOn: ['contractors.view'] },
 ]
 ```
 
 `createContractor`/`updateContractor`/`createContractorBankAccount`/
-`updateContractorBankAccount`/`applyContractorApprovalDecision` require
-`contractors.manage`; `checkBankAccountWhitelist` requires
-`contractors.view` (read-only check, callable by anyone who can see
-the contractor — the actual payment-blocking decision belongs to AP's
-own guard, not to this module's ACL).
+`updateContractorBankAccount` require `contractors.manage` at the
+route/page level (a plain `registerCommand` carries no ACL of its
+own — enforcement is declarative, via `metadata.requireFeatures` on
+the API route and on the backend page). `applyContractorApprovalDecision`
+requires `contractors.approve`, not `contractors.manage` (see Design
+decisions) — enforced via `registerWorkflowSafeCommands`'s
+`requiredFeatures`, the one command-adjacent ACL mechanism that
+actually exists in this repo. `checkBankAccountWhitelist`'s own HTTP
+route (this module's "verify now" button) requires `contractors.view`.
+The DI-resolved path used by `accounts_payable_payments` (see DI
+Registrar, Cross-module integration) bypasses this route entirely and
+is unguarded by design — the caller owns authorization for its own
+request, the same as any other `tryResolve`d service call.
 
 ### Module Setup (`setup.ts`)
 
@@ -439,12 +568,14 @@ review — see Changelog).
   standard CRUD; `isPrimary: true` on one account automatically
   unsets it on any other account for the same contractor (single
   invariant enforced in the command, not left to the client).
-- `checkBankAccountWhitelist` — **not a plain query**: performs a live
-  call to the Ministry of Finance's Biała Lista API for the given
-  `accountNumber` and `nip`, returns the fresh result to the caller,
-  and — as a side effect only — updates
-  `lastVerifiedAt`/`lastVerificationStatus` on the matching
-  `ContractorBankAccount` for UX display. Never reads
+- `checkBankAccountWhitelist` — **not a plain query**: first rejects
+  with a typed error, before any network call, if the contractor's
+  `approvalStatus` is not `APPROVED` (see Design decisions,
+  2026-09-08) — otherwise performs a live call to the Ministry of
+  Finance's Biała Lista API for the given `accountNumber` and `nip`,
+  returns the fresh result to the caller, and — as a side effect
+  only — updates `lastVerifiedAt`/`lastVerificationStatus` on the
+  matching `ContractorBankAccount` for UX display. Never reads
   `lastVerifiedAt` to short-circuit the live call (see Design
   decisions). Idempotent to call repeatedly. Registered in `di.ts` as
   a resolvable service (see DI Registrar above) — this is the
@@ -456,8 +587,12 @@ review — see Changelog).
   `contractors.vendor-approval` workflow (not directly from the UI),
   via `UPDATE_ENTITY`, `PENDING_APPROVAL` → `APPROVED` or `REJECTED`
   and nothing else (accepts no other fields). Registered separately in
-  `registerWorkflowSafeCommands`, requires `contractors.manage`.
-  **Deliberately not `updateContractor`** — see Design decisions
+  `registerWorkflowSafeCommands`, requires `contractors.approve`, a
+  distinct feature from `contractors.manage` (see Design decisions,
+  2026-09-08) — and additionally rejects the decision if the acting
+  user equals the contractor's own `createdByUserId` (self-approval
+  guard, see Design decisions). **Deliberately not `updateContractor`**
+  — see Design decisions
   ("`approveContractor`'s mechanism is now resolved") for the
   contradiction this avoids, mirroring AP's identical fix to the same
   latent issue in `sales.order-approval`. **Reversibility (added
@@ -502,7 +637,7 @@ import { defineWorkflow, createWorkflowsModuleConfig } from '@open-mercato/share
 import { registerWorkflowSafeCommands } from '@open-mercato/core/modules/workflows/lib/workflow-safe-commands'
 
 registerWorkflowSafeCommands([
-  { commandId: 'contractors.contractor.applyApprovalDecision', requiredFeatures: ['contractors.manage'] },
+  { commandId: 'contractors.contractor.applyApprovalDecision', requiredFeatures: ['contractors.approve'] },
 ])
 
 const vendorApproval = defineWorkflow({
@@ -646,16 +781,19 @@ or hard-require the consumer."
 ### Contractor
 
 One row per contractor. `nip`/`nipHash` unique per
-`(tenant_id, organization_id)` — enforces one registration per tax
+`(tenant_id, organization_id)` while `deletedAt` is null — a partial
+index, see Design decisions — enforces one registration per tax
 identity within an organization and backs duplicate detection at
-`createContractor`. `verificationStatus` starts `PENDING`, moves to
-`VERIFIED`/`FAILED` asynchronously via the `verifyContractorRegistry`
-worker. `gusData`/`viesData` store the raw response from the most
-recent check for diagnostics — never read as a source of truth by any
-command, only surfaced in the UI. `deletedAt` blocks deletion while any
-`JournalEntryLine.contractorSnapshot` references this contractor or any
+`createContractor`, while letting a soft-deleted registration free its
+NIP for re-registration. `verificationStatus` starts `PENDING`, moves
+to `VERIFIED`/`FAILED` asynchronously via the `verifyContractorRegistry`
+worker. `lastCheckStatus`/`lastCheckedAt`/`lastCheckRequestId` —
+typed, non-PII diagnostics only, never the raw GUS/VIES payload (see
+Design decisions) — never read as a source of truth by any command,
+only surfaced in the UI. `deletedAt` blocks deletion only while an
 active `ContractorBankAccount` exists (enforced in `updateContractor`'s
-delete path — see Commands).
+delete path — see Commands); a `JournalEntryLine`-based guard was
+considered and dropped (see Design decisions).
 
 Confirmed in scope, 2026-09-08 (see Design decisions):
 `approvalStatus` (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`),
@@ -673,11 +811,10 @@ the composite-index approach in #5663's `journal_entry`/
 
 One row per bank account registered for a contractor. `accountNumber`
 encrypted at rest. `isPrimary` — exactly one `true` per contractor,
-enforced by the command layer, not a database constraint (a partial
-unique index would work too but the command-level invariant is
-simpler and matches this repo's general preference for
-command-enforced business rules over database-level ones beyond raw
-integrity). `lastVerifiedAt`/`lastVerificationStatus` — UX cache only,
+enforced by both the command (unsets any existing primary in the same
+transaction) and a partial unique index at the database level (see
+Design decisions), closing the concurrent-race gap a command-only
+invariant would leave open. `lastVerifiedAt`/`lastVerificationStatus` — UX cache only,
 written only as a side effect of `checkBankAccountWhitelist`, never
 read by any command to skip the live check (see Design decisions).
 Own `organizationId`/`tenantId` (see Design decisions).
@@ -698,6 +835,9 @@ Standard `makeCrudRoute` list + create.
 - **Create body**: `{ isVendor, isCustomer, name, nip, address,
   contactEmail, contactPhone }`. `verificationStatus` not settable —
   always starts `PENDING`.
+- **Response shape** (list/detail): includes `updatedAt` on every
+  row, per root `AGENTS.md`'s requirement so `CrudForm` can
+  auto-derive the optimistic-lock header for `PUT` below.
 - **Response 403**: caller lacks `contractors.view` (list) or
   `contractors.manage` (create).
 - **Response 409** (create): `nip` already registered for this
@@ -716,7 +856,8 @@ Standard `makeCrudRoute` update.
 ### `GET /api/contractors/:id/bank-accounts` / `POST .../bank-accounts`
 
 Standard `makeCrudRoute` list + create, scoped to the parent
-contractor.
+contractor. **Response shape** (list): includes `updatedAt` per row,
+same rationale as `GET /api/contractors` above.
 
 - **Create body**: `{ accountNumber, isPrimary? }`.
 
@@ -816,6 +957,7 @@ exactly as `sales.order-approval` and
 | `events.ts` | Create | **Confirmed in scope, 2026-09-08** — `contractors.contractor.created`, the workflow's sole trigger |
 | `widgets/injection/vendor-approval/` | Create | **In `workflows`, not this module** — approval-task widget injected into `contractors.contractor.detail:details`, mirroring `workflows/widgets/injection/order-approval/` |
 | `commands/contractors.ts` | Update | Adds `applyContractorApprovalDecision`, called only from inside the workflow |
+| `i18n/` | Create | Locale keys for status labels (`PENDING`/`VERIFIED`/`FAILED`, `WHITELISTED`/`NOT_WHITELISTED`/`UNKNOWN`, `PENDING_APPROVAL`/`APPROVED`/`REJECTED`), the "last checked: N days ago" badge, the "Verify now" button, and 400/409/502 error copy — per root `AGENTS.md`'s "never hard-code user-facing strings" rule |
 | `api/openapi.ts` | Create | `openApi` exports for every route above |
 | `backend/contractors/page.tsx` (+ create/[id]) | Create | List/create/edit UI with inline bank-account sub-list |
 | `commands/__tests__/*` | Create | Regression coverage |
@@ -853,7 +995,7 @@ exactly as `sales.order-approval` and
   never any other transition.
 - Assert `verifyContractorRegistry` worker is idempotent — running it
   twice for the same contractor does not duplicate or corrupt
-  `gusData`/`viesData`.
+  `lastCheckStatus`/`lastCheckedAt`/`lastCheckRequestId`.
 - Assert encryption round-trip: `nip`/`address`/`contactEmail`/
   `contactPhone`/`accountNumber` are stored encrypted and returned in
   plaintext only through `findWithDecryption`.
@@ -863,6 +1005,31 @@ exactly as `sales.order-approval` and
   `contractors.view`; the verify route returns 200 with a fresh
   `checkedAt` on each call (not a cached timestamp) and 502 when the
   Biała Lista API is unavailable.
+- **Confirmed 2026-09-08 (maintainer review):** assert
+  `checkBankAccountWhitelist` rejects with a typed error — never
+  reaching the live API client — when `approvalStatus` is
+  `PENDING_APPROVAL` or `REJECTED`, and proceeds normally once
+  `APPROVED`.
+- Assert `applyContractorApprovalDecision` rejects a decision where
+  the acting user equals `createdByUserId`, even when that user holds
+  both `contractors.manage` and `contractors.approve`.
+- Assert `Contractor.lastCheckStatus`/`lastCheckedAt`/
+  `lastCheckRequestId` never contain the raw GUS/VIES response, and
+  that no `gusData`/`viesData` column exists.
+- Assert deleting a contractor with an active `ContractorBankAccount`
+  is blocked; assert deleting a contractor with `JournalEntryLine`
+  history but no active bank accounts succeeds — the corrected
+  behavior after the ledger-side guard was dropped (see Design
+  decisions).
+- Assert `contractor_bank_account_one_primary_uq` and the NIP partial
+  uniqueness index both exist and are exercised at the database level
+  (a raw insert bypassing the command still fails for two primaries or
+  two live NIPs), and that re-registering a soft-deleted NIP succeeds.
+- Reserved integration test category: `TC-CONTRACTOR-*`, including a
+  `__integration__/TC-CONTRACTOR-CRUDFORM-001.spec.ts` covering the
+  `Contractor` create/update `CrudForm` flow end to end (list → create
+  → edit → optimistic-lock conflict), per `.ai/qa/AGENTS.md`'s
+  mandatory CRUDFORM convention for every module shipping one.
 
 ## Risks & Impact Review
 
@@ -872,20 +1039,61 @@ exactly as `sales.order-approval` and
   NIP within the same organization race past an application-level
   uniqueness check before either commits.
   **Severity**: Medium. **Affected area**: `Contractor` registration.
-  **Mitigation**: `nipHash` carries a `UNIQUE (tenant_id,
-  organization_id, nip_hash)` database constraint, not just an
-  application-level check — the second insert fails at the database
-  regardless of the race. **Residual risk**: none; this is exactly
-  the failure mode a DB unique constraint is for.
+  **Mitigation**: `nipHash` carries a partial `UNIQUE (tenant_id,
+  organization_id, nip_hash) where deleted_at is null` database index
+  (see Design decisions), not just an application-level check — the
+  second insert fails at the database regardless of the race.
+  **Residual risk**: none; this is exactly the failure mode a DB
+  unique index is for.
+- **Scenario (found in maintainer review, 2026-09-08)**: a contractor
+  is registered with a NIP, has no bank accounts or ledger references,
+  and is soft-deleted (`deletedAt` set). The organization later tries
+  to register that same NIP again — including the legitimate
+  contractor it actually belongs to. **Severity**: Medium. **Affected
+  area**: `Contractor` registration. **Mitigation**: the uniqueness
+  index above is scoped `where deleted_at is null` (see Design
+  decisions, Data Models) — a soft-deleted row no longer occupies the
+  unique tuple, so re-registration succeeds. **Residual risk**: none —
+  this was a real gap in an earlier draft (a plain, unscoped unique
+  constraint would have burned the NIP permanently, since `nip` is
+  unconditionally immutable and cannot be corrected on the old row
+  either), closed by scoping the index to match this entity's own
+  soft-delete column.
 - **Scenario**: `createContractorBankAccount` sets `isPrimary: true`
   concurrently on two different accounts for the same contractor.
   **Severity**: Low. **Affected area**: `ContractorBankAccount`.
   **Mitigation**: command re-reads and unsets any existing primary
-  inside the same transaction as the insert/update. **Residual risk**:
-  a genuine race could still produce two primaries momentarily under
-  extreme concurrency (no DB-level partial unique index) — acceptable
-  for a low-frequency, human-initiated action; revisit if it proves to
-  matter in practice.
+  inside the same transaction as the insert/update, backed by a
+  partial unique index at the database level (see Design decisions).
+  **Residual risk**: none — the index closes the concurrent-race gap
+  the command alone would leave open; the command's unset-the-other
+  logic stays as the ergonomic path so a normal request never hits the
+  constraint.
+- **Scenario (found in maintainer review, 2026-09-08)**: the same user
+  who registers a fictitious vendor (holding `contractors.manage`)
+  also completes its own approval task. **Severity**: High — this is
+  precisely the internal fraud scheme the approval gate exists to
+  prevent. **Affected area**: `applyContractorApprovalDecision`.
+  **Mitigation**: `contractors.approve` is a distinct feature from
+  `contractors.manage` (see Design decisions, Access Control), and the
+  command additionally rejects a decision where the acting user equals
+  the contractor's `createdByUserId`, regardless of which features
+  they hold. **Residual risk**: none identified beyond two different
+  colluding accounts, which is an organizational control, not a
+  technical one.
+- **Scenario (found in maintainer review, 2026-09-08)**: a contractor
+  is registered and left `PENDING_APPROVAL` indefinitely;
+  `accounts_payable_payments` attempts a payment to it before anyone
+  acts on the approval task. **Severity**: High — defeats the entire
+  fraud-prevention rationale for the gate. **Affected area**:
+  `checkBankAccountWhitelist`, `accounts_payable_payments`'s payment
+  flow. **Mitigation**: `checkBankAccountWhitelist` rejects with a
+  typed error before making the live Biała Lista call whenever
+  `approvalStatus !== 'APPROVED'` (see Design decisions, Commands) —
+  `accounts_payable_payments` already treats any error from this call
+  as "block the payment" (see Cross-module integration), so no change
+  is needed on AP's side. **Residual risk**: none identified — every
+  payment path already goes through this single choke point.
 
 ### Cascading failures & side effects
 
@@ -973,11 +1181,12 @@ independently of AP, which does not yet exist.
   replaced by the `JournalEntryLine.contractorSnapshot` point-in-time
   copy (see Design decisions) — no separate audit-log table for every
   field change.
-- **Whether Accounts Payable should block using a contractor still in
-  `PENDING_APPROVAL` status.** Phase 1 does not gate on this — `Contractor`
-  exposes `approvalStatus` as a field AP can read, but this document
-  doesn't mandate AP enforce it before a first payment. Left as an
-  open question for AP's own design (see Architecture → Entities).
+- ~~Whether Accounts Payable should block using a contractor still
+  in `PENDING_APPROVAL` status.~~ **Resolved 2026-09-08, no longer out
+  of scope** — `checkBankAccountWhitelist` itself now rejects a
+  non-`APPROVED` contractor before AP's payment flow ever reaches the
+  live check (see Design decisions, Commands). AP does not need to
+  separately read or interpret `approvalStatus`.
 
 ## Final Compliance Report — 2026-09-07
 
@@ -1003,9 +1212,13 @@ independently of AP, which does not yet exist.
 | `AGENTS.md` | Write operations via Command pattern | Compliant | All mutations go through `createContractor`/`updateContractor`, `createContractorBankAccount`/`updateContractorBankAccount`, `checkBankAccountWhitelist` |
 | `AGENTS.md` / core `AGENTS.md` | Declarative feature guards; `acl.ts` synced to `setup.ts` | Compliant | Two `contractors.*` features, `defaultRoleFeatures` in `setup.ts`, `sync-role-acls` in Implementation Plan step 2 |
 | Core `AGENTS.md` § Database Entities | User-editable entities MUST include `updated_at` | Compliant | Both entities have `updatedAt`; `CrudForm` auto-derives the lock header |
-| Core `AGENTS.md` § Database Entities | Standard column contract includes `deleted_at` | Compliant | Both entities have `deletedAt` (soft delete); deletion of `Contractor` blocked while snapshot references or active bank accounts exist |
+| Core `AGENTS.md` § Database Entities | Standard column contract includes `deleted_at` | Compliant | Both entities have `deletedAt` (soft delete); deletion of `Contractor` blocked only while an active `ContractorBankAccount` exists — a `JournalEntryLine`-based check was dropped, see Design decisions |
 | `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |
-| `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | Compliant | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared |
+| `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | **Compliant (fixed 2026-09-08, maintainer review)** | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared. Originally, `gusData`/`viesData` stored the raw GUS/VIES payload — which duplicates the same PII in plaintext for a JDG contractor — outside this map entirely; narrowed to typed, non-PII diagnostic fields instead (see Design decisions) |
+| `packages/core/AGENTS.md` → Cross-Module Coupling | Upstream module MUST NOT import, resolve, or hard-require its own consumer | **Compliant (fixed 2026-09-08, maintainer review)** | The `Contractor` delete guard originally checked `ledger`'s `JournalEntryLine` from inside this (upstream) module — the exact inverted direction this same rule forbids, and a `module-decoupling.test.ts` failure waiting to happen. Dropped; `contractorSnapshot` already makes this unnecessary (see Design decisions) |
+| Problem Statement / fraud-prevention rationale (four-eyes) | The approval gate must actually separate "who registers" from "who approves" | **Compliant (fixed 2026-09-08, maintainer review)** | Both were gated on the same `contractors.manage` feature, permitting self-approval. Split into `contractors.manage` / `contractors.approve`, plus an explicit `createdByUserId` self-approval check (see Design decisions, Access Control) |
+| Problem Statement / fraud-prevention rationale (approval enforcement) | A control must have an actual enforcement point, not just a status field | **Compliant (fixed 2026-09-08, maintainer review)** | `approvalStatus` was previously read by nothing — `checkBankAccountWhitelist` now rejects a non-`APPROVED` contractor before any payment can reach the live check (see Design decisions, Commands, Out of scope) |
+| Root `AGENTS.md` | Never hard-code user-facing strings — use locale files | **Compliant (fixed 2026-09-08, maintainer review)** | File Manifest was missing an `i18n/` entry entirely, unlike every other core module; added |
 | `packages/queue/AGENTS.md` | Workers MUST be idempotent; MUST export `metadata: { queue, id?, concurrency? }` | Compliant | `verifyContractorRegistry.ts` follows the exact shape verified against `customers/workers/*.ts` |
 | `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. **Resolved 2026-09-08** (superseding the 2026-09-07 correction, which only removed a false citation without replacing the design): the approval step (confirmed in scope, 2026-09-08) now uses the `workflows` engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`/`accounts_payable.invoice-approval`, not `useGuardedMutation` — consistent with the same principle already settled for `accounts_payable.invoice-approval`: a guarded row action is a real pattern only for a simple, reversible toggle (GL's fiscal-period lock/unlock), not a one-time approve/reject decision. See Design decisions, Workflow definition |
 | `packages/core/AGENTS.md` → Command Side Effects | The workflow's own transition calls a command dedicated to that transition, not the entity's general-purpose update command | **Compliant (fixed this round)** | Carried over from AP's own fix to the identical latent issue in `sales.order-approval` (which reuses `sales.orders.update` for its transition): `applyContractorApprovalDecision` is a separate, narrow command, not `updateContractor` — see Design decisions |
@@ -1027,15 +1240,30 @@ independently of AP, which does not yet exist.
 
 ### Non-Compliant Items
 
-None. `approveContractor` (the one-step vendor approval workflow,
-now `applyContractorApprovalDecision`) was the one item carried as
-**not yet decided** in the prior round; both its scope and its
-mechanism are now resolved (2026-09-08) — see Design decisions,
-backed by explicit research (the AFP's 2025 Payments Fraud and
-Control Survey, the documented limits of the mandatory Biała Lista
-check, and existing ERP precedent in SAP Ariba/ApprovalMax). Final
-sign-off with Łukasz happens through the normal PR review, same as
-every other decision in this document.
+None outstanding. An external maintainer review (PR #5955, 2026-09-08)
+found two blockers (unencrypted PII duplicated in `gusData`/`viesData`;
+the `Contractor` delete guard reading `ledger`'s `JournalEntryLine`,
+inverting the cross-module dependency direction) and six majors (no
+enforcement point for the approval gate; four-eyes defeated by a
+shared ACL feature; missing `i18n/` in the File Manifest; the
+`Contractor Registry` and implementation-guide README rows filed under
+"Fully implemented and deployed"; the implementation guide describing
+the approval gate as still pending after the spec resolved it; the
+`isPrimary` command-only-invariant rationale citing a repo preference
+that doesn't exist), plus five minors/nits (the NIP unique index not
+accounting for soft delete; no reserved `TC-` integration test IDs;
+"Related" documents linking to specs not yet merged; ACL requirements
+attributed to the command layer rather than routes; the existing
+`plNip` address field and `updatedAt` response-shape omissions). All
+addressed in this round — see Design decisions and Changelog. Prior to
+this, `approveContractor` (now `applyContractorApprovalDecision`) was
+the one item carried as **not yet decided**; both its scope and its
+mechanism were resolved 2026-09-08 — see Design decisions, backed by
+explicit research (the AFP's 2025 Payments Fraud and Control Survey,
+the documented limits of the mandatory Biała Lista check, and existing
+ERP precedent in SAP Ariba/ApprovalMax). Final sign-off with Łukasz
+happens through the normal PR review, same as every other decision in
+this document.
 
 ### Verdict
 
@@ -1074,6 +1302,23 @@ shortcut — remain fully threaded through Design decisions, Data
 Models, Commands, Testing Strategy, and Risks. This document unblocks
 the full expansion of `2026-09-06-accounts-payable.md`, which already
 assumed this registry's existence.
+
+**Updated 2026-09-08, after an external maintainer review (PR
+#5955).** The review found real defects this document's own
+self-review and fresh-context checklist passes had missed — precisely
+because they only surface when the design is checked against the
+codebase's actual module-isolation and ACL mechanisms, not against the
+document's own citations. Two blockers and six majors, all now
+resolved (see Design decisions, Compliance Matrix, Non-Compliant
+Items, Changelog): the `gusData`/`viesData` PII duplication, the
+inverted-direction delete guard, the missing approval-gate enforcement
+point, the four-eyes-defeating shared ACL feature, the missing `i18n/`
+manifest entry, the README miscategorization, the implementation-guide
+drift, and the `isPrimary` invariant's mistaken rationale. The
+document's core shape — the separate `ContractorBankAccount` entity,
+the DI/`tryResolve` cross-module design, the workflow-engine approval
+mechanism, the YAGNI deferrals — was not in question; every finding
+was a correction within that shape, not a challenge to it.
 
 ## Changelog
 
@@ -1333,3 +1578,64 @@ stated identically everywhere they recur, and the document
 consistently frames the vendor-approval decision as a recommendation
 for the normal PR review, not an already-audited fact overriding
 Łukasz's sign-off.
+
+### 2026-09-08 (cont. — external maintainer review, PR #5955)
+
+An external maintainer review on the open PR found real defects this
+document's own review rounds had missed, each independently
+re-verified against the real repository before being accepted:
+
+- **Blocker**: `gusData`/`viesData` stored the raw GUS/VIES response
+  verbatim, duplicating PII (a JDG contractor's personal name/address)
+  in plaintext beside the encrypted `name`/`address` columns. Narrowed
+  to typed, non-PII diagnostic fields (`lastCheckStatus`,
+  `lastCheckedAt`, `lastCheckRequestId`); dropped the raw payload.
+- **Blocker**: the `Contractor` delete guard checked `ledger`'s
+  `JournalEntryLine` from inside this upstream module — the exact
+  inverted dependency direction `packages/core/AGENTS.md` forbids, and
+  a document that itself quotes that rule correctly elsewhere.
+  Dropped; `contractorSnapshot` already makes it unnecessary, and
+  deletion here is a soft delete regardless.
+- **Major**: the confirmed approval gate had no enforcement point —
+  nothing blocked AP from using a `PENDING_APPROVAL` contractor.
+  `checkBankAccountWhitelist` now rejects non-`APPROVED` contractors
+  before the live check.
+- **Major**: `createContractor` and `applyContractorApprovalDecision`
+  shared one ACL feature (`contractors.manage`), permitting
+  self-approval and defeating the four-eyes rationale. Split into
+  `contractors.manage`/`contractors.approve` plus an explicit
+  `createdByUserId` self-approval check.
+- **Major**: File Manifest omitted `i18n/` entirely. Added, with the
+  key groups named.
+- **Major**: both README rows filed this and the implementation guide
+  under "Fully implemented and deployed" despite neither being merged.
+  Moved to Pending Specifications (see `.ai/specs/README.md`).
+- **Major**: the implementation guide still described the approval
+  gate as "pending team confirmation" and a 10-step Phase 1, both
+  superseded by this document's own 2026-09-08 resolution (11 steps).
+  Re-synced (see `2026-09-06-contractor-registry-implementation-guide.md`).
+- **Major**: the `isPrimary` command-only-invariant rationale cited
+  "this repo's general preference for command-enforced business rules
+  over database-level ones" — a preference that doesn't exist; both
+  real repo precedents for this exact invariant use a partial unique
+  index. Added `contractor_bank_account_one_primary_uq`.
+- **Minor**: the `nipHash` unique constraint didn't account for this
+  entity's own soft delete, permanently burning a NIP on
+  re-registration after a soft-deleted row. Scoped to a partial index
+  `where deleted_at is null`.
+- **Minor**: no reserved `TC-` integration-test category/IDs, no
+  `CRUDFORM` coverage row despite shipping a full `CrudForm`. Reserved
+  `TC-CONTRACTOR-*`, added the CRUDFORM row.
+- **Minor**: three of four "Related" documents link to specs not yet
+  merged into `develop`. Annotated each with its PR number.
+- **Minor**: ACL requirements were attributed to the command layer;
+  restated as route/page guards, with the DI-resolved path explicitly
+  marked as unguarded by design.
+- **Nit**: Problem Statement didn't acknowledge the existing
+  address-level `plNip` field in `customers`. Added a sentence.
+- **Nit**: API Contracts didn't document `updatedAt` in list/detail
+  response shapes, needed for the optimistic-lock 409 path to be
+  reachable from `CrudForm`. Added.
+
+Updated the Compliance Matrix, Non-Compliant Items, and Verdict to
+record all of the above.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -415,6 +415,21 @@ where the acting user is the same as the contractor's
 who happens to hold both features. `Contractor` gains a
 `createdByUserId` column to make this check possible.
 
+This deliberately diverges from `sales.order-approval` and
+`2026-09-06-accounts-payable.md`'s own `applyVendorInvoiceApprovalDecision`,
+both of which explicitly accept self-approval as a documented Phase-1
+risk rather than an oversight (see `2026-09-06-accounts-payable.md`,
+"No maker-checker control (self-approval) in Phase 1"). That
+acceptance is consistent with *their* stated rationale — an ordinary
+authorization/oversight step, not a fraud control. It would not be
+consistent here: this document's own Problem Statement justifies the
+entire approval gate specifically as a four-eyes control against
+internal fictitious-vendor registration (see Problem Statement,
+Non-Compliant Items). Accepting self-approval while citing four-eyes
+as the reason for existing would be a direct contradiction within this
+document, not a repo-wide inconsistency — the other two modules never
+made that specific claim.
+
 **`isPrimary` and the `nip`/`nipHash` uniqueness constraint get
 partial indexes, not the reasoning originally given (2026-09-08,
 maintainer review).** Two corrections. First,
@@ -540,9 +555,19 @@ request, the same as any other `tryResolve`d service call.
 
 ### Module Setup (`setup.ts`)
 
-`defaultRoleFeatures` for `admin`/`employee` (mirroring GL's `acl.ts`
-sync pattern). No `seedDefaults` hook — unlike GL's jurisdiction
-dictionaries, there is no system reference data to seed here;
+`defaultRoleFeatures` for `admin`/`employee`, split deliberately
+(2026-09-08, second review pass — the four-eyes fix has no teeth if
+this table isn't spelled out): `admin` gets all three features
+(`contractors.view`/`.manage`/`.approve`); `employee` gets
+`contractors.view`/`.manage` only, **not** `.approve` — the person who
+can register a vendor is, by default, never also the person who can
+approve one. This is the concrete wiring the `contractors.approve`
+feature (see Access Control, Design decisions) depends on; declaring
+the feature without this split would ship the four-eyes fix granted to
+nobody, or worse, silently re-bundled onto the same role as
+`contractors.manage`. Mirrors GL's `acl.ts` sync pattern otherwise. No
+`seedDefaults` hook — unlike GL's jurisdiction dictionaries, there is
+no system reference data to seed here;
 contractors are entirely tenant-authored.
 
 ### DI Registrar (`di.ts`)
@@ -569,7 +594,8 @@ review — see Changelog).
   unsets it on any other account for the same contractor (single
   invariant enforced in the command, not left to the client).
 - `checkBankAccountWhitelist` — **not a plain query**: first rejects
-  with a typed error, before any network call, if the contractor's
+  with `{ code: 'CONTRACTOR_NOT_APPROVED', approvalStatus }` (`422`,
+  see API Contracts), before any network call, if the contractor's
   `approvalStatus` is not `APPROVED` (see Design decisions,
   2026-09-08) — otherwise performs a live call to the Ministry of
   Finance's Biała Lista API for the given `accountNumber` and `nip`,
@@ -589,9 +615,13 @@ review — see Changelog).
   and nothing else (accepts no other fields). Registered separately in
   `registerWorkflowSafeCommands`, requires `contractors.approve`, a
   distinct feature from `contractors.manage` (see Design decisions,
-  2026-09-08) — and additionally rejects the decision if the acting
-  user equals the contractor's own `createdByUserId` (self-approval
-  guard, see Design decisions). **Deliberately not `updateContractor`**
+  2026-09-08) — and additionally rejects with `{ code:
+  'SELF_APPROVAL_NOT_ALLOWED' }` (`422`, surfaced through the generic
+  `POST /api/workflows/tasks/:id/complete` route's error passthrough —
+  this module has no dedicated approval route, see API Contracts) if
+  the acting user equals the contractor's own `createdByUserId`
+  (self-approval guard, see Design decisions). **Deliberately not
+  `updateContractor`**
   — see Design decisions
   ("`approveContractor`'s mechanism is now resolved") for the
   contradiction this avoids, mirroring AP's identical fix to the same
@@ -798,7 +828,11 @@ considered and dropped (see Design decisions).
 Confirmed in scope, 2026-09-08 (see Design decisions):
 `approvalStatus` (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`),
 `approvedByUserId`, `approvedAt` on this entity — also listed
-directly in Architecture → Entities.
+directly in Architecture → Entities. Added 2026-09-08, second review
+pass: `createdByUserId` (set once, at `createContractor` time, to the
+authenticated caller) — backs the self-approval guard on
+`applyContractorApprovalDecision` (see Design decisions, Commands),
+also listed directly in Architecture → Entities.
 
 Supporting index for the `contractors` list filters (see API
 Contracts / Queries-API): `(tenant_id, organization_id, is_vendor,
@@ -869,6 +903,12 @@ Custom write route (mutation guard registry, mapped to `update`).
   always the result of a live call made during this request, never a
   cached value.
 - **Response 403**: caller lacks `contractors.view`.
+- **Response 422 `CONTRACTOR_NOT_APPROVED`** (added 2026-09-08, second
+  review pass): `{ code: 'CONTRACTOR_NOT_APPROVED', approvalStatus }` —
+  `checkBankAccountWhitelist` rejected before making the live call
+  because the contractor's `approvalStatus` isn't `APPROVED` (see
+  Design decisions, Commands). Same shape convention as AP's
+  `FISCAL_PERIOD_LOCKED` (`2026-09-06-accounts-payable.md`).
 - **Response 502**: Biała Lista API unavailable — see Risks.
 
 ### Contractor approval — no dedicated route
@@ -890,7 +930,7 @@ exactly as `sales.order-approval` and
    migration (additive only). Add `encryption.ts` declaring
    `defaultEncryptionMaps` for both entities (`nip` with `hashField:
    'nip_hash'`, `account_number` on the bank account entity).
-2. Add `acl.ts` (two features) and `setup.ts`
+2. Add `acl.ts` (three features — `.view`/`.manage`/`.approve`) and `setup.ts`
    (`defaultRoleFeatures` for `admin`/`employee`); run
    `yarn mercato auth sync-role-acls`.
 3. Implement `createContractor` / `updateContractor` (NIP
@@ -942,10 +982,10 @@ exactly as `sales.order-approval` and
 | File | Action | Purpose |
 | --- | --- | --- |
 | `data/entities.ts` | Create | `Contractor`, `ContractorBankAccount` |
-| `migrations/MigrationXXXXXXXXXXXXXX.ts` | Create | Tables for both entities above |
+| `migrations/MigrationXXXXXXXXXXXXXX.ts` | Create | Tables for both entities above, plus the partial indexes `contractor_bank_account_one_primary_uq` and the `nip_hash` uniqueness index scoped `where deleted_at is null` (see Design decisions) |
 | `encryption.ts` | Create | `defaultEncryptionMaps` for `contractors:contractor` (incl. `nip` → `nip_hash`) and `contractors:contractor_bank_account` |
 | `di.ts` | Create | Registers `contractorBankWhitelistCheck` (`checkBankAccountWhitelist`) for cross-module resolution — see DI Registrar |
-| `acl.ts` | Create | Two `contractors.*` features |
+| `acl.ts` | Create | Three `contractors.*` features (`.view`/`.manage`/`.approve`) |
 | `setup.ts` | Create | `defaultRoleFeatures` for `admin`/`employee`; no `seedDefaults` |
 | `commands/contractors.ts` | Create | `createContractor` / `updateContractor` |
 | `commands/contractorBankAccounts.ts` | Create | `createContractorBankAccount` / `updateContractorBankAccount` / `checkBankAccountWhitelist` |
@@ -1210,7 +1250,7 @@ independently of AP, which does not yet exist.
 | `AGENTS.md` | No direct ORM relationships between modules | Compliant | `contractorSnapshot` on `JournalEntryLine` is a plain `json` copy, not a relation; AP will reference `Contractor` by FK-id only, never an ORM relation |
 | `AGENTS.md` | Filter by tenant/organization | Compliant | `Contractor` and `ContractorBankAccount` both carry their own `organizationId`/`tenantId`, matching the `sales.SalesInvoiceLine` precedent |
 | `AGENTS.md` | Write operations via Command pattern | Compliant | All mutations go through `createContractor`/`updateContractor`, `createContractorBankAccount`/`updateContractorBankAccount`, `checkBankAccountWhitelist` |
-| `AGENTS.md` / core `AGENTS.md` | Declarative feature guards; `acl.ts` synced to `setup.ts` | Compliant | Two `contractors.*` features, `defaultRoleFeatures` in `setup.ts`, `sync-role-acls` in Implementation Plan step 2 |
+| `AGENTS.md` / core `AGENTS.md` | Declarative feature guards; `acl.ts` synced to `setup.ts` | **Compliant (fixed 2026-09-08, second review pass)** | Three `contractors.*` features (`contractors.approve` added for four-eyes, see Design decisions) — `admin` gets all three, `employee` gets `.view`/`.manage` only, so approval always requires a different role than registration even within this repo's two-role default set; `defaultRoleFeatures` in `setup.ts`, `sync-role-acls` in Implementation Plan step 2 |
 | Core `AGENTS.md` § Database Entities | User-editable entities MUST include `updated_at` | Compliant | Both entities have `updatedAt`; `CrudForm` auto-derives the lock header |
 | Core `AGENTS.md` § Database Entities | Standard column contract includes `deleted_at` | Compliant | Both entities have `deletedAt` (soft delete); deletion of `Contractor` blocked only while an active `ContractorBankAccount` exists — a `JournalEntryLine`-based check was dropped, see Design decisions |
 | `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -202,18 +202,53 @@ snapshotting.
 registration + mandatory, live, on every payment.** A direct
 consequence of Art. 96b of the VAT Act.
 
-**Recommendation (not confirmed by evidence from the Event Storming
-wall or from SPEC-024): a light, one-step new-vendor approval step in
-Phase 1.** Adding a fake, nonexistent vendor to the system is a common
-invoice-fraud vector (someone impersonates a vendor, swaps the bank
-account) — a light approval of a new contractor before first use
-reduces this risk, and is consistent with the fact that Accounts
-Payable already has its own approval flow for invoices themselves.
-**This is a security proposal pending explicit sign-off from
-Łukasz/the team before implementation — it is not confirmed by source
-material.** Modeled below (Architecture/Commands/Backend Pages) so it
-can be cut without redesigning the rest of the module, if the team
-decides otherwise.
+**Resolved (2026-09-08): a light, one-step new-vendor approval gate
+is confirmed in scope for Phase 1.** This started as an unconfirmed
+recommendation (not backed by the Event Storming wall or SPEC-024) —
+it is now backed by explicit research done before committing to it,
+not assumption:
+
+- *What it adds, given the mandatory live Biała Lista check already
+  in Accounts Payable.* That check only confirms a NIP and a bank
+  account are registered together in the Ministry of Finance's
+  registry (Art. 96b VAT Act) — it says nothing about whether the
+  request that produced that data was genuine. A Polish industry
+  source ([ksbot.pl](https://ksbot.pl/bezpieczenstwo/ksef-bezpieczenstwo-bialy-wykaz-vat-a-oszustwo/))
+  is explicit that the whitelist alone is not sufficient protection
+  against invoice fraud, and recommends exactly the complementary
+  controls a human approval gate provides: independent-channel
+  verification of account changes, a four-eyes principle, and a
+  documented internal approval procedure. A one-step approval at
+  first use is that control at the *vendor-onboarding* moment
+  specifically — distinct from the *payment* moment, which the
+  mandatory live check already covers.
+- *The threat is real and growing, not hypothetical.* The three
+  vendor-fraud schemes documented by Trustpair — BEC/phishing
+  impersonating a supplier, an internal employee registering a
+  fictitious vendor, and a compromised real vendor requesting a
+  bank-detail change — all attack exactly the moment this gate sits
+  at (registering/first-using a contractor), and none is detectable
+  by a registry lookup. The AFP's 2025 Payments Fraud and Control
+  Survey found 45% of organizations hit by vendor-impersonation fraud
+  (up from 34% the prior year), against 63% hit by BEC overall, and
+  explicitly recommends streamlining vendor verification as a
+  control.
+- *This is standard industry practice, not a bespoke control.*
+  Segregating "who registers a vendor" from "who approves it for use"
+  is a textbook Purchase-to-Pay internal control; SAP Ariba's
+  supplier-onboarding module and ApprovalMax's dedicated "Vendor
+  Workflows" both ship it as a named feature, not an edge case.
+
+Decision: implement it as part of Phase 1, not defer it — the cost is
+low (the `workflows` engine already exists and is reused, not built
+new; see Workflow definition below) and it closes a documented gap the
+mandatory Biała Lista check does not close. This resolves the scope
+question every "pending team confirmation" marker below referred to;
+the mechanism itself was already resolved separately (see below).
+Final sign-off still happens through the normal PR review with
+Łukasz, same as every other decision in this document — this is no
+longer an unconfirmed proposal awaiting a business case, since the
+business case has now been made and documented (see Changelog).
 
 **Resolved (2026-09-07, after an independent scope-cohesion check):
 `approveContractor` stays threaded as a conditional through the same
@@ -225,19 +260,18 @@ it together. Rationale: in practice this isn't a separate,
 independently deployable capability — it concerns the same entity
 (`Contractor`), the same ACL feature (`contractors.manage`), and the
 same screen (contractor list/edit), so it naturally belongs to the
-same implementation cycle; if/when Łukasz/the team confirms this step,
-it should ship together with the rest of Phase 1, not as a separate
-follow-up. The per-section "pending team confirmation" markers stay —
-they, not a separate document, are what carries the "this isn't
-approved yet" signal.
+same implementation cycle — now confirmed (see the resolution
+above), it ships together with the rest of Phase 1, not as a separate
+follow-up. The per-section markers below are updated accordingly to
+no longer read as conditional on scope.
 
 **`approveContractor`'s mechanism is now resolved: the `workflows`
 engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`
 and `accounts_payable.invoice-approval` — not `useGuardedMutation`
 (2026-09-08, this round).** The scope question (whether this feature
-ships at all) stays pending Łukasz/the team's confirmation — this
-decision only settles *how* it would be built, once confirmed, so the
-document stops carrying a half-fixed citation (see Changelog,
+ships at all) is now resolved too (see above) — this decision
+settles *how* it is built, so the document stops carrying a
+half-fixed citation (see Changelog,
 "approval-pattern citation corrected," which removed the false GL
 comparison but left no replacement design). Verified directly: the
 repo's only implemented approve/reject precedent is
@@ -331,7 +365,8 @@ encrypted column without a hash doesn't work.
   lock), `deletedAt` (soft delete — per the standard column contract;
   deletion blocked if the contractor has any `JournalEntryLine`
   references via snapshot or any active `ContractorBankAccount`).
-  *If `approveContractor` is confirmed in scope*: `approvalStatus`
+  Confirmed in scope, 2026-09-08 (see Design decisions):
+  `approvalStatus`
   (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`), `approvedByUserId`,
   `approvedAt` — set only by `applyContractorApprovalDecision` from
   inside the workflow, never through `updateContractor` (see Design
@@ -412,7 +447,7 @@ review — see Changelog).
   sanctioned entry point for another module to call it synchronously
   in the same request; the HTTP route below wraps the same command
   only for this module's own backend UI.
-- `applyContractorApprovalDecision` — **pending team confirmation,
+- `applyContractorApprovalDecision` — **confirmed in scope,
   see Design decisions.** Called **only** from inside the
   `contractors.vendor-approval` workflow (not directly from the UI),
   via `UPDATE_ENTITY`, `PENDING_APPROVAL` → `APPROVED` or `REJECTED`
@@ -425,14 +460,14 @@ review — see Changelog).
 
 ### Events
 
-**One conditional event, only if `approveContractor` is confirmed in
-scope: `contractors.contractor.created` (persistent), emitted by
-`createContractor`.** Its sole purpose is triggering the
+**`contractors.contractor.created` (persistent), emitted by
+`createContractor` — confirmed in scope, 2026-09-08 (see Design
+decisions).** Its sole purpose is triggering the
 `contractors.vendor-approval` workflow (see Workflow definition) —
 exactly mirroring `sales.order.created` triggering
 `sales.order-approval`, not a general-purpose "contractor created"
-notification for other consumers. If the approval feature is cut,
-this event is cut with it; nothing else in this module needs it. AP
+notification for other consumers. This event exists solely for that
+trigger; nothing else in this module needs it. AP
 still consumes `Contractor`/`ContractorBankAccount` by resolving this
 module's `di.ts`-registered service directly (see DI Registrar and
 Cross-module integration below) at the moment it needs an answer —
@@ -444,8 +479,8 @@ cross-organization sharing).
 
 ### Workflow definition (`workflows.ts`)
 
-**Only ships if `approveContractor` is confirmed in scope** (see
-Design decisions). A 1:1 mirror of the `sales.order-approval` pattern
+**Confirmed in scope, 2026-09-08** (see Design decisions). A 1:1
+mirror of the `sales.order-approval` pattern
 (`packages/core/src/modules/sales/workflows.ts`) — not a new
 mechanism, the same one AP already adopted for its own invoice
 approval:
@@ -530,9 +565,8 @@ triggers on `sales.order.created`.
   integration path for AP. See Cross-module integration below.
 - **Removed 2026-09-08**: no dedicated approve route. See API
   Contracts, "Contractor approval — no dedicated route" — approval
-  now completes through the generic
-  `POST /api/workflows/tasks/:id/complete`, once `approveContractor`
-  is confirmed in scope.
+  (confirmed in scope, 2026-09-08) completes through the generic
+  `POST /api/workflows/tasks/:id/complete`.
 
 ### Cross-module integration
 
@@ -569,7 +603,7 @@ or hard-require the consumer."
   showing the UX-only "last checked: N days ago" badge, plus a
   "Verify now" button per row that calls the live-check route above
   and refreshes the badge.
-- Pending team confirmation: an injected approval-task widget at a
+- Confirmed in scope, 2026-09-08: an injected approval-task widget at a
   `contractors.contractor.detail:details` spot ID, visible when
   `approvalStatus === 'PENDING_APPROVAL'` and there's a task assigned
   to the current user. **Resolved 2026-09-08** (see Design decisions,
@@ -599,10 +633,10 @@ command, only surfaced in the UI. `deletedAt` blocks deletion while any
 active `ContractorBankAccount` exists (enforced in `updateContractor`'s
 delete path — see Commands).
 
-*If `approveContractor` is confirmed in scope:* add
+Confirmed in scope, 2026-09-08 (see Design decisions):
 `approvalStatus` (`PENDING_APPROVAL`/`APPROVED`/`REJECTED`),
-`approvedByUserId`, `approvedAt` to this entity — now also listed
-directly in Architecture → Entities (2026-09-08), not only here.
+`approvedByUserId`, `approvedAt` on this entity — also listed
+directly in Architecture → Entities.
 
 Supporting index for the `contractors` list filters (see API
 Contracts / Queries-API): `(tenant_id, organization_id, is_vendor,
@@ -680,8 +714,8 @@ route. Once the mechanism moved to the `workflows` engine, approval no
 longer needs a module-specific route — completing the decision goes
 through the existing, generic `POST /api/workflows/tasks/:id/complete`,
 exactly as `sales.order-approval` and
-`accounts_payable.invoice-approval` already do. Still pending team
-confirmation whether the feature ships at all (see Design decisions).
+`accounts_payable.invoice-approval` already do. Confirmed in scope,
+2026-09-08 (see Design decisions).
 
 ## Implementation Plan
 
@@ -715,9 +749,9 @@ confirmation whether the feature ships at all (see Design decisions).
    yet), so nothing has actually "landed" in running code; listed here
    only for traceability against the sibling spec.
 10. Regression + integration test coverage (see Testing Strategy).
-11. *If `approveContractor` is confirmed in scope* (pending team
-    confirmation, not deferred to Phase 2 — see Design decisions,
-    "stays threaded... same implementation cycle"): add `approvalStatus`/
+11. **Confirmed in scope, 2026-09-08** (not deferred to Phase 2 —
+    see Design decisions, "stays threaded... same implementation
+    cycle"): add `approvalStatus`/
     `approvedByUserId`/`approvedAt` to `Contractor`; implement
     `workflows.ts` (`contractors.vendor-approval`) and `events.ts`
     (`contractors.contractor.created`); implement
@@ -729,7 +763,7 @@ confirmation whether the feature ships at all (see Design decisions).
     implementation cycle once confirmed, not a separate follow-up —
     moved here.
 
-### Phase 2 (deferred, pending team confirmation)
+### Phase 2 (deferred)
 
 - A more elaborate multi-step/threshold-based approval, if the team
   decides the light, one-step version (Phase 1, step 11) isn't
@@ -754,10 +788,10 @@ confirmation whether the feature ships at all (see Design decisions).
 | `api/contractors/route.ts` | Create | `Contractor` CRUD (`makeCrudRoute`) |
 | `api/contractors/[id]/bank-accounts/route.ts` | Create | `ContractorBankAccount` CRUD (`makeCrudRoute`) |
 | `api/contractors/[id]/bank-accounts/[bankAccountId]/verify/route.ts` | Create | Live Biała Lista check |
-| `workflows.ts` | Create, conditional | **Only if `approveContractor` is confirmed in scope** — the `contractors.vendor-approval` definition, `registerWorkflowSafeCommands` on `applyContractorApprovalDecision` |
-| `events.ts` | Create, conditional | **Only if `approveContractor` is confirmed in scope** — `contractors.contractor.created`, the workflow's sole trigger |
-| `widgets/injection/vendor-approval/` | Create, conditional | **In `workflows`, not this module** — approval-task widget injected into `contractors.contractor.detail:details`, mirroring `workflows/widgets/injection/order-approval/` |
-| `commands/contractors.ts` | Update, conditional | Adds `applyContractorApprovalDecision`, called only from inside the workflow |
+| `workflows.ts` | Create | **Confirmed in scope, 2026-09-08** — the `contractors.vendor-approval` definition, `registerWorkflowSafeCommands` on `applyContractorApprovalDecision` |
+| `events.ts` | Create | **Confirmed in scope, 2026-09-08** — `contractors.contractor.created`, the workflow's sole trigger |
+| `widgets/injection/vendor-approval/` | Create | **In `workflows`, not this module** — approval-task widget injected into `contractors.contractor.detail:details`, mirroring `workflows/widgets/injection/order-approval/` |
+| `commands/contractors.ts` | Update | Adds `applyContractorApprovalDecision`, called only from inside the workflow |
 | `api/openapi.ts` | Create | `openApi` exports for every route above |
 | `backend/contractors/page.tsx` (+ create/[id]) | Create | List/create/edit UI with inline bank-account sub-list |
 | `commands/__tests__/*` | Create | Regression coverage |
@@ -785,7 +819,7 @@ confirmation whether the feature ships at all (see Design decisions).
   Regression test: seed a `ContractorBankAccount` with
   `lastVerifiedAt: now()`, call `checkBankAccountWhitelist`, assert the
   live API client was actually invoked.
-- *If `approveContractor` is confirmed in scope*: assert
+- Confirmed in scope, 2026-09-08: assert
   `applyContractorApprovalDecision` is only reachable through the
   `contractors.vendor-approval` workflow (via `registerWorkflowSafeCommands`),
   not directly callable to bypass the approval task, and that it moves
@@ -935,7 +969,7 @@ independently of AP, which does not yet exist.
 | `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |
 | `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | Compliant | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared |
 | `packages/queue/AGENTS.md` | Workers MUST be idempotent; MUST export `metadata: { queue, id?, concurrency? }` | Compliant | `verifyContractorRegistry.ts` follows the exact shape verified against `customers/workers/*.ts` |
-| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. **Resolved 2026-09-08** (superseding the 2026-09-07 correction, which only removed a false citation without replacing the design): the pending-confirmation approval step now uses the `workflows` engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`/`accounts_payable.invoice-approval`, not `useGuardedMutation` — consistent with the same principle already settled for `accounts_payable.invoice-approval`: a guarded row action is a real pattern only for a simple, reversible toggle (GL's fiscal-period lock/unlock), not a one-time approve/reject decision. See Design decisions, Workflow definition |
+| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. **Resolved 2026-09-08** (superseding the 2026-09-07 correction, which only removed a false citation without replacing the design): the approval step (confirmed in scope, 2026-09-08) now uses the `workflows` engine (`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval`/`accounts_payable.invoice-approval`, not `useGuardedMutation` — consistent with the same principle already settled for `accounts_payable.invoice-approval`: a guarded row action is a real pattern only for a simple, reversible toggle (GL's fiscal-period lock/unlock), not a one-time approve/reject decision. See Design decisions, Workflow definition |
 | `packages/core/AGENTS.md` → Command Side Effects | The workflow's own transition calls a command dedicated to that transition, not the entity's general-purpose update command | **Compliant (fixed this round)** | Carried over from AP's own fix to the identical latent issue in `sales.order-approval` (which reuses `sales.orders.update` for its transition): `applyContractorApprovalDecision` is a separate, narrow command, not `updateContractor` — see Design decisions |
 | `BACKWARD_COMPATIBILITY.md` | Database schema additive-only | Compliant | Two new tables only |
 | `packages/core/AGENTS.md` → Cross-Module Coupling | Optional-peer sync calls resolve via a local `tryResolve` in `try/catch`; never a hard `requires`; upstream MUST NOT resolve the consumer | **Compliant (fixed this round)** | Originally designed as a plain HTTP route AP would call — an independent review caught this as the wrong mechanism (no degrade path if `contractors` is disabled). Corrected: `checkBankAccountWhitelist` is now also registered in `di.ts`; AP resolves it via `tryResolve`; the HTTP route is now scoped to this module's own UI only. See DI Registrar, Cross-module integration, Risks & Impact Review. |
@@ -955,27 +989,37 @@ independently of AP, which does not yet exist.
 
 ### Non-Compliant Items
 
-None. One item is explicitly **not yet decided** rather than
-non-compliant: `approveContractor` (the one-step vendor approval
-workflow) is marked throughout as pending confirmation from
-Łukasz/the team — it is designed so it can be dropped without
-reworking any other section, not silently assumed as approved. Its
-*mechanism*, unlike its scope, is no longer undecided — see Design
-decisions and Workflow definition (2026-09-08).
+None. `approveContractor` (the one-step vendor approval workflow,
+now `applyContractorApprovalDecision`) was the one item carried as
+**not yet decided** in the prior round; both its scope and its
+mechanism are now resolved (2026-09-08) — see Design decisions,
+backed by explicit research (the AFP's 2025 Payments Fraud and
+Control Survey, the documented limits of the mandatory Biała Lista
+check, and existing ERP precedent in SAP Ariba/ApprovalMax). Final
+sign-off with Łukasz happens through the normal PR review, same as
+every other decision in this document.
 
 ### Verdict
 
-**Ready for maintainer review, with one item flagged for explicit
-team confirmation before implementation (not a compliance blocker):**
-whether the `approveContractor` one-step vendor acceptance workflow
-ships at all. Its mechanism, if it does, is now fully resolved
-(2026-09-08): the `workflows` engine (`defineWorkflow`/`USER_TASK`),
-1:1 with `sales.order-approval` and AP's own
-`accounts_payable.invoice-approval`, with the same dedicated-command
-departure AP made from `sales.order-approval`'s one latent issue (see
-Design decisions, Workflow definition) — replacing an earlier,
-half-finished correction that had removed a false citation
-("verified GL precedent") without replacing it with a real design.
+**Ready for maintainer review — no items outstanding.** The
+`approveContractor` one-step vendor acceptance workflow (now
+`applyContractorApprovalDecision`) is confirmed in scope for Phase 1
+(2026-09-08), on the strength of explicit research rather than
+assumption: the mandatory Biała Lista check already in Accounts
+Payable verifies NIP-to-account registry data but, per a documented
+Polish industry source, is explicitly not sufficient alone against
+invoice/vendor fraud, and the AFP's 2025 Payments Fraud and Control
+Survey found vendor-impersonation fraud at 45% of organizations
+surveyed (up from 34% the prior year) — a growing threat this gate
+targets specifically at the vendor-onboarding moment the whitelist
+check doesn't cover. The pattern mirrors existing ERP practice (SAP
+Ariba's supplier onboarding, ApprovalMax's Vendor Workflows) and this
+module's own sibling document, `2026-09-06-accounts-payable.md`. Its
+mechanism was resolved the same day: the `workflows` engine
+(`defineWorkflow`/`USER_TASK`), 1:1 with `sales.order-approval` and
+AP's own `accounts_payable.invoice-approval`, with the same
+dedicated-command departure AP made from `sales.order-approval`'s one
+latent issue (see Design decisions, Workflow definition).
 Every AGENTS.md rule checked is compliant — an independent review
 round (2026-09-07, second pass) found and fixed a real
 cross-module-coupling gap (`checkBankAccountWhitelist` was designed as
@@ -1146,3 +1190,49 @@ This round applies that same, now-proven resolution here:
   record the above. The scope question itself — whether
   `approveContractor` ships at all — remains unchanged: still pending
   Łukasz/the team's confirmation.
+
+### 2026-09-08 (cont. — business case for vendor approval resolved, scope confirmed)
+
+Following the mechanism resolution above (same day), the remaining
+open question — whether `approveContractor` ships at all — was
+resolved through explicit research rather than assumption, per an
+explicit request to properly answer what vendor approval means, how
+it should work, what it adds given the already-mandatory Biała Lista
+check, whether other systems have it, and whether it's worth
+implementing:
+
+- Confirmed the mandatory live Biała Lista check (Art. 96b VAT Act,
+  already in Accounts Payable) is explicitly documented as
+  insufficient alone against invoice/vendor fraud by a Polish
+  industry source
+  ([ksbot.pl](https://ksbot.pl/bezpieczenstwo/ksef-bezpieczenstwo-bialy-wykaz-vat-a-oszustwo/))
+  — it verifies NIP-to-account registry data only, not the
+  authenticity of the request, the legitimacy of the transaction, or
+  whether a registered company is itself a fraud front. The same
+  source recommends independent-channel verification, a four-eyes
+  principle, and a documented approval procedure — exactly what a
+  one-step approval gate provides at vendor onboarding.
+- Confirmed via Trustpair's vendor-fraud research that the three main
+  vendor-fraud schemes (BEC/phishing impersonation, internal
+  fictitious-vendor registration, and compromised-vendor bank-detail
+  changes) all target the vendor-registration/first-use moment, none
+  of which the whitelist check detects.
+- Confirmed via the AFP's 2025 Payments Fraud and Control Survey that
+  vendor-impersonation fraud hit 45% of organizations surveyed (up
+  from 34% the prior year) against 63% for BEC overall — a real,
+  growing threat class, not a hypothetical one.
+- Confirmed vendor-onboarding approval is standard, not bespoke,
+  practice in existing ERP/AP tooling (SAP Ariba's supplier
+  onboarding module, ApprovalMax's dedicated "Vendor Workflows"
+  feature).
+- Decision: implement the one-step approval gate as part of Phase 1
+  (not deferred). Updated Design decisions, Commands, Events,
+  Architecture → Entities, Backend Pages, Implementation Plan (step
+  11 and the Phase 2 heading), File Manifest, Testing Strategy,
+  Compliance Matrix, Non-Compliant Items, and Verdict to drop every
+  "pending team confirmation"/"conditional" marker tied to *scope* —
+  the mechanism markers (already resolved earlier the same day) were
+  untouched. Final sign-off with Łukasz still happens through the
+  normal PR review, same as every other decision in this document —
+  this was a recommendation backed by evidence, not a unilateral
+  decision.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -1,0 +1,905 @@
+# Contractor Registry — shared contractor registry (AP + AR)
+
+**Related:** [Accounts Payable](2026-09-06-accounts-payable.md) (consumer
+— vendors), sales-invoice-gl-posting (consumer — customers, indirectly
+through `sales`; **planned, not yet written** spec — see
+`2026-08-18-general-ledger-core-engine.md` Out of scope), [General
+Ledger core engine](2026-08-18-general-ledger-core-engine.md)
+(`JournalEntryLine` gets a new `contractorSnapshot` field from this
+spec)
+
+## TLDR
+
+One shared contractor registry module — tax-identity verification
+(GUS, VIES, VAT whitelist/Biała Lista), contact data, bank accounts as
+a separate entity, a light new-vendor approval step. Used both by
+Accounts Payable (vendors) and by the sales path (customers).
+
+## Overview
+
+`contractors` is a new, independent module modeling the **tax
+identity** of an entity the company does business with — as opposed
+to `customers`, which models the sales relationship (CRM, pipeline,
+deals). Consumers of this module: Accounts Payable staff (registering
+and verifying vendors before the first payment), accounting (a
+historical, immutable copy of contractor data on posted documents),
+and — indirectly, through the future `sales-invoice-gl-posting` — the
+sales path. Core value: one source of truth for a contractor, one
+GUS/VIES/Biała Lista verification regardless of whether the entity is
+a vendor, a customer, or both at once — instead of two, drifting
+copies of the same data in AP and AR.
+
+> **Market Reference**: The open-source reference studied was Odoo's
+> `res.partner` — a single partner entity with `customer_rank`/
+> `supplier_rank` flags instead of separate Customer/Vendor models,
+> exactly the same pattern as our `isVendor`/`isCustomer` below.
+> Rejected from Odoo: `res.partner` is also a CRM entity (shipping
+> addresses, contacts, portal access), which in our system is already
+> covered by `customers` — duplicating that in `contractors` would
+> duplicate `customers`' responsibility, so `contractors` deliberately
+> narrows itself to tax identity and verification, leaving CRM where
+> it already lives.
+
+## Problem Statement
+
+Today the repo has no module responsible for a contractor's tax
+identity. Checked directly against
+`packages/core/src/modules/customers`: this is a mature CRM module —
+person/company entities with a `kind` field (enum), a sales pipeline
+(deals), role assignment. Zero concept of a vendor, tax verification,
+or GUS/VIES/Biała Lista. "vendor" appears in this module only as free
+text in demo data (`cli.ts`) and as a sample value in one integration
+test (`__integration__/TC-CRM-078.spec.ts`) — `roleType` is a
+`z.string()` field (free text, not an enum; see `data/validators.ts`),
+so "vendor" isn't a recognized domain concept there, just a sample
+free-text value.
+
+All entities in `customers` carry both `organizationId` and
+`tenantId` (a separate `Tenant` lives in `modules/directory`), and
+none of them has a mechanism for sharing a single entity across
+organizations of the same tenant. (Exception in the repo: `ApiKey` has
+both fields `nullable` for tenant-/system-wide keys — but that's not a
+pattern for a domain, tenant/org-scoped entity like `Contractor`, just
+a deliberate exception for one, different use case.)
+
+**Conclusion:** `customers` models leads/clients from a CRM angle
+(sales pipeline), not a contractor's tax identity. Forcing
+GUS/VIES/Biała Lista onto the existing `CustomerEntity` would violate
+the module's single-responsibility principle.
+
+While writing `2026-09-06-accounts-payable.md` we recorded a Design
+Decision: "The contractor is a shared entity, not duplicated in AP and
+AR" — but AP itself doesn't design this registry, it just assumes one
+exists somewhere. Without this document, AP and the future, expanded
+AR module would risk two independent, drifting implementations of the
+same "contractor" concept.
+
+### Legal context — why contractor verification is a requirement at all
+
+**VAT Act, Art. 96b** — the Head of the National Revenue
+Administration maintains a public, electronic register of VAT
+taxpayers (the so-called Biała Lista / VAT whitelist), which includes
+bank account numbers reported by the taxpayer to the tax office.
+Paying into an account outside this register, for transactions above
+the PLN 15,000 threshold, exposes the payer (not just the invoice
+issuer) to joint-and-several liability for the contractor's VAT
+arrears — i.e. the paying company can be held liable for someone
+else's tax debt if it doesn't check the account before the transfer.
+Protection from this liability requires verification on the day the
+transfer is ordered — checking once, at contractor registration, is
+not enough.
+
+**Consequence for the project:** bank account verification against the
+Biała Lista must repeat at every payment, not just once at
+registration — this is not an open design question, it's a hard legal
+requirement.
+
+**GUS (Polish Central Statistical Office)** — the REGON register, used
+to verify that a given NIP (tax ID) corresponds to an existing,
+registered business entity, and to pull basic company data (name,
+address) without manual entry.
+
+**VIES (VAT Information Exchange System)** — the EU-wide VAT-number
+verification system, needed for transactions with contractors from
+other EU member states (to confirm the contractor is a registered
+VAT-UE taxpayer, which affects how an intra-Community transaction is
+settled).
+
+## Proposed Solution
+
+A new, independent `contractors` module with one `Contractor` entity
+(`isVendor`/`isCustomer` flags, GUS/VIES data, verification status)
+and a separate `ContractorBankAccount` entity (bank accounts, 0..N per
+contractor). GUS/VIES verification happens asynchronously through a
+queue (`@open-mercato/queue`), with a visible status
+(`PENDING`/`VERIFIED`/`FAILED`). Biała Lista verification is always
+**live** — on the day the transfer is ordered — and is never replaced
+by a cache. PII data (NIP, name, address, bank account, contact) is
+encrypted per the `encryption.ts` convention.
+
+### Design decisions (2026-09-07 — resolved)
+
+**Independent module, no integration with
+`packages/core/src/modules/customers`.** Rationale: see Problem
+Statement.
+
+**GUS/VIES verification: asynchronous, via `@open-mercato/queue`, with
+a status.** A `verificationStatus: PENDING | VERIFIED | FAILED` field
+on `Contractor`. Blocking contractor creation on the availability of an
+external API (GUS/VIES are sometimes unavailable) is bad practice.
+`createContractor` persists the contractor with status `PENDING` and
+enqueues `workers/verifyContractorRegistry.ts` (`metadata: { queue, id,
+concurrency }` per `packages/queue/AGENTS.md`), which calls GUS/VIES
+and updates the status. Idempotent — safe to retry.
+
+**One `Contractor` entity with `isVendor`/`isCustomer` flags.** The
+same entity is often both a vendor and a customer of the same company
+(e.g. we buy materials from someone we also sell services to) — one
+entity with non-exclusive flags avoids duplicating GUS/VIES/account
+data for the same NIP.
+
+**`NIP` is immutable once the contractor is created.** NIP is the
+identity key (hash-indexed, see below) and the basis for duplicate
+detection and historical snapshots on `JournalEntryLine`. Allowing a
+NIP change after the fact would undermine both mechanisms —
+`updateContractor` rejects a `nip` change regardless of whether the
+contractor already has linked documents (unlike GL's guards, which
+unlock editing as long as there are no posted entries — here the block
+is unconditional, because `nip` is identity, not an operational
+attribute). Changing the NIP requires creating a new contractor.
+
+**Contractor bank accounts: a separate `ContractorBankAccount` entity,
+not a field/array on `Contractor` (resolved after discussion on
+2026-09-07).** Three reasons: (1) the project checklist explicitly
+forbids `unbounded arrays`/`nested JSON blobs` in the schema; (2) the
+Biała Lista publishes a **list** of accounts registered for a given
+NIP — "one field" doesn't reflect reality, a contractor can legally
+have and use several accounts; (3) the same, proven pattern already
+used elsewhere in this repo as `JournalEntryLine`/`SalesInvoiceLine` —
+"a line owns its own scope" (`ContractorBankAccount` carries its own
+`organizationId`/`tenantId`, not just scope inherited via
+`contractorId`).
+
+**`ContractorBankAccount.lastVerifiedAt`/`lastVerificationStatus` is a
+UX cache only — it never replaces the mandatory, live verification at
+payment time, even if it's "fresh" (resolved after discussion on
+2026-09-07).** Two possible uses of the cache were considered: (A)
+purely informational — e.g. a "last checked: 3 days ago" badge on the
+contractor list, before anyone attempts to pay; (B) an optimization —
+skipping the live check at payment time if the cache is "fresh".
+**Chosen: (A) only.** (B) would directly violate the requirement in
+Art. 96b of the VAT Act ("on the day of transfer", not "within the
+last N days") — an account could have disappeared from the Biała
+Lista this morning, and yesterday's cache wouldn't catch that,
+restoring exactly the joint-liability risk this whole feature exists
+to eliminate. `checkBankAccountWhitelist` (see Commands) **always**
+performs a live call to the Biała Lista API, regardless of the cache
+value; the cache is updated as a side effect of every live check,
+never as its substitute.
+
+**History of contractor data changes: a snapshot on
+`JournalEntryLine`, not full versioning.** A contractor's NIP is
+fixed, but its name, address, and bank account can change over time.
+Without a safeguard, a contractor's bank account change would silently
+alter what's shown when browsing old, already-posted invoices — an
+audit problem. Solution: a `contractorSnapshot` field (`json`, matching
+the type declared in the GL core engine — see below) directly on
+`JournalEntryLine` in the GL core engine (#5663) — it records the
+name, NIP, account, and verification status exactly as of the moment
+the transaction was posted. This is the third field added to
+`JournalEntryLine` "just in case," in the same spirit as the earlier
+`referenceType`/`referenceId` (link to the source document) and
+`parentAccountId` (chart-of-accounts hierarchy) — a cheap, structural
+change on an empty/growing table, expensive to add later on a table
+with production data. **Who populates the snapshot and stores proof of
+a specific live check for a specific payment is Accounts Payable's
+job, not this module's** (see Out of scope); this module only provides
+`checkBankAccountWhitelist` as a callable service and
+`Contractor`/`ContractorBankAccount` as the source data for
+snapshotting.
+
+**Bank account verification against the Biała Lista: at account
+registration + mandatory, live, on every payment.** A direct
+consequence of Art. 96b of the VAT Act.
+
+**Recommendation (not confirmed by evidence from the Event Storming
+wall or from SPEC-024): a light, one-step new-vendor approval step in
+Phase 1.** Adding a fake, nonexistent vendor to the system is a common
+invoice-fraud vector (someone impersonates a vendor, swaps the bank
+account) — a light approval of a new contractor before first use
+reduces this risk, and is consistent with the fact that Accounts
+Payable already has its own approval flow for invoices themselves.
+**This is a security proposal pending explicit sign-off from
+Łukasz/the team before implementation — it is not confirmed by source
+material.** Modeled below (Architecture/Commands/Backend Pages) so it
+can be cut without redesigning the rest of the module, if the team
+decides otherwise.
+
+**Resolved (2026-09-07, after an independent scope-cohesion check):
+`approveContractor` stays threaded as a conditional through the same
+sections as the rest of the module, rather than being extracted into a
+separate document/block.** A fresh-context scope-cohesion check
+returned a SPLIT verdict for this item — the document itself admits it
+can be cut without redesigning the rest. Even so, the decision is: keep
+it together. Rationale: in practice this isn't a separate,
+independently deployable capability — it concerns the same entity
+(`Contractor`), the same ACL feature (`contractors.manage`), and the
+same screen (contractor list/edit), so it naturally belongs to the
+same implementation cycle; if/when Łukasz/the team confirms this step,
+it should ship together with the rest of Phase 1, not as a separate
+follow-up. The per-section "pending team confirmation" markers stay —
+they, not a separate document, are what carries the "this isn't
+approved yet" signal.
+
+**Registry is per-organization, not shared across a tenant's
+organizations.** No precedent for such a pattern for a domain,
+tenant/org-scoped entity in the code — the only nullable
+`organizationId` in the repo belongs to `ApiKey` (a deliberate
+exception for tenant-/system-wide API keys, not for domain entities
+like `Contractor`). Sharing a contractor across a tenant's
+organizations is new architecture, for which there is today neither a
+code precedent nor a confirmed business requirement — deliberately
+deferred (YAGNI) until it actually emerges as a requirement.
+
+**Encryption maps: two declarations, one per entity.**
+`contractors:contractor` encrypts `name`, `address`, `contact_email`,
+`contact_phone`; `nip` additionally gets `hashField: 'nip_hash'`
+(pattern: `messages:message.external_email` → `external_email_hash`,
+verified in `packages/core/src/modules/messages/encryption.ts`) —
+registration must detect a duplicate by NIP, and searching an
+encrypted column without a hash doesn't work.
+`contractors:contractor_bank_account` encrypts `account_number`
+(financial data, PII). Reads go through
+`findWithDecryption`/`findOneWithDecryption`, never hand-rolled crypto.
+
+### Alternatives considered
+
+| Alternative | Why Rejected |
+|-------------|---------------|
+| Extend `customers.CustomerEntity` with tax fields instead of a new module | Violates single responsibility — `customers` is CRM (pipeline, deals), not tax identity; GUS/VIES/Biała Lista is a completely different data lifecycle |
+| Separate `Vendor`/`Customer` entities instead of one `Contractor` with flags | Would duplicate GUS/VIES/account data for an entity that is simultaneously a vendor and a customer of the same company |
+| Contractor snapshot based on the future `journal_entry_line_dimension` instead of a field on `JournalEntryLine` | Would create a transitional audit gap — AP invoices posted before the Posting Rules Engine even exists would have no protection at all for contractor history |
+| Bank account as a single field/JSON array on `Contractor` | Violates the project's rule against unbounded arrays/nested JSON; doesn't reflect the reality of multiple registered accounts per NIP |
+| `lastVerifiedAt`/`lastVerificationStatus` as a shortcut skipping the live check when the cache is "fresh" | Directly violates Art. 96b of the VAT Act ("on the day of transfer"); restores the joint-liability risk this module exists to eliminate |
+| Sharing a contractor across a tenant's organizations | No precedent in the code and no confirmed business requirement — YAGNI |
+
+## User Stories
+
+- An AP staff member registers a new vendor by entering a NIP — the
+  system automatically pulls the name and address from GUS, with no
+  manual entry.
+- An AP staff member cannot approve a transfer to an account that is
+  not on the Biała Lista **today** — the system blocks the payment and
+  shows a warning about joint VAT liability risk, regardless of what
+  the cache showed the last time the contractor list was visited.
+- An accountant reviewing an invoice from six months ago sees exactly
+  the vendor's bank account as it was current on the day that invoice
+  was posted — even if the vendor later changed accounts.
+- The same entity can be registered simultaneously as a vendor (AP)
+  and a customer (AR) without duplicating its tax data.
+- An AP staff member sees on the contractor list when a given account
+  was last checked against the Biała Lista — as helpful information,
+  not as a guarantee of current status.
+
+## Architecture
+
+### Entities (`data/entities.ts`)
+
+- `Contractor` — `isVendor` (bool), `isCustomer` (bool), `name`,
+  `nip` (+ `nipHash` for lookup on the encrypted column, unique per
+  `(tenant_id, organization_id)` — duplicate detection), `address`,
+  `contactEmail`, `contactPhone`, `verificationStatus`
+  (`PENDING`/`VERIFIED`/`FAILED`), `gusData`/`viesData` (`jsonb`, the
+  raw response from the last check — diagnostics, not a source of
+  truth), tenant/org scoped, `updatedAt` (user-editable → optimistic
+  lock), `deletedAt` (soft delete — per the standard column contract;
+  deletion blocked if the contractor has any `JournalEntryLine`
+  references via snapshot or any active `ContractorBankAccount`).
+- `ContractorBankAccount` — `contractorId` (FK to `Contractor`),
+  `accountNumber` (encrypted), `isPrimary` (bool — exactly one primary
+  per contractor, enforced in the command), `lastVerifiedAt` (nullable,
+  UX cache — see Design decisions), `lastVerificationStatus`
+  (`WHITELISTED`/`NOT_WHITELISTED`/`UNKNOWN`, UX cache), its own
+  `organizationId`/`tenantId` (own scope columns, matching the
+  `JournalEntryLine`/`SalesInvoiceLine` precedent — see Design
+  decisions), `updatedAt`, `deletedAt` (soft "deactivate" rather than
+  actual deletion — account history has audit value).
+
+### Access Control (`acl.ts`)
+
+Following the `customers` module convention
+(`<module>.<resource>.view` / `.manage`, `manage` depends on `view`):
+
+```typescript
+export const features = [
+  { id: 'contractors.view', title: 'View contractors', module: 'contractors' },
+  { id: 'contractors.manage', title: 'Manage contractors', module: 'contractors', dependsOn: ['contractors.view'] },
+]
+```
+
+`createContractor`/`updateContractor`/`createContractorBankAccount`/
+`updateContractorBankAccount`/`approveContractor` require
+`contractors.manage`; `checkBankAccountWhitelist` requires
+`contractors.view` (read-only check, callable by anyone who can see
+the contractor — the actual payment-blocking decision belongs to AP's
+own guard, not to this module's ACL).
+
+### Module Setup (`setup.ts`)
+
+`defaultRoleFeatures` for `admin`/`employee` (mirroring GL's `acl.ts`
+sync pattern). No `seedDefaults` hook — unlike GL's jurisdiction
+dictionaries, there is no system reference data to seed here;
+contractors are entirely tenant-authored.
+
+### DI Registrar (`di.ts`)
+
+Registers `checkBankAccountWhitelist` as a resolvable service (DI
+token `contractorBankWhitelistCheck`) — this is what makes it usable
+as a synchronous, in-process cross-module call per
+`packages/core/AGENTS.md` → Cross-Module Coupling, instead of forcing
+a consumer into an HTTP round-trip to its own app for a same-request
+need (see Queries / API and Cross-module integration below for the
+resolved design; this was corrected during independent compliance
+review — see Changelog).
+
+### Commands (Command Pattern, `commands/`)
+
+- `createContractor` — validates NIP uniqueness (via `nipHash` lookup)
+  per `(tenant, organization)`, persists with `verificationStatus:
+  'PENDING'`, enqueues `verifyContractorRegistry` worker.
+- `updateContractor` — rejects any change to `nip` unconditionally
+  (see Design decisions); everything else editable; enforces
+  optimistic lock via `updated_at`.
+- `createContractorBankAccount` / `updateContractorBankAccount` —
+  standard CRUD; `isPrimary: true` on one account automatically
+  unsets it on any other account for the same contractor (single
+  invariant enforced in the command, not left to the client).
+- `checkBankAccountWhitelist` — **not a plain query**: performs a live
+  call to the Ministry of Finance's Biała Lista API for the given
+  `accountNumber` and `nip`, returns the fresh result to the caller,
+  and — as a side effect only — updates
+  `lastVerifiedAt`/`lastVerificationStatus` on the matching
+  `ContractorBankAccount` for UX display. Never reads
+  `lastVerifiedAt` to short-circuit the live call (see Design
+  decisions). Idempotent to call repeatedly. Registered in `di.ts` as
+  a resolvable service (see DI Registrar above) — this is the
+  sanctioned entry point for another module to call it synchronously
+  in the same request; the HTTP route below wraps the same command
+  only for this module's own backend UI.
+- `approveContractor` — **pending team confirmation, see Design
+  decisions.** One approver, binary decision (approve/reject),
+  mirroring AP's own one-step invoice approval. Sets
+  `approvalStatus`/`approvedByUserId`/`approvedAt` (fields added to
+  `Contractor` only if this command is confirmed in scope — see
+  Data Models note).
+
+### Events
+
+None declared in Phase 1. AP consumes `Contractor`/
+`ContractorBankAccount` by resolving this module's `di.ts`-registered
+service directly (see DI Registrar and Cross-module integration below)
+at the moment it needs an answer — payment approval and vendor
+registration are both synchronous, user-initiated flows, not something
+a downstream module needs to react to automatically after the fact.
+Revisit if a real asynchronous consumer emerges (YAGNI — matches the
+same reasoning already used for cross-organization sharing).
+
+### Queries / API
+
+- `api/contractors/route.ts` — standard `makeCrudRoute` CRUD
+  (list/create/update/soft-delete), filterable by `isVendor`,
+  `isCustomer`, `verificationStatus`. List/detail responses never
+  return raw `nip`/`accountNumber` in plaintext logs (decrypted only
+  for the authenticated, authorized caller via `findWithDecryption`).
+- `api/contractors/[id]/bank-accounts/route.ts` — standard
+  `makeCrudRoute` CRUD for `ContractorBankAccount`, scoped to the
+  parent contractor.
+- `api/contractors/[id]/bank-accounts/[bankAccountId]/verify/route.ts`
+  — custom write route (mapped to `update` in the mutation guard
+  registry) invoking `checkBankAccountWhitelist` synchronously and
+  returning the live result. This route backs only this module's own
+  backend UI (the per-row "verify now" button) — it is **not** the
+  integration path for AP. See Cross-module integration below.
+- `api/contractors/[id]/approve/route.ts` — pending team confirmation
+  (see Design decisions); custom write route calling `approveContractor`.
+
+### Cross-module integration
+
+AP does not call the HTTP route above at payment time. Per
+`packages/core/AGENTS.md` → Cross-Module Coupling, a same-request
+synchronous need on an optional peer resolves that peer's service
+locally via a `tryResolve`-in-`try/catch` helper (precedent:
+`inbox_ops/subscribers/extractionWorker.ts`,
+`shipping_carriers/api/webhook/[provider]/route.ts`) — never a hard
+`container.resolve(...)` and never an HTTP call to itself. AP's
+payment command resolves `contractorBankWhitelistCheck` (the DI token
+registered in this module's `di.ts`) this way and calls it in-process.
+Two distinct degradation cases follow from this, both resolving to the
+same policy (block the payment, never proceed without a live check —
+see Risks & Impact Review):
+- **`contractors` module disabled/absent** — `tryResolve` returns
+  `undefined`; AP's own guard treats a missing whitelist-check service
+  as "cannot verify," and blocks the payment.
+- **`contractors` module present, but the live Biała Lista API call
+  itself fails** — `checkBankAccountWhitelist` throws or returns an
+  error result; AP catches it and blocks the payment the same way.
+This module never imports or resolves anything belonging to AP —
+the dependency direction is one-way (AP → `contractors`), matching
+`packages/core/AGENTS.md`'s "upstream module MUST NOT import, resolve,
+or hard-require the consumer."
+
+### Backend Pages (`backend/contractors/`)
+
+- `contractors/page.tsx` (+ `create/page.tsx`, `[id]/page.tsx`) —
+  `DataTable` + `CrudForm` for `Contractor`; `nip` field disabled on
+  edit (immutable, see Design decisions).
+- `contractors/[id]/page.tsx` also lists the contractor's
+  `ContractorBankAccount` rows inline (own mini `DataTable`), each
+  showing the UX-only "last checked: N days ago" badge, plus a
+  "Verify now" button per row that calls the live-check route above
+  and refreshes the badge.
+- Pending team confirmation: an "Approve contractor" guarded row
+  action on the list, using `useGuardedMutation`, visible only for
+  contractors not yet approved — same interaction pattern as GL's
+  fiscal-period lock/unlock row action.
+
+## Data Models
+
+### Contractor
+
+One row per contractor. `nip`/`nipHash` unique per
+`(tenant_id, organization_id)` — enforces one registration per tax
+identity within an organization and backs duplicate detection at
+`createContractor`. `verificationStatus` starts `PENDING`, moves to
+`VERIFIED`/`FAILED` asynchronously via the `verifyContractorRegistry`
+worker. `gusData`/`viesData` store the raw response from the most
+recent check for diagnostics — never read as a source of truth by any
+command, only surfaced in the UI. `deletedAt` blocks deletion while any
+`JournalEntryLine.contractorSnapshot` references this contractor or any
+active `ContractorBankAccount` exists (enforced in `updateContractor`'s
+delete path — see Commands).
+
+*If `approveContractor` is confirmed in scope:* add
+`approvalStatus` (`PENDING`/`APPROVED`/`REJECTED`), `approvedByUserId`,
+`approvedAt` to this entity.
+
+Supporting index for the `contractors` list filters (see API
+Contracts / Queries-API): `(tenant_id, organization_id, is_vendor,
+is_customer, verification_status)` on `contractor` backs the
+`isVendor`/`isCustomer`/`verificationStatus` filters together (mirrors
+the composite-index approach in #5663's `journal_entry`/
+`journal_entry_line` indexes).
+
+### ContractorBankAccount
+
+One row per bank account registered for a contractor. `accountNumber`
+encrypted at rest. `isPrimary` — exactly one `true` per contractor,
+enforced by the command layer, not a database constraint (a partial
+unique index would work too but the command-level invariant is
+simpler and matches this repo's general preference for
+command-enforced business rules over database-level ones beyond raw
+integrity). `lastVerifiedAt`/`lastVerificationStatus` — UX cache only,
+written only as a side effect of `checkBankAccountWhitelist`, never
+read by any command to skip the live check (see Design decisions).
+Own `organizationId`/`tenantId` (see Design decisions).
+
+Supporting index: `(tenant_id, organization_id, contractor_id)` on
+`contractor_bank_account` backs the inline-list lookup from a
+contractor's detail page and the primary-account uniqueness check in
+`createContractorBankAccount`/`updateContractorBankAccount`.
+
+## API Contracts
+
+### `GET /api/contractors` / `POST /api/contractors`
+
+Standard `makeCrudRoute` list + create.
+
+- **Query**: `page?`, `pageSize?` (≤100), `isVendor?`, `isCustomer?`,
+  `verificationStatus?`.
+- **Create body**: `{ isVendor, isCustomer, name, nip, address,
+  contactEmail, contactPhone }`. `verificationStatus` not settable —
+  always starts `PENDING`.
+- **Response 403**: caller lacks `contractors.view` (list) or
+  `contractors.manage` (create).
+- **Response 409** (create): `nip` already registered for this
+  organization (duplicate, detected via `nipHash`).
+
+### `PUT /api/contractors/:id`
+
+Standard `makeCrudRoute` update.
+
+- **Response 400**: attempted change to `nip` — rejected
+  unconditionally (see Design decisions), distinct from GL's
+  posted-entries-gated immutability guards.
+- **Response 409**: `OptimisticLockConflictBody` on a stale
+  `updated_at`.
+
+### `GET /api/contractors/:id/bank-accounts` / `POST .../bank-accounts`
+
+Standard `makeCrudRoute` list + create, scoped to the parent
+contractor.
+
+- **Create body**: `{ accountNumber, isPrimary? }`.
+
+### `POST /api/contractors/:id/bank-accounts/:bankAccountId/verify`
+
+Custom write route (mutation guard registry, mapped to `update`).
+
+- **Response 200**: `{ status: 'WHITELISTED' | 'NOT_WHITELISTED', checkedAt: string }` —
+  always the result of a live call made during this request, never a
+  cached value.
+- **Response 403**: caller lacks `contractors.view`.
+- **Response 502**: Biała Lista API unavailable — see Risks.
+
+### `POST /api/contractors/:id/approve`
+
+Pending team confirmation (see Design decisions). Custom write route,
+`contractors.manage` required.
+
+## Implementation Plan
+
+### Phase 1: Core registry, verification, snapshotting
+
+1. Add `Contractor`, `ContractorBankAccount` entities and their
+   migration (additive only). Add `encryption.ts` declaring
+   `defaultEncryptionMaps` for both entities (`nip` with `hashField:
+   'nip_hash'`, `account_number` on the bank account entity).
+2. Add `acl.ts` (two features) and `setup.ts`
+   (`defaultRoleFeatures` for `admin`/`employee`); run
+   `yarn mercato auth sync-role-acls`.
+3. Implement `createContractor` / `updateContractor` (NIP
+   immutability, duplicate detection, optimistic lock).
+4. Implement `createContractorBankAccount` /
+   `updateContractorBankAccount` (single-`isPrimary` invariant).
+5. Implement the GUS/VIES integration as
+   `workers/verifyContractorRegistry.ts` (queue-backed, idempotent,
+   per `packages/queue/AGENTS.md`), enqueued from `createContractor`.
+6. Implement `checkBankAccountWhitelist` — live Biała Lista call,
+   never short-circuited by cache (see Design decisions).
+7. Implement `api/contractors/route.ts`, `.../bank-accounts/route.ts`,
+   `.../bank-accounts/[id]/verify/route.ts`, and `api/openapi.ts`
+   exporting `openApi` for every route above.
+8. Build backend pages: `contractors/` (list/create/edit) with the
+   inline bank-account sub-list and per-row "verify now" action.
+9. In #5663 (GL core engine): add `contractorSnapshot` (`json`,
+   nullable) to `JournalEntryLine` — **this is already specified in
+   #5663's own Design Decisions and File Manifest (2026-09-07)**, but
+   #5663 itself is still spec-only (no `ledger` module exists in code
+   yet), so nothing has actually "landed" in running code; listed here
+   only for traceability against the sibling spec.
+10. Regression + integration test coverage (see Testing Strategy).
+
+### Phase 2 (deferred, pending team confirmation)
+
+- `approveContractor` one-step approval flow, if confirmed — or a
+  more elaborate multi-step/threshold-based approval if the team
+  decides the light version isn't sufficient (mirrors AP's own
+  Phase 2 deferral of multi-step invoice approval).
+- Cross-organization contractor sharing, if a real business need
+  emerges (currently YAGNI — see Design decisions).
+
+### File Manifest
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `data/entities.ts` | Create | `Contractor`, `ContractorBankAccount` |
+| `migrations/MigrationXXXXXXXXXXXXXX.ts` | Create | Tables for both entities above |
+| `encryption.ts` | Create | `defaultEncryptionMaps` for `contractors:contractor` (incl. `nip` → `nip_hash`) and `contractors:contractor_bank_account` |
+| `di.ts` | Create | Registers `contractorBankWhitelistCheck` (`checkBankAccountWhitelist`) for cross-module resolution — see DI Registrar |
+| `acl.ts` | Create | Two `contractors.*` features |
+| `setup.ts` | Create | `defaultRoleFeatures` for `admin`/`employee`; no `seedDefaults` |
+| `commands/contractors.ts` | Create | `createContractor` / `updateContractor` |
+| `commands/contractorBankAccounts.ts` | Create | `createContractorBankAccount` / `updateContractorBankAccount` / `checkBankAccountWhitelist` |
+| `workers/verifyContractorRegistry.ts` | Create | Async GUS/VIES lookup, updates `verificationStatus` |
+| `api/contractors/route.ts` | Create | `Contractor` CRUD (`makeCrudRoute`) |
+| `api/contractors/[id]/bank-accounts/route.ts` | Create | `ContractorBankAccount` CRUD (`makeCrudRoute`) |
+| `api/contractors/[id]/bank-accounts/[bankAccountId]/verify/route.ts` | Create | Live Biała Lista check |
+| `api/openapi.ts` | Create | `openApi` exports for every route above |
+| `backend/contractors/page.tsx` (+ create/[id]) | Create | List/create/edit UI with inline bank-account sub-list |
+| `commands/__tests__/*` | Create | Regression coverage |
+| `__integration__/*` | Create | Integration coverage |
+
+### Testing Strategy
+
+- Assert the module-decoupling test
+  (`packages/core/src/__tests__/module-decoupling.test.ts`) passes with
+  `contractors` disabled, and that AP's own `tryResolve` wrapper around
+  `contractorBankWhitelistCheck` degrades to "block the payment" in
+  that case rather than throwing unhandled (see Cross-module
+  integration, Risks & Impact Review).
+- Assert `createContractor` rejects a duplicate `nip` within the same
+  `(tenant, organization)` (via `nipHash` lookup), and allows the same
+  `nip` across different organizations.
+- Assert `updateContractor` rejects any `nip` change, unconditionally
+  (not gated on any related data existing — unlike GL's guards).
+- Assert `createContractorBankAccount`/`updateContractorBankAccount`
+  enforce exactly one `isPrimary: true` per contractor.
+- **Assert `checkBankAccountWhitelist` always performs a live call and
+  never short-circuits based on `lastVerifiedAt` freshness** — this is
+  the single most safety-critical test in this module, given the
+  explicit rejection of cache-as-shortcut in Design decisions.
+  Regression test: seed a `ContractorBankAccount` with
+  `lastVerifiedAt: now()`, call `checkBankAccountWhitelist`, assert the
+  live API client was actually invoked.
+- Assert `verifyContractorRegistry` worker is idempotent — running it
+  twice for the same contractor does not duplicate or corrupt
+  `gusData`/`viesData`.
+- Assert encryption round-trip: `nip`/`address`/`contactEmail`/
+  `contactPhone`/`accountNumber` are stored encrypted and returned in
+  plaintext only through `findWithDecryption`.
+- Assert optimistic-lock 409 on `updateContractor`/
+  `updateContractorBankAccount` with a stale `updated_at`.
+- Integration: `GET /api/contractors` filters and 403s without
+  `contractors.view`; the verify route returns 200 with a fresh
+  `checkedAt` on each call (not a cached timestamp) and 502 when the
+  Biała Lista API is unavailable.
+
+## Risks & Impact Review
+
+### Data integrity failures
+
+- **Scenario**: two concurrent `createContractor` calls for the same
+  NIP within the same organization race past an application-level
+  uniqueness check before either commits.
+  **Severity**: Medium. **Affected area**: `Contractor` registration.
+  **Mitigation**: `nipHash` carries a `UNIQUE (tenant_id,
+  organization_id, nip_hash)` database constraint, not just an
+  application-level check — the second insert fails at the database
+  regardless of the race. **Residual risk**: none; this is exactly
+  the failure mode a DB unique constraint is for.
+- **Scenario**: `createContractorBankAccount` sets `isPrimary: true`
+  concurrently on two different accounts for the same contractor.
+  **Severity**: Low. **Affected area**: `ContractorBankAccount`.
+  **Mitigation**: command re-reads and unsets any existing primary
+  inside the same transaction as the insert/update. **Residual risk**:
+  a genuine race could still produce two primaries momentarily under
+  extreme concurrency (no DB-level partial unique index) — acceptable
+  for a low-frequency, human-initiated action; revisit if it proves to
+  matter in practice.
+
+### Cascading failures & side effects
+
+- **Scenario**: GUS or VIES API is down when `verifyContractorRegistry`
+  runs. **Severity**: Low. **Affected area**: `Contractor.verificationStatus`.
+  **Mitigation**: worker sets `verificationStatus: 'FAILED'`, queue
+  retry policy (per `@open-mercato/queue`) re-attempts later; contractor
+  remains usable (registration is never blocked on this — see Design
+  decisions) but AP's own workflow should surface unverified
+  contractors before payment. **Residual risk**: a contractor could
+  stay `FAILED` indefinitely if GUS/VIES are down long-term — no
+  automatic re-enqueue beyond the queue's own retry window; manual
+  re-trigger needed (out of scope for this document's Phase 1 UI).
+- **Scenario**: Biała Lista API is down at the exact moment AP needs
+  to execute a payment (AP has resolved `checkBankAccountWhitelist` via
+  `tryResolve` — see Cross-module integration — and the in-process call
+  itself fails). **Severity**: High (business-blocking, not
+  data-corrupting). **Affected area**: AP's payment execution flow.
+  **Mitigation**: `checkBankAccountWhitelist` throws/returns an error
+  result; AP is expected to block the payment rather than proceed
+  without a live check (this module cannot make that policy decision
+  for AP — noted explicitly as AP's own responsibility, see Out of
+  scope). **Residual risk**: legitimate payments could be delayed
+  during a Biała Lista outage; accepted as the safer failure mode given
+  the legal exposure of paying without verification.
+- **Scenario**: the `contractors` module itself is disabled or absent
+  when AP tries to resolve `contractorBankWhitelistCheck`.
+  **Severity**: High (business-blocking). **Affected area**: AP's
+  payment execution flow. **Mitigation**: AP's local `tryResolve`
+  wrapper (per `packages/core/AGENTS.md` → Cross-Module Coupling)
+  returns `undefined` instead of throwing; AP treats a missing service
+  identically to a failed live check — block the payment. Covered by
+  `packages/core/src/__tests__/module-decoupling.test.ts` per repo
+  convention (see Testing Strategy). **Residual risk**: none identified
+  — this is the sanctioned degrade-gracefully path, not a gap.
+
+### Tenant & data isolation
+
+`Contractor` and `ContractorBankAccount` are both tenant/organization
+scoped, with `ContractorBankAccount` carrying its own scope columns
+rather than relying only on a join through `contractorId` (matching
+the `JournalEntryLine`/`SalesInvoiceLine` precedent — see Design
+decisions). No cross-organization sharing exists in Phase 1 (YAGNI,
+see Design decisions), so there is no shared/global resource for a
+noisy-neighbor scenario to exploit.
+
+### Migration & deployment
+
+Additive only — two new tables (with the indexes named in Data
+Models), no changes to existing schema (except the
+`JournalEntryLine.contractorSnapshot` (`json`, nullable) addition
+already specified in #5663's own design — see Implementation Plan
+step 9). #5663 is itself still spec-only (not yet implemented), so
+this module's Phase 1 does not have a hard runtime dependency on it;
+it becomes relevant once GL is actually implemented. Safe to deploy
+independently of AP, which does not yet exist.
+
+## Out of scope (tracked separately)
+
+- **Attaching a specific verification result to a specific payment
+  for legal audit trail.** This module exposes
+  `checkBankAccountWhitelist` as a callable, live check — persisting
+  its result against a particular payment/invoice record is Accounts
+  Payable's concern (AP owns the "payment" concept; this module does
+  not know what a payment is).
+- **Multi-step or threshold-based vendor approval.** Phase 2, pending
+  the same team confirmation as the Phase 1 one-step version — see
+  Design decisions.
+- **Cross-organization contractor sharing.** YAGNI — no precedent in
+  the codebase, no confirmed business requirement (see Design
+  decisions).
+- **Purchase order / three-way matching, invoice lifecycle, payment
+  execution.** Accounts Payable's concern, not this module's.
+- **`journal_entry_line_dimension` (cost-center/MPK tagging).**
+  Separate, earlier-sequenced document; unrelated to contractor
+  identity.
+- **Full historical versioning of contractor data.** Deliberately
+  replaced by the `JournalEntryLine.contractorSnapshot` point-in-time
+  copy (see Design decisions) — no separate audit-log table for every
+  field change.
+
+## Final Compliance Report — 2026-09-07
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md` (root)
+- `packages/core/AGENTS.md`
+- `.ai/docs/module-development.md`
+- `packages/core/src/modules/customers/AGENTS.md`
+- `packages/queue/AGENTS.md`
+- `packages/cache/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `.ai/qa/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+| --- | --- | --- | --- |
+| `AGENTS.md` | No direct ORM relationships between modules | Compliant | `contractorSnapshot` on `JournalEntryLine` is a plain `json` copy, not a relation; AP will reference `Contractor` by FK-id only, never an ORM relation |
+| `AGENTS.md` | Filter by tenant/organization | Compliant | `Contractor` and `ContractorBankAccount` both carry their own `organizationId`/`tenantId`, matching the `sales.SalesInvoiceLine` precedent |
+| `AGENTS.md` | Write operations via Command pattern | Compliant | All mutations go through `createContractor`/`updateContractor`, `createContractorBankAccount`/`updateContractorBankAccount`, `checkBankAccountWhitelist` |
+| `AGENTS.md` / core `AGENTS.md` | Declarative feature guards; `acl.ts` synced to `setup.ts` | Compliant | Two `contractors.*` features, `defaultRoleFeatures` in `setup.ts`, `sync-role-acls` in Implementation Plan step 2 |
+| Core `AGENTS.md` § Database Entities | User-editable entities MUST include `updated_at` | Compliant | Both entities have `updatedAt`; `CrudForm` auto-derives the lock header |
+| Core `AGENTS.md` § Database Entities | Standard column contract includes `deleted_at` | Compliant | Both entities have `deletedAt` (soft delete); deletion of `Contractor` blocked while snapshot references or active bank accounts exist |
+| `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |
+| `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | Compliant | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared |
+| `packages/queue/AGENTS.md` | Workers MUST be idempotent; MUST export `metadata: { queue, id?, concurrency? }` | Compliant | `verifyContractorRegistry.ts` follows the exact shape verified against `customers/workers/*.ts` |
+| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`; the pending-confirmation "approve" row action follows the same guarded-row-action pattern already verified for GL's fiscal-period lock/unlock |
+| `BACKWARD_COMPATIBILITY.md` | Database schema additive-only | Compliant | Two new tables only |
+| `packages/core/AGENTS.md` → Cross-Module Coupling | Optional-peer sync calls resolve via a local `tryResolve` in `try/catch`; never a hard `requires`; upstream MUST NOT resolve the consumer | **Compliant (fixed this round)** | Originally designed as a plain HTTP route AP would call — an independent review caught this as the wrong mechanism (no degrade path if `contractors` is disabled). Corrected: `checkBankAccountWhitelist` is now also registered in `di.ts`; AP resolves it via `tryResolve`; the HTTP route is now scoped to this module's own UI only. See DI Registrar, Cross-module integration, Risks & Impact Review. |
+| Checklist § Performance | Every query pattern names its supporting index | **Compliant (fixed this round)** | Missing from the first draft of this expansion; added to Data Models for both entities' list/lookup filters. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Data models match architecture | Pass | Entities in Architecture and Data Models agree |
+| API contracts match data models | Pass | Every documented field/filter has a backing column; no `periodId`-style undesigned filter (learned directly from #5663's independent review this same day) |
+| Commands defined for all mutations | Pass | Every entity and every side-effecting check (`checkBankAccountWhitelist`) has a named command |
+| Risks cover all write operations | Pass | Registration race, primary-account race, GUS/VIES outage, Biała Lista outage all addressed |
+| Scope cohesion vs. other modules | Pass | Single capability (contractor tax identity + verification), independently deployable without AP or AR existing — verified by construction: this document has zero write path into any other module's tables |
+| Scope cohesion *within* this document | Pass | A fresh-context scope-cohesion check flagged `approveContractor` as bundled-but-severable; resolved 2026-09-07 as a deliberate choice to keep it threaded through the same sections (same entity, same ACL feature, same screen) rather than split into a separate document — see Design decisions |
+| Encryption maps declared before any PII column ships | Pass | Both entities' encryption maps written in the same Implementation Plan step as their migration (step 1), not deferred |
+
+### Non-Compliant Items
+
+None. One item is explicitly **not yet decided** rather than
+non-compliant: `approveContractor` (the one-step vendor approval
+workflow) is marked throughout as pending confirmation from
+Łukasz/the team — it is designed so it can be dropped without
+reworking any other section, not silently assumed as approved.
+
+### Verdict
+
+**Ready for maintainer review, with one item flagged for explicit
+team confirmation before implementation (not a compliance blocker):**
+the `approveContractor` one-step vendor acceptance workflow. Every
+AGENTS.md rule checked is compliant — an independent review round
+(2026-09-07, second pass) found and fixed a real cross-module-coupling
+gap (`checkBankAccountWhitelist` was designed as an HTTP-only call with
+no degrade path; now also a `di.ts`-resolvable service behind
+`tryResolve`) and a missing supporting-index gap (now added to Data
+Models), and corrected several factual citation errors (see Changelog).
+A separate scope-cohesion check flagged `approveContractor` as
+bundled-but-severable; resolved as a deliberate choice to keep it
+threaded through the same sections rather than split out (see Design
+decisions). The two design decisions worked through with the team
+earlier this session — `ContractorBankAccount` as its own entity, and
+its verification cache as strictly UX-only, never a compliance
+shortcut — remain fully threaded through Design decisions, Data
+Models, Commands, Testing Strategy, and Risks. This document unblocks
+the full expansion of `2026-09-06-accounts-payable.md`, which already
+assumed this registry's existence.
+
+## Changelog
+
+### 2026-09-06
+
+- Initial specification: TLDR, legal context (Art. 96b, GUS, VIES),
+  research into the `customers` module, Design Decisions (resolved),
+  User Stories, Implementation Plan (sketch).
+
+### 2026-09-07
+
+- Full expansion to the `om-spec-writing` template: added Overview,
+  formalized Problem Statement, Proposed Solution (with Alternatives
+  considered), full Architecture (Entities/Access Control/Module
+  Setup/Commands/Events/Queries-API/Backend Pages), Data Models, API
+  Contracts, full Implementation Plan with File Manifest and Testing
+  Strategy, Risks & Impact Review, Out of scope, Final Compliance
+  Report.
+- Resolved, after discussion: `ContractorBankAccount` is a separate
+  entity (own tenant/org scope columns), not a field/array on
+  `Contractor` — matches the `JournalEntryLine`/`SalesInvoiceLine`
+  "line has its own scope" precedent and avoids the project's
+  anti-pattern of unbounded arrays/nested JSON.
+- Resolved, after discussion: `ContractorBankAccount.lastVerifiedAt`/
+  `lastVerificationStatus` is strictly a UX cache — `checkBankAccountWhitelist`
+  always performs a live Biała Lista check and never short-circuits on
+  cache freshness, per Art. 96b's "on the day of transfer" requirement.
+  Flagged as the single most safety-critical test in Testing Strategy.
+- Added `NIP` immutability as an explicit Design Decision (unconditional,
+  unlike GL's posted-entries-gated guards) — was implicit before, now
+  a named invariant with its own test.
+- Clarified module boundary: this document exposes
+  `checkBankAccountWhitelist` as a callable service; attaching its
+  result to a specific payment for legal audit-trail purposes belongs
+  to Accounts Payable, not this module (added to Out of scope).
+
+### 2026-09-07 (cont. — independent review round)
+
+- Independent compliance/checklist review (fresh-context subagent,
+  re-verified against source, not the spec's own citations) found and
+  fixed: (1) a real cross-module-coupling gap — `checkBankAccountWhitelist`
+  was designed as a plain HTTP route with no degrade path if `contractors`
+  is disabled; corrected to also be a `di.ts`-resolvable service that AP
+  reaches via a local `tryResolve` wrapper, per `packages/core/AGENTS.md`
+  → Cross-Module Coupling (new DI Registrar subsection; Events,
+  Queries/API, Risks & Impact Review, File Manifest, Testing Strategy all
+  updated to match); (2) a missing supporting-index for both entities'
+  list/lookup filters (added to Data Models, mirroring #5663's index
+  documentation style); (3) an overclaimed "`organizationId` is nowhere
+  nullable in the whole repo" citation (refuted by `ApiKey`; narrowed to
+  the accurate claim about tenant/org-scoped domain entities); (4) an
+  inaccurate "only occurrence of 'vendor'" citation in Problem Statement;
+  (5) a real cross-spec inconsistency — this document typed
+  `JournalEntryLine.contractorSnapshot` as `jsonb` and claimed it "already
+  landed," when #5663 itself specifies `json` and is still spec-only, not
+  implemented; (6) a stale/incorrect citation of a nonexistent
+  `packages/core/src/modules/messages/AGENTS.md` file in the Final
+  Compliance Report's file list. Two candidate findings were investigated
+  and ruled out as non-issues after checking real precedent: the
+  `contractors.view`/`contractors.manage` ACL feature IDs (bare
+  `<module>.<action>`, not `<module>.<resource>.<action>`) exactly match
+  the documented convention in `packages/core/AGENTS.md` §RBAC and the
+  real `currencies.view`/`currencies.manage` precedent; and the absence of
+  a `packages/cache/AGENTS.md`-style caching-strategy section is not a gap,
+  since that file governs *how* to use the cache service when one is
+  added, not a mandate that every list endpoint must add one.
+- A separate, narrow fresh-context scope-cohesion check (same protocol as
+  #5663's Q2) returned **SPLIT**: not for the module's core (tax identity
+  + GUS/VIES + bank accounts + Biała Lista verification, judged cohesive),
+  but specifically for `approveContractor`, which the document itself
+  already flags as severable yet threads as a conditional through five
+  separate sections instead of isolating it. Per `spec-checklist.md`, a
+  SPLIT verdict goes back to the maintainer as an open question, not an
+  automatic rewrite — recorded as **Q1** (pending resolution).
+
+### 2026-09-07 (cont. — Q1 resolved)
+
+- Resolved Q1 (scope-cohesion SPLIT finding on `approveContractor`):
+  keep it threaded through the same sections as the rest of the module
+  (Architecture → Commands, Data Models, Queries/API, Backend Pages,
+  Implementation Plan) rather than extracting it into a separate
+  "proposal" block. Decision: it shares the same entity (`Contractor`),
+  the same ACL feature (`contractors.manage`), and the same screen
+  (contractor list/edit) as the rest of Phase 1, so it belongs to the
+  same implementation cycle once confirmed — not a separate follow-up.
+  The per-section "pending team confirmation" flags remain the
+  mechanism that signals it isn't approved yet. Folded into Design
+  decisions; removed the temporary Open Questions section;
+  Internal Consistency Check and Verdict rewritten to be unconditional
+  again.
+- Translated the full document from Polish to English (matching
+  #5663's language) ahead of committing to git.

--- a/.ai/specs/2026-09-06-contractor-registry.md
+++ b/.ai/specs/2026-09-06-contractor-registry.md
@@ -440,8 +440,13 @@ or hard-require the consumer."
   and refreshes the badge.
 - Pending team confirmation: an "Approve contractor" guarded row
   action on the list, using `useGuardedMutation`, visible only for
-  contractors not yet approved — same interaction pattern as GL's
-  fiscal-period lock/unlock row action.
+  contractors not yet approved. **Correction (2026-09-07):** this is
+  a deliberate Phase-1 simplification, not a verified precedent — see
+  the Compliance Matrix note below. If `approveContractor` is
+  confirmed in scope, revisit against the workflow-engine pattern
+  (`defineWorkflow`/`USER_TASK`, as used by `sales.order-approval`)
+  before committing to `useGuardedMutation` for a real approve/reject
+  decision.
 
 ## Data Models
 
@@ -765,7 +770,7 @@ independently of AP, which does not yet exist.
 | `packages/core/AGENTS.md` → API Routes | All API route files MUST export `openApi` | Compliant | `api/openapi.ts` in File Manifest and Implementation Plan step 7, covering every route in this module |
 | `packages/core/AGENTS.md` → Encryption | GDPR/PII fields declared in `<module>/encryption.ts`, read via `findWithDecryption` | Compliant | `contractors:contractor` (name, address, contact, `nip`+`nipHash`) and `contractors:contractor_bank_account` (`account_number`) both declared |
 | `packages/queue/AGENTS.md` | Workers MUST be idempotent; MUST export `metadata: { queue, id?, concurrency? }` | Compliant | `verifyContractorRegistry.ts` follows the exact shape verified against `customers/workers/*.ts` |
-| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`; the pending-confirmation "approve" row action follows the same guarded-row-action pattern already verified for GL's fiscal-period lock/unlock |
+| `packages/ui/AGENTS.md` | `CrudForm`/`DataTable`; guarded row actions via `useGuardedMutation` | Compliant | Contractor list/create/edit use `CrudForm`+`DataTable`. The pending-confirmation "approve" row action is drafted as a `useGuardedMutation` toggle — **corrected 2026-09-07:** this document originally claimed parity with "GL's fiscal-period lock/unlock row action," but that comparison doesn't hold: the repo's only implemented approve/reject precedent (`sales.order-approval`) uses a full workflow (`defineWorkflow`/`USER_TASK`), not a guarded row action. `useGuardedMutation` here is now flagged as an unverified Phase-1 shortcut, to revisit against the workflow-engine pattern if `approveContractor` is confirmed in scope, not cited as an already-proven pattern |
 | `BACKWARD_COMPATIBILITY.md` | Database schema additive-only | Compliant | Two new tables only |
 | `packages/core/AGENTS.md` → Cross-Module Coupling | Optional-peer sync calls resolve via a local `tryResolve` in `try/catch`; never a hard `requires`; upstream MUST NOT resolve the consumer | **Compliant (fixed this round)** | Originally designed as a plain HTTP route AP would call — an independent review caught this as the wrong mechanism (no degrade path if `contractors` is disabled). Corrected: `checkBankAccountWhitelist` is now also registered in `di.ts`; AP resolves it via `tryResolve`; the HTTP route is now scoped to this module's own UI only. See DI Registrar, Cross-module integration, Risks & Impact Review. |
 | Checklist § Performance | Every query pattern names its supporting index | **Compliant (fixed this round)** | Missing from the first draft of this expansion; added to Data Models for both entities' list/lookup filters. |
@@ -903,3 +908,21 @@ assumed this registry's existence.
   again.
 - Translated the full document from Polish to English (matching
   #5663's language) ahead of committing to git.
+
+### 2026-09-07 (cont. — approval-pattern citation corrected)
+
+- Cross-module verification while drafting Accounts Payable's own
+  invoice-approval design found this document's Compliance Matrix and
+  Backend Pages sections overclaiming: the "approve contractor" row
+  action was described as following "the same guarded-row-action
+  pattern already verified for GL's fiscal-period lock/unlock." That
+  citation doesn't hold — the repo's only implemented approve/reject
+  precedent (`sales.order-approval`) uses a full workflow engine
+  (`defineWorkflow`/`USER_TASK`), not `useGuardedMutation`; the GL
+  lock/unlock action is a simple reversible toggle, not a one-time
+  approve/reject decision, so it isn't the right comparison either.
+  Both sections corrected to flag `useGuardedMutation` here as an
+  unverified Phase-1 simplification instead of a proven pattern.
+  `approveContractor` remains pending team confirmation either way —
+  this changes only how its eventual mechanism is justified, not its
+  scope status.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -49,6 +49,8 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 
 | SPEC | Date | Title | Description |
 | --- | --- | --- | --- |
+| [Contractor Registry](2026-09-06-contractor-registry.md) | 2026-09-06 | Contractor Registry | Shared registry for contractor tax identity (NIP/GUS/VIES) and bank accounts, with mandatory live VAT-whitelist (Biała Lista) verification at every payment per Art. 96b, plus a workflow-based new-vendor approval gate — consumed by Accounts Payable and the future AR path; deliberately excludes CRM (stays in `customers`) and payment execution (stays in AP); **moved here 2026-09-08 — not yet merged, PR #5955** |
+| [Contractor Registry — Implementation Guide](2026-09-06-contractor-registry-implementation-guide.md) | 2026-09-06 | Contractor Registry — Implementation Guide | Short build-order companion to the full spec: entity cheat sheet, one worked vendor-registration-to-payment flow, and the pitfalls (DI-resolvable whitelist check vs. HTTP-only, cache-never-shortcuts-live-check, unconditional NIP immutability, the ledger-facing delete guard that was removed) a developer implementing it needs to know upfront; **moved here 2026-09-08 — not yet merged, PR #5955** |
 | [SPEC-008](SPEC-008-2026-01-27-product-quality-widget.md) | 2026-01-27 | Product Quality Widget | Dashboard widget for tracking products with missing images/descriptions |
 | [SPEC-012](implemented/SPEC-012-2026-01-27-ai-assistant-schema-discovery.md) | 2026-01-27 | AI Assistant Schema Discovery | Entity schema extraction and OpenAPI integration for MCP tools |
 | [SPEC-018](implemented/SPEC-018-2026-02-05-safe-entity-flush.md) | 2026-02-05 | Atomic Phased Flush | `withAtomicFlush` — N-phase flush pipeline with optional transactions to prevent UoW data loss and partial commits |
@@ -205,8 +207,6 @@ Fully implemented and deployed. Canonical files live in [`implemented/`](impleme
 | [SPEC-066](implemented/SPEC-066-2026-03-15-official-modules-changesets-release-workflow.md) | 2026-03-15 | Official Modules Changesets Release Workflow | Changesets-based release workflow for official modules |
 | [Checkout Pay Links](implemented/2026-03-19-checkout-pay-links.md) | 2026-03-19 | Checkout Pay Links | Pay link generation and checkout flow (Phase A) |
 | [Checkout Wireframes](implemented/2026-03-19-checkout-pay-links-wireframes.md) | 2026-03-19 | Checkout Pay Links Wireframes | Companion wireframes for the Checkout Pay Links spec |
-| [Contractor Registry](2026-09-06-contractor-registry.md) | 2026-09-06 | Contractor Registry | Shared registry for contractor tax identity (NIP/GUS/VIES) and bank accounts, with mandatory live VAT-whitelist (Biała Lista) verification at every payment per Art. 96b — consumed by Accounts Payable and the future AR path; deliberately excludes CRM (stays in `customers`) and payment execution (stays in AP) |
-| [Contractor Registry — Implementation Guide](2026-09-06-contractor-registry-implementation-guide.md) | 2026-09-06 | Contractor Registry — Implementation Guide | Short build-order companion to the full spec: entity cheat sheet, one worked vendor-registration-to-payment flow, and the pitfalls (DI-resolvable whitelist check vs. HTTP-only, cache-never-shortcuts-live-check, unconditional NIP immutability) a developer implementing it needs to know upfront |
 
 ## Specification Structure
 

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -205,6 +205,8 @@ Fully implemented and deployed. Canonical files live in [`implemented/`](impleme
 | [SPEC-066](implemented/SPEC-066-2026-03-15-official-modules-changesets-release-workflow.md) | 2026-03-15 | Official Modules Changesets Release Workflow | Changesets-based release workflow for official modules |
 | [Checkout Pay Links](implemented/2026-03-19-checkout-pay-links.md) | 2026-03-19 | Checkout Pay Links | Pay link generation and checkout flow (Phase A) |
 | [Checkout Wireframes](implemented/2026-03-19-checkout-pay-links-wireframes.md) | 2026-03-19 | Checkout Pay Links Wireframes | Companion wireframes for the Checkout Pay Links spec |
+| [Contractor Registry](2026-09-06-contractor-registry.md) | 2026-09-06 | Contractor Registry | Shared registry for contractor tax identity (NIP/GUS/VIES) and bank accounts, with mandatory live VAT-whitelist (Biała Lista) verification at every payment per Art. 96b — consumed by Accounts Payable and the future AR path; deliberately excludes CRM (stays in `customers`) and payment execution (stays in AP) |
+| [Contractor Registry — Implementation Guide](2026-09-06-contractor-registry-implementation-guide.md) | 2026-09-06 | Contractor Registry — Implementation Guide | Short build-order companion to the full spec: entity cheat sheet, one worked vendor-registration-to-payment flow, and the pitfalls (DI-resolvable whitelist check vs. HTTP-only, cache-never-shortcuts-live-check, unconditional NIP immutability) a developer implementing it needs to know upfront |
 
 ## Specification Structure
 


### PR DESCRIPTION
## Summary

Adds the `2026-09-06-contractor-registry.md` spec for a new,
independent `contractors` module: shared registry of contractor tax
identity (NIP, GUS/VIES verification) and bank accounts, with
mandatory live VAT-whitelist (Biała Lista) verification at every
payment per Art. 96b of the VAT Act. Consumed by Accounts Payable
(`2026-09-06-accounts-payable.md`) and, later, the AR path — it does
not duplicate `customers` (CRM stays there) and does not own payment
execution (stays in AP).

The spec went through the same independent review process as #5663
(General Ledger core engine): a fresh-context compliance/checklist
review against the real `AGENTS.md` files and source (not the
document's own citations), and a separate fresh-context scope-cohesion
check. The compliance review found and fixed a real cross-module-
coupling gap (`checkBankAccountWhitelist` was designed as an HTTP-only
call with no degrade path if the module is disabled; corrected to a
DI-resolvable service reached via `tryResolve`), a missing supporting
index, and several factual citation errors. The scope-cohesion check
flagged `approveContractor` as bundled-but-severable; resolved as a
deliberate choice to keep it threaded through the module rather than
split into a separate document.

## Changes

- `.ai/specs/2026-09-06-contractor-registry.md` — full spec (Overview
  through Final Compliance Report / Changelog)
- `.ai/specs/2026-09-06-contractor-registry-implementation-guide.md` —
  short build-order companion (entity cheat sheet, one worked
  vendor-registration-to-payment flow, pitfalls), mirroring the GL
  core engine's implementation guide
- `.ai/specs/README.md` — indexes both new documents

## Specification

**Does a spec exist for this feature/module?**
- [x] No (created a new spec)

**Spec file path:**
`.ai/specs/2026-09-06-contractor-registry.md`

## Testing

Docs-only change — no code. Verified structurally: heading/table
integrity, no orphaned template placeholders, cross-checked every
technical claim (encryption map syntax, queue worker shape, ACL
naming convention, GL's `JournalEntryLine.contractorSnapshot` field
type) against the real source on disk.

## Checklist

- [ ] This pull request targets `develop`. *(opened against the same
  base as the GL spec PR — adjust if your workflow expects `develop`)*
- [ ] I have read and accept the Open Mercato Contributor License
  Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change
  requires it. *(spec + implementation guide + README index)*
- [ ] I added or adjusted tests that cover the change. *(N/A — no
  code in this PR)*
- [ ] I added or updated integration tests in `.ai/qa/tests/` *(N/A —
  no code in this PR)*
- [x] I created or updated the spec in `.ai/specs/` with a changelog
  entry.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: `risk-low` suggested — docs-only, no code, no schema,
  no API surface change.
- [ ] QA routing set: `skip-qa` suggested — no manually exercisable UI
  surface, no database/API change.

### Design System Compliance
N/A — no UI code in this PR.

## Linked issues

_None yet — link the tracking issue/ticket if one exists for this
module._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791405539&installation_model_id=432243&pr_number=5955&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5955&signature=a6e4b7e26ba2ff2a42de6723ba693ae67f986fd64203bc18d739464c2c3963f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->