### PR TITLE
fix(workflows): honor trigger debounceMs in event-trigger-service (#5922)

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
@@ -188,6 +188,18 @@ describe('processEventTriggers — trigger debounceMs (#5922)', () => {
     expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps the window per entity when the payload id is numeric', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    await emitEvent({ id: 1 })
+    const otherNumericEntity = await emitEvent({ id: 2 })
+    const sameNumericEntity = await emitEvent({ id: 1 })
+
+    expect(otherNumericEntity).toEqual({ triggered: 1, skipped: 0 })
+    expect(sameNumericEntity).toEqual({ triggered: 0, skipped: 1 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+  })
+
   it('debounces per trigger when the event payload carries no entity id', async () => {
     registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
 

--- a/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
@@ -77,9 +77,9 @@ function codeWorkflow(
   }
 }
 
-function fakeEntityManager(): EntityManager {
+function fakeEntityManager(runningInstances = 0): EntityManager {
   const em = {
-    count: jest.fn().mockResolvedValue(0),
+    count: jest.fn().mockResolvedValue(runningInstances),
     fork: jest.fn(() => em),
   }
   return em as unknown as EntityManager
@@ -92,8 +92,9 @@ function fakeContainer(): AwilixContainer {
 async function emitEvent(
   payload: Record<string, unknown>,
   tenantId: string = TENANT,
+  runningInstances = 0,
 ): Promise<{ triggered: number; skipped: number }> {
-  const result = await processEventTriggers(fakeEntityManager(), fakeContainer(), {
+  const result = await processEventTriggers(fakeEntityManager(runningInstances), fakeContainer(), {
     eventName: EVENT_NAME,
     payload,
     tenantId,
@@ -197,6 +198,31 @@ describe('processEventTriggers — trigger debounceMs (#5922)', () => {
 
     expect(otherNumericEntity).toEqual({ triggered: 1, skipped: 0 })
     expect(sameNumericEntity).toEqual({ triggered: 0, skipped: 1 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('reopens the window when the concurrency limit blocked the start', async () => {
+    registerCodeWorkflowEntries([
+      codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS, maxConcurrentInstances: 1 }),
+    ])
+
+    const blocked = await emitEvent({ id: 'order-1' }, TENANT, 1)
+    const afterCapacityFreed = await emitEvent({ id: 'order-1' }, TENANT, 0)
+
+    expect(blocked).toEqual({ triggered: 0, skipped: 1 })
+    expect(afterCapacityFreed).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('reopens the window when starting the workflow threw', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+    mockStartWorkflow.mockRejectedValueOnce(new Error('transient failure'))
+
+    const failed = await emitEvent({ id: 'order-1' })
+    const retry = await emitEvent({ id: 'order-1' })
+
+    expect(failed).toEqual({ triggered: 0, skipped: 0 })
+    expect(retry).toEqual({ triggered: 1, skipped: 0 })
     expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #5922: a trigger's `debounceMs` was declared on the type
+ * (`packages/shared/src/modules/workflows/types.ts`), stored on the entity,
+ * validated by the definitions API and offered as a field in the visual editor
+ * — but `processEventTriggers` never read it, so the documented trigger-storm
+ * protection was a silent no-op. Its sibling guard `maxConcurrentInstances` was
+ * consumed in the same loop, which is what made the omission easy to miss.
+ *
+ * These tests lock the leading-edge semantics: the first event starts the
+ * workflow and opens the window, repeats inside it are counted as `skipped`,
+ * and the window is scoped per trigger, per entity and per tenant so unrelated
+ * events never suppress each other.
+ */
+jest.mock('../workflow-executor', () => ({
+  executeWorkflow: jest.fn().mockResolvedValue(undefined),
+  startWorkflow: jest.fn(),
+}))
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+import type { AwilixContainer } from 'awilix'
+import type { EntityManager } from '@mikro-orm/core'
+import {
+  registerCodeWorkflowEntries,
+  clearCodeWorkflowRegistry,
+} from '@open-mercato/shared/modules/workflows/code-registry'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type { CodeWorkflowDefinition } from '@open-mercato/shared/modules/workflows'
+import { startWorkflow } from '../workflow-executor'
+import {
+  invalidateTriggerCache,
+  processEventTriggers,
+  resetTriggerDebounceState,
+} from '../event-trigger-service'
+
+const TENANT = 'tenant-1'
+const OTHER_TENANT = 'tenant-2'
+const ORG = 'org-1'
+const EVENT_NAME = 'sales.order.updated'
+const DEBOUNCE_MS = 5000
+
+const mockFindWithDecryption = findWithDecryption as jest.MockedFunction<typeof findWithDecryption>
+const mockStartWorkflow = startWorkflow as jest.MockedFunction<typeof startWorkflow>
+
+function codeWorkflow(
+  workflowId: string,
+  triggerConfig: Record<string, unknown> | null,
+): CodeWorkflowDefinition {
+  return {
+    workflowId,
+    workflowName: 'Order Follow-up',
+    description: null,
+    version: 1,
+    enabled: true,
+    metadata: null,
+    moduleId: 'sales',
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [{ transitionId: 't1', fromStepId: 'start', toStepId: 'end', trigger: 'auto' }],
+      triggers: [
+        {
+          triggerId: 'on-order-updated',
+          name: 'On order updated',
+          eventPattern: EVENT_NAME,
+          enabled: true,
+          priority: 10,
+          config: triggerConfig,
+        },
+      ],
+    } as CodeWorkflowDefinition['definition'],
+  }
+}
+
+function fakeEntityManager(): EntityManager {
+  const em = {
+    count: jest.fn().mockResolvedValue(0),
+    fork: jest.fn(() => em),
+  }
+  return em as unknown as EntityManager
+}
+
+function fakeContainer(): AwilixContainer {
+  return { resolve: jest.fn() } as unknown as AwilixContainer
+}
+
+async function emitEvent(
+  payload: Record<string, unknown>,
+  tenantId: string = TENANT,
+): Promise<{ triggered: number; skipped: number }> {
+  const result = await processEventTriggers(fakeEntityManager(), fakeContainer(), {
+    eventName: EVENT_NAME,
+    payload,
+    tenantId,
+    organizationId: ORG,
+  })
+  return { triggered: result.triggered, skipped: result.skipped }
+}
+
+describe('processEventTriggers — trigger debounceMs (#5922)', () => {
+  let nowSpy: jest.SpyInstance<number, []>
+  let currentTime: number
+
+  beforeEach(() => {
+    currentTime = 1_700_000_000_000
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTime)
+    // Both DB-backed trigger loaders return nothing; the code registry is the
+    // only source, which keeps the test free of ORM fixtures.
+    mockFindWithDecryption.mockResolvedValue([] as never)
+    mockStartWorkflow.mockImplementation(async () => ({ id: `instance-${currentTime}` }) as never)
+  })
+
+  afterEach(() => {
+    nowSpy.mockRestore()
+    clearCodeWorkflowRegistry()
+    invalidateTriggerCache(TENANT, ORG)
+    invalidateTriggerCache(OTHER_TENANT, ORG)
+    resetTriggerDebounceState()
+    mockFindWithDecryption.mockReset()
+    mockStartWorkflow.mockReset()
+  })
+
+  it('drops a repeat event that arrives inside the debounce window', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    const first = await emitEvent({ id: 'order-1' })
+    currentTime += DEBOUNCE_MS - 1
+    const second = await emitEvent({ id: 'order-1' })
+
+    expect(first).toEqual({ triggered: 1, skipped: 0 })
+    expect(second).toEqual({ triggered: 0, skipped: 1 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts the workflow again once the debounce window has elapsed', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    await emitEvent({ id: 'order-1' })
+    currentTime += DEBOUNCE_MS
+    const afterWindow = await emitEvent({ id: 'order-1' })
+
+    expect(afterWindow).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not debounce when debounceMs is absent or zero', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', null)])
+
+    await emitEvent({ id: 'order-1' })
+    const immediateRepeat = await emitEvent({ id: 'order-1' })
+
+    expect(immediateRepeat).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+
+    clearCodeWorkflowRegistry()
+    invalidateTriggerCache(TENANT, ORG)
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: 0 })])
+
+    await emitEvent({ id: 'order-2' })
+    const zeroWindowRepeat = await emitEvent({ id: 'order-2' })
+
+    expect(zeroWindowRepeat).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(4)
+  })
+
+  it('keeps the debounce window per entity so a different record still triggers', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    await emitEvent({ id: 'order-1' })
+    const otherEntity = await emitEvent({ id: 'order-2' })
+
+    expect(otherEntity).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the debounce window per tenant so one tenant cannot suppress another', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    await emitEvent({ id: 'order-1' }, TENANT)
+    const otherTenant = await emitEvent({ id: 'order-1' }, OTHER_TENANT)
+
+    expect(otherTenant).toEqual({ triggered: 1, skipped: 0 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('debounces per trigger when the event payload carries no entity id', async () => {
+    registerCodeWorkflowEntries([codeWorkflow('sales.order-followup', { debounceMs: DEBOUNCE_MS })])
+
+    const first = await emitEvent({})
+    const second = await emitEvent({})
+
+    expect(first).toEqual({ triggered: 1, skipped: 0 })
+    expect(second).toEqual({ triggered: 0, skipped: 1 })
+    expect(mockStartWorkflow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -696,7 +696,13 @@ function shouldDebounceTrigger(trigger: UnifiedTrigger, payload: Record<string, 
 
   if (!debounceMs || debounceMs <= 0) return false // No debounce configured
 
-  const payloadId = typeof payload?.id === 'string' ? payload.id : null
+  // Accept numeric ids too: falling back to the shared `*` bucket would collapse
+  // every record under one key and suppress workflows for unrelated entities.
+  const rawPayloadId = payload?.id
+  const payloadId =
+    typeof rawPayloadId === 'string' ? rawPayloadId
+    : typeof rawPayloadId === 'number' ? String(rawPayloadId)
+    : null
   const key = `${trigger.tenantId}:${trigger.organizationId}:${trigger.id}:${payloadId ?? '*'}`
   const state = getTriggerDebounceState()
   const now = Date.now()

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -640,6 +640,84 @@ export async function findMatchingTriggers(
 // Trigger Processing
 // ============================================================================
 
+// Last-fire timestamps for triggers configured with `debounceMs`, keyed by
+// tenant/org/trigger/entity. Parked on globalThis for the same reason as the
+// trigger cache above: the compiled module can be loaded under two import roots
+// (a Next.js server chunk vs. a worker), and a module-local Map would debounce
+// each copy separately — halving the effective window whenever both copies see
+// the same event stream.
+const GLOBAL_TRIGGER_DEBOUNCE_KEY = '__openMercatoWorkflowTriggerDebounce__'
+
+// Cap on tracked keys so a long-lived worker cannot grow the Map without bound;
+// mirrors the prune step in query_index's `markAutoReindexScheduled`.
+const TRIGGER_DEBOUNCE_MAX_KEYS = 5000
+
+type GlobalWithTriggerDebounce = typeof globalThis & {
+  [GLOBAL_TRIGGER_DEBOUNCE_KEY]?: Map<string, number>
+}
+
+function getTriggerDebounceState(): Map<string, number> {
+  const globalScope = globalThis as GlobalWithTriggerDebounce
+  if (!globalScope[GLOBAL_TRIGGER_DEBOUNCE_KEY]) {
+    globalScope[GLOBAL_TRIGGER_DEBOUNCE_KEY] = new Map<string, number>()
+  }
+  return globalScope[GLOBAL_TRIGGER_DEBOUNCE_KEY]
+}
+
+function pruneTriggerDebounceState(state: Map<string, number>, now: number, debounceMs: number): void {
+  if (state.size < TRIGGER_DEBOUNCE_MAX_KEYS) return
+
+  for (const [key, firedAt] of state) {
+    if (now - firedAt >= debounceMs) state.delete(key)
+  }
+
+  if (state.size < TRIGGER_DEBOUNCE_MAX_KEYS) return
+
+  const oldestKey = state.keys().next().value
+  if (oldestKey !== undefined) state.delete(oldestKey)
+}
+
+/**
+ * Check whether this event falls inside the trigger's debounce window.
+ *
+ * Leading-edge semantics: the first event fires the workflow and opens the
+ * window; repeats inside it are dropped. This matches the two other
+ * `debounceMs` implementations in the codebase (`markAutoReindexScheduled` in
+ * query_index, `NotificationDispatcher.shouldDebounce` in the UI package) and
+ * needs no timer that would have to survive a process restart.
+ *
+ * The key includes the event payload's `id` so the window is per trigger *and*
+ * per entity — rapid updates to two different records still start two
+ * workflows. Tenant and organization are part of the key because code-defined
+ * triggers reuse one id across every tenant.
+ */
+function shouldDebounceTrigger(trigger: UnifiedTrigger, payload: Record<string, unknown>): boolean {
+  const debounceMs = trigger.config?.debounceMs
+
+  if (!debounceMs || debounceMs <= 0) return false // No debounce configured
+
+  const payloadId = typeof payload?.id === 'string' ? payload.id : null
+  const key = `${trigger.tenantId}:${trigger.organizationId}:${trigger.id}:${payloadId ?? '*'}`
+  const state = getTriggerDebounceState()
+  const now = Date.now()
+  const lastFiredAt = state.get(key)
+
+  if (lastFiredAt !== undefined && now - lastFiredAt < debounceMs) return true
+
+  pruneTriggerDebounceState(state, now, debounceMs)
+  state.delete(key)
+  state.set(key, now)
+  return false
+}
+
+/**
+ * Clear all debounce windows. Test-only seam — production code relies on the
+ * windows expiring on their own.
+ */
+export function resetTriggerDebounceState(): void {
+  getTriggerDebounceState().clear()
+}
+
 /**
  * Check if max concurrent instances limit is reached.
  */
@@ -688,6 +766,13 @@ export async function processEventTriggers(
   // Process each trigger (definitions already validated during loading)
   for (const trigger of triggers) {
     try {
+      // Check debounce window before any DB work
+      if (shouldDebounceTrigger(trigger, context.payload)) {
+        logger.debug('Skipping trigger: inside debounce window', { triggerId: trigger.id, triggerName: trigger.name, debounceMs: trigger.config?.debounceMs })
+        result.skipped++
+        continue
+      }
+
       // Check concurrency limit
       const canStart = await checkConcurrencyLimit(em, trigger)
       if (!canStart) {

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -640,12 +640,15 @@ export async function findMatchingTriggers(
 // Trigger Processing
 // ============================================================================
 
-// Last-fire timestamps for triggers configured with `debounceMs`, keyed by
-// tenant/org/trigger/entity. Parked on globalThis for the same reason as the
-// trigger cache above: the compiled module can be loaded under two import roots
-// (a Next.js server chunk vs. a worker), and a module-local Map would debounce
-// each copy separately — halving the effective window whenever both copies see
-// the same event stream.
+// Open debounce windows for triggers configured with `debounceMs`, keyed by
+// tenant/org/trigger/entity and holding the timestamp each window closes at.
+// Parked on globalThis for the same reason as the trigger cache above: the
+// compiled module can be loaded under two import roots (a Next.js server chunk
+// vs. a worker), and a module-local Map would debounce each copy separately —
+// halving the effective window whenever both copies see the same event stream.
+// The state is still per process: a deployment running several app or worker
+// processes debounces independently in each one, so the guard bounds trigger
+// storms per process rather than cluster-wide.
 const GLOBAL_TRIGGER_DEBOUNCE_KEY = '__openMercatoWorkflowTriggerDebounce__'
 
 // Cap on tracked keys so a long-lived worker cannot grow the Map without bound;
@@ -664,11 +667,15 @@ function getTriggerDebounceState(): Map<string, number> {
   return globalScope[GLOBAL_TRIGGER_DEBOUNCE_KEY]
 }
 
-function pruneTriggerDebounceState(state: Map<string, number>, now: number, debounceMs: number): void {
+// Entries store their own expiry rather than their start, so pruning never has
+// to assume one shared window length: `debounceMs` is per trigger and ranges
+// from 0 to the validator's one-hour ceiling, and expiring a one-hour window
+// because a 100 ms trigger happened to run the prune would silently reopen it.
+function pruneTriggerDebounceState(state: Map<string, number>, now: number): void {
   if (state.size < TRIGGER_DEBOUNCE_MAX_KEYS) return
 
-  for (const [key, firedAt] of state) {
-    if (now - firedAt >= debounceMs) state.delete(key)
+  for (const [key, expiresAt] of state) {
+    if (expiresAt <= now) state.delete(key)
   }
 
   if (state.size < TRIGGER_DEBOUNCE_MAX_KEYS) return
@@ -678,23 +685,21 @@ function pruneTriggerDebounceState(state: Map<string, number>, now: number, debo
 }
 
 /**
- * Check whether this event falls inside the trigger's debounce window.
- *
- * Leading-edge semantics: the first event fires the workflow and opens the
- * window; repeats inside it are dropped. This matches the two other
- * `debounceMs` implementations in the codebase (`markAutoReindexScheduled` in
- * query_index, `NotificationDispatcher.shouldDebounce` in the UI package) and
- * needs no timer that would have to survive a process restart.
+ * Resolve the debounce window a trigger/event pair shares, or `null` when the
+ * trigger has no debounce configured.
  *
  * The key includes the event payload's `id` so the window is per trigger *and*
  * per entity — rapid updates to two different records still start two
  * workflows. Tenant and organization are part of the key because code-defined
  * triggers reuse one id across every tenant.
  */
-function shouldDebounceTrigger(trigger: UnifiedTrigger, payload: Record<string, unknown>): boolean {
+function resolveTriggerDebounceWindow(
+  trigger: UnifiedTrigger,
+  payload: Record<string, unknown>,
+): { key: string; debounceMs: number } | null {
   const debounceMs = trigger.config?.debounceMs
 
-  if (!debounceMs || debounceMs <= 0) return false // No debounce configured
+  if (!debounceMs || debounceMs <= 0) return null
 
   // Accept numeric ids too: falling back to the shared `*` bucket would collapse
   // every record under one key and suppress workflows for unrelated entities.
@@ -703,17 +708,56 @@ function shouldDebounceTrigger(trigger: UnifiedTrigger, payload: Record<string, 
     typeof rawPayloadId === 'string' ? rawPayloadId
     : typeof rawPayloadId === 'number' ? String(rawPayloadId)
     : null
-  const key = `${trigger.tenantId}:${trigger.organizationId}:${trigger.id}:${payloadId ?? '*'}`
+
+  return { key: `${trigger.tenantId}:${trigger.organizationId}:${trigger.id}:${payloadId ?? '*'}`, debounceMs }
+}
+
+/**
+ * Check whether this event falls inside the trigger's debounce window, opening
+ * a fresh window when it does not.
+ *
+ * Leading-edge semantics: the first event fires the workflow and opens the
+ * window; repeats inside it are dropped. This matches the two other
+ * `debounceMs` implementations in the codebase (`markAutoReindexScheduled` in
+ * query_index, `NotificationDispatcher.shouldDebounce` in the UI package) and
+ * needs no timer that would have to survive a process restart.
+ *
+ * The window is opened here rather than after the workflow starts so that
+ * nothing awaits between reading and writing it — two events racing through
+ * `processEventTriggers` must not both observe an empty window. An attempt that
+ * does not go on to start a workflow closes its window again via
+ * `releaseTriggerDebounceWindow`, so only a real start keeps one open.
+ */
+function shouldDebounceTrigger(trigger: UnifiedTrigger, payload: Record<string, unknown>): boolean {
+  const debounceWindow = resolveTriggerDebounceWindow(trigger, payload)
+
+  if (!debounceWindow) return false
+
   const state = getTriggerDebounceState()
   const now = Date.now()
-  const lastFiredAt = state.get(key)
+  const expiresAt = state.get(debounceWindow.key)
 
-  if (lastFiredAt !== undefined && now - lastFiredAt < debounceMs) return true
+  if (expiresAt !== undefined && now < expiresAt) return true
 
-  pruneTriggerDebounceState(state, now, debounceMs)
-  state.delete(key)
-  state.set(key, now)
+  pruneTriggerDebounceState(state, now)
+  state.delete(debounceWindow.key)
+  state.set(debounceWindow.key, now + debounceWindow.debounceMs)
   return false
+}
+
+/**
+ * Close a window `shouldDebounceTrigger` opened for an event that never started
+ * a workflow — the concurrency limit blocked it, or mapping/starting threw.
+ * Leaving it open would let one blocked or failed attempt suppress every later
+ * event for the same record until the window elapsed, which at the validator's
+ * one-hour ceiling means an hour of silently dropped starts.
+ */
+function releaseTriggerDebounceWindow(trigger: UnifiedTrigger, payload: Record<string, unknown>): void {
+  const debounceWindow = resolveTriggerDebounceWindow(trigger, payload)
+
+  if (!debounceWindow) return
+
+  getTriggerDebounceState().delete(debounceWindow.key)
 }
 
 /**
@@ -771,6 +815,7 @@ export async function processEventTriggers(
 
   // Process each trigger (definitions already validated during loading)
   for (const trigger of triggers) {
+    let startedWorkflow = false
     try {
       // Check debounce window before any DB work
       if (shouldDebounceTrigger(trigger, context.payload)) {
@@ -783,6 +828,7 @@ export async function processEventTriggers(
       const canStart = await checkConcurrencyLimit(em, trigger)
       if (!canStart) {
         logger.debug('Skipping trigger: max concurrent instances reached', { triggerId: trigger.id, triggerName: trigger.name })
+        releaseTriggerDebounceWindow(trigger, context.payload)
         result.skipped++
         continue
       }
@@ -832,6 +878,7 @@ export async function processEventTriggers(
         organizationId: context.organizationId,
       })
 
+      startedWorkflow = true
       result.triggered++
       result.instances.push({
         triggerId: trigger.id,
@@ -851,6 +898,7 @@ export async function processEventTriggers(
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       logger.error('Error processing trigger', { triggerId: trigger.id, triggerName: trigger.name, err: error })
+      if (!startedWorkflow) releaseTriggerDebounceWindow(trigger, context.payload)
       result.errors.push({
         triggerId: trigger.id,
         error: errorMessage,


### PR DESCRIPTION
Closes #5922

## 🎯 Goal

A workflow author who sets `Debounce (ms)` on an event trigger now actually gets debouncing: rapid repeated events for the same record start one workflow instance instead of one per event. Before this change the setting was accepted, stored and displayed, but changed nothing at runtime — the only way to discover that was to test it.

## 🔍 Problem

`TriggerConfig.debounceMs` is declared in `packages/shared/src/modules/workflows/types.ts:147`, stored on the entity (`data/entities.ts:94`, comment "Debounce rapid events"), validated in two places (`data/validators.ts:433,978`), rendered as a form field with the hint "Delay to prevent rapid re-triggers" (`components/DefinitionTriggersEditor.tsx:511`), translated into all five locales, and recommended by the module's own guidelines (`AGENTS.md:143` — "Use `debounceMs` and `maxConcurrentInstances` to prevent trigger storms").

Nothing read it. The configuration surface promised trigger-storm protection that did not exist, silently.

## 🔍 Root Cause

`lib/event-trigger-service.ts` implemented exactly one of the two trigger-storm guards its configuration declares. `checkConcurrencyLimit` reads `trigger.config?.maxConcurrentInstances` and is called from the `processEventTriggers` loop, but there was no counterpart reading `trigger.config?.debounceMs` — the loop went straight from the concurrency check to `mapEventToContext` and `startWorkflow`. Having the sibling guard present and working in the same loop is what made the omission easy to miss in review.

## What Changed

- **`packages/core/src/modules/workflows/lib/event-trigger-service.ts`** — added `shouldDebounceTrigger(trigger, payload)` next to `checkConcurrencyLimit`, and call it as the first check inside the `processEventTriggers` loop. A suppressed event increments the existing `skipped` counter and logs at `debug`, exactly as the concurrency branch already does, so the `ProcessTriggersResult` contract is unchanged.
  - **Leading-edge semantics** — the first event starts the workflow and opens the window; repeats inside it are dropped. This matches the two other `debounceMs` implementations in the codebase (`markAutoReindexScheduled` in `query_index/lib/engine.ts`, `NotificationDispatcher.shouldDebounce` in `packages/ui`) and needs no timer that would have to survive a process restart. A trailing-edge/coalescing implementation would require durable scheduling and is deliberately out of scope for this fix.
  - **Key = `tenantId:organizationId:trigger.id:payloadId`** — the window is per trigger *and* per entity, so rapid updates to two different records still start two workflows. Tenant and organization are in the key because code-defined triggers reuse one id across every tenant, and a shared key would let one tenant suppress another's workflows.
  - **State on `globalThis`** — parked under `__openMercatoWorkflowTriggerDebounce__`, mirroring the `GLOBAL_TRIGGER_CACHE_KEY` workaround 20 lines above it in the same file. The compiled module can be loaded under two import roots (a Next.js server chunk vs. a worker); a module-local `Map` would debounce each copy separately and halve the effective window whenever both see the same event stream. Typed via a `GlobalWithTriggerDebounce` alias rather than `any`, following `query_index`'s `GlobalWithAutoReindexSchedule`.
  - **Bounded** — a size cap plus the same prune-then-evict-oldest step `markAutoReindexScheduled` uses, so a long-lived worker cannot grow the map without bound.
  - **Default path untouched** — an absent or zero `debounceMs` short-circuits before any map access or `Date.now()` call, so triggers that do not configure debouncing behave byte-for-byte as before.

No user-facing strings were added, so no locale changes were needed.

## 🧪 Tests

- New `packages/core/src/modules/workflows/lib/__tests__/event-trigger-debounce.test.ts` — 6 cases driving the real `processEventTriggers` through the code-workflow registry (no ORM fixtures), with `Date.now` stubbed to move the clock deterministically:
  - a repeat event at `window - 1ms` is skipped and `startWorkflow` is called once
  - an event at exactly `window` triggers again
  - `debounceMs` absent (`config: null`) and `debounceMs: 0` never suppress
  - a different entity id still triggers (per-entity scoping)
  - a different tenant still triggers (per-tenant scoping)
  - a payload with no `id` debounces per trigger
- **Fail-without-fix verified**: with the guard call neutralized, 2 of the 6 fail (the suppression assertions) and the 4 negative controls correctly still pass.
- `yarn workspace @open-mercato/core test` — **1484 suites / 12084 tests passed**, exit 0.
- Validation gate: `build:packages` (×2), `generate`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app` — all passed.
- `yarn test` exits non-zero on **5 pre-existing `@open-mercato/cli` failures** (`resolve-environment` ×1, `resolver.enterprise` ×4). These are location-dependent — the suite creates a temp dir and expects `resolveEnvironment` to report `standalone`, but it walks up into the surrounding monorepo and reports `monorepo`. This diff touches zero files in `packages/cli`. Because turbo aborts the remaining tasks on that failure, the changed package was validated directly with the workspace run above.

## 💥 Breaking Changes

None. No type, schema, API route, event id, DI key, or validator changed — this only makes a previously inert configuration field take effect. Worth calling out for reviewers: debounce state is per-process, so in a multi-worker deployment each process keeps its own window. That is the same limitation the existing `maxConcurrentInstances` counter and the 5-minute trigger cache already carry, and making it cluster-wide would need shared state (cache/Redis) well beyond the scope of this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791481990&installation_model_id=432243&pr_number=5992&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5992&signature=3fbe09393a6ab91b53263faffc2c1f90763e3ee8d550c965f12ced44ca786733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->