### PR TITLE
fix(auth): resend-invite returns 400 behind a reverse proxy

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
@@ -291,6 +291,29 @@ describe('POST /api/auth/users/resend-invite', () => {
     expect(mockSendEmail).toHaveBeenCalledTimes(1)
   })
 
+  test('allows a loopback request URL behind a reverse proxy that forwards the public host in production', async () => {
+    process.env = {
+      ...process.env,
+      APP_URL: 'https://app.example',
+      NODE_ENV: 'production',
+      JWT_SECRET: 'test-jwt-secret',
+    }
+
+    const res = await POST(makeRequest(
+      { id: userId },
+      'https://localhost:3000/api/auth/users/resend-invite',
+      {
+        host: 'app.example',
+        'x-forwarded-proto': 'https',
+      },
+    ))
+
+    expect(res.status).toBe(200)
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+    const [emailArgs] = mockSendEmail.mock.calls[0]
+    expect(emailArgs.to).toBe('invited@example.com')
+  })
+
   test('allows equivalent loopback proxy origins in production', async () => {
     process.env = {
       ...process.env,

--- a/packages/core/src/modules/auth/api/users/resend-invite/route.ts
+++ b/packages/core/src/modules/auth/api/users/resend-invite/route.ts
@@ -139,7 +139,7 @@ export async function POST(req: Request) {
 
   let base: string
   try {
-    base = getSecurityEmailBaseUrl(req.url)
+    base = getSecurityEmailBaseUrl(req)
   } catch (error) {
     const mapped = mapSecurityEmailUrlError(error, {
       scope: 'auth.users.resend-invite',

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -10,7 +10,7 @@ type EnvLike = Record<string, string | undefined> & {
   APP_ALLOWED_ORIGINS?: string
   NODE_ENV?: string
 }
-type RequestInput = Request | string | undefined
+type RequestInput = Request | undefined
 
 export type SecurityEmailUrlErrorMapping = {
   scope: string
@@ -93,16 +93,14 @@ function readRequestOriginCandidates(input: RequestInput): RequestOriginCandidat
   }
   if (!input) return candidates
 
-  const requestUrl = typeof input === 'string' ? input : input.url
   let parsedUrl: URL
   try {
-    parsedUrl = new URL(requestUrl)
+    parsedUrl = new URL(input.url)
   } catch {
     return candidates
   }
 
   candidates.urlOrigin = normalizeOrigin(parsedUrl.origin)
-  if (typeof input === 'string') return candidates
 
   const forwardedProto = readFirstHeaderValue(input.headers.get('x-forwarded-proto')) ?? parsedUrl.protocol.replace(/:$/, '')
   const protocol = forwardedProto.endsWith(':') ? forwardedProto : `${forwardedProto}:`
@@ -131,15 +129,6 @@ function logOriginDebugContext(
   if (level === 'warn' && nodeEnv === 'test') return
   const log = (msg: string, fields: Record<string, unknown>) =>
     level === 'warn' ? logger.warn(msg, fields) : logger.error(msg, fields)
-
-  if (typeof input === 'string') {
-    log('Origin check rejected string input', {
-      requestUrl: input,
-      rejectedOrigin: rejectedOrigin ?? null,
-      allowedOrigins: Array.from(allowedOrigins),
-    })
-    return
-  }
 
   if (!input) {
     log('Origin check rejected empty input', {


### PR DESCRIPTION
## Summary

`POST /api/auth/users/resend-invite` answers `400 {"error":"Invalid request origin"}` on any production deployment behind a reverse proxy. Creating a user still sends the invite email. Only the "Resend invite" action breaks. Present in 0.6.7 and 0.7.0.

The route passed `req.url` to `getSecurityEmailBaseUrl` while every other caller passes `req`. Given a `Request`, the origin check also reads `Host`, `X-Forwarded-Host` and `X-Forwarded-Proto`, finds the public origin there, and then tolerates a loopback URL origin. Given a string it only has the URL origin. Next.js builds a route handler's request URL from its own listen hostname and port (`next-server.js`, `${protocol}://${this.fetchHostname}:${this.port}${req.url}`), so under `next start` behind a proxy that origin is `https://localhost:3000`, never the public host. With `NODE_ENV=production` and a non-loopback `APP_URL` no exemption applies, the check throws, and the route maps it to 400.

Log line seen in production:

```
Origin check rejected string input
requestUrl=https://localhost:3000/api/auth/users/resend-invite
allowedOrigins=['https://app.example']
```

## Changes

- `packages/core/src/modules/auth/api/users/resend-invite/route.ts`: pass `req` instead of `req.url` to `getSecurityEmailBaseUrl`.
- `packages/shared/src/lib/url.ts`: narrow the input type of `getSecurityEmailBaseUrl`, `toSecurityEmailUrl` and `assertAllowedAppOrigin` from `Request | string | undefined` to `Request | undefined` and drop the string branches. A string can never satisfy the check behind a proxy, so the overload existed only to be misused. The no-argument form stays for callers without a request (the CLI user command, the onboarding ready email). Passing a string is now a compile error.
- `packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts`: regression test for the proxy case.

Note for reviewers: these helpers are not in the `BACKWARD_COMPATIBILITY.md` signature table, but they are exported from `@open-mercato/shared`. A third-party caller passing a string would stop compiling. Such a caller was already getting 400s behind a proxy. If you would rather keep the string overload with a `@deprecated` bridge for one minor release, the second commit can be dropped and the one-line route fix stands on its own.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

New test: production mode, `APP_URL=https://app.example`, request URL `https://localhost:3000/...`, headers `host: app.example` and `x-forwarded-proto: https`. It returned 400 and logged the warning above before the route change. It passes now.

- `packages/core`: resend-invite route suite, 14 passed; signup source check, 3 passed
- `packages/shared`: url and url-safety suites, 54 passed
- `eslint` on the three changed files: clean
- `tsc --noEmit` on `packages/shared` and `packages/onboarding`: 0 errors. `packages/core` reports only pre-existing errors in unrelated files, none in the origin-check callers.

Integration coverage: not added. The change has no manually exercisable UI surface of its own, the API surface and database are unchanged, and the route-level unit test exercises the exact request shape a proxy produces.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (Documented above.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (Not applicable.)
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

### Design System Compliance
Not applicable, no UI files changed.
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791534387&installation_model_id=432243&pr_number=6009&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6009&signature=465c68774cbc9d0ed2b13deb3d0d04f129f7c6a6f2aaec009660afad97f5e0e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->