### PR TITLE
fix(ui): add titleClassName and localize the CollapsibleSection toggle aria-label (#5929)

### DIFF
--- a/apps/mercato/src/i18n/de.json
+++ b/apps/mercato/src/i18n/de.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} von {max}",
   "ui.recordNotFound.backToList": "Zurück zur Liste",
   "ui.rowActions.openActions": "Aktionen öffnen",
+  "ui.sectionHeader.collapse": "Abschnitt {title} einklappen",
+  "ui.sectionHeader.expand": "Abschnitt {title} ausklappen",
   "ui.sidebar.chevron.scrollBottom": "Nach unten scrollen",
   "ui.sidebar.chevron.scrollTop": "Nach oben scrollen",
   "ui.spinner.ariaLabel": "Wird geladen",

--- a/apps/mercato/src/i18n/en.json
+++ b/apps/mercato/src/i18n/en.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} out of {max}",
   "ui.recordNotFound.backToList": "Back to list",
   "ui.rowActions.openActions": "Open actions",
+  "ui.sectionHeader.collapse": "Collapse {title} section",
+  "ui.sectionHeader.expand": "Expand {title} section",
   "ui.sidebar.chevron.scrollBottom": "Scroll to bottom",
   "ui.sidebar.chevron.scrollTop": "Scroll to top",
   "ui.spinner.ariaLabel": "Loading",

--- a/apps/mercato/src/i18n/es.json
+++ b/apps/mercato/src/i18n/es.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} de {max}",
   "ui.recordNotFound.backToList": "Volver a la lista",
   "ui.rowActions.openActions": "Abrir acciones",
+  "ui.sectionHeader.collapse": "Contraer la sección {title}",
+  "ui.sectionHeader.expand": "Expandir la sección {title}",
   "ui.sidebar.chevron.scrollBottom": "Desplazar hacia abajo",
   "ui.sidebar.chevron.scrollTop": "Desplazar hacia arriba",
   "ui.spinner.ariaLabel": "Cargando",

--- a/apps/mercato/src/i18n/ko.json
+++ b/apps/mercato/src/i18n/ko.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{max} 중 {value}",
   "ui.recordNotFound.backToList": "목록으로 돌아가기",
   "ui.rowActions.openActions": "작업 메뉴 열기",
+  "ui.sectionHeader.collapse": "{title} 섹션 접기",
+  "ui.sectionHeader.expand": "{title} 섹션 펼치기",
   "ui.sidebar.chevron.scrollBottom": "맨 아래로 스크롤",
   "ui.sidebar.chevron.scrollTop": "맨 위로 스크롤",
   "ui.spinner.ariaLabel": "로딩 중",

--- a/apps/mercato/src/i18n/pl.json
+++ b/apps/mercato/src/i18n/pl.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} z {max}",
   "ui.recordNotFound.backToList": "Powrót do listy",
   "ui.rowActions.openActions": "Otwórz akcje",
+  "ui.sectionHeader.collapse": "Zwiń sekcję {title}",
+  "ui.sectionHeader.expand": "Rozwiń sekcję {title}",
   "ui.sidebar.chevron.scrollBottom": "Przewiń do dołu",
   "ui.sidebar.chevron.scrollTop": "Przewiń do góry",
   "ui.spinner.ariaLabel": "Ładowanie",

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} von {max}",
   "ui.recordNotFound.backToList": "Zurück zur Liste",
   "ui.rowActions.openActions": "Aktionen öffnen",
+  "ui.sectionHeader.collapse": "Abschnitt {title} einklappen",
+  "ui.sectionHeader.expand": "Abschnitt {title} ausklappen",
   "ui.sidebar.chevron.scrollBottom": "Nach unten scrollen",
   "ui.sidebar.chevron.scrollTop": "Nach oben scrollen",
   "ui.spinner.ariaLabel": "Wird geladen",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} out of {max}",
   "ui.recordNotFound.backToList": "Back to list",
   "ui.rowActions.openActions": "Open actions",
+  "ui.sectionHeader.collapse": "Collapse {title} section",
+  "ui.sectionHeader.expand": "Expand {title} section",
   "ui.sidebar.chevron.scrollBottom": "Scroll to bottom",
   "ui.sidebar.chevron.scrollTop": "Scroll to top",
   "ui.spinner.ariaLabel": "Loading",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} de {max}",
   "ui.recordNotFound.backToList": "Volver a la lista",
   "ui.rowActions.openActions": "Abrir acciones",
+  "ui.sectionHeader.collapse": "Contraer la sección {title}",
+  "ui.sectionHeader.expand": "Expandir la sección {title}",
   "ui.sidebar.chevron.scrollBottom": "Desplazar hacia abajo",
   "ui.sidebar.chevron.scrollTop": "Desplazar hacia arriba",
   "ui.spinner.ariaLabel": "Cargando",

