### PR TITLE
fix(shared,crud): run hooks.afterList before serializing an export (#5969)

### DIFF
--- a/apps/docs/docs/framework/api/crud-factory.mdx
+++ b/apps/docs/docs/framework/api/crud-factory.mdx
@@ -441,6 +441,12 @@ hooks: {
 }
 ```
 
+`afterList` runs on the export paths too (`?format=csv|json|xml|markdown`), before the file
+bytes are produced, so a route that patches values in `afterList` exports the same shape it
+serves as JSON. The hook may mutate `response.items` in place or replace the array outright;
+either form is picked up. Note that `response.total`/`pageSize` on an export call describe the
+pre-hook batch, so use `response.items.length` if you need the exported row count.
+
 ## Response Caching
 
 The CRUD factory includes sophisticated caching to improve performance:

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -802,6 +802,84 @@ describe('CRUD Factory', () => {
     })
   })
 
+  describe('afterList hook ordering on the export paths', () => {
+    // Issue #5969: both export branches used to call serializeExport() before awaiting
+    // hooks.afterList, so a hook that patches values the base query cannot compute reached
+    // the JSON list response but never the exported file.
+    const patchTitles = (res: any) => {
+      for (const item of res.items) item.title = `patched:${item.title}`
+    }
+
+    it('GET applies afterList mutations to the query-engine export, matching the JSON list', async () => {
+      const hookedRoute = makeCrudRoute({
+        metadata: { GET: { requireAuth: true } },
+        orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+        indexer: { entityType: 'example.todo' },
+        list: {
+          schema: querySchema,
+          entityId: 'example.todo',
+          fields: ['id', 'title', 'is_done'],
+          sortFieldMap: { id: 'id' },
+          buildFilters: () => ({} as any),
+          transformItem: (i: any) => ({ id: i.id, title: i.title }),
+          allowCsv: true,
+          csv: { headers: ['id', 'title'], row: (t: any) => [t.id, t.title], filename: 'todos.csv' },
+        },
+        hooks: { afterList: patchTitles },
+      })
+
+      const jsonRes = await hookedRoute.GET(new Request('http://x/api/example/todos'))
+      expect((await jsonRes.json()).items[0].title).toBe('patched:A')
+
+      const csvRes = await hookedRoute.GET(new Request('http://x/api/example/todos?format=csv'))
+      expect((await csvRes.text()).split('\n')[1]).toBe('id-1,patched:A')
+    })
+
+    it('GET honors an afterList hook that replaces the export payload items', async () => {
+      const replacingRoute = makeCrudRoute({
+        metadata: { GET: { requireAuth: true } },
+        orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+        indexer: { entityType: 'example.todo' },
+        list: {
+          schema: querySchema,
+          entityId: 'example.todo',
+          fields: ['id', 'title', 'is_done'],
+          sortFieldMap: { id: 'id' },
+          buildFilters: () => ({} as any),
+          transformItem: (i: any) => ({ id: i.id, title: i.title }),
+          allowCsv: true,
+          csv: { headers: ['id', 'title'], row: (t: any) => [t.id, t.title], filename: 'todos.csv' },
+        },
+        hooks: { afterList: (res: any) => { res.items = [{ id: 'replaced', title: 'Z' }] } },
+      })
+
+      const csvRes = await replacingRoute.GET(new Request('http://x/api/example/todos?format=csv'))
+      expect((await csvRes.text()).split('\n').slice(1)).toEqual(['replaced,Z'])
+    })
+
+    it('GET applies afterList mutations to the ORM-fallback export', async () => {
+      db['id-1'] = { id: 'id-1', title: 'A', organizationId: defaultOrganizationId, tenantId: defaultTenantId }
+      const fallbackRoute = makeCrudRoute({
+        metadata: { GET: { requireAuth: true } },
+        orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+        list: {
+          schema: querySchema,
+          buildFilters: () => ({} as any),
+          allowCsv: true,
+          csv: { headers: ['id', 'title'], row: (t: any) => [t.id, t.title], filename: 'todos.csv' },
+        },
+        hooks: { afterList: patchTitles },
+      })
+
+      const jsonRes = await fallbackRoute.GET(new Request('http://x/api/example/todos'))
+      expect((await jsonRes.json()).items[0].title).toBe('patched:A')
+
+      db['id-1'] = { id: 'id-1', title: 'A', organizationId: defaultOrganizationId, tenantId: defaultTenantId }
+      const csvRes = await fallbackRoute.GET(new Request('http://x/api/example/todos?format=csv'))
+      expect((await csvRes.text()).split('\n')[1]).toBe('id-1,patched:A')
+    })
+  })
+
   describe('export loop termination', () => {
     const EXPORT_PAGE_SIZE = 1000
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -1967,15 +1967,19 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
               nextPage += 1
             }
           }
+          const exportPayload = { items: exportItems, total, page: 1, pageSize: exportItems.length, totalPages: 1, ...(res.meta ? { meta: res.meta } : {}) }
+          // Serialize only after `afterList` has run: the hook is the documented place to
+          // patch values the base query cannot compute, and an export built before it runs
+          // ships a different shape than the JSON list response for the same request (#5969).
+          await opts.hooks?.afterList?.(exportPayload, { ...ctx, query: validated as any })
+          profiler.mark('after_list_hook')
+          const finalExportItems = Array.isArray(exportPayload.items) ? exportPayload.items : exportItems
           const prepared = exportFullRequested
-            ? { columns: ensureColumns(exportItems), rows: exportItems }
-            : prepareExportData(exportItems, opts.list, validated as any, ctx)
+            ? { columns: ensureColumns(finalExportItems), rows: finalExportItems }
+            : prepareExportData(finalExportItems, opts.list, validated as any, ctx)
           const fallbackBase = `${opts.events?.entity || resourceKind || 'list'}${exportFullRequested ? '_full' : ''}`
           const filename = finalizeExportFilename(opts.list, requestedExport, fallbackBase)
           const serialized = serializeExport(prepared, requestedExport)
-          const exportPayload = { items: exportItems, total, page: 1, pageSize: exportItems.length, totalPages: 1, ...(res.meta ? { meta: res.meta } : {}) }
-          await opts.hooks?.afterList?.(exportPayload, { ...ctx, query: validated as any })
-          profiler.mark('after_list_hook')
           const response = new Response(serialized.body, {
             headers: {
               'content-type': serialized.contentType,
@@ -1998,7 +2002,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           finishProfile({
             result: 'export',
             cacheStatus,
-            itemCount: exportItems.length,
+            itemCount: finalExportItems.length,
             total,
           })
           return response
@@ -2170,14 +2174,17 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       profiler.mark('access_logged', accessLogResult)
       if (exportRequested && requestedExport) {
         const exportItems = exportFullRequested ? list.map(normalizeFullRecordForExport) : list
+        const exportPayload = { items: exportItems, total: exportItems.length, page: 1, pageSize: exportItems.length, totalPages: 1 }
+        // Same ordering contract as the query-engine export path above (#5969).
+        await opts.hooks?.afterList?.(exportPayload, { ...ctx, query: validated as any })
+        profiler.mark('after_list_hook')
+        const finalExportItems = Array.isArray(exportPayload.items) ? exportPayload.items : exportItems
         const prepared = exportFullRequested
-          ? { columns: ensureColumns(exportItems), rows: exportItems }
-          : prepareExportData(exportItems, opts.list, validated as any, ctx)
+          ? { columns: ensureColumns(finalExportItems), rows: finalExportItems }
+          : prepareExportData(finalExportItems, opts.list, validated as any, ctx)
         const fallbackBase = `${opts.events?.entity || resourceKind || 'list'}${exportFullRequested ? '_full' : ''}`
         const filename = finalizeExportFilename(opts.list, requestedExport, fallbackBase)
         const serialized = serializeExport(prepared, requestedExport)
-        await opts.hooks?.afterList?.({ items: exportItems, total: exportItems.length, page: 1, pageSize: exportItems.length, totalPages: 1 }, { ...ctx, query: validated as any })
-        profiler.mark('after_list_hook')
         const response = new Response(serialized.body, {
           headers: {
             'content-type': serialized.contentType,
@@ -2187,8 +2194,8 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         finishProfile({
           result: 'export',
           cacheStatus,
-          itemCount: exportItems.length,
-          total: exportItems.length,
+          itemCount: finalExportItems.length,
+          total: finalExportItems.length,
           branch: 'fallback',
         })
         return response


### PR DESCRIPTION
## What was wrong

A route built with `makeCrudRoute` could return two different values for the same field depending only on whether the caller asked for the JSON list or an export. `hooks.afterList` is the documented place to patch values the base query or index projection cannot compute — decrypting a field, deriving a display value, redacting something — and the JSON list path awaits it before building the response. Both export branches did not: they called `serializeExport(...)` first and awaited the hook afterwards. The hook still ran and still mutated the in-memory array, but the file bytes had already been produced from the pre-hook shape, so the mutation went nowhere.

For a host relying on `afterList` to fix up stale or projected values, the downloaded CSV/JSON/XML/Markdown silently disagreed with the UI and the API for the same data.

## The change

`packages/shared/src/lib/crud/factory.ts` — on both export branches (query-engine and ORM fallback), `hooks.afterList` now runs before `prepareExportData(...)`/`serializeExport(...)`. The items are read back off the payload afterwards, so a hook that *replaces* `response.items` is honoured as well as one that mutates in place. Profiler `itemCount`/`total` for the export now describe what was actually written.

No signature, response shape, or schema change: the export payload the hook receives is the same object it received before, only earlier. A route without an `afterList` hook is byte-identical.

## Tests

Three regression tests in `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts` — the query-engine export matching the JSON list, an `afterList` that replaces the items array, and the ORM-fallback export. All three fail against the unpatched factory and pass with the fix.

Fixes #5969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791573435&installation_model_id=432243&pr_number=6019&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6019&signature=15853b9ac595ab44bd3c4dfa6ace00e07a4b516722d8d496eaaf08e9b65f1d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->