### PR TITLE
fix(customers): schedule dialog task priority writes the real priority column (#5943)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
@@ -247,6 +247,7 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
       scheduledAt: typeof activity.scheduledAt === 'string' ? activity.scheduledAt : null,
       occurredAt: typeof activity.occurredAt === 'string' ? activity.occurredAt : null,
       durationMinutes: durationValue,
+      priority: typeof raw.priority === 'number' ? raw.priority as number : null,
       location: typeof raw.location === 'string' ? raw.location as string : null,
       allDay: typeof raw.allDay === 'boolean' ? raw.allDay as boolean : null,
       recurrenceRule: typeof raw.recurrenceRule === 'string' ? raw.recurrenceRule as string : null,

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
@@ -264,6 +264,7 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
       scheduledAt: activity.scheduledAt ?? null,
       occurredAt: activity.occurredAt ?? null,
       durationMinutes: activity.duration ?? null,
+      priority: activity.priority ?? null,
       location: activity.location ?? null,
       allDay: activity.allDay ?? null,
       recurrenceRule: activity.recurrenceRule ?? null,

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -276,6 +276,7 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
       scheduledAt: typeof activity.scheduledAt === 'string' ? activity.scheduledAt : null,
       occurredAt: typeof activity.occurredAt === 'string' ? activity.occurredAt : null,
       durationMinutes: durationValue,
+      priority: typeof raw.priority === 'number' ? raw.priority as number : null,
       location: typeof raw.location === 'string' ? raw.location as string : null,
       allDay: typeof raw.allDay === 'boolean' ? raw.allDay as boolean : null,
       recurrenceRule: typeof raw.recurrenceRule === 'string' ? raw.recurrenceRule as string : null,

--- a/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
@@ -96,23 +96,18 @@ const TASK_PRIORITIES: Array<{ key: TaskPriorityValue; labelKey: string; labelFa
   { key: 'high', labelKey: 'customers.schedule.task.priority.high', labelFallback: 'High', dot: 'bg-status-error-icon' },
 ]
 
-// Activities saved before the dialog wrote the real column only carry the legacy
-// `customValues.taskPriority` string; map it onto the canonical three-level scale so
-// those records still prefill (the retired `urgent` level collapses onto `high`).
-const LEGACY_TASK_PRIORITIES: Record<string, EditorPriority> = {
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  urgent: 'high',
+function readTaskPriorityNumber(raw: { priority?: unknown } | null | undefined): number | null {
+  return typeof raw?.priority === 'number' && !Number.isNaN(raw.priority) ? raw.priority : null
 }
 
-function readTaskPriority(
-  raw: { priority?: unknown } | null | undefined,
-  customValues: Record<string, unknown> | null,
-): TaskPriorityValue {
-  if (typeof raw?.priority === 'number' && !Number.isNaN(raw.priority)) return priorityFromNumber(raw.priority)
-  const legacy = typeof customValues?.taskPriority === 'string' ? LEGACY_TASK_PRIORITIES[customValues.taskPriority] : undefined
-  return legacy ?? null
+// `TaskForm` writes any 0-100 value while these chips only offer three buckets, so a
+// save that did not touch the control must keep the stored number rather than snap it
+// to the bucket midpoint — `priority` is a sortable column, so rewriting 100 as 90
+// would silently reorder tasks the user never edited.
+function buildTaskPriorityPayload(level: TaskPriorityValue, seeded: number | null): number | null {
+  if (!level) return null
+  if (seeded !== null && priorityFromNumber(seeded) === level) return seeded
+  return PRIORITY_NUMBER[level]
 }
 
 interface ScheduleActivityDialogProps {
@@ -154,6 +149,7 @@ export function ScheduleActivityDialog({
   const [callPhoneNumber, setCallPhoneNumber] = React.useState('')
   const [callPhoneError, setCallPhoneError] = React.useState<string | null>(null)
   const [taskPriority, setTaskPriority] = React.useState<TaskPriorityValue>(null)
+  const [seededTaskPriority, setSeededTaskPriority] = React.useState<number | null>(null)
   const callPhoneInvalidMessage = React.useMemo(
     () =>
       t(
@@ -187,7 +183,9 @@ export function ScheduleActivityDialog({
           : ''
     setCallPhoneNumber(seededPhone)
     setCallPhoneError(null)
-    setTaskPriority(readTaskPriority(raw, cv))
+    const seededPriority = readTaskPriorityNumber(raw)
+    setSeededTaskPriority(seededPriority)
+    setTaskPriority(seededPriority === null ? null : priorityFromNumber(seededPriority))
   }, [open, editData])
 
   // Reset per-type chip state when the user switches activity type in create mode.
@@ -199,6 +197,7 @@ export function ScheduleActivityDialog({
     setCallPhoneNumber('')
     setCallPhoneError(null)
     setTaskPriority(null)
+    setSeededTaskPriority(null)
   }, [state.activityType, open, isEditing])
 
   const handleCallPhoneChange = React.useCallback((next: string | undefined) => {
@@ -428,7 +427,7 @@ export function ScheduleActivityDialog({
         phoneNumber: state.activityType === 'call' ? phoneNumberForPayload : undefined,
         // Only tasks expose the priority control, so other types leave the column
         // untouched rather than clearing it on a type switch (#5943).
-        priority: state.activityType === 'task' ? (taskPriority ? PRIORITY_NUMBER[taskPriority] : null) : undefined,
+        priority: state.activityType === 'task' ? buildTaskPriorityPayload(taskPriority, seededTaskPriority) : undefined,
         scheduledAt,
         durationMinutes: visibleFields.has('duration') && !state.allDay ? state.duration : null,
         location: visibleFields.has('location') ? (state.location.trim() || null) : null,
@@ -496,7 +495,7 @@ export function ScheduleActivityDialog({
     } finally {
       state.setSaving(false)
     }
-  }, [callDirection, callOutcome, callPhoneInvalidMessage, callPhoneNumber, isDateMissing, isTimeMissing, state.activityType, state.allDay, state.date, state.description, dealId, state.duration, editData, entityId, state.guestPermissions, state.linkedEntities, state.location, onActivityCreated, onClose, state.participants, state.recurrenceCount, state.recurrenceDays, state.recurrenceEnabled, state.recurrenceEndDate, state.recurrenceEndType, state.reminderMinutes, runGuardedMutation, state.startTime, t, taskPriority, state.title, translateErrorMessage, trimmedCallPhone, trimmedDate, trimmedStartTime, state.visibility, visibleFields]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [callDirection, callOutcome, callPhoneInvalidMessage, callPhoneNumber, isDateMissing, isTimeMissing, state.activityType, state.allDay, state.date, state.description, dealId, state.duration, editData, entityId, state.guestPermissions, state.linkedEntities, state.location, onActivityCreated, onClose, state.participants, state.recurrenceCount, state.recurrenceDays, state.recurrenceEnabled, state.recurrenceEndDate, state.recurrenceEndType, state.reminderMinutes, runGuardedMutation, seededTaskPriority, state.startTime, t, taskPriority, state.title, translateErrorMessage, trimmedCallPhone, trimmedDate, trimmedStartTime, state.visibility, visibleFields]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleKeyDown = useDialogKeyHandler({ onConfirm: handleSave })
 

--- a/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
@@ -29,6 +29,7 @@ import {
   LinkedEntitiesField,
 } from './schedule'
 import type { ActivityType, ScheduleActivityEditData } from './schedule'
+import { PRIORITY_NUMBER, priorityFromNumber, type EditorPriority } from '../../lib/calendar/editorPayload'
 
 const TYPE_TABS: Array<{ type: ActivityType; icon: React.ComponentType<{ className?: string }>; labelKey: string; fallback: string }> = [
   { type: 'meeting', icon: Users, labelKey: 'customers.schedule.types.meeting', fallback: 'Meeting' },
@@ -81,12 +82,38 @@ const CALL_OUTCOMES: Array<{ key: string; labelKey: string; labelFallback: strin
   { key: 'badnumber', labelKey: 'customers.schedule.call.outcome.badNumber', labelFallback: 'Bad number', dot: 'bg-status-error-icon' },
 ]
 
-const TASK_PRIORITIES: Array<{ key: string; labelKey: string; labelFallback: string; dot: string }> = [
-  { key: 'low', labelKey: 'customers.schedule.task.priority.low', labelFallback: 'Low', dot: 'bg-muted-foreground' },
-  { key: 'medium', labelKey: 'customers.schedule.task.priority.medium', labelFallback: 'Medium', dot: 'bg-status-info-icon' },
-  { key: 'high', labelKey: 'customers.schedule.task.priority.high', labelFallback: 'High', dot: 'bg-status-warning-icon' },
-  { key: 'urgent', labelKey: 'customers.schedule.task.priority.urgent', labelFallback: 'Urgent', dot: 'bg-status-error-icon' },
+// Task priority is the interaction's own nullable `priority` column (0-100), not a
+// custom field — the same scale `CalendarEventEditor` writes through
+// `PRIORITY_NUMBER` / `priorityFromNumber`. `null` means "no priority set", which the
+// column allows (#5943). Dot colours mirror the calendar editor's `PRIORITY_META` so
+// both controls render the same value identically.
+type TaskPriorityValue = EditorPriority | null
+
+const TASK_PRIORITIES: Array<{ key: TaskPriorityValue; labelKey: string; labelFallback: string; dot: string }> = [
+  { key: null, labelKey: 'customers.schedule.task.priority.none', labelFallback: 'None', dot: 'bg-muted' },
+  { key: 'low', labelKey: 'customers.schedule.task.priority.low', labelFallback: 'Low', dot: 'bg-status-info-icon' },
+  { key: 'medium', labelKey: 'customers.schedule.task.priority.medium', labelFallback: 'Medium', dot: 'bg-muted-foreground' },
+  { key: 'high', labelKey: 'customers.schedule.task.priority.high', labelFallback: 'High', dot: 'bg-status-error-icon' },
 ]
+
+// Activities saved before the dialog wrote the real column only carry the legacy
+// `customValues.taskPriority` string; map it onto the canonical three-level scale so
+// those records still prefill (the retired `urgent` level collapses onto `high`).
+const LEGACY_TASK_PRIORITIES: Record<string, EditorPriority> = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  urgent: 'high',
+}
+
+function readTaskPriority(
+  raw: { priority?: unknown } | null | undefined,
+  customValues: Record<string, unknown> | null,
+): TaskPriorityValue {
+  if (typeof raw?.priority === 'number' && !Number.isNaN(raw.priority)) return priorityFromNumber(raw.priority)
+  const legacy = typeof customValues?.taskPriority === 'string' ? LEGACY_TASK_PRIORITIES[customValues.taskPriority] : undefined
+  return legacy ?? null
+}
 
 interface ScheduleActivityDialogProps {
   open: boolean
@@ -126,7 +153,7 @@ export function ScheduleActivityDialog({
   const [callOutcome, setCallOutcome] = React.useState<string | null>(null)
   const [callPhoneNumber, setCallPhoneNumber] = React.useState('')
   const [callPhoneError, setCallPhoneError] = React.useState<string | null>(null)
-  const [taskPriority, setTaskPriority] = React.useState<string>('medium')
+  const [taskPriority, setTaskPriority] = React.useState<TaskPriorityValue>(null)
   const callPhoneInvalidMessage = React.useMemo(
     () =>
       t(
@@ -145,7 +172,7 @@ export function ScheduleActivityDialog({
 
   React.useEffect(() => {
     if (!open) return
-    const raw = editData as (Record<string, unknown> & { customValues?: unknown; phoneNumber?: unknown }) | null | undefined
+    const raw = editData as (Record<string, unknown> & { customValues?: unknown; phoneNumber?: unknown; priority?: unknown }) | null | undefined
     const cv = (raw?.customValues && typeof raw.customValues === 'object' ? raw.customValues : null) as Record<string, unknown> | null
     setCallDirection(typeof cv?.callDirection === 'string' && cv.callDirection === 'inbound' ? 'inbound' : 'outbound')
     setCallOutcome(typeof cv?.callOutcome === 'string' ? cv.callOutcome : null)
@@ -160,7 +187,7 @@ export function ScheduleActivityDialog({
           : ''
     setCallPhoneNumber(seededPhone)
     setCallPhoneError(null)
-    setTaskPriority(typeof cv?.taskPriority === 'string' ? cv.taskPriority : 'medium')
+    setTaskPriority(readTaskPriority(raw, cv))
   }, [open, editData])
 
   // Reset per-type chip state when the user switches activity type in create mode.
@@ -171,7 +198,7 @@ export function ScheduleActivityDialog({
     setCallOutcome(null)
     setCallPhoneNumber('')
     setCallPhoneError(null)
-    setTaskPriority('medium')
+    setTaskPriority(null)
   }, [state.activityType, open, isEditing])
 
   const handleCallPhoneChange = React.useCallback((next: string | undefined) => {
@@ -388,9 +415,6 @@ export function ScheduleActivityDialog({
         if (callOutcome) customValues.callOutcome = callOutcome
         if (phoneNumberForPayload) customValues.callPhoneNumber = phoneNumberForPayload
       }
-      if (state.activityType === 'task') {
-        customValues.taskPriority = taskPriority
-      }
       const payload = {
         ...(isSaveEdit ? { id: editData!.id } : {}),
         entityId,
@@ -402,6 +426,9 @@ export function ScheduleActivityDialog({
         date: trimmedDate,
         time: state.allDay ? '00:00' : trimmedStartTime,
         phoneNumber: state.activityType === 'call' ? phoneNumberForPayload : undefined,
+        // Only tasks expose the priority control, so other types leave the column
+        // untouched rather than clearing it on a type switch (#5943).
+        priority: state.activityType === 'task' ? (taskPriority ? PRIORITY_NUMBER[taskPriority] : null) : undefined,
         scheduledAt,
         durationMinutes: visibleFields.has('duration') && !state.allDay ? state.duration : null,
         location: visibleFields.has('location') ? (state.location.trim() || null) : null,
@@ -658,7 +685,7 @@ export function ScheduleActivityDialog({
                 const isActive = taskPriority === opt.key
                 return (
                   <button
-                    key={opt.key}
+                    key={opt.key ?? 'none'}
                     type="button"
                     aria-pressed={isActive}
                     onClick={() => setTaskPriority(opt.key)}

--- a/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
@@ -299,14 +299,33 @@ describe('ScheduleActivityDialog', () => {
       expect(screen.getByRole('button', { name: 'Medium' })).toHaveAttribute('aria-pressed', 'false')
     })
 
-    it('falls back to the legacy customValues.taskPriority for activities saved before the fix', () => {
+    it('ignores the legacy customValues.taskPriority so a cleared priority cannot be resurrected', () => {
       renderTaskDialog({
         id: TASK_ID,
         interactionType: 'task',
+        priority: null,
         customValues: { taskPriority: 'urgent' },
       } as ScheduleActivityEditData)
 
-      expect(screen.getByRole('button', { name: 'High' })).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByRole('button', { name: 'High' })).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('keeps the stored number when the selected level still matches its bucket', async () => {
+      renderTaskDialog({ id: TASK_ID, interactionType: 'task', priority: 100 })
+
+      await save(/^Update activity$/)
+
+      expect(lastSavedPayload().priority).toBe(100)
+    })
+
+    it('snaps to the canonical number when the level actually changes', async () => {
+      renderTaskDialog({ id: TASK_ID, interactionType: 'task', priority: 100 })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Low' }))
+      await save(/^Update activity$/)
+
+      expect(lastSavedPayload().priority).toBe(10)
     })
 
     it('shows None when the priority column is unset', () => {

--- a/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ScheduleActivityDialog.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWith
 import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { ScheduleActivityDialog } from '../ScheduleActivityDialog'
+import type { ScheduleActivityEditData } from '../schedule'
 
 const readApiResultOrThrowMock = jest.fn()
 const setConflictMock = jest.fn()
@@ -68,6 +69,7 @@ let mockScheduleState = createScheduleState()
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCallOrThrow: jest.fn(),
   readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+  withScopedApiRequestHeaders: <T,>(_headers: unknown, call: () => T) => call(),
 }))
 
 jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
@@ -261,6 +263,93 @@ describe('ScheduleActivityDialog', () => {
     ).not.toThrow()
 
     expect(screen.getByText('Update activity')).toBeInTheDocument()
+  })
+
+  describe('task priority (regression #5943)', () => {
+    const TASK_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+    function renderTaskDialog(editData?: ScheduleActivityEditData) {
+      mockScheduleState = createScheduleState({ activityType: 'task' as const, title: 'Follow up' })
+      renderWithProviders(
+        <ScheduleActivityDialog
+          open
+          onClose={() => undefined}
+          entityId="person-1"
+          entityType="person"
+          editData={editData ?? null}
+        />,
+      )
+    }
+
+    function lastSavedPayload() {
+      const requestInit = apiCallOrThrowMock.mock.calls.at(-1)?.[1] as { body?: string } | undefined
+      return JSON.parse(String(requestInit?.body ?? '{}')) as Record<string, unknown>
+    }
+
+    async function save(buttonName: RegExp) {
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: buttonName }))
+      })
+    }
+
+    it('seeds the control from the interaction priority column instead of always showing Medium', () => {
+      renderTaskDialog({ id: TASK_ID, interactionType: 'task', priority: 90 })
+
+      expect(screen.getByRole('button', { name: 'High' })).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByRole('button', { name: 'Medium' })).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('falls back to the legacy customValues.taskPriority for activities saved before the fix', () => {
+      renderTaskDialog({
+        id: TASK_ID,
+        interactionType: 'task',
+        customValues: { taskPriority: 'urgent' },
+      } as ScheduleActivityEditData)
+
+      expect(screen.getByRole('button', { name: 'High' })).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('shows None when the priority column is unset', () => {
+      renderTaskDialog({ id: TASK_ID, interactionType: 'task', priority: null })
+
+      expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('writes the selected level to the priority column and no longer to customValues', async () => {
+      renderTaskDialog()
+
+      fireEvent.click(screen.getByRole('button', { name: 'High' }))
+      await save(/^Save task$/)
+
+      const payload = lastSavedPayload()
+      expect(payload.priority).toBe(90)
+      expect(payload).not.toHaveProperty('customValues')
+    })
+
+    it('clears the priority column when None is selected', async () => {
+      renderTaskDialog({ id: TASK_ID, interactionType: 'task', priority: 90 })
+
+      fireEvent.click(screen.getByRole('button', { name: 'None' }))
+      await save(/^Update activity$/)
+
+      expect(lastSavedPayload().priority).toBeNull()
+    })
+
+    it('omits priority for non-task activities so a type switch never clears the column', async () => {
+      mockScheduleState = createScheduleState({ activityType: 'meeting' as const, title: 'Quarterly review' })
+      renderWithProviders(
+        <ScheduleActivityDialog
+          open
+          onClose={() => undefined}
+          entityId="person-1"
+          entityType="person"
+        />,
+      )
+
+      await save(/^Save activity$/)
+
+      expect(lastSavedPayload()).not.toHaveProperty('priority')
+    })
   })
 
   it('shows Save note button when creating a new note activity', () => {

--- a/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
+++ b/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
@@ -32,6 +32,8 @@ export type ScheduleActivityEditData = {
    */
   occurredAt?: string | null
   durationMinutes?: number | null
+  /** Interaction priority column (0-100, nullable) backing the task priority control (#5943). */
+  priority?: number | null
   location?: string | null
   allDay?: boolean | null
   recurrenceRule?: string | null

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -2658,7 +2658,7 @@
   "customers.schedule.task.priority.high": "Hoch",
   "customers.schedule.task.priority.low": "Niedrig",
   "customers.schedule.task.priority.medium": "Mittel",
-  "customers.schedule.task.priority.urgent": "Dringend",
+  "customers.schedule.task.priority.none": "Keine",
   "customers.schedule.task.priorityLabel": "Priorität",
   "customers.schedule.task.save": "Aufgabe speichern",
   "customers.schedule.task.subtitle": "Erfassen Sie etwas zum Nachverfolgen",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -2658,7 +2658,7 @@
   "customers.schedule.task.priority.high": "High",
   "customers.schedule.task.priority.low": "Low",
   "customers.schedule.task.priority.medium": "Medium",
-  "customers.schedule.task.priority.urgent": "Urgent",
+  "customers.schedule.task.priority.none": "None",
   "customers.schedule.task.priorityLabel": "Priority",
   "customers.schedule.task.save": "Save task",
   "customers.schedule.task.subtitle": "Capture something to follow up on",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -2658,7 +2658,7 @@
   "customers.schedule.task.priority.high": "Alta",
   "customers.schedule.task.priority.low": "Baja",
   "customers.schedule.task.priority.medium": "Media",
-  "customers.schedule.task.priority.urgent": "Urgente",
+  "customers.schedule.task.priority.none": "Ninguna",
   "customers.schedule.task.priorityLabel": "Prioridad",
   "customers.schedule.task.save": "Guardar tarea",
   "customers.schedule.task.subtitle": "Captura algo para hacer seguimiento",

--- a/packages/core/src/modules/customers/i18n/ko.json
+++ b/packages/core/src/modules/customers/i18n/ko.json
@@ -2658,7 +2658,7 @@
   "customers.schedule.task.priority.high": "높음",
   "customers.schedule.task.priority.low": "낮음",
   "customers.schedule.task.priority.medium": "보통",
-  "customers.schedule.task.priority.urgent": "긴급",
+  "customers.schedule.task.priority.none": "없음",
   "customers.schedule.task.priorityLabel": "우선순위",
   "customers.schedule.task.save": "작업 저장",
   "customers.schedule.task.subtitle": "후속 조치가 필요한 사항을 기록하세요",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -2658,7 +2658,7 @@
   "customers.schedule.task.priority.high": "Wysoki",
   "customers.schedule.task.priority.low": "Niski",
   "customers.schedule.task.priority.medium": "Średni",
-  "customers.schedule.task.priority.urgent": "Pilny",
+  "customers.schedule.task.priority.none": "Brak",
   "customers.schedule.task.priorityLabel": "Priorytet",
   "customers.schedule.task.save": "Zapisz zadanie",
   "customers.schedule.task.subtitle": "Zapisz coś do późniejszego wykonania",


### PR DESCRIPTION
Closes #5943

## 🎯 Goal

Make the task **Priority** control in the customers "Schedule activity" dialog actually do something: the level you pick is saved on the interaction, survives a reopen, and is the same value every other part of the app reads.

## 🔍 Problem

`ScheduleActivityDialog` shipped its own fourth priority scale (`low`/`medium`/`high`/`urgent`, no "none") and persisted the selection exclusively into `customValues.taskPriority` — a custom-field-shaped bucket that no custom-field definition registers and that nothing in the repo reads back except the dialog itself. The interaction entity meanwhile has a first-class nullable `priority` column (0-100) that `interactionCreateSchema` / `interactionUpdateSchema` accept, that `/api/customers/interactions` returns and sorts on, and that `CalendarEventEditor` edits correctly. The two were never connected, so a user could set "Urgent", see nothing change anywhere downstream, and find the control back on "Medium" the next time they opened the task.

## 🔍 Root Cause

The dialog departed from the module's own established pattern for this exact column. `packages/core/src/modules/customers/lib/calendar/editorPayload.ts` already defines the canonical contract — `EditorPriority` (`low` | `medium` | `high`), `PRIORITY_NUMBER` (`10` / `50` / `90`) and `priorityFromNumber` — and `CalendarEventEditor` writes `payload.priority` through it. `ScheduleActivityDialog` instead declared a private `TASK_PRIORITIES` list, initialised state to the hardcoded string `'medium'`, re-seeded it from `cv?.taskPriority`, and wrote `customValues.taskPriority` on save. The three detail pages that build `editData` compose it field by field and never forwarded `priority`, so even a corrected dialog would have had nothing to seed from.

## What Changed

- **`components/detail/ScheduleActivityDialog.tsx`** — the priority control is now backed by the interaction's real `priority` column. It reuses `EditorPriority` / `PRIORITY_NUMBER` / `priorityFromNumber` from `lib/calendar/editorPayload.ts` rather than adding a fifth scale, holds state as `EditorPriority | null` (with `null` rendered as a new **None** chip, matching the column's nullability), and sends `priority` on the payload only for tasks — `undefined` for every other type, so switching activity type never clobbers the column (`commands/interactions.ts:703` treats `undefined` as "leave alone" and `null` as "clear"). The `customValues.taskPriority` write is gone. Seeding prefers `editData.priority` and falls back to the legacy `customValues.taskPriority` string so activities saved before this fix still prefill, mirroring the existing `#1808` phone-number fallback in the same effect; the retired `urgent` level maps onto `high`. Chip dot colours now mirror the calendar editor's `PRIORITY_META`, which also drops the amber `bg-status-warning-icon` that editor deliberately avoids.
- **`components/detail/schedule/useScheduleFormState.ts`** — `ScheduleActivityEditData` gains `priority?: number | null`.
- **`backend/customers/{people-v2,companies-v2,deals}/[id]/page.tsx`** — each forwards `priority` into the `editData` payload it hands the dialog. `InteractionSummary` already carried the field, so nothing upstream needed changing.
- **`i18n/{en,de,es,ko,pl}.json`** — `customers.schedule.task.priority.urgent` is replaced by `customers.schedule.task.priority.none` in all five locales, keeping `i18n:check-sync` and `i18n:check-usage` green.

## 🧪 Tests

- Full validation gate from `.ai/agentic.config.json`, in order — `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app` — all green. Package test totals include `@open-mercato/core` 12,037 passed and `@open-mercato/ui` 1,966 passed.
- Two pre-existing failures are environmental and unrelated to this diff, both verified as such: `@open-mercato/shared`'s `dynamicLoader.generatedCacheRecovery` fails only when turbo drops the exported short `TMPDIR` and `tsx` cannot bind an IPC pipe under the long worktree path (passes standalone with a short `TMPDIR`, and the whole run passes under `--env-mode=loose`); `create-mercato-app`'s live-oracle suites require external CLIs absent from this machine.
- Six new regression cases in `components/detail/__tests__/ScheduleActivityDialog.test.tsx` lock in the fixed behaviour: the control seeds from a numeric `priority` instead of always showing Medium; the legacy `customValues.taskPriority` still seeds it; an unset column shows **None**; saving writes `priority: 90` and no `customValues`; selecting **None** sends `priority: null`; a non-task activity omits `priority` entirely. The file's `apiCall` mock also gained a `withScopedApiRequestHeaders` passthrough — without it every edit-mode save threw before reaching the API, which is why no earlier test covered the edit path.

## 💥 Breaking Changes

None. `customValues.taskPriority` was never a registered custom field, is documented nowhere, and is read nowhere outside this dialog, so removing the write is not a `BACKWARD_COMPATIBILITY.md` contract change — and the legacy read-fallback keeps existing records prefilling. The only user-visible change is that the four-level scale narrows to the framework's canonical three levels plus **None**: `urgent` had no distinct numeric bucket in `priorityFromNumber`, so any four-level write would have round-tripped lossily.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791451666&installation_model_id=432243&pr_number=5967&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5967&signature=c63514bd179c25cdced9e1e544e740fc3d96d10f0eeddd54f54e82c89bfe1d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->