--- a/packages/create-app/template/src/i18n/ko.json
+++ b/packages/create-app/template/src/i18n/ko.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{max} 중 {value}",
   "ui.recordNotFound.backToList": "목록으로 돌아가기",
   "ui.rowActions.openActions": "작업 메뉴 열기",
+  "ui.sectionHeader.collapse": "{title} 섹션 접기",
+  "ui.sectionHeader.expand": "{title} 섹션 펼치기",
   "ui.sidebar.chevron.scrollBottom": "맨 아래로 스크롤",
   "ui.sidebar.chevron.scrollTop": "맨 위로 스크롤",
   "ui.spinner.ariaLabel": "로딩 중",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -1084,6 +1084,8 @@
   "ui.rating.summary.ariaLabel": "{value} z {max}",
   "ui.recordNotFound.backToList": "Powrót do listy",
   "ui.rowActions.openActions": "Otwórz akcje",
+  "ui.sectionHeader.collapse": "Zwiń sekcję {title}",
+  "ui.sectionHeader.expand": "Rozwiń sekcję {title}",
   "ui.sidebar.chevron.scrollBottom": "Przewiń do dołu",
   "ui.sidebar.chevron.scrollTop": "Przewiń do góry",
   "ui.spinner.ariaLabel": "Ładowanie",

--- a/packages/ui/src/backend/SectionHeader.tsx
+++ b/packages/ui/src/backend/SectionHeader.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { ChevronDown } from 'lucide-react'
 import { Badge } from '../primitives/badge'
 import { cn } from '@open-mercato/shared/lib/utils'
