### PR TITLE
fix(customers): accept 'person' as an interaction linked-entity type (#5934)

### DIFF
--- a/packages/core/src/modules/customers/data/__tests__/interactionSchemas.test.ts
+++ b/packages/core/src/modules/customers/data/__tests__/interactionSchemas.test.ts
@@ -7,6 +7,7 @@ const tenantId = '11111111-1111-4111-8111-111111111111'
 const orgId = '22222222-2222-4222-8222-222222222222'
 const entityId = '33333333-3333-4333-8333-333333333333'
 const interactionId = '44444444-4444-4444-8444-444444444444'
+const personId = '55555555-5555-4555-8555-555555555555'
 const userA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const userB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
@@ -119,10 +120,48 @@ describe('interaction validators — extended scheduling fields', () => {
         id: interactionId,
         tenantId,
         organizationId: orgId,
-        linkedEntities: [{ id: entityId, type: 'person', label: 'Nope' }],
+        linkedEntities: [{ id: entityId, type: 'unicorn', label: 'Nope' }],
       }),
     ).toThrow()
   })
+
+  test('interactionCreateSchema accepts a person linked entity', () => {
+    const parsed = interactionCreateSchema.parse({
+      tenantId,
+      organizationId: orgId,
+      entityId,
+      interactionType: 'task',
+      linkedEntities: [{ id: personId, type: 'person', label: 'Ada Lovelace' }],
+    })
+    expect(parsed.linkedEntities).toEqual([
+      { id: personId, type: 'person', label: 'Ada Lovelace' },
+    ])
+  })
+
+  test('interactionUpdateSchema accepts a person linked entity', () => {
+    const parsed = interactionUpdateSchema.parse({
+      id: interactionId,
+      tenantId,
+      organizationId: orgId,
+      linkedEntities: [{ id: personId, type: 'person', label: 'Ada Lovelace' }],
+    })
+    expect(parsed.linkedEntities).toEqual([
+      { id: personId, type: 'person', label: 'Ada Lovelace' },
+    ])
+  })
+
+  test.each(['company', 'deal', 'offer', 'resource', 'person'])(
+    'interactionUpdateSchema accepts the %s linked entity type',
+    (type) => {
+      const parsed = interactionUpdateSchema.parse({
+        id: interactionId,
+        tenantId,
+        organizationId: orgId,
+        linkedEntities: [{ id: entityId, type, label: 'Linked' }],
+      })
+      expect(parsed.linkedEntities?.[0].type).toBe(type)
+    },
+  )
 
   test('interactionCreateSchema accepts a guest participant identified only by email', () => {
     const parsed = interactionCreateSchema.parse({

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -461,7 +461,9 @@ const interactionLinkedEntitySchema = z.object({
   id: z.string().uuid(),
   // 'resource' links calendar events to bookable resources (rooms, cars,
   // equipment) from the optional resources module (#3552).
-  type: z.enum(['company', 'deal', 'offer', 'resource']),
+  // 'person' links an interaction to a `customer_entities` row with kind='person',
+  // a first-class CRM record like a company (#5934).
+  type: z.enum(['company', 'deal', 'offer', 'resource', 'person']),
   label: z.string().trim().max(500),
 })
 


### PR DESCRIPTION
Closes #5934

## 🎯 Goal

Let the core API attach an interaction (activity/task/meeting) to a **person** record, the same way it already attaches one to a company, deal, offer or resource. Before this change, any `POST`/`PUT /api/customers/interactions` carrying `linkedEntities: [{ type: 'person', … }]` was rejected with a `400`, so hosts had to build a parallel person↔activity link table outside the framework's own linking mechanism.

## 🔍 Problem

`interactionLinkedEntitySchema` in `packages/core/src/modules/customers/data/validators.ts` gates the `type` of every entry in an interaction's `linkedEntities` array behind a closed enum. That enum listed `'company' | 'deal' | 'offer' | 'resource'` and omitted `'person'` — even though a person (a `customer_entities` row with `kind='person'`) is a first-class CRM record with its own profile and activity timeline, and is one of the most natural targets to link an activity to.

Reproducer from the issue:

```
PUT /api/customers/interactions
{ "id": "<uuid>", "linkedEntities": [{ "id": "<person-uuid>", "type": "person", "label": "…" }] }
→ 400, `type` fails enum validation
```

## 🔍 Root Cause

The omission is historical rather than deliberate. The enum was introduced in the CRM CR4 work as `['company', 'deal', 'offer']` and later widened to include `'resource'` for calendar resource assignment (#3552) — it grows as new linkable record types are needed, and `'person'` was simply never added. Nothing downstream enforces the restriction:

- the entity column is `linked_entities jsonb` typed as `Array<{ id: string; type: string; label: string }>` (`data/entities.ts`) — no DB-level constraint;
- `parseLinkedEntities` in `lib/calendar/editorPayload.ts` preserves every non-`resource` link verbatim through `preservedLinkedEntities`, so a person link round-trips through the calendar editor untouched;
- `useScheduleFormState` loads existing links through a cast and `LinkedEntitiesField` falls back to a generic icon for unrecognised types, so a person link renders and survives a save.

The zod enum was the single point of rejection.

Worth flagging for the reviewer: the pre-existing negative test `interactionUpdateSchema rejects invalid linked entity type` used `'person'` as its stand-in for "some invalid value". It was asserting the enum boundary, not a policy that persons must never be linkable — the commit that added it (`a7e154d9`, CRM CR4) created the whole file in one go and picked an arbitrary out-of-enum string. This PR repoints it at `'unicorn'` so it still guards the boundary without contradicting the new behaviour.

## What Changed

- **`packages/core/src/modules/customers/data/validators.ts`** — `interactionLinkedEntitySchema.type` is now `z.enum(['company', 'deal', 'offer', 'resource', 'person'])`. This is the schema behind `interactionCreateBaseSchema` / `interactionUpdateBaseSchema`, so both `POST` and `PUT /api/customers/interactions` now accept a person link. A comment records why `'person'` belongs there, matching the existing note for `'resource'`. The route's OpenAPI document is generated from this schema, so the published contract updates automatically.
- **`packages/core/src/modules/customers/data/__tests__/interactionSchemas.test.ts`** — regression coverage (below).

Deliberately **not** changed, to keep this to the minimal scope the issue describes:

- The backoffice link picker (`components/detail/schedule/LinkedEntitiesField.tsx`) still offers only `company | deal | offer`. Adding a person tab needs a people-search endpoint wiring, an icon and new locale keys — a separate, UI-facing change. Note that the validator enum already exceeded the picker's list before this PR (`'resource'` is API/calendar-only), so validator-wider-than-picker is the established shape here, not a new inconsistency.
- `.ai/specs/2026-06-11-crm-calendar.md` still describes the four-value enum as it stood when that spec shipped; it is a record of the #3552 work and its TC-CAL-011 description remains accurate about the resource contract.

## 🧪 Tests

Full configured validation gate (`.ai/agentic.config.json`), run locally in this worktree:

| Step | Result |
|---|---|
| `yarn build:packages` (×2, with `yarn generate` between) | ✅ pass |
| `yarn generate` | ✅ pass — no generated-file drift |
| `yarn i18n:check-sync` | ✅ pass |
| `yarn i18n:check-usage` | ✅ pass |
| `yarn typecheck` | ✅ pass |
| `yarn test` | ✅ pass — see note below |
| `yarn build:app` | ✅ pass |

`yarn test` detail: `@open-mercato/core` **12083 passed / 1482 suites** (the package this change lives in), plus `ui` 1966, `ai-assistant` 1482, `enterprise` 533, `scheduler` 466, `search` 346, `channel-discord` 277, `app` 576 and every other workspace green. The only red is 5 pre-existing failures in `@open-mercato/cli` (`resolve-environment.test.ts`, `resolver.enterprise.test.ts`) which assert `standalone` and get `monorepo` — they are location-dependent (the checkout sits inside the monorepo) and fail identically without this change; nothing in this diff is reachable from them.

New/updated cases in `interactionSchemas.test.ts` (24 passing in that file, up from 18):

- `interactionCreateSchema accepts a person linked entity` — locks in that `POST` accepts `type: 'person'` and preserves `id`/`type`/`label` intact.
- `interactionUpdateSchema accepts a person linked entity` — the exact reproducer from the issue, now green.
- `interactionUpdateSchema accepts the %s linked entity type` — a `test.each` over all five members (`company`, `deal`, `offer`, `resource`, `person`), so the enum cannot silently narrow again and drop any of them.
- `interactionUpdateSchema rejects invalid linked entity type` — retargeted from `'person'` to `'unicorn'`, keeping the boundary guard intact now that `'person'` is legal.

The existing integration test `TC-CAL-011.spec.ts` already pins the API-level enum boundary and uses `'not_a_real_type'` as its rejected value, so it is unaffected by this change.

## 💥 Breaking Changes

**None.** Widening an *input* enum is strictly additive: every payload that validated before still validates, and no previously-accepted request is now rejected. Per `BACKWARD_COMPATIBILITY.md` this is an ADDITIVE-ONLY change to the API-route contract surface.

The one direction worth calling out for a reviewer: consumers reading `linkedEntities[].type` off a *response* can now encounter `'person'`. Every in-repo consumer already handles it — the entity and read-model types it as `string`, `parseLinkedEntities` preserves unknown types, and `LinkedEntitiesField` renders unrecognised types with a generic icon rather than throwing. No migration is required, and no DB change is involved (`linked_entities` is untyped `jsonb`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791468407&installation_model_id=432243&pr_number=5978&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5978&signature=c343a0bb1dc6d920a224a34907ad1bde90e88a88f855d75e54d75cf103ece5d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->