### PR TITLE
fix(attachments): resolve the storage root from configuration, not process.cwd() (#5946)

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -625,6 +625,17 @@ OCR_MODEL=gpt-4o
 # OM_ATTACHMENT_MAX_UPLOAD_MB=25
 # OM_ATTACHMENT_TENANT_QUOTA_MB=512
 
+# Base directory holding one sub-directory per attachment partition for the
+# `local` storage driver. Treat it like DATABASE_URL: point it at the volume
+# that survives redeploys, otherwise the location defaults to
+# `<process working directory>/storage/attachments` and the same database rows
+# resolve to different files depending on where the app was started from.
+# The value must be absolute — a relative one is rejected at startup rather
+# than silently creating a second, empty store. To adopt it on an existing
+# install without moving files, set it to `<old working directory>/storage/attachments`.
+# A per-partition override (ATTACHMENTS_PARTITION_<CODE>_ROOT) still wins.
+# ATTACHMENTS_STORAGE_ROOT=/var/lib/open-mercato/attachments
+
 # Outbound request timeouts for the AI Assistant / OpenCode stack.
 # OPENCODE_REQUEST_TIMEOUT_MS=30000
 # OPENCODE_SSE_CONNECT_TIMEOUT_MS=15000

--- a/packages/core/src/modules/attachments/lib/__tests__/storage.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/storage.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+import path from 'path'
+import { resolvePartitionRoot, resolveStorageRoot, STORAGE_ROOT_ENV_KEY } from '../storage'
+
+const PARTITION_ENV_KEY = 'ATTACHMENTS_PARTITION_PRODUCTS_MEDIA_ROOT'
+
+describe('attachments storage root resolution', () => {
+  let cwdSpy: jest.SpyInstance<string, []> | null = null
+
+  afterEach(() => {
+    delete process.env[STORAGE_ROOT_ENV_KEY]
+    delete process.env[PARTITION_ENV_KEY]
+    cwdSpy?.mockRestore()
+    cwdSpy = null
+  })
+
+  function mockCwd(value: string): void {
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(value)
+  }
+
+  it('keeps the historical cwd-relative default when no env var is set', () => {
+    mockCwd(path.join(path.sep, 'srv', 'app'))
+
+    expect(resolveStorageRoot()).toBe(path.join(path.sep, 'srv', 'app', 'storage', 'attachments'))
+    expect(resolvePartitionRoot('productsMedia')).toBe(
+      path.join(path.sep, 'srv', 'app', 'storage', 'attachments', 'productsMedia'),
+    )
+  })
+
+  it('resolves the same partition path from any working directory once the base root is configured', () => {
+    process.env[STORAGE_ROOT_ENV_KEY] = path.join(path.sep, 'var', 'lib', 'mercato', 'attachments')
+
+    mockCwd(path.join(path.sep, 'srv', 'app'))
+    const fromAppRoot = resolvePartitionRoot('productsMedia')
+    cwdSpy?.mockRestore()
+
+    mockCwd(path.join(path.sep, 'home', 'dev', 'worktree'))
+    const fromWorktree = resolvePartitionRoot('productsMedia')
+
+    expect(fromAppRoot).toBe(path.join(path.sep, 'var', 'lib', 'mercato', 'attachments', 'productsMedia'))
+    expect(fromWorktree).toBe(fromAppRoot)
+  })
+
+  it('lets the per-partition env var win over the base root', () => {
+    process.env[STORAGE_ROOT_ENV_KEY] = path.join(path.sep, 'var', 'lib', 'mercato', 'attachments')
+    process.env[PARTITION_ENV_KEY] = path.join(path.sep, 'mnt', 'media')
+
+    expect(resolvePartitionRoot('productsMedia')).toBe(path.join(path.sep, 'mnt', 'media'))
+  })
+
+  it('ignores a blank base root and falls back to the default', () => {
+    process.env[STORAGE_ROOT_ENV_KEY] = '   '
+    mockCwd(path.join(path.sep, 'srv', 'app'))
+
+    expect(resolveStorageRoot()).toBe(path.join(path.sep, 'srv', 'app', 'storage', 'attachments'))
+  })
+
+  it('rejects a relative base root instead of creating a second store next to the process', () => {
+    process.env[STORAGE_ROOT_ENV_KEY] = 'storage/attachments'
+
+    expect(() => resolveStorageRoot()).toThrow(STORAGE_ROOT_ENV_KEY)
+    expect(() => resolvePartitionRoot('productsMedia')).toThrow(STORAGE_ROOT_ENV_KEY)
+  })
+})

--- a/packages/core/src/modules/attachments/lib/storage.ts
+++ b/packages/core/src/modules/attachments/lib/storage.ts
@@ -4,13 +4,36 @@ import { randomUUID } from 'crypto'
 import { resolvePartitionEnvKey } from './partitionEnv'
 import { resolveContainedPath, resolveLegacyPublicRoot } from './pathContainment'
 
+export const STORAGE_ROOT_ENV_KEY = 'ATTACHMENTS_STORAGE_ROOT'
+
+/**
+ * Resolves the base directory that holds every partition directory. Deployment
+ * configuration (`ATTACHMENTS_STORAGE_ROOT`) wins over the historical
+ * `process.cwd()`-relative default, so the same attachment row resolves to the
+ * same file regardless of the directory the process was started from. A
+ * relative value is rejected rather than resolved against `process.cwd()`,
+ * because `LocalStorageDriver.store()` creates missing directories and a typo
+ * would otherwise silently produce a second, empty store.
+ */
+export function resolveStorageRoot(): string {
+  const envPath = process.env[STORAGE_ROOT_ENV_KEY]
+  if (envPath && envPath.trim().length > 0) {
+    const trimmed = envPath.trim()
+    if (!path.isAbsolute(trimmed)) {
+      throw new Error(`[internal] ${STORAGE_ROOT_ENV_KEY} must be an absolute path, received: ${trimmed}`)
+    }
+    return path.resolve(trimmed)
+  }
+  return path.join(process.cwd(), 'storage', 'attachments')
+}
+
 export function resolvePartitionRoot(code: string): string {
   const envKey = resolvePartitionEnvKey(code)
   const envPath = process.env[envKey]
   if (envPath && envPath.trim().length > 0) {
     return path.resolve(envPath)
   }
-  return path.join(process.cwd(), 'storage', 'attachments', code)
+  return path.join(resolveStorageRoot(), code)
 }
 
 function sanitizeFileName(fileName: string): string {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -571,6 +571,17 @@ OCR_MODEL=gpt-4o
 # OCR_DEFAULT_PROMPT="Extract all text content from this image..."
 # OPENMERCATO_DEFAULT_ATTACHMENT_OCR_ENABLED=true
 
+# Base directory holding one sub-directory per attachment partition for the
+# `local` storage driver. Treat it like DATABASE_URL: point it at the volume
+# that survives redeploys, otherwise the location defaults to
+# `<process working directory>/storage/attachments` and the same database rows
+# resolve to different files depending on where the app was started from.
+# The value must be absolute — a relative one is rejected at startup rather
+# than silently creating a second, empty store. To adopt it on an existing
+# install without moving files, set it to `<old working directory>/storage/attachments`.
+# A per-partition override (ATTACHMENTS_PARTITION_<CODE>_ROOT) still wins.
+# ATTACHMENTS_STORAGE_ROOT=/var/lib/open-mercato/attachments
+
 # Outbound request timeouts for the AI Assistant / OpenCode stack.
 # OPENCODE_REQUEST_TIMEOUT_MS=30000
 # OPENCODE_SSE_CONNECT_TIMEOUT_MS=15000


### PR DESCRIPTION
Closes #5946

## 🎯 Goal
- Attachment files stay findable after a redeploy: the location of the local attachment store becomes explicit deployment configuration (`ATTACHMENTS_STORAGE_ROOT`) instead of something derived from whatever directory the process happened to start in.

## 🔍 Problem
With the `local` storage driver, an attachment row records a partition code plus a relative path. Resolving that to a file went through `resolvePartitionRoot()`, which fell back to `<process working directory>/storage/attachments/<code>` whenever the per-partition variable `ATTACHMENTS_PARTITION_<CODE>_ROOT` was unset — and no base-level variable existed to override that fallback. The same database, served by a process started from a different directory (a release directory, a `systemd` unit with a different `WorkingDirectory`, a rebuilt container without the storage volume mounted at the expected path), therefore resolved every attachment to a path that does not exist and returned `500` for all of them while the rows were entirely intact. Per-partition variables did not close the gap, because partitions are created ad hoc from the admin UI and each new one silently fell back to the working directory again.

## 🔍 Root Cause
`packages/core/src/modules/attachments/lib/storage.ts` computed the partition root as `path.join(process.cwd(), 'storage', 'attachments', code)`. Every local-driver read and write funnels through that one function (`LocalStorageDriver.store()`, `resolveAbsolutePath()`, and the deprecated `storage.ts` helpers), so the working directory silently became part of the storage address.

## What Changed
- `packages/core/src/modules/attachments/lib/storage.ts` — new exported `resolveStorageRoot()` resolving the base directory that holds one sub-directory per partition. Precedence is `ATTACHMENTS_PARTITION_<CODE>_ROOT` → `ATTACHMENTS_STORAGE_ROOT` → the historical `<cwd>/storage/attachments`. A value that is set but not absolute is rejected with an explicit error instead of being resolved against the working directory: `LocalStorageDriver.store()` creates missing directories unconditionally, so a typo would otherwise quietly produce a second, empty store rather than stopping the app.
- `apps/mercato/.env.example` and `packages/create-app/template/.env.example` — document the variable, including the zero-file-move migration for an existing install (point it at `<old working directory>/storage/attachments`).

With neither variable set, resolution is byte-for-byte what it was before, so existing deployments are unaffected until they opt in.

## 🧪 Tests
- New `packages/core/src/modules/attachments/lib/__tests__/storage.test.ts` (5 cases). Two of them fail against the pre-fix code — the same partition resolving to different paths from two working directories, and the fail-closed rejection of a relative value; the other three lock in the unchanged behavior (cwd default when unset, per-partition override still winning, blank value ignored).
- Full configured validation gate run locally: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.

## 💥 Breaking Changes
- None. The new variable is opt-in and unset behavior is unchanged. The only new failure mode is an app that sets `ATTACHMENTS_STORAGE_ROOT` to a relative path, which now fails loudly by design.

## Deliberately out of scope
The issue also flags `thumbnailCache.ts` (regenerable per-process cache) and `resolveLegacyPublicRoot()` (`legacyPublic` rows) as sharing the same `cwd` shape — both are left alone here so the fix stays minimal and reviewable; they are worth a follow-up. The third note, unsanitized interpolation of the partition `code` into the path, is inert: `sanitizePartitionCode()` (`lib/partitions.ts:61`) already restricts codes to `[a-zA-Z0-9_-]` at creation, so no traversal segment can reach the join.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574292&installation_model_id=432243&pr_number=6020&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6020&signature=14d6b11d40778b7c4ddda91e5d38d98105117efb31f9c1fdc2309d9564f06b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->