### PR TITLE
fix(customers): seed the schedule edit form from scheduledAt before occurredAt (#5939)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/schedule/__tests__/useScheduleFormState.dateSeed.test.ts
+++ b/packages/core/src/modules/customers/components/detail/schedule/__tests__/useScheduleFormState.dateSeed.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react'
+import { useScheduleFormState } from '../useScheduleFormState'
+import type { ScheduleActivityEditData } from '../useScheduleFormState'
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+// The hook seeds the form in the user's local timezone, so the expectations are
+// derived the same way instead of hardcoding a UTC-shaped string.
+function localDate(iso: string): string {
+  const date = new Date(iso)
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+function localTime(iso: string): string {
+  const date = new Date(iso)
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function editData(overrides: Partial<ScheduleActivityEditData>): ScheduleActivityEditData {
+  return { id: 'interaction-1', interactionType: 'task', title: 'Send the offer', ...overrides }
+}
+
+function seed(data: ScheduleActivityEditData) {
+  const { result } = renderHook(() => useScheduleFormState({ open: true, editData: data }))
+  return { date: result.current.date, startTime: result.current.startTime }
+}
+
+describe('useScheduleFormState — edit-mode date/time seed precedence (#5939)', () => {
+  const scheduledAt = '2026-03-18T15:16:00.000Z'
+  const occurredAt = '2026-03-17T15:19:00.000Z'
+
+  it('seeds a completed planned task from scheduledAt so an unrelated edit keeps its due date', () => {
+    // A planned task marked done carries both timestamps. The dialog recomputes
+    // `scheduledAt` from these fields on save, so seeding from `occurredAt` would
+    // persist the completion moment over the original deadline.
+    expect(seed(editData({ scheduledAt, occurredAt }))).toEqual({
+      date: localDate(scheduledAt),
+      startTime: localTime(scheduledAt),
+    })
+  })
+
+  it('still seeds a purely historical activity from occurredAt when scheduledAt is absent (#1807)', () => {
+    expect(seed(editData({ interactionType: 'call', scheduledAt: null, occurredAt }))).toEqual({
+      date: localDate(occurredAt),
+      startTime: localTime(occurredAt),
+    })
+  })
+
+  it('falls back to today when the record carries neither timestamp', () => {
+    const now = new Date()
+    expect(seed(editData({ scheduledAt: null, occurredAt: null })).date).toBe(
+      `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`,
+    )
+  })
+
+  it('falls back to today when the seeded timestamp is unparseable', () => {
+    const now = new Date()
+    expect(seed(editData({ scheduledAt: 'not-a-date' })).date).toBe(
+      `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`,
+    )
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
+++ b/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
@@ -114,12 +114,16 @@ export function useScheduleFormState({ open, editData }: UseScheduleFormStatePar
         const resolvedType = (editData.interactionType as ActivityType) ?? 'meeting'
         setActivityType(resolvedType)
         setTitle(editData.title ?? '')
-        // For historical activities the canonical timestamp is `occurredAt`; for
-        // planned/future ones it's `scheduledAt`. Without this fallback editing a
-        // past activity prefilled to "today" instead of its actual moment (#1807).
+        // `scheduledAt` is the canonical term of anything that was ever planned, so it
+        // wins whenever it is set: the save path recomputes `scheduledAt` from these
+        // seeded date/time fields, and seeding from `occurredAt` first silently
+        // overwrote a completed task's due date on unrelated edits (#5939).
+        // `occurredAt` stays the fallback for purely historical entries (a logged call
+        // or note) that never had a `scheduledAt`, so editing those still restores
+        // their actual moment instead of falling back to "today" (#1807).
         // Keep seed values in the user's local timezone, matching the cluster-E
         // local-day convention.
-        const sourceTimestamp = editData.occurredAt ?? editData.scheduledAt ?? null
+        const sourceTimestamp = editData.scheduledAt ?? editData.occurredAt ?? null
         const seedDate = sourceTimestamp ? new Date(sourceTimestamp) : new Date()
         const seedDateValid = !Number.isNaN(seedDate.getTime())
         const fallbackNow = new Date()


### PR DESCRIPTION
Closes #5939

## 🎯 Goal
Editing an unrelated field on a completed *planned* activity — fixing a typo in its title, say — no longer rewrites the activity's recorded due date. The schedule/activity edit dialog now opens showing the task's actual deadline rather than the moment it was checked off.

## 🔍 Problem
`useScheduleFormState` seeds the dialog's "Date"/"Time" fields from an existing interaction when opening it in edit mode. Those same two fields are the source of truth on save. For a planned activity that has already been marked done — so it carries both a `scheduledAt` (its real due date) and an `occurredAt` (when it was completed) — the form was seeded from the completion timestamp, and every save wrote that value back over the deadline. The reporter confirmed it by hand: a task's due time was overwritten simply by fixing its title. This is silent data loss on the field a task-tracking feature exists for.

## 🔍 Root Cause
`packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts` computed the prefill as `editData.occurredAt ?? editData.scheduledAt ?? null`. That fallback was introduced for #1807 so a purely historical activity (a logged call or note, which never had a `scheduledAt`) prefills to its real moment instead of defaulting to "today" — but the order is inverted for a record carrying *both* fields.

The damage is done by the save path: `ScheduleActivityDialog.tsx` recomputes `scheduledAt` from the seeded `date`/`startTime` on every submit (`new Date(\`${state.date}T${state.startTime}:00\`).toISOString()`) and sends it unconditionally. So a mis-seeded form persists its mis-seed even when the user never touches the date row.

Worth noting that every other consumer in the module already uses the opposite precedence — `ActivitiesCard.tsx`, `MiniWeekCalendar.tsx` and `ActivitiesDayStrip.tsx` all read `scheduledAt ?? occurredAt ?? createdAt`. This line was the outlier, which is corroborating evidence for the direction of the fix rather than against it.

## What Changed
- `packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts` — the edit-mode prefill now reads `editData.scheduledAt ?? editData.occurredAt ?? null`. `scheduledAt` is the canonical term of anything that was ever planned, so it wins whenever it is set; `occurredAt` stays the fallback for purely historical entries that never had one, which keeps #1807's behavior intact; `new Date()` remains the last resort. The adjacent comment was rewritten to record both halves of that precedence and why, so the next reader does not re-flip it.

No types, API contracts, response shapes, DB schema, or user-facing strings were touched — the change is confined to which of two already-present timestamps seeds the form.

## 🧪 Tests
- New `packages/core/src/modules/customers/components/detail/schedule/__tests__/useScheduleFormState.dateSeed.test.ts` — 4 cases locking in the full precedence chain: both timestamps present (seeds from `scheduledAt`, the reported bug), `occurredAt` only (the #1807 fallback still restores the real moment), neither present (falls back to today), and an unparseable timestamp (falls back to today). Expectations are derived in the local timezone the same way the hook formats them, so the suite is not timezone-dependent.
- The test was verified **red against the pre-fix code**: exactly the both-timestamps case fails there while the other three pass, so it discriminates this bug rather than the surrounding behavior.
- `@open-mercato/core` — 1483 suites, 12080 tests, 0 failures.
- Validation gate: `yarn build:packages` (x2), `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck` and `yarn build:app` all green. Every workspace's `yarn test` is green when run with a workable `TMPDIR`.
- One caveat for transparency: under `turbo`, `@open-mercato/shared`'s `dynamicLoader.generatedCacheRecovery` suite fails in this sandbox because tsx's IPC pipe hits `EINVAL` on a long in-repo temp path. It passes standalone with a short `TMPDIR`, and this branch changes no file in `packages/shared`, so it is an environment artifact rather than a regression — CI should be the arbiter.

## 💥 Breaking Changes
None. The only behavior change is which of two already-persisted timestamps seeds the edit form. A historical activity with no `scheduledAt` is unaffected, so #1807 does not regress. The one intended visible consequence is that opening a completed planned task for edit now shows its due date instead of its completion time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791468338&installation_model_id=432243&pr_number=5977&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5977&signature=ff913593be5ec0fa626146bd2d71651282c460bed995081374e236d525be1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->