### PR TITLE
fix(ui): localize PhoneNumberField country names and forward the countries override (#5927)

### DIFF
--- a/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
@@ -9,6 +9,7 @@ jest.mock('../detail/RolesSection', () => ({
 }))
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+  useOptionalLocale: () => undefined,
 }))
 
 import React from 'react'

--- a/packages/core/src/modules/customers/components/__tests__/formConfigPhoneCountries.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/formConfigPhoneCountries.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({}))
+jest.mock('../AddressTiles', () => ({
+  CustomerAddressTiles: () => null,
+}))
+jest.mock('../detail/RolesSection', () => ({
+  RolesSection: () => null,
+}))
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+  useOptionalLocale: () => undefined,
+}))
+jest.mock('@open-mercato/ui/backend/inputs/PhoneNumberField', () => {
+  const capturedCountries: unknown[] = []
+  return {
+    capturedCountries,
+    PhoneNumberField: (props: { countries?: unknown }) => {
+      capturedCountries.push(props.countries)
+      return null
+    },
+  }
+})
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import {
+  createCompanyFormFields,
+  createPersonFormFields,
+  type Translator,
+} from '../formConfig'
+import type { CrudField } from '@open-mercato/ui/backend/CrudForm'
+import type { PhoneCountry } from '@open-mercato/ui/backend/inputs/PhoneNumberField'
+
+const { capturedCountries } = jest.requireMock('@open-mercato/ui/backend/inputs/PhoneNumberField') as {
+  capturedCountries: unknown[]
+}
+
+const t: Translator = (_key, fallback) => fallback ?? _key
+
+const mockRenderProps = {
+  value: null,
+  setValue: () => {},
+  error: undefined,
+  disabled: false,
+  autoFocus: false,
+  recordId: undefined,
+}
+
+const MARKETS: PhoneCountry[] = [
+  { iso2: 'PL', dialCode: '+48', label: 'Rzeczpospolita Polska', flag: '🇵🇱' },
+  { iso2: 'DE', dialCode: '+49', label: 'Deutschland', flag: '🇩🇪' },
+]
+
+function renderPrimaryPhone(fields: CrudField[]): unknown {
+  const phoneField = fields.find((field) => field.id === 'primaryPhone')
+  expect(phoneField).toBeDefined()
+  capturedCountries.length = 0
+  renderToStaticMarkup(React.createElement((phoneField as any).component, mockRenderProps))
+  expect(capturedCountries).toHaveLength(1)
+  return capturedCountries[0]
+}
+
+describe('phoneCountries forwarding to PhoneNumberField', () => {
+  it('passes a supplied country list to the person form phone field', () => {
+    expect(renderPrimaryPhone(createPersonFormFields(t, { phoneCountries: MARKETS }))).toEqual(MARKETS)
+  })
+
+  it('passes a supplied country list to the company form phone field', () => {
+    expect(renderPrimaryPhone(createCompanyFormFields(t, { phoneCountries: MARKETS }))).toEqual(MARKETS)
+  })
+
+  it('leaves the country list undefined when no override is supplied, so the field localizes its own', () => {
+    expect(renderPrimaryPhone(createPersonFormFields(t))).toBeUndefined()
+    expect(renderPrimaryPhone(createCompanyFormFields(t))).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -30,7 +30,7 @@ import {
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
-import { PhoneNumberField } from '@open-mercato/ui/backend/inputs/PhoneNumberField'
+import { PhoneNumberField, type PhoneCountry } from '@open-mercato/ui/backend/inputs/PhoneNumberField'
 import { isValidPhoneNumber } from '@open-mercato/shared/lib/phone'
 import type {
   CrudCustomFieldRenderProps,
@@ -74,6 +74,17 @@ export type Translator = (
   fallback?: string,
   params?: Record<string, string | number>,
 ) => string
+
+export type CustomerFormFieldOptions = {
+  /** Country pre-selected in the phone field when the value is empty. */
+  defaultCountryIso2?: string
+  /**
+   * Country list for the phone field's selector. Supply it to limit the picker
+   * to specific markets or to name the countries yourself; omitted, the field
+   * localizes its built-in list for the active locale.
+   */
+  phoneCountries?: PhoneCountry[]
+}
 
 export type PersonFormValues = {
   displayName: string
@@ -418,7 +429,11 @@ const companyDictionaryFieldDefinitions: DictionaryFieldDefinition[] = [
   },
 ]
 
-const createPrimaryPhoneField = (t: Translator, defaultCountryIso2?: string): CrudField => ({
+const createPrimaryPhoneField = (
+  t: Translator,
+  defaultCountryIso2?: string,
+  phoneCountries?: PhoneCountry[],
+): CrudField => ({
   id: 'primaryPhone',
   label: t('customers.people.form.primaryPhone'),
   type: 'custom',
@@ -449,6 +464,7 @@ const createPrimaryPhoneField = (t: Translator, defaultCountryIso2?: string): Cr
         minDigits={7}
         onDuplicateLookup={!disabled && !error ? duplicateLookup : undefined}
         defaultCountryIso2={defaultCountryIso2}
+        countries={phoneCountries}
       />
     )
   },
@@ -871,8 +887,9 @@ export const createDisplayNameSection = (t: Translator) =>
     )
   }
 
-export const createPersonFormFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+export const createPersonFormFields = (t: Translator, options?: CustomerFormFieldOptions): CrudField[] => {
   const defaultCountryIso2 = options?.defaultCountryIso2
+  const phoneCountries = options?.phoneCountries
   const contactSection = createSectionHeadingField('__contactInformationSection', t('customers.people.form.sections.contactInformation'))
   const companySection = createSectionHeadingField('__companyInformationSection', t('customers.people.form.sections.companyInformation'))
   const dictionaryFields: CrudField[] = dictionaryFieldDefinitions.map((definition) => ({
@@ -933,7 +950,7 @@ export const createPersonFormFields = (t: Translator, options?: { defaultCountry
     },
     contactSection,
     createPrimaryEmailField(t),
-    createPrimaryPhoneField(t, defaultCountryIso2),
+    createPrimaryPhoneField(t, defaultCountryIso2, phoneCountries),
     companySection,
     {
       id: 'companyEntityId',
@@ -1228,8 +1245,9 @@ export const createCompanyFormSchema = () =>
     })
     .passthrough()
 
-export const createCompanyFormFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+export const createCompanyFormFields = (t: Translator, options?: CustomerFormFieldOptions): CrudField[] => {
   const defaultCountryIso2 = options?.defaultCountryIso2
+  const phoneCountries = options?.phoneCountries
   const dictionaryFields: CrudField[] = companyDictionaryFieldDefinitions.map((definition) => ({
     id: definition.id,
     label: t(definition.labelKey),
@@ -1276,6 +1294,7 @@ export const createCompanyFormFields = (t: Translator, options?: { defaultCountr
           invalidLabel={t('customers.people.form.primaryPhone.invalid', 'Enter a valid phone number with country code (e.g. +1 212 555 1234)')}
           minDigits={7}
           defaultCountryIso2={defaultCountryIso2}
+          countries={phoneCountries}
         />
       ),
     } as CrudField,
@@ -1657,7 +1676,7 @@ const buildIndustryLabels = (t: Translator): DictionarySelectLabels => ({
   manageTitle: t('customers.people.form.dictionary.manage'),
 })
 
-export const createCompanyEditFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+export const createCompanyEditFields = (t: Translator, options?: CustomerFormFieldOptions): CrudField[] => {
   const baseFields = createCompanyFormFields(t, options)
   const industryLabels = buildIndustryLabels(t)
 
@@ -1682,7 +1701,7 @@ export const createCompanyEditFields = (t: Translator, options?: { defaultCountr
   })
 }
 
-export const createPersonEditFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+export const createPersonEditFields = (t: Translator, options?: CustomerFormFieldOptions): CrudField[] => {
   const baseFields = createPersonFormFields(t, options)
   return [
     ...baseFields,

--- a/packages/ui/src/backend/inputs/PhoneNumberField.tsx
+++ b/packages/ui/src/backend/inputs/PhoneNumberField.tsx
@@ -378,6 +378,16 @@ export type PhoneCountryOption = {
 }
 
 /**
+ * Locale safe to hand to `localeCompare`. A tag `Intl` cannot construct would
+ * throw there just as it does in `getRegionDisplayNames`, so both fall back to
+ * English together.
+ */
+function resolveCollationLocale(locale: string | undefined): string {
+  if (!locale) return 'en'
+  return getRegionDisplayNames(locale) ? locale : 'en'
+}
+
+/**
  * Options rendered in the country dropdown. A caller-supplied list is
  * authoritative — its labels and its order are preserved verbatim — while the
  * built-in dictionary is localized and re-sorted for the active locale, since
@@ -389,9 +399,10 @@ export function buildPhoneCountryOptions(
   locale: string | undefined,
 ): PhoneCountryOption[] {
   if (countries) return countries.map((country) => ({ country, label: country.label }))
+  const collationLocale = resolveCollationLocale(locale)
   return PHONE_COUNTRIES
     .map((country) => ({ country, label: resolvePhoneCountryLabel(country, t, locale) }))
-    .sort((a, b) => a.label.localeCompare(b.label, locale ?? 'en', { sensitivity: 'base' }))
+    .sort((a, b) => a.label.localeCompare(b.label, collationLocale, { sensitivity: 'base' }))
 }
 
 /**

--- a/packages/ui/src/backend/inputs/PhoneNumberField.tsx
+++ b/packages/ui/src/backend/inputs/PhoneNumberField.tsx
@@ -357,10 +357,19 @@ function regionDisplayName(iso2: string, locale: string | undefined): string | n
   }
 }
 
+function isEnglishLocale(locale: string | undefined): boolean {
+  return !locale || locale.toLowerCase().split(/[-_]/)[0] === 'en'
+}
+
 /**
  * Display name for a built-in country in the active locale. A locale-file entry
  * wins so a deployment can correct or override any name; otherwise the
  * platform's region data localizes it; the English label is the last resort.
+ *
+ * English deliberately skips the region data: the dictionary already holds
+ * curated English names, and CLDR spells several of them differently
+ * ("Antigua & Barbuda" for "Antigua and Barbuda"), so consulting it would
+ * silently rewrite existing English copy for no gain.
  */
 export function resolvePhoneCountryLabel(
   country: PhoneCountry,
@@ -369,6 +378,7 @@ export function resolvePhoneCountryLabel(
 ): string {
   const translated = t(phoneCountryLabelKey(country.iso2), '')
   if (translated) return translated
+  if (isEnglishLocale(locale)) return country.label
   return regionDisplayName(country.iso2, locale) ?? country.label
 }
 

--- a/packages/ui/src/backend/inputs/PhoneNumberField.tsx
+++ b/packages/ui/src/backend/inputs/PhoneNumberField.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from 'react'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useOptionalLocale, useT, type TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { extractPhoneDigits, validatePhoneNumber } from '@open-mercato/shared/lib/phone'
 import { cn } from '@open-mercato/shared/lib/utils'
 import {
@@ -23,7 +23,11 @@ export type PhoneCountry = {
   iso2: string
   /** International dial code (with `+`). */
   dialCode: string
-  /** Human-readable country name (English). Override per surface for i18n. */
+  /**
+   * Human-readable country name (English). Used as the last-resort fallback
+   * when neither a locale file nor the platform's region data can name the
+   * country in the active locale.
+   */
   label: string
   /** Emoji flag (no asset dependency). */
   flag: string
@@ -312,6 +316,85 @@ export const PHONE_COUNTRIES: PhoneCountry[] = RAW_PHONE_COUNTRIES
   .sort((a, b) => a.label.localeCompare(b.label, 'en', { sensitivity: 'base' }))
 
 /**
+ * Translation key holding a country's display name, e.g.
+ * `ui.inputs.phoneNumberField.country.PL`. Locale files only need entries for
+ * the countries whose platform-provided name a deployment wants to change.
+ */
+export function phoneCountryLabelKey(iso2: string): string {
+  return `ui.inputs.phoneNumberField.country.${iso2.toUpperCase()}`
+}
+
+const regionDisplayNamesByLocale = new Map<string, Intl.DisplayNames | null>()
+
+function getRegionDisplayNames(locale: string): Intl.DisplayNames | null {
+  const cached = regionDisplayNamesByLocale.get(locale)
+  if (cached !== undefined) return cached
+  let displayNames: Intl.DisplayNames | null = null
+  try {
+    displayNames = new Intl.DisplayNames([locale], { type: 'region' })
+  } catch {
+    displayNames = null
+  }
+  regionDisplayNamesByLocale.set(locale, displayNames)
+  return displayNames
+}
+
+/**
+ * Country name in `locale` from the platform's own region data, or `null` when
+ * the runtime cannot name that region (unknown code, trimmed ICU data).
+ */
+function regionDisplayName(iso2: string, locale: string | undefined): string | null {
+  if (!locale) return null
+  const code = iso2.toUpperCase()
+  if (!/^[A-Z]{2}$/.test(code)) return null
+  const displayNames = getRegionDisplayNames(locale)
+  if (!displayNames) return null
+  try {
+    const name = displayNames.of(code)
+    return name && name !== code ? name : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Display name for a built-in country in the active locale. A locale-file entry
+ * wins so a deployment can correct or override any name; otherwise the
+ * platform's region data localizes it; the English label is the last resort.
+ */
+export function resolvePhoneCountryLabel(
+  country: PhoneCountry,
+  t: TranslateFn,
+  locale: string | undefined,
+): string {
+  const translated = t(phoneCountryLabelKey(country.iso2), '')
+  if (translated) return translated
+  return regionDisplayName(country.iso2, locale) ?? country.label
+}
+
+export type PhoneCountryOption = {
+  country: PhoneCountry
+  label: string
+}
+
+/**
+ * Options rendered in the country dropdown. A caller-supplied list is
+ * authoritative — its labels and its order are preserved verbatim — while the
+ * built-in dictionary is localized and re-sorted for the active locale, since
+ * its module-level ordering is alphabetical by the English name.
+ */
+export function buildPhoneCountryOptions(
+  countries: PhoneCountry[] | undefined,
+  t: TranslateFn,
+  locale: string | undefined,
+): PhoneCountryOption[] {
+  if (countries) return countries.map((country) => ({ country, label: country.label }))
+  return PHONE_COUNTRIES
+    .map((country) => ({ country, label: resolvePhoneCountryLabel(country, t, locale) }))
+    .sort((a, b) => a.label.localeCompare(b.label, locale ?? 'en', { sensitivity: 'base' }))
+}
+
+/**
  * Sovereign/primary country that wins auto-detection for a calling code shared
  * by several territories. US vs. Canada is the one irreducible ambiguity — both
  * are `+1` — and it resolves to the US.
@@ -386,7 +469,11 @@ export type PhoneNumberFieldProps = {
   duplicateLinkLabel?: string
   invalidLabel?: string
   onDuplicateLookup?: (normalizedValue: string) => Promise<PhoneDuplicateMatch | null>
-  /** Override the static country list (e.g. limit to specific markets). */
+  /**
+   * Override the static country list (e.g. limit to specific markets, or supply
+   * names already translated by the host). Both the labels and the order of the
+   * supplied list are rendered verbatim.
+   */
   countries?: PhoneCountry[]
   /** Initial country shown when `value` is empty / unparseable. Defaults to US. */
   defaultCountryIso2?: string
@@ -416,6 +503,7 @@ export function PhoneNumberField({
   defaultCountryIso2,
 }: PhoneNumberFieldProps) {
   const t = useT()
+  const locale = useOptionalLocale()
   const resolvedInvalidLabel = invalidLabel ?? t(
     'ui.inputs.phoneNumberField.invalid',
     'Enter a valid phone number with country code (e.g. +1 212 555 1234)'
@@ -429,7 +517,10 @@ export function PhoneNumberField({
     'Open record'
   )
   const resolvedPlaceholder = placeholder ?? DEFAULT_PLACEHOLDER
-  const countries = countriesProp ?? PHONE_COUNTRIES
+  const countryOptions = React.useMemo(
+    () => buildPhoneCountryOptions(countriesProp, t, locale),
+    [countriesProp, t, locale],
+  )
   const fallbackCountry = React.useMemo(
     () => (defaultCountryIso2 && findCountryByIso(defaultCountryIso2)) || DEFAULT_COUNTRY,
     [defaultCountryIso2],
@@ -596,12 +687,12 @@ export function PhoneNumberField({
             <span className="text-sm text-foreground tabular-nums">{country.dialCode}</span>
           </SelectTrigger>
           <SelectContent align="start">
-            {countries.map((c) => (
+            {countryOptions.map(({ country: c, label }) => (
               <SelectItem key={`${c.iso2}-${c.dialCode}`} value={c.iso2}>
                 <SelectItemLeading>
                   <span className="text-base leading-none">{c.flag}</span>
                 </SelectItemLeading>
-                <span className="flex-1 truncate">{c.label}</span>
+                <span className="flex-1 truncate">{label}</span>
                 <span className="ml-2 text-xs text-muted-foreground tabular-nums">{c.dialCode}</span>
               </SelectItem>
             ))}

--- a/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
@@ -215,3 +215,15 @@ describe('PhoneNumberField country option list', () => {
     ])
   })
 })
+
+describe('PhoneNumberField option list under an unusable locale', () => {
+  it('falls back to English names and English collation instead of throwing', () => {
+    const options = buildPhoneCountryOptions(undefined, englishOnly, 'not a locale tag')
+
+    expect(options.find((option) => option.country.iso2 === 'DE')?.label).toBe('Germany')
+
+    const labels = options.map((option) => option.label)
+    const sorted = [...labels].sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
+    expect(labels).toEqual(sorted)
+  })
+})

--- a/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
@@ -182,6 +182,17 @@ describe('PhoneNumberField country name localization', () => {
     expect(resolvePhoneCountryLabel(poland, englishOnly, undefined)).toBe('Poland')
   })
 
+  it('keeps the curated English dictionary names under an English locale', () => {
+    const antigua = PHONE_COUNTRIES.find((country) => country.iso2 === 'AG') as PhoneCountry
+
+    expect(resolvePhoneCountryLabel(poland, englishOnly, 'en')).toBe('Poland')
+    // CLDR spells this "Antigua & Barbuda"; the dictionary wins so existing
+    // English copy is never silently rewritten.
+    expect(antigua.label).toBe('Antigua and Barbuda')
+    expect(resolvePhoneCountryLabel(antigua, englishOnly, 'en')).toBe('Antigua and Barbuda')
+    expect(resolvePhoneCountryLabel(antigua, englishOnly, 'en-GB')).toBe('Antigua and Barbuda')
+  })
+
   it('falls back to the English label for a code the runtime cannot name', () => {
     const unassigned: PhoneCountry = { iso2: 'QQ', dialCode: '+999', label: 'Nowhere', flag: '' }
     const malformed: PhoneCountry = { iso2: 'QQQ', dialCode: '+999', label: 'Nowhere', flag: '' }

--- a/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx
@@ -2,6 +2,7 @@
 
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   useT: () => (_key: string, fallback: string) => fallback,
+  useOptionalLocale: () => undefined,
 }))
 
 jest.mock('@open-mercato/shared/lib/phone', () => ({
@@ -22,7 +23,15 @@ jest.mock('@open-mercato/shared/lib/phone', () => ({
 
 import * as React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { PHONE_COUNTRIES, PhoneNumberField } from '../PhoneNumberField'
+import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
+import {
+  PHONE_COUNTRIES,
+  PhoneNumberField,
+  buildPhoneCountryOptions,
+  phoneCountryLabelKey,
+  resolvePhoneCountryLabel,
+  type PhoneCountry,
+} from '../PhoneNumberField'
 
 function PhoneFieldHarness(props: Partial<React.ComponentProps<typeof PhoneNumberField>>) {
   const [value, setValue] = React.useState<string | undefined>(undefined)
@@ -145,5 +154,64 @@ describe('PhoneNumberField initial country detection', () => {
   it.each(cases)('resolves %s to dial code %s (longest prefix, sovereign first)', (value, expected) => {
     render(<PhoneFieldHarness value={value} />)
     expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+})
+
+const englishOnly: TranslateFn = (key, fallback) => (typeof fallback === 'string' ? fallback : key)
+
+describe('PhoneNumberField country name localization', () => {
+  const poland = PHONE_COUNTRIES.find((country) => country.iso2 === 'PL') as PhoneCountry
+
+  it('builds the translation key from the ISO 3166-1 alpha-2 code', () => {
+    expect(phoneCountryLabelKey('pl')).toBe('ui.inputs.phoneNumberField.country.PL')
+  })
+
+  it('prefers a locale-file entry over every other source', () => {
+    const withOverride: TranslateFn = (key, fallback) =>
+      key === 'ui.inputs.phoneNumberField.country.PL' ? 'Rzeczpospolita Polska' : englishOnly(key, fallback)
+
+    expect(resolvePhoneCountryLabel(poland, withOverride, 'pl')).toBe('Rzeczpospolita Polska')
+  })
+
+  it('localizes an untranslated country through the active locale region data', () => {
+    expect(resolvePhoneCountryLabel(poland, englishOnly, 'pl')).toBe('Polska')
+    expect(resolvePhoneCountryLabel(poland, englishOnly, 'de')).toBe('Polen')
+  })
+
+  it('falls back to the English label when no locale is in scope', () => {
+    expect(resolvePhoneCountryLabel(poland, englishOnly, undefined)).toBe('Poland')
+  })
+
+  it('falls back to the English label for a code the runtime cannot name', () => {
+    const unassigned: PhoneCountry = { iso2: 'QQ', dialCode: '+999', label: 'Nowhere', flag: '' }
+    const malformed: PhoneCountry = { iso2: 'QQQ', dialCode: '+999', label: 'Nowhere', flag: '' }
+
+    expect(resolvePhoneCountryLabel(unassigned, englishOnly, 'pl')).toBe('Nowhere')
+    expect(resolvePhoneCountryLabel(malformed, englishOnly, 'pl')).toBe('Nowhere')
+  })
+})
+
+describe('PhoneNumberField country option list', () => {
+  it('localizes the built-in list and re-sorts it for the active locale', () => {
+    const options = buildPhoneCountryOptions(undefined, englishOnly, 'pl')
+
+    expect(options).toHaveLength(PHONE_COUNTRIES.length)
+    expect(options.find((option) => option.country.iso2 === 'DE')?.label).toBe('Niemcy')
+
+    const labels = options.map((option) => option.label)
+    const sorted = [...labels].sort((a, b) => a.localeCompare(b, 'pl', { sensitivity: 'base' }))
+    expect(labels).toEqual(sorted)
+  })
+
+  it('keeps a caller-supplied list authoritative in both label and order', () => {
+    const supplied: PhoneCountry[] = [
+      { iso2: 'DE', dialCode: '+49', label: 'Deutschland', flag: '🇩🇪' },
+      { iso2: 'PL', dialCode: '+48', label: 'Rzeczpospolita', flag: '🇵🇱' },
+    ]
+
+    expect(buildPhoneCountryOptions(supplied, englishOnly, 'pl')).toEqual([
+      { country: supplied[0], label: 'Deutschland' },
+      { country: supplied[1], label: 'Rzeczpospolita' },
+    ])
   })
 })


### PR DESCRIPTION
Fixes #5927

## 🎯 Problem

`PhoneNumberField` already routes its own copy through `t('ui.inputs.phoneNumberField.*', …)`, but the country dropdown rendered `label` straight from the hardcoded English `RAW_PHONE_COUNTRIES` dictionary. Under `locale: 'pl'` (or any non-English locale) every country in a near-complete ~250-entry picker read "Poland", "Germany", "United States" while the rest of the form was translated.

The component does expose a `countries?: PhoneCountry[]` override, but `createPrimaryPhoneField` — the only core consumer, used by both the people and the companies form — never passed it. Overriding the list app-side therefore meant forking the large `formConfig.tsx` rather than passing a prop.

## 🔧 What changed

**`packages/ui/src/backend/inputs/PhoneNumberField.tsx`**

- `resolvePhoneCountryLabel(country, t, locale)` resolves each built-in country's display name in three steps: a locale-file entry (`ui.inputs.phoneNumberField.country.<ISO2>`, the key shape the issue suggested) wins so a deployment can correct or override any name; otherwise the platform's own region data for the active locale names it; the English `label` is the last resort.
- Going through the platform's region data means the picker follows the locale **out of the box**, without any locale file having to carry ~250 country names × 5 locales. Locale files stay the override mechanism rather than the only mechanism — which is why this PR adds no new translation keys.
- `buildPhoneCountryOptions(countries, t, locale)` builds the rendered option list. The built-in dictionary is localized **and re-sorted** by the resolved name, because `PHONE_COUNTRIES` is ordered alphabetically by the *English* label at module level — without the re-sort a localized list would render out of alphabetical order.
- A caller-supplied `countries` list stays **authoritative**: its labels and its order are rendered verbatim, exactly as before. This keeps the existing prop contract unchanged for anyone already passing a curated or pre-translated list.
- The active locale comes from `useOptionalLocale()`, so the component still renders outside an `I18nProvider` (it simply falls back to the English labels there).

**`packages/core/src/modules/customers/components/formConfig.tsx`**

- The repeated inline `{ defaultCountryIso2?: string }` options bag is now the named, exported `CustomerFormFieldOptions`, extended with `phoneCountries?: PhoneCountry[]`.
- Both `<PhoneNumberField>` call sites — `createPrimaryPhoneField` (people) and the companies `primaryPhone` field — now forward it, so `createPersonFormFields` / `createCompanyFormFields` / `createPersonEditFields` / `createCompanyEditFields` can all supply a list without forking the file. Widening an optional options bag is additive; every existing caller is unaffected.

## 🧪 Tests

Nine new regression tests, all coupled to the fix (they fail without it — the helpers do not exist, and the `countries` prop is never passed):

`packages/ui/src/backend/inputs/__tests__/PhoneNumberField.test.tsx`
- `phoneCountryLabelKey` builds the key from the ISO 3166-1 alpha-2 code, upper-cased.
- A locale-file entry beats every other source.
- An untranslated country is localized through the active locale's region data (`PL` → `Polska` in `pl`, `Polen` in `de`) — the actual reported bug.
- Falls back to the English label when no locale is in scope.
- Falls back to the English label for a code the runtime cannot name (unassigned `QQ` and malformed `QQQ`).
- The built-in list is localized and re-sorted for the active locale (`DE` → `Niemcy`, and the whole label sequence matches a `pl` collation).
- A caller-supplied list keeps both its labels and its order.

`packages/core/src/modules/customers/components/__tests__/formConfigPhoneCountries.test.tsx` (new)
- A supplied `phoneCountries` list reaches the person form's phone field.
- A supplied list reaches the company form's phone field.
- With no override the prop stays `undefined`, so the field localizes its own list.

## ✅ Validation

Full configured gate, run locally (no compose container was up):

| Step | Result |
|---|---|
| `yarn build:packages` (×2) | ✅ |
| `yarn generate` | ✅ |
| `yarn i18n:check-sync` | ✅ |
| `yarn i18n:check-usage` | ✅ |
| `yarn typecheck` | ✅ |
| `yarn test` | ✅ 31/34 packages, including `@open-mercato/ui` (1973) and `@open-mercato/core` |
| `yarn build:app` | ✅ |

Three packages are red on this machine for reasons that pre-date and are independent of this branch, each checked individually:

- `@open-mercato/cli` — 5 failures in `resolve-environment` / `resolver.enterprise`, which are location-dependent env-resolution suites. This diff touches no file under `packages/cli`.
- `@open-mercato/shared` — 2 failures in `dynamicLoader.generatedCacheRecovery` from a `tsx` IPC socket path that exceeds the unix-socket length limit under the long temp dir turbo passes down. The suite **passes standalone** with a short `TMPDIR`.
- `create-mercato-app` — the live Codex/Claude oracle suites, which need those CLIs installed. The genuine repo-state guard, `harness:check-source-link-inventory`, **passes** on this branch.

## 💥 Breaking changes

None. `PhoneCountry`, `PhoneNumberFieldProps.countries` and every exported form-field builder keep their existing shapes and behavior; the new exports (`phoneCountryLabelKey`, `resolvePhoneCountryLabel`, `buildPhoneCountryOptions`, `PhoneCountryOption`, `CustomerFormFieldOptions`) and the `phoneCountries` option are additive. No new locale keys, so no locale-file parity change. The one observable difference is the intended one: with a locale in scope and no `countries` override, the picker now shows localized, locale-sorted country names instead of English ones.

## 📸 QA

`needs-qa` — this changes what an operator sees in the phone country picker on the customer people and companies create/edit forms. Worth exercising under a non-English locale (`pl`/`de`): open the picker, confirm the names are translated, alphabetically ordered for that locale, and that selecting a country still writes the right dial code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791469280&installation_model_id=432243&pr_number=5983&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5983&signature=da501688717164fcfa2effc4cc8565b9a34884c123b02fa18ab26e3ec2e46dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->