+import { useOptionalT } from '@open-mercato/shared/lib/i18n/context'
 
 export type SectionHeaderProps = {
   /** Section title */
@@ -14,6 +15,11 @@ export type SectionHeaderProps = {
   action?: React.ReactNode
   /** Additional className */
   className?: string
+  /**
+   * Additional className on the title element. Supplying it also lets the title row
+   * shrink below its content width, so `truncate` takes effect in narrow containers.
+   */
+  titleClassName?: string
 }
 
 export function SectionHeader({
@@ -21,11 +27,13 @@ export function SectionHeader({
   count,
   action,
   className,
+  titleClassName,
 }: SectionHeaderProps) {
+  const allowsTitleShrink = Boolean(titleClassName)
   return (
     <div className={cn('flex items-center justify-between', className)}>
-      <div className="flex items-center gap-2">
-        <h3 className="text-sm font-semibold">{title}</h3>
+      <div className={cn('flex items-center gap-2', allowsTitleShrink && 'min-w-0')}>
+        <h3 className={cn('text-sm font-semibold', allowsTitleShrink && 'min-w-0', titleClassName)}>{title}</h3>
         {count != null && (
           <Badge variant="muted" className="text-xs tabular-nums">
             {count}
@@ -56,6 +64,11 @@ export type CollapsibleSectionProps = {
   className?: string
   /** Additional className on content wrapper */
   contentClassName?: string
+  /**
+   * Additional className on the title element. Supplying it also lets the header row
+   * shrink below its content width, so `truncate` takes effect in narrow containers.
+   */
+  titleClassName?: string
 }
 
 export function CollapsibleSection({
@@ -68,6 +81,7 @@ export function CollapsibleSection({
   children,
   className,
   contentClassName,
+  titleClassName,
 }: CollapsibleSectionProps) {
   const [internalCollapsed, setInternalCollapsed] = React.useState(defaultCollapsed)
   const isControlled = controlledCollapsed !== undefined
@@ -79,23 +93,32 @@ export function CollapsibleSection({
     onCollapsedChange?.(next)
   }, [isCollapsed, isControlled, onCollapsedChange])
 
+  const contextT = useOptionalT()
+  const t = (key: string, fallback: string) =>
+    contextT ? contextT(key, fallback, { title }) : fallback.replace('{title}', title)
+  const toggleAriaLabel = isCollapsed
+    ? t('ui.sectionHeader.expand', 'Expand {title} section')
+    : t('ui.sectionHeader.collapse', 'Collapse {title} section')
+  const allowsTitleShrink = Boolean(titleClassName)
+
   return (
     <div className={cn('space-y-3', className)}>
       <div className="flex items-center justify-between">
         <button
           type="button"
           onClick={toggle}
-          className="flex items-center gap-2 group"
+          className={cn('flex items-center gap-2 group', allowsTitleShrink && 'min-w-0')}
           aria-expanded={!isCollapsed}
-          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${title} section`}
+          aria-label={toggleAriaLabel}
         >
           <ChevronDown
             className={cn(
               'h-4 w-4 text-muted-foreground transition-transform duration-200',
               isCollapsed && '-rotate-90',
+              allowsTitleShrink && 'shrink-0',
             )}
           />
-          <h3 className="text-sm font-semibold">{title}</h3>
+          <h3 className={cn('text-sm font-semibold', allowsTitleShrink && 'min-w-0', titleClassName)}>{title}</h3>
           {count != null && (
             <Badge variant="muted" className="text-xs tabular-nums">
               {count}

--- a/packages/ui/src/backend/__tests__/SectionHeader.test.tsx
+++ b/packages/ui/src/backend/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CollapsibleSection, SectionHeader } from '../SectionHeader'
+
+const plDict = {
+  'ui.sectionHeader.collapse': 'Zwiń sekcję {title}',
+  'ui.sectionHeader.expand': 'Rozwiń sekcję {title}',
+}
+
+describe('CollapsibleSection', () => {
+  it('translates the toggle aria-label for the active locale', () => {
+    renderWithProviders(
+      <CollapsibleSection title="Skrzynka">
+        <p>Treść</p>
+      </CollapsibleSection>,
+      { locale: 'pl', dict: plDict },
+    )
+
+    expect(screen.getByRole('button', { name: 'Zwiń sekcję Skrzynka' })).toBeTruthy()
+  })
+
+  it('switches to the expand key once collapsed', () => {
+    renderWithProviders(
+      <CollapsibleSection title="Skrzynka">
+        <p>Treść</p>
+      </CollapsibleSection>,
+      { locale: 'pl', dict: plDict },
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zwiń sekcję Skrzynka' }))
+
+    expect(screen.getByRole('button', { name: 'Rozwiń sekcję Skrzynka' })).toBeTruthy()
+  })
+
+  it('falls back to English when the locale has no translation', () => {
+    renderWithProviders(
+      <CollapsibleSection title="Billing details">
+        <p>Content</p>
+      </CollapsibleSection>,
+      { locale: 'en', dict: {} },
+    )
+
+    expect(screen.getByRole('button', { name: 'Collapse Billing details section' })).toBeTruthy()
+  })
+
+  it('renders outside an I18nProvider using the English fallback', () => {
+    render(
+      <CollapsibleSection title="Billing details">
+        <p>Content</p>
+      </CollapsibleSection>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Collapse Billing details section' })).toBeTruthy()
+  })
+
+  it('applies titleClassName and lets the header row shrink so truncation works', () => {
+    renderWithProviders(
+      <CollapsibleSection title="a-fairly-long-identifier@example.com" titleClassName="truncate">
+        <p>Content</p>
+      </CollapsibleSection>,
+      { locale: 'en', dict: {} },
+    )
+
+    const heading = screen.getByRole('heading', { level: 3 })
+    expect(heading.className).toContain('truncate')
+    expect(heading.className).toContain('min-w-0')
+    expect(heading.className).toContain('text-sm')
+    expect(screen.getByRole('button').className).toContain('min-w-0')
+  })
+
+  it('keeps the header row unconstrained when no titleClassName is supplied', () => {
+    renderWithProviders(
+      <CollapsibleSection title="Billing details">
+        <p>Content</p>
+      </CollapsibleSection>,
+      { locale: 'en', dict: {} },
+    )
+
+    expect(screen.getByRole('heading', { level: 3 }).className).not.toContain('min-w-0')
+    expect(screen.getByRole('button').className).not.toContain('min-w-0')
+  })
+})
+
+describe('SectionHeader', () => {
+  it('applies titleClassName to the title element', () => {
+    renderWithProviders(<SectionHeader title="a-fairly-long-identifier@example.com" titleClassName="truncate" />, {
+      locale: 'en',
+      dict: {},
+    })
+
+    const heading = screen.getByRole('heading', { level: 3 })
+    expect(heading.className).toContain('truncate')
+    expect(heading.className).toContain('min-w-0')
+  })
+
+  it('keeps the title unconstrained when no titleClassName is supplied', () => {
+    renderWithProviders(<SectionHeader title="Billing details" />, { locale: 'en', dict: {} })
+
+    expect(screen.getByRole('heading', { level: 3 }).className).not.toContain('min-w-0')
+  })
+})


### PR DESCRIPTION
Closes #5929

## 🎯 Goal
`CollapsibleSection` / `SectionHeader` are the framework's canonical building block for section headers, but a host could not truncate a long title without reaching into the component's internal DOM, and every collapse toggle announced itself in English regardless of the active locale. This PR closes both gaps so the component is usable in a narrow container and in a non-English deployment without patching the package.

## 🔍 Problem
Two independent gaps in `packages/ui/src/backend/SectionHeader.tsx`, reported in #5929:

1. The title was rendered in a bare `<h3 className="text-sm font-semibold">` with no `min-w-0`/`truncate` and no prop to add either. In a narrow container (a sidebar panel, say, with an email address as the section title) the title forced the container wider instead of eliding. The reporter's workaround was a brittle descendant-selector `className` (`[&_h3]:min-w-0 [&_h3]:truncate …`) that depends on the component's internal DOM structure.
2. The toggle's `aria-label` was the raw template literal `` `${isCollapsed ? 'Expand' : 'Collapse'} ${title} section` `` — never routed through `t()`, with no override prop. Under `locale: 'pl'` a screen reader announced "Collapse <title> section" in English in the middle of an otherwise fully localized UI.

## 🔍 Root Cause
The component predates the package's i18n convention (`ui.*` keys resolved through the i18n context) and its prop surface only ever exposed `className` / `contentClassName` — nothing that reaches the title element. Neither gap is a regression; both are original omissions carried since the component was introduced.

## What Changed
- **`packages/ui/src/backend/SectionHeader.tsx`** — added an optional `titleClassName` to both `SectionHeaderProps` and `CollapsibleSectionProps`, merged onto the `<h3>` via `cn('text-sm font-semibold', titleClassName)`. Because `truncate` alone cannot shrink a flex item whose ancestors default to `min-width: auto`, supplying `titleClassName` also opts the header row into the `min-w-0` chain (title element, the toggle button, and the badge/title wrapper) and pins the chevron with `shrink-0`. That opt-in is deliberate: consumers who pass no `titleClassName` keep byte-identical layout, so an existing long title still widens its container exactly as before rather than silently starting to wrap.
- **`packages/ui/src/backend/SectionHeader.tsx`** — the toggle `aria-label` now resolves through the i18n context using the new `ui.sectionHeader.expand` / `ui.sectionHeader.collapse` keys, with the previous English wording kept verbatim as the fallback template. It reads the context via `useOptionalT()` rather than `useT()` on purpose: `useT()` throws outside an `I18nProvider`, so switching to it would turn a working render into a crash for any host (or gallery, or test) that renders this component without a provider — a breaking change the issue does not ask for.
- **`apps/mercato/src/i18n/{en,pl,de,es,ko}.json`** — added the two `ui.sectionHeader.*` keys with a `{title}` parameter, translated per locale.
- **`packages/create-app/template/src/i18n/{en,pl,de,es,ko}.json`** — mirrored the same keys into the create-app template, as `AGENTS.md` requires for any change to `apps/mercato/src/i18n/**`. `yarn template:sync` reports no i18n drift (the one `modules.ts` mismatch it lists is pre-existing on `develop` and untouched here).

The issue offered `useT()`-keys *or* a `toggleAriaLabel` prop as alternatives for gap 2. This PR takes the keys route only — it is the option that satisfies the repo's "never hard-code user-facing strings" rule, and adding a second override prop on top would widen the public surface beyond what the issue needs.

## 🧪 Tests
- New suite `packages/ui/src/backend/__tests__/SectionHeader.test.tsx` — 8 cases. Verified as a genuine regression guard: **4 of the 8 fail against the pre-fix component** (the two localized-`aria-label` cases and the two `titleClassName` cases) and all 8 pass with the fix.
  - the toggle `aria-label` renders from the `pl` dictionary, and flips from the collapse key to the expand key when the section is collapsed;
  - it falls back to the original English wording when the dictionary lacks the key, and when the component renders with no `I18nProvider` at all (locking in the `useOptionalT` choice above);
  - `titleClassName` lands on the `<h3>` alongside the existing `text-sm font-semibold`, and brings `min-w-0` to both the heading and the toggle button so `truncate` can take effect;
  - omitting `titleClassName` leaves no `min-w-0` on either element, locking in the unchanged-layout guarantee for existing consumers.
- `yarn workspace @open-mercato/ui test` — 1974 passed / 238 suites, including the 8 new cases.
- Full configured gate, in order: `yarn build:packages` ✅, `yarn generate` ✅, `yarn build:packages` ✅, `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅, `yarn typecheck` ✅, `yarn test` ⚠️, `yarn build:app` ✅.
- The one `yarn test` failure is environmental, not a regression: `packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts` (2 cases) dies with `listen EINVAL … /tsx-501/<pid>.pipe` because the sandbox's in-repo `TMPDIR` exceeds the macOS unix-socket path limit once Turbo drops the exported override. Re-run standalone with a short `TMPDIR`, the same suite passes 2/2. It exercises bootstrap cache recovery and imports nothing this PR touches.

## 💥 Breaking Changes
None. `titleClassName` is additive and optional, and every layout tweak it enables is gated behind supplying it. The `aria-label` keeps its exact previous English text whenever the key is absent or no provider is mounted, so only a locale that ships the new keys sees different output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791463253&installation_model_id=432243&pr_number=5973&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5973&signature=ee63e5fa300a2a87d3c9dab77acd81bdcc7761b30518f056d13752334cd40ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->