### PR TITLE
fix(ui): include widget-injected columns in the column chooser (#5928)

### DIFF
--- a/packages/ui/src/backend/utils/__tests__/useAutoDiscoveredFields.injectedColumns.test.tsx
+++ b/packages/ui/src/backend/utils/__tests__/useAutoDiscoveredFields.injectedColumns.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react'
+import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
+import { useAutoDiscoveredFields } from '../useAutoDiscoveredFields'
+import type { CustomFieldDefDto } from '../customFieldDefs'
+
+type Row = { id: string; name: string; person?: { company?: { name?: string } } }
+
+const NO_CUSTOM_FIELDS = [] as unknown as CustomFieldDefDto[]
+
+function renderFields(columns: ColumnDef<Row>[]) {
+  return renderHook(
+    () => useAutoDiscoveredFields<Row>({ columns, customFieldDefs: NO_CUSTOM_FIELDS }),
+  ).result.current
+}
+
+describe('useAutoDiscoveredFields with widget-injected columns', () => {
+  // DataTable builds columns from the `data-table:<tableId>:columns` injection spot
+  // as `accessorFn` + `id` so dotted access paths stay expressible.
+  const injectedColumn: ColumnDef<Row> = {
+    id: 'person.company.name',
+    accessorFn: (row: Row) => row.person?.company?.name,
+    header: 'Company',
+  }
+
+  it('lists an injected column in the column chooser keyed by its column id', () => {
+    const { columnChooserFields } = renderFields([
+      { accessorKey: 'name', header: 'Name' },
+      injectedColumn,
+    ])
+
+    expect(columnChooserFields.map((field) => field.key)).toEqual(['name', 'person.company.name'])
+    const injectedChooserField = columnChooserFields.find((field) => field.key === 'person.company.name')
+    expect(injectedChooserField?.label).toBe('Company')
+    expect(injectedChooserField?.alwaysVisible).toBe(false)
+    expect(injectedChooserField?.defaultVisible).toBe(true)
+  })
+
+  it('keeps an injected column out of the auto-discovered filter fields', () => {
+    const { advancedFilterFields } = renderFields([
+      { accessorKey: 'name', header: 'Name' },
+      injectedColumn,
+    ])
+
+    expect(advancedFilterFields.map((field) => field.key)).toEqual(['name'])
+  })
+
+  it('still derives a filter field when an injected column declares an explicit filterKey', () => {
+    const { advancedFilterFields, columnChooserFields } = renderFields([
+      { ...injectedColumn, meta: { filterKey: 'person_company_name' } } as ColumnDef<Row>,
+    ])
+
+    expect(advancedFilterFields.map((field) => field.key)).toEqual(['person_company_name'])
+    expect(columnChooserFields.map((field) => field.key)).toEqual(['person.company.name'])
+  })
+
+  it('skips a column that has neither an accessorKey nor an id', () => {
+    const { columnChooserFields, advancedFilterFields } = renderFields([
+      { header: 'Orphan' } as ColumnDef<Row>,
+    ])
+
+    expect(columnChooserFields).toEqual([])
+    expect(advancedFilterFields).toEqual([])
+  })
+
+  it('leaves ordinary accessorKey columns keyed by their accessorKey', () => {
+    const { columnChooserFields, advancedFilterFields } = renderFields([
+      { accessorKey: 'name', header: 'Name' },
+    ])
+
+    expect(columnChooserFields.map((field) => field.key)).toEqual(['name'])
+    expect(advancedFilterFields.map((field) => field.key)).toEqual(['name'])
+  })
+})

--- a/packages/ui/src/backend/utils/useAutoDiscoveredFields.ts
+++ b/packages/ui/src/backend/utils/useAutoDiscoveredFields.ts
@@ -76,7 +76,11 @@ export function useAutoDiscoveredFields<T extends RowData = RowData>({
     for (let i = 0; i < columns.length; i++) {
       const col = columns[i]
       const accessorKey = (col as any).accessorKey as string | undefined
-      if (!accessorKey) continue
+      // Widget-injected columns carry `accessorFn` + `id` instead of `accessorKey`
+      // (dotted access paths cannot be an object key), and the column id is what
+      // the chooser toggle and visibility state already round-trip on.
+      const chooserKey = accessorKey ?? ((col as any).id as string | undefined)
+      if (!chooserKey) continue
 
       const meta = (col as any).meta as ColumnMeta | undefined
       const label = resolveHeaderLabel(col)
@@ -100,10 +104,10 @@ export function useAutoDiscoveredFields<T extends RowData = RowData>({
       }
 
       // Column chooser field
-      if (!seenChooserKeys.has(accessorKey)) {
-        seenChooserKeys.add(accessorKey)
+      if (!seenChooserKeys.has(chooserKey)) {
+        seenChooserKeys.add(chooserKey)
         chooserFields.push({
-          key: accessorKey,
+          key: chooserKey,
           label,
           group: meta?.columnChooserGroup ?? defaultGroupLabel,
           alwaysVisible: meta?.alwaysVisible ?? i === 0,


### PR DESCRIPTION
## Summary

`useAutoDiscoveredFields` — the hook that builds the "Customize columns" panel and the auto-discovered advanced-filter field list for `DataTable` — opened its column loop with `if (!accessorKey) continue`, so every column authored as `accessorFn` + `id` was dropped before it could reach the chooser.

That is exactly the shape `DataTable` gives columns injected through the `data-table:<tableId>:columns` widget spot: `injectedColumnDefs` (`packages/ui/src/backend/DataTable.tsx:1546-1557`) builds `{ id, accessorFn, header }` because `readInjectedColumnValue` must support dotted access paths that a plain object-key `accessorKey` cannot represent. Those defs are merged into `mergedColumns` (`DataTable.tsx:1618-1630`), and `mergedColumns` is what feeds the hook (`DataTable.tsx:2828`) — so a documented extension mechanism silently produced columns that were invisible to the column chooser, could not be hidden or shown from the UI, and were always rendered.

Fixes #5928

## What changed

`packages/ui/src/backend/utils/useAutoDiscoveredFields.ts` now derives `chooserKey = accessorKey ?? col.id` and skips a column only when both are absent. The chooser entry and its dedupe set key off `chooserKey`.

The column id is the correct identifier to fall back on, not an arbitrary one: `handleColumnChooserToggle` resolves entries via `table.getColumn(key)` (`DataTable.tsx:2495`) and `visibleColumnKeys` reads `col.id` (`DataTable.tsx:2862`), so an injected column now toggles, orders, and persists exactly like an ordinary `accessorKey` column.

**The advanced-filter branch is deliberately untouched.** `filterKey` stays `meta?.filterKey ?? accessorKey`, and the pre-existing `filterKey &&` guard already skips the branch when neither exists. So a column with no real queryable backend field still produces no filter field — matching the issue's own guidance that "filtering needs an actual queryable field" — while a host that declares an explicit `meta.filterKey` still gets one.

## Scope notes

Two things the issue mentions are intentionally **not** in this PR, to keep it to the issue's own "Suggested fix":

- **`meta.excludeFromColumnChooser`** — part of the reporter's app-side workaround, but not part of their suggested fix. Adding a new public `ColumnMeta` flag is an API surface change that deserves its own discussion.
- **`alwaysVisible: meta?.alwaysVisible ?? i === 0`** — a `placement: 'start'` injected column landing at index 0 is now *listed* in the chooser but pinned as always-visible, since it becomes the table's first column. Changing that heuristic is a separate behavior decision.

## Tests

New `packages/ui/src/backend/utils/__tests__/useAutoDiscoveredFields.injectedColumns.test.tsx`, 5 cases:

- an injected-shape column (`accessorFn` + `id`) is listed in `columnChooserFields`, keyed by its column id, with the expected label and visibility defaults
- an injected column stays **out** of `advancedFilterFields`
- an accessorKey-less column that declares an explicit `meta.filterKey` still yields a filter field
- a column with neither `accessorKey` nor `id` is still skipped entirely
- ordinary `accessorKey` columns remain keyed by their `accessorKey` in both outputs

Verified red before the fix (2 failures) and green after.

## Validation

Full gate from `.ai/agentic.config.json`, local mode:

| Command | Result |
|---|---|
| `yarn build:packages` | ✅ exit 0 |
| `yarn generate` | ✅ exit 0 |
| `yarn build:packages` | ✅ exit 0 |
| `yarn i18n:check-sync` | ✅ exit 0 |
| `yarn i18n:check-usage` | ✅ exit 0 |
| `yarn typecheck` | ✅ exit 0 |
| `yarn test` | ⚠️ 33/34 turbo tasks successful — see below |
| `yarn build:app` | ✅ exit 0 |

The single failing task is `create-mercato-app#test`. It was reproduced identically on a clean tree at the same commit with this branch's changes removed — **161 failures both times** — so it is a pre-existing local-environment failure of the AI-harness oracle suites (they shell out to external CLIs), not a regression from this change. This PR touches only `packages/ui`.

No user-facing strings were added, so no locale work was needed. `yarn i18n:check-sync` and `yarn i18n:check-usage` both pass.

## Breaking changes

None. No exported signature, prop, or type changed — `ColumnChooserField` and `UseAutoDiscoveredFieldsResult` are untouched. The one behavior change is the intended one: a host that authored an `id`-only column with a string header now sees it in the column chooser.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791469255&installation_model_id=432243&pr_number=5981&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5981&signature=3be57c45af3ecccfd3d6163bdb7c8fe28e78ce6e774c1e986e094a82ae58675b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->