### PR TITLE
security(customers): decrypt every encryption-map field on the interactions list (#5945)

### DIFF
--- a/packages/core/src/modules/customers/api/interactions/__tests__/decryptedFields.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/__tests__/decryptedFields.test.ts
@@ -1,0 +1,57 @@
+import { applyDecryptedFields } from '../decryptedFields'
+
+describe('applyDecryptedFields (#5945)', () => {
+  test('overrides every response key the encryption map declares, not just title/body', () => {
+    const item = { id: 'a', title: 'cipher-title', body: 'cipher-body', location: 'cipher-location' }
+    const record = { id: 'a', title: 'Kickoff', body: 'Notes', location: 'https://meet.example/room' }
+
+    expect(applyDecryptedFields(item, record, ['title', 'body', 'location'])).toEqual({
+      id: 'a',
+      title: 'Kickoff',
+      body: 'Notes',
+      location: 'https://meet.example/room',
+    })
+  })
+
+  test('matches a snake_case map field against its camelCase response key and entity property', () => {
+    const item = { id: 'a', recurrenceRule: 'cipher-rule' }
+    const record = { id: 'a', recurrenceRule: 'FREQ=WEEKLY' }
+
+    expect(applyDecryptedFields(item, record, ['recurrence_rule']).recurrenceRule).toBe('FREQ=WEEKLY')
+  })
+
+  test('carries non-string decrypted values through unchanged', () => {
+    const item = { id: 'a', participants: 'cipher-participants' as unknown }
+    const participants = [{ email: 'guest@example.test' }]
+
+    expect(applyDecryptedFields(item, { id: 'a', participants }, ['participants']).participants).toBe(participants)
+  })
+
+  test('normalizes an absent decrypted value to null rather than undefined', () => {
+    const item = { id: 'a', title: 'cipher-title' as string | null }
+
+    expect(applyDecryptedFields(item, { id: 'a', title: undefined }, ['title']).title).toBeNull()
+    expect(applyDecryptedFields(item, { id: 'a', title: null }, ['title']).title).toBeNull()
+  })
+
+  test('serializes a decrypted Date so the response keeps its ISO string shape', () => {
+    const item = { id: 'a', recurrenceEnd: 'cipher-end' as unknown }
+    const record = { id: 'a', recurrenceEnd: new Date('2026-03-01T10:00:00.000Z') }
+
+    expect(applyDecryptedFields(item, record, ['recurrence_end']).recurrenceEnd).toBe('2026-03-01T10:00:00.000Z')
+  })
+
+  test('leaves the item untouched when there is no decrypted record or no declared field', () => {
+    const item = { id: 'a', title: 'raw-title' }
+
+    expect(applyDecryptedFields(item, undefined, ['title'])).toBe(item)
+    expect(applyDecryptedFields(item, { id: 'a', title: 'decrypted' }, [])).toBe(item)
+  })
+
+  test('never introduces a response key the item does not already expose', () => {
+    const item = { id: 'a', title: 'cipher-title' }
+    const patched = applyDecryptedFields(item, { id: 'a', title: 'Kickoff', location: 'Room 4' }, ['title', 'location'])
+
+    expect(Object.keys(patched).sort()).toEqual(['id', 'title'])
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/__tests__/listDecryptsMappedFields.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/__tests__/listDecryptsMappedFields.test.ts
@@ -1,0 +1,194 @@
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresQueryCompiler,
+  PostgresIntrospector,
+  DummyDriver,
+  type CompiledQuery,
+} from 'kysely'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const interactionId = '33333333-3333-4333-8333-333333333333'
+
+let listRows: Array<Record<string, unknown>> = []
+
+function createKysely(): Kysely<any> {
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+    },
+  })
+  ;(db.getExecutor() as any).executeQuery = async (compiledQuery: CompiledQuery) => {
+    if (!compiledQuery.sql.includes('customer_interactions')) return { rows: [] }
+    return { rows: listRows }
+  }
+  return db
+}
+
+const fakeEm = {
+  fork() {
+    return { getKysely: () => createKysely() }
+  },
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (token: string) => (token === 'em' ? fakeEm : undefined),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({ tenantId, orgId, sub: null, isApiKey: true }),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ filterIds: [orgId], selectedId: orgId }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({ translate: (_key: string, fallback: string) => fallback }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/enricher-runner', () => ({
+  applyResponseEnrichers: async (items: unknown[]) => ({ items }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: async () => ({}),
+}))
+
+const mockGetEncryptedFieldNames = jest.fn<Promise<string[]>, unknown[]>(async () => ['title', 'body'])
+jest.mock('@open-mercato/shared/lib/encryption/customFieldValues', () => ({
+  resolveTenantEncryptionService: () => ({
+    isEnabled: () => true,
+    getEncryptedFieldNames: (...args: unknown[]) => mockGetEncryptedFieldNames(...args),
+    decryptEntityPayload: async (_entityId: string, payload: Record<string, unknown>) => payload,
+  }),
+}))
+
+let decryptedInteractions: Array<Record<string, unknown>> = []
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: async (_em: unknown, entity: unknown) => {
+    const name = typeof entity === 'function' ? (entity as { name: string }).name : String(entity)
+    return name === 'CustomerInteraction' ? decryptedInteractions : []
+  },
+}))
+
+import { GET } from '../route'
+
+function ciphertextRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: interactionId,
+    entity_id: '44444444-4444-4444-8444-444444444444',
+    deal_id: null,
+    interaction_type: 'meeting',
+    title: 'enc:v1:title',
+    body: 'enc:v1:body',
+    status: 'planned',
+    scheduled_at: null,
+    occurred_at: null,
+    priority: null,
+    author_user_id: null,
+    owner_user_id: null,
+    external_message_id: null,
+    appearance_icon: null,
+    appearance_color: null,
+    source: null,
+    duration_minutes: null,
+    location: 'enc:v1:location',
+    all_day: null,
+    recurrence_rule: null,
+    recurrence_end: null,
+    participants: 'enc:v1:participants',
+    reminder_minutes: null,
+    visibility: null,
+    linked_entities: null,
+    guest_permissions: null,
+    pinned: false,
+    organization_id: orgId,
+    tenant_id: tenantId,
+    created_at: new Date('2026-03-01T00:00:00.000Z'),
+    updated_at: new Date('2026-03-01T00:00:00.000Z'),
+    __sort_value: new Date('2026-03-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+const decryptedParticipants = [{ email: 'guest@example.test', name: 'Guest' }]
+
+function decryptedInteraction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: interactionId,
+    title: 'Quarterly review',
+    body: 'Agenda and notes',
+    location: 'https://meet.example.test/room-42',
+    participants: decryptedParticipants,
+    ...overrides,
+  }
+}
+
+async function listItems() {
+  const res = await GET(new Request('https://example.test/api/customers/interactions'))
+  expect(res.status).toBe(200)
+  const payload = await res.json()
+  return payload.items as Array<Record<string, unknown>>
+}
+
+beforeEach(() => {
+  listRows = [ciphertextRow()]
+  decryptedInteractions = [decryptedInteraction()]
+  mockGetEncryptedFieldNames.mockReset()
+  mockGetEncryptedFieldNames.mockImplementation(async () => ['title', 'body'])
+})
+
+describe('interactions list — decrypts every encryption-map field (#5945)', () => {
+  test('a map extended beyond title/body returns plaintext for the added fields', async () => {
+    mockGetEncryptedFieldNames.mockImplementation(async () => ['title', 'body', 'location', 'participants'])
+
+    const [item] = await listItems()
+
+    expect(item.location).toBe('https://meet.example.test/room-42')
+    expect(item.participants).toEqual(decryptedParticipants)
+    expect(item.title).toBe('Quarterly review')
+    expect(item.body).toBe('Agenda and notes')
+  })
+
+  test('the field set comes from the resolved map for the caller tenant and organization', async () => {
+    await listItems()
+
+    expect(mockGetEncryptedFieldNames).toHaveBeenCalledWith('customers:customer_interaction', tenantId, orgId)
+  })
+
+  test('the shipped title/body map keeps decrypting exactly those two fields', async () => {
+    const [item] = await listItems()
+
+    expect(item.title).toBe('Quarterly review')
+    expect(item.body).toBe('Agenda and notes')
+    expect(item.location).toBe('enc:v1:location')
+  })
+
+  test('with encryption disabled the response keeps the raw column values', async () => {
+    mockGetEncryptedFieldNames.mockImplementation(async () => [])
+    listRows = [ciphertextRow({ title: 'Plain title', body: 'Plain body', location: 'Room 4' })]
+
+    const [item] = await listItems()
+
+    expect(item.title).toBe('Plain title')
+    expect(item.body).toBe('Plain body')
+    expect(item.location).toBe('Room 4')
+  })
+
+  test('a row with no decrypted record falls back to its raw column values', async () => {
+    mockGetEncryptedFieldNames.mockImplementation(async () => ['title', 'body', 'location'])
+    decryptedInteractions = []
+
+    const [item] = await listItems()
+
+    expect(item.title).toBe('enc:v1:title')
+    expect(item.location).toBe('enc:v1:location')
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/decryptedFields.ts
+++ b/packages/core/src/modules/customers/api/interactions/decryptedFields.ts
@@ -1,0 +1,52 @@
+import { fieldNameCandidates } from '@open-mercato/shared/lib/query/encrypted-sort'
+
+function normalizeDecryptedValue(value: unknown): unknown {
+  if (value === undefined || value === null) return null
+  if (value instanceof Date) return value.toISOString()
+  return value
+}
+
+function findKey(target: Record<string, unknown>, field: string): string | null {
+  for (const candidate of fieldNameCandidates(field)) {
+    if (Object.prototype.hasOwnProperty.call(target, candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * Overrides the response fields an entity's encryption map covers with the
+ * plaintext carried by its decrypted ORM record.
+ *
+ * List routes that read their base rows through Kysely get raw column values,
+ * so every field the map declares arrives as ciphertext. Encryption maps are
+ * configurable per deployment, so the covered set is resolved at runtime rather
+ * than hard-coded — extending a map must not leave a field passing through as
+ * ciphertext (#5945).
+ *
+ * Map fields are authored as column names (`recurrence_rule`) while response
+ * keys and entity properties are camelCase (`recurrenceRule`), so each declared
+ * field is matched through the shared candidate spellings. Fields that resolve
+ * to neither a response key nor a record property are skipped, which keeps the
+ * response shape unchanged.
+ */
+export function applyDecryptedFields<T extends Record<string, unknown>>(
+  item: T,
+  decryptedRecord: object | undefined,
+  encryptedFields: readonly string[],
+): T {
+  if (!decryptedRecord || encryptedFields.length === 0) return item
+  // ORM entities are class instances rather than index-signature types; the
+  // encryption map addresses their columns by name, so read them as a record.
+  const source = decryptedRecord as Record<string, unknown>
+  let patched: T | null = null
+  for (const field of encryptedFields) {
+    const responseKey = findKey(item, field)
+    const recordKey = findKey(source, field)
+    if (!responseKey || !recordKey) continue
+    const value = normalizeDecryptedValue(source[recordKey])
+    if (value === item[responseKey]) continue
+    patched = patched ?? { ...item }
+    ;(patched as Record<string, unknown>)[responseKey] = value
+  }
+  return patched ?? item
+}

--- a/packages/core/src/modules/customers/api/interactions/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/route.ts
@@ -27,6 +27,7 @@ import {
 import { CUSTOMER_INTERACTION_ENTITY_ID } from '../../lib/interactionCompatibility'
 import { applyEmailVisibilityFilter } from '../../lib/visibilityFilter'
 import { resolveEncryptedSortPage } from './encryptedSortPage'
+import { applyDecryptedFields } from './decryptedFields'
 import { resolveCanonicalActivityTargetId } from '../../lib/legacyActivityBridge'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -604,7 +605,7 @@ export async function GET(req: Request) {
     )
     const interactionIds = pageRows.map((row) => row.id)
 
-    const [users, deals, customFieldValues, interactionRecords] = await Promise.all([
+    const [users, deals, customFieldValues, interactionRecords, encryptedInteractionFields] = await Promise.all([
       authorIds.length > 0 ? findWithDecryption(em, User, { id: { $in: authorIds } }, undefined, { tenantId: auth.tenantId, organizationId: selectedOrganizationId }) : Promise.resolve([]),
       dealIds.length > 0 ? findWithDecryption(em, CustomerDeal, { id: { $in: dealIds } }, undefined, { tenantId: auth.tenantId, organizationId: selectedOrganizationId }) : Promise.resolve([]),
       interactionIds.length > 0
@@ -620,6 +621,9 @@ export async function GET(req: Request) {
       interactionIds.length > 0
         ? findWithDecryption(em, CustomerInteraction, { id: { $in: interactionIds } } as never, undefined, { tenantId: auth.tenantId, organizationId: selectedOrganizationId })
         : Promise.resolve([]),
+      interactionIds.length > 0 && encryptionService?.getEncryptedFieldNames
+        ? encryptionService.getEncryptedFieldNames(CUSTOMER_INTERACTION_ENTITY_ID, auth.tenantId, selectedOrganizationId)
+        : Promise.resolve<readonly string[]>([]),
     ])
 
     const userMap = new Map(
@@ -634,22 +638,23 @@ export async function GET(req: Request) {
     const dealMap = new Map(
       deals.map((deal) => [deal.id, deal.title]),
     )
-    // title/body are encrypted at rest (see encryption.ts). The kysely rows above
-    // carry ciphertext when tenant encryption is enabled, so override them with the
-    // decrypted values from findWithDecryption for the returned page.
-    const interactionContentMap = new Map(
-      (interactionRecords as Array<{ id: string; title?: string | null; body?: string | null }>).map(
-        (record) => [record.id, { title: record.title ?? null, body: record.body ?? null }],
-      ),
+    // The kysely rows above carry raw column values, so every field the entity's
+    // encryption map covers arrives as ciphertext. findWithDecryption already
+    // returned those fields in plaintext, so the response takes them from the
+    // decrypted records. The covered set is read from the resolved map rather
+    // than hard-coded, so extending the map cannot leave a field passing through
+    // as ciphertext (#5945).
+    const interactionRecordMap = new Map<string, CustomerInteraction>(
+      (interactionRecords as CustomerInteraction[]).map((record) => [record.id, record]),
     )
 
-    const baseItems = pageRows.map((row) => ({
+    const baseItems = pageRows.map((row) => applyDecryptedFields({
       id: row.id,
       entityId: row.entity_id,
       dealId: row.deal_id ?? null,
       interactionType: row.interaction_type,
-      title: (interactionContentMap.has(row.id) ? interactionContentMap.get(row.id)!.title : row.title) ?? null,
-      body: (interactionContentMap.has(row.id) ? interactionContentMap.get(row.id)!.body : row.body) ?? null,
+      title: row.title ?? null,
+      body: row.body ?? null,
       status: row.status,
       scheduledAt: toIsoString(row.scheduled_at),
       occurredAt: toIsoString(row.occurred_at),
@@ -680,7 +685,7 @@ export async function GET(req: Request) {
       authorEmail: row.author_user_id ? userMap.get(row.author_user_id)?.email ?? null : null,
       dealTitle: row.deal_id ? dealMap.get(row.deal_id) ?? null : null,
       customValues: normalizeCustomFieldResponse(customFieldValues[row.id]) ?? null,
-    }))
+    }, interactionRecordMap.get(row.id), encryptedInteractionFields))
 
     const enricherContext = await buildEnricherContext(
       container,


### PR DESCRIPTION
Closes #5945

## 🎯 Goal
Extending an interaction's encryption map is a documented, supported deployment customization. Today doing so silently breaks the list API: the newly-covered field comes back as raw AES-GCM ciphertext instead of plaintext. This makes the route correct for every field the map declares, so extending the map is safe by construction.

## 🔍 Problem
`GET /api/customers/interactions` reads its base rows through Kysely — raw column values, so ciphertext for anything encrypted at rest — and then patches decrypted values back in for exactly two fields, `title` and `body`. Every other field is copied straight off the raw row. Nothing errors and nothing signals the consumer. An operator who adds, say, `location` (a meeting URL) or `participants` (external attendees) to the `customers:customer_interaction` map gets ciphertext in the same response where `title`/`body` decrypt correctly. The gap is dormant only because the shipped map happens to declare just those two fields.

## 🔍 Root Cause
`interactionContentMap` was built with a hardcoded `{ title, body }` projection over the entities returned by `findWithDecryption`. That helper already decrypts **every** field the resolved map declares, so the full plaintext was present on those records and simply discarded — the two-field projection, not the decryption, was the limit. Both the SQL-sort and encrypted-sort branches converge on this same response-assembly step, so it was the single defect site.

## What Changed
- **`packages/core/src/modules/customers/api/interactions/route.ts`** — the covered field set is now resolved per request via `encryptionService.getEncryptedFieldNames(CUSTOMER_INTERACTION_ENTITY_ID, tenantId, organizationId)` instead of being hardcoded. The call joins the existing `Promise.all`, so there is no extra round-trip and no work on an empty page (the encryption map is already cached from the sort-field lookup earlier in the same request). `title`/`body` are no longer special-cased — they now fall out of the same mechanism.
- **`packages/core/src/modules/customers/api/interactions/decryptedFields.ts`** (new) — `applyDecryptedFields` overlays the decrypted record's values onto a response item for each declared field. Map fields are authored as column names (`recurrence_rule`) while response keys and entity properties are camelCase (`recurrenceRule`), so each is matched through the shared `fieldNameCandidates` helper. It writes **only** keys the response item already exposes, so the wire shape cannot change; it preserves the existing `?? null` coercion and the existing fall-back-to-raw-row behavior when a row has no decrypted record; and it serializes a decrypted `Date` to an ISO string so date-shaped keys keep their format.

Behavior with the shipped configuration is unchanged. With encryption disabled `getEncryptedFieldNames` returns an empty set, no overlay runs, and the raw columns already hold plaintext.

## 🧪 Tests
- `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — the configured gate, run in order, all green. `@open-mercato/core` (where the change lives): 9 suites / 54 tests pass for `api/interactions`.
- `__tests__/listDecryptsMappedFields.test.ts` (new, 5 cases) drives the real `GET` handler: a map extended with `location`/`participants` returns plaintext; the shipped title/body map still decrypts exactly those two; encryption disabled keeps the raw column values; a row with no decrypted record falls back to its raw values; and the map lookup is made for the caller's tenant and organization.
- `__tests__/decryptedFields.test.ts` (new, 7 cases) covers the helper: snake→camel matching, non-string (JSONB) values, `null` normalization, `Date` → ISO serialization, no-op paths, and the guarantee that no new response key is introduced.
- Verified the tests genuinely fail without the fix: pinning the field list back to `['title','body']` fails the route test with `Expected "https://meet.example.test/room-42" / Received "enc:v1:location"` — the exact symptom in the issue.
- Three packages fail under `turbo run test` but pass standalone or are pre-existing local-environment failures, none of which reference the changed path: `@open-mercato/cli` (99/99 pass standalone), `@open-mercato/shared` (192 suites / 2158 tests pass standalone), and `create-mercato-app` (its `source-link-inventory` release-sandbox harness fails on a temp-dir `ENOENT`).

## 💥 Breaking Changes
None. No schema, DI, event, ACL, or OpenAPI change, and no new or removed response keys — a test asserts the key set is unchanged. Only the *values* of already-declared encrypted fields change, and only in a configuration that is currently returning ciphertext.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574570&installation_model_id=432243&pr_number=6021&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6021&signature=f715604a87ca6d7929722ff9610ecb76850629f921fc7067bc03a0a050aa4e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->