### PR TITLE
fix(customers): remove residual soft-deleted person links when deleting a company (#5965)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-company-delete-guard.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-company-delete-guard.spec.ts
@@ -62,3 +62,42 @@ test('TC-CRM-company-delete-guard: company with a linked person is refused with 
     await deleteEntityByBody(request, token, '/api/customers/companies', companyId)
   }
 })
+
+/**
+ * Regression for #5965: unlinking a person from a company soft-deletes the
+ * `customer_person_company_links` row, and the row keeps its `company_entity_id`
+ * foreign key. The dependency guard only counts active links, so the delete passed
+ * the 422 check and then blew up on the foreign key with an HTTP 500.
+ */
+test('TC-CRM-company-delete-guard: company deletes after its only person link was soft-deleted', async ({ request }) => {
+  const token = await getAuthToken(request, 'admin')
+  let companyId: string | null = null
+  let personId: string | null = null
+
+  try {
+    companyId = await createCompanyFixture(request, token, `TC-DELGUARD Unlinked Co ${Date.now()}`)
+    personId = await createPersonFixture(request, token, {
+      firstName: 'Soft',
+      lastName: 'Unlinked',
+      displayName: 'Soft Unlinked',
+      companyEntityId: companyId,
+    })
+
+    const unlinked = await request.fetch(resolveUrl(`/api/customers/people/${personId}/companies/${companyId}`), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    })
+    expect(unlinked.status(), 'canonical unlink soft-deletes the person-company link').toBe(200)
+
+    const deleted = await request.fetch(resolveUrl('/api/customers/companies'), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { id: companyId },
+    })
+    expect(deleted.status(), 'company with no active links deletes instead of returning 500').toBe(200)
+    companyId = null
+  } finally {
+    await deleteEntityByBody(request, token, '/api/customers/people', personId)
+    await deleteEntityByBody(request, token, '/api/customers/companies', companyId)
+  }
+})

--- a/packages/core/src/modules/customers/commands/__tests__/deleteCompany.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/deleteCompany.test.ts
@@ -77,11 +77,20 @@ type Counts = {
   personLinks?: number
   dealLinks?: number
   directPeople?: number
+  softDeletedPersonLinks?: number
+}
+
+function isSoftDeletedLinkFilter(where: unknown): boolean {
+  if (typeof where !== 'object' || where === null) return false
+  const deletedAt = (where as { deletedAt?: unknown }).deletedAt
+  return typeof deletedAt === 'object' && deletedAt !== null && '$ne' in deletedAt
 }
 
 function makeEm(entity: CustomerEntity, counts: Counts = {}): jest.Mocked<Pick<EntityManager,
   'fork' | 'findOne' | 'find' | 'count' | 'nativeDelete' | 'nativeUpdate' | 'remove' | 'flush' | 'transactional' | 'create' | 'persist' | 'getReference'
 >> {
+  let residualSoftDeletedLinks = counts.softDeletedPersonLinks ?? 0
+  let companyRemoved = false
   const em: any = {
     fork: jest.fn().mockReturnThis(),
     findOne: jest.fn(async (ctor: any) => {
@@ -95,11 +104,29 @@ function makeEm(entity: CustomerEntity, counts: Counts = {}): jest.Mocked<Pick<E
       if (ctor === CustomerPersonProfile) return counts.directPeople ?? 0
       return 0
     }),
-    nativeDelete: jest.fn(async () => undefined),
+    nativeDelete: jest.fn(async (ctor: any, where: any) => {
+      if (ctor === CustomerPersonCompanyLink && isSoftDeletedLinkFilter(where)) {
+        residualSoftDeletedLinks = 0
+      }
+      return undefined
+    }),
     nativeUpdate: jest.fn(async () => undefined),
-    remove: jest.fn().mockReturnValue(undefined),
+    remove: jest.fn(() => {
+      companyRemoved = true
+    }),
     flush: jest.fn().mockResolvedValue(undefined),
-    transactional: jest.fn(async (fn: any) => fn(em)),
+    // Postgres enforces `customer_person_company_links_company_entity_id_foreign` at commit,
+    // so removing the company entity while a soft-deleted link row survives fails the
+    // transaction — the HTTP 500 reported in #5965.
+    transactional: jest.fn(async (fn: any) => {
+      const result = await fn(em)
+      if (companyRemoved && residualSoftDeletedLinks > 0) {
+        throw new Error(
+          'update or delete on table "customer_entities" violates foreign key constraint "customer_person_company_links_company_entity_id_foreign"',
+        )
+      }
+      return result
+    }),
     create: jest.fn((_ctor: any, data: any) => ({ id: 'new-id', ...data })),
     persist: jest.fn(),
     getReference: jest.fn((_ctor: any, id: string) => ({ id })),
@@ -149,6 +176,35 @@ describe('customers.companies.delete — dependent guard', () => {
 
     expect(em.transactional).toHaveBeenCalledTimes(1)
     expect(em.remove).toHaveBeenCalledWith(entity)
+  })
+
+  it('removes residual soft-deleted person links so the company delete does not break the foreign key', async () => {
+    const entity = makeCompanyEntity()
+    const em = makeEm(entity, { personLinks: 0, softDeletedPersonLinks: 1 })
+    const ctx = makeCtx(em)
+    const handler = commandRegistry.get('customers.companies.delete') as CommandHandler
+
+    mockFindOneWithDecryption.mockResolvedValueOnce(entity as unknown as null)
+
+    await expect(handler.execute({ body: { id: COMPANY_ID } }, ctx)).resolves.toEqual({ entityId: COMPANY_ID })
+
+    expect(em.nativeDelete).toHaveBeenCalledWith(CustomerPersonCompanyLink, {
+      company: entity,
+      deletedAt: { $ne: null },
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+    })
+  })
+
+  it('never hard-deletes active person links — the 422 guard runs before any cleanup', async () => {
+    const entity = makeCompanyEntity()
+    const em = makeEm(entity, { personLinks: 1, softDeletedPersonLinks: 1 })
+    const ctx = makeCtx(em)
+    const handler = commandRegistry.get('customers.companies.delete') as CommandHandler
+
+    await expect(handler.execute({ body: { id: COMPANY_ID } }, ctx)).rejects.toBeInstanceOf(CrudHttpError)
+
+    expect(em.nativeDelete).not.toHaveBeenCalledWith(CustomerPersonCompanyLink, expect.anything())
   })
 
   it('throws 422 with a "linked persons" blocker when person links are active', async () => {

--- a/packages/core/src/modules/customers/commands/companies.ts
+++ b/packages/core/src/modules/customers/commands/companies.ts
@@ -1035,6 +1035,14 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
         }
 
         await em.nativeUpdate(CustomerPersonProfile, { company: record }, { company: null })
+        // Soft-deleted person links keep their `company_entity_id` foreign key, so the hard
+        // delete below would violate it. The guard above already proved no active link
+        // remains, and restricting the filter to `deletedAt != null` keeps that guarantee.
+        await em.nativeDelete(CustomerPersonCompanyLink, {
+          company: record,
+          deletedAt: { $ne: null },
+          ...dependentScope,
+        })
         await em.nativeDelete(CustomerDealCompanyLink, { company: record })
         await em.nativeDelete(CustomerActivity, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
         await em.nativeDelete(CustomerInteraction, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })


### PR DESCRIPTION
Closes #5965

## 🎯 Goal
Deleting a Company whose last Person-Company link has already been unlinked now succeeds instead of returning HTTP 500.

## 🔍 Problem
`deletePersonCompanyLinkCommand` soft-deletes a person-company link by setting `deleted_at`; the row survives with its `company_entity_id` foreign key intact. `deleteCompanyCommand`'s dependency guard counts only **active** links (`deletedAt: null`), so a company whose only link was unlinked passes the `422 COMPANY_HAS_DEPENDENTS` check — and then the hard delete of the `customer_entities` row violates `customer_person_company_links_company_entity_id_foreign` and surfaces as a 500.

This is distinct from #1713: active links are correctly refused with a structured 422. The gap is the residual soft-deleted row.

## 🔍 Root Cause
The company-delete transaction cleans up every other dependent table (`CustomerDealCompanyLink`, activities, interactions, todo links, addresses, comments, tag assignments, custom-field values) but never touches `customer_person_company_links`. The person-delete path already does the analogous cleanup (`packages/core/src/modules/customers/commands/people.ts:1251`); the company path was missing it.

The foreign key is declared `on update cascade` only — there is no `on delete cascade` — so the residual row is a hard blocker.

## What Changed
- `packages/core/src/modules/customers/commands/companies.ts` — inside the existing company-delete transaction, after the in-transaction re-check of active dependents and before the entity is removed, physically delete the residual soft-deleted person links in the same tenant/organization scope:

  ```ts
  await em.nativeDelete(CustomerPersonCompanyLink, {
    company: record,
    deletedAt: { $ne: null },
    ...dependentScope,
  })
  ```

  Restricting the filter to `deletedAt != null` keeps the 422 guard authoritative: active links are never silently hard-deleted by this cleanup, and reusing `dependentScope` keeps the delete tenant/organization-scoped, matching the guard that precedes it.

## 🧪 Tests
- `packages/core/src/modules/customers/commands/__tests__/deleteCompany.test.ts` — the `EntityManager` mock now models the commit-time foreign-key constraint: removing the company entity while a soft-deleted link row survives throws, reproducing the reported 500. Two new cases:
  - *removes residual soft-deleted person links so the company delete does not break the foreign key* — **fails without the production change** (verified by reverting the fix: 1 failed / 5 passed) and passes with it.
  - *never hard-deletes active person links — the 422 guard runs before any cleanup* — pins that the cleanup cannot be used to bypass the dependency guard.
- `packages/core/src/modules/customers/__integration__/TC-CRM-company-delete-guard.spec.ts` — new API-level regression walking the exact reported flow: create company + linked person → `DELETE /api/customers/people/{personId}/companies/{companyId}` (canonical unlink, soft-deletes the link) → `DELETE /api/customers/companies` expects 200, not 500.
- Validation gate (`.ai/agentic.config.json`), local runner: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all green. `@open-mercato/core` — 268 suites / 1729 tests passed; `shared`, `ui`, `app`, `cli` also run clean per-package.
- `yarn test` under turbo reports three failing packages that are **pre-existing and environmental**, none in the changed package: `@open-mercato/shared#test` (the `dynamicLoader.generatedCacheRecovery` suite needs a short `TMPDIR` for tsx's IPC socket — passes standalone), `@open-mercato/cli#test` (the 5 known location-dependent `resolve-environment` / `resolver.enterprise` failures), and `create-mercato-app#test` (the AI-harness oracle suites that require the `codex`/`claude` CLIs).

## 💥 Breaking Changes
None. No schema, API, or response-shape change; the `422 COMPANY_HAS_DEPENDENTS` contract is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791573367&installation_model_id=432243&pr_number=6018&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6018&signature=fa4bb906a1884ed11b040d6d7b50e2e5e9116610cb8c895e242213719b860c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->