### PR TITLE
fix(encryption): warn when an encrypted custom field falls back to plaintext (#5921)

### DIFF
--- a/apps/docs/docs/user-guide/encryption.mdx
+++ b/apps/docs/docs/user-guide/encryption.mdx
@@ -159,6 +159,7 @@ The `--confirm <tenantUuid>` flag is a required safety gate — it must exactly 
 - Turn on `TENANT_DATA_ENCRYPTION_DEBUG=yes` to see KMS cache hits/misses, Vault calls, and which fields were encrypted.
 - Debug logs also call out Vault health and the selected KMS path (Vault vs derived vs noop) so you can verify `VAULT_ADDR`, `VAULT_TOKEN`, and `VAULT_KV_PATH` without exposing the token value.
 - If Vault is unreachable, the runtime logs a warning and falls back to the derived-key KMS when a dedicated fallback secret is present; otherwise it becomes a noop KMS (data stays plaintext). Integration credentials fail closed instead of saving under a noop or auth-derived key.
+- When a custom field configured as encrypted is written but no tenant key can be read or created, the value is stored as plaintext and the runtime logs `Custom field configured as encrypted was stored as plaintext` at WARN level with the tenant, entity, and field key (never the value). It is emitted once per tenant/entity/field per process, so grep for it after any key-store outage and re-save the affected records once key access is restored.
 - Use **Configuration → System status** to confirm the active values of the encryption env vars in the running instance.
 
 ## Running without Vault

--- a/packages/core/src/modules/entities/lib/helpers.ts
+++ b/packages/core/src/modules/entities/lib/helpers.ts
@@ -164,7 +164,7 @@ export async function setRecordCustomFields(
         const cf = em.create(CustomFieldValue, { entityId, recordId, organizationId, tenantId, fieldKey, createdAt: new Date() })
         clearValueColumns(cf)
         const stored = encrypted
-          ? await encryptCustomFieldValue(val, tenantId, getEncryptionService(), encryptionCache)
+          ? await encryptCustomFieldValue(val, tenantId, getEncryptionService(), encryptionCache, { entityId, fieldKey })
           : val
         switch (col) {
           case 'valueText': cf.valueText = stored == null ? null : String(stored); break
@@ -181,7 +181,7 @@ export async function setRecordCustomFields(
 
     const column: keyof CustomFieldValue = encrypted ? 'valueText' : def ? columnFromKind(def.kind) : columnFromJsValue(raw as Primitive)
     const storedValue = encrypted
-      ? await encryptCustomFieldValue(raw as Primitive, tenantId, getEncryptionService(), encryptionCache)
+      ? await encryptCustomFieldValue(raw as Primitive, tenantId, getEncryptionService(), encryptionCache, { entityId, fieldKey })
       : raw
 
     let cf = await em.findOne(CustomFieldValue, { entityId, recordId, organizationId, tenantId, fieldKey })

--- a/packages/shared/src/lib/encryption/__tests__/customFieldValues.plaintext-fallback.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/customFieldValues.plaintext-fallback.test.ts
@@ -1,0 +1,119 @@
+import {
+  encryptCustomFieldValue,
+  resetEncryptedFieldPlaintextFallbackWarnCache,
+} from '../customFieldValues'
+
+jest.mock('../../logger', () => {
+  const warn = jest.fn()
+  const debug = jest.fn()
+  const info = jest.fn()
+  const error = jest.fn()
+  const child = jest.fn(() => ({ warn, debug, info, error }))
+  return { createLogger: jest.fn(() => ({ child })), __warn: warn }
+})
+
+const loggerModule = jest.requireMock('../../logger') as { __warn: jest.Mock }
+
+const WARN_MESSAGE = 'Custom field configured as encrypted was stored as plaintext'
+
+const warnCalls = () =>
+  loggerModule.__warn.mock.calls.filter(([message]) => message === WARN_MESSAGE)
+
+/** Encryption is on and the tenant is scoped, but no DEK can be read or created. */
+function unresolvableDekService(overrides: Record<string, unknown> = {}) {
+  return {
+    isEnabled: () => true,
+    getDek: jest.fn(async () => null),
+    createDek: jest.fn(async () => null),
+    ...overrides,
+  } as any
+}
+
+describe('encryptCustomFieldValue plaintext fallback (regression: issue #5921)', () => {
+  beforeEach(() => {
+    resetEncryptedFieldPlaintextFallbackWarnCache()
+    loggerModule.__warn.mockClear()
+  })
+
+  it('warns when an encrypted field falls back to plaintext because the DEK is unavailable', async () => {
+    const service = unresolvableDekService()
+
+    const stored = await encryptCustomFieldValue('secret', 'tenant-1', service, undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'national_id',
+    })
+
+    expect(stored).toBe('secret')
+    expect(service.createDek).toHaveBeenCalledTimes(1)
+    expect(warnCalls()).toHaveLength(1)
+    const [, payload] = warnCalls()[0]
+    expect(payload).toMatchObject({
+      tenantId: 'tenant-1',
+      entity: 'customers:person',
+      field: 'national_id',
+    })
+    expect(typeof payload.hint).toBe('string')
+  })
+
+  it('never puts the field value in the warning payload', async () => {
+    await encryptCustomFieldValue('super-secret-value', 'tenant-1', unresolvableDekService(), undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'national_id',
+    })
+
+    expect(JSON.stringify(warnCalls()[0])).not.toContain('super-secret-value')
+  })
+
+  it('still warns when the caller does not identify the field', async () => {
+    await encryptCustomFieldValue('secret', 'tenant-1', unresolvableDekService())
+
+    expect(warnCalls()).toHaveLength(1)
+    expect(warnCalls()[0][1]).toMatchObject({ tenantId: 'tenant-1', entity: null, field: null })
+  })
+
+  it('stays silent for the intentional plaintext cases', async () => {
+    const disabled = { isEnabled: () => false, getDek: jest.fn(async () => null) } as any
+
+    // Encryption feature turned off.
+    expect(await encryptCustomFieldValue('plain', 'tenant-1', disabled)).toBe('plain')
+    // No tenant scope, so there is no tenant DEK to resolve.
+    expect(await encryptCustomFieldValue('plain', null, unresolvableDekService())).toBe('plain')
+    expect(await encryptCustomFieldValue('plain', undefined, unresolvableDekService())).toBe('plain')
+    // No encryption service wired at all.
+    expect(await encryptCustomFieldValue('plain', 'tenant-1', null)).toBe('plain')
+    // Null/undefined values are skipped before key resolution.
+    expect(await encryptCustomFieldValue(null, 'tenant-1', unresolvableDekService())).toBe(null)
+
+    expect(warnCalls()).toHaveLength(0)
+  })
+
+  it('warns once per tenant/entity/field so a key outage cannot flood the log', async () => {
+    const service = unresolvableDekService()
+    const field = { entityId: 'customers:person', fieldKey: 'national_id' }
+
+    await encryptCustomFieldValue('a', 'tenant-1', service, undefined, field)
+    await encryptCustomFieldValue('b', 'tenant-1', service, undefined, field)
+    await encryptCustomFieldValue('c', 'tenant-1', service, undefined, field)
+
+    expect(warnCalls()).toHaveLength(1)
+  })
+
+  it('reports each degraded field and tenant separately', async () => {
+    const service = unresolvableDekService()
+
+    await encryptCustomFieldValue('a', 'tenant-1', service, undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'national_id',
+    })
+    await encryptCustomFieldValue('b', 'tenant-1', service, undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'passport_no',
+    })
+    await encryptCustomFieldValue('c', 'tenant-2', service, undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'national_id',
+    })
+
+    expect(warnCalls()).toHaveLength(3)
+  })
+})

--- a/packages/shared/src/lib/encryption/__tests__/customFieldValues.plaintext-fallback.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/customFieldValues.plaintext-fallback.test.ts
@@ -19,6 +19,8 @@ const WARN_MESSAGE = 'Custom field configured as encrypted was stored as plainte
 const warnCalls = () =>
   loggerModule.__warn.mock.calls.filter(([message]) => message === WARN_MESSAGE)
 
+const fixedKey = Buffer.alloc(32, 1).toString('base64')
+
 /** Encryption is on and the tenant is scoped, but no DEK can be read or created. */
 function unresolvableDekService(overrides: Record<string, unknown> = {}) {
   return {
@@ -30,9 +32,17 @@ function unresolvableDekService(overrides: Record<string, unknown> = {}) {
 }
 
 describe('encryptCustomFieldValue plaintext fallback (regression: issue #5921)', () => {
+  const previousToggle = process.env.TENANT_DATA_ENCRYPTION
+
   beforeEach(() => {
     resetEncryptedFieldPlaintextFallbackWarnCache()
     loggerModule.__warn.mockClear()
+    delete process.env.TENANT_DATA_ENCRYPTION
+  })
+
+  afterAll(() => {
+    if (previousToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = previousToggle
   })
 
   it('warns when an encrypted field falls back to plaintext because the DEK is unavailable', async () => {
@@ -71,11 +81,33 @@ describe('encryptCustomFieldValue plaintext fallback (regression: issue #5921)',
     expect(warnCalls()[0][1]).toMatchObject({ tenantId: 'tenant-1', entity: null, field: null })
   })
 
-  it('stays silent for the intentional plaintext cases', async () => {
-    const disabled = { isEnabled: () => false, getDek: jest.fn(async () => null) } as any
+  // The issue's own reproduction: VAULT_ADDR points at an unreachable Vault and
+  // no fallback secret is set, so createKmsService() hands back a NoopKmsService
+  // whose isHealthy() is false while TENANT_DATA_ENCRYPTION is on — which makes
+  // service.isEnabled() false. Gating the warning on isEnabled() would go silent
+  // in exactly this case, so it must be driven by the env toggle instead.
+  it('warns when the KMS is unhealthy and the service therefore reports itself disabled', async () => {
+    const unhealthyKms = {
+      isEnabled: () => false,
+      getDek: jest.fn(async () => null),
+      createDek: jest.fn(async () => null),
+    } as any
 
-    // Encryption feature turned off.
-    expect(await encryptCustomFieldValue('plain', 'tenant-1', disabled)).toBe('plain')
+    const stored = await encryptCustomFieldValue('secret', 'tenant-1', unhealthyKms, undefined, {
+      entityId: 'customers:person',
+      fieldKey: 'national_id',
+    })
+
+    expect(stored).toBe('secret')
+    expect(warnCalls()).toHaveLength(1)
+  })
+
+  it('stays silent for the intentional plaintext cases', async () => {
+    // Operator deliberately runs unencrypted, so a plaintext write is correct.
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+    expect(await encryptCustomFieldValue('plain', 'tenant-1', unresolvableDekService())).toBe('plain')
+    delete process.env.TENANT_DATA_ENCRYPTION
+
     // No tenant scope, so there is no tenant DEK to resolve.
     expect(await encryptCustomFieldValue('plain', null, unresolvableDekService())).toBe('plain')
     expect(await encryptCustomFieldValue('plain', undefined, unresolvableDekService())).toBe('plain')
@@ -115,5 +147,36 @@ describe('encryptCustomFieldValue plaintext fallback (regression: issue #5921)',
     })
 
     expect(warnCalls()).toHaveLength(3)
+  })
+
+  // Throttling for the whole process lifetime would report the first outage and
+  // hide every later one — the exact blind spot this warning exists to remove.
+  it('reports a second outage after the key has recovered in between', async () => {
+    const field = { entityId: 'customers:person', fieldKey: 'national_id' }
+    const recovered = { isEnabled: () => true, getDek: async () => ({ key: fixedKey }) } as any
+
+    await encryptCustomFieldValue('a', 'tenant-1', unresolvableDekService(), undefined, field)
+    expect(warnCalls()).toHaveLength(1)
+
+    const encrypted = await encryptCustomFieldValue('b', 'tenant-1', recovered, undefined, field)
+    expect(encrypted).not.toBe('b')
+
+    await encryptCustomFieldValue('c', 'tenant-1', unresolvableDekService(), undefined, field)
+    expect(warnCalls()).toHaveLength(2)
+  })
+
+  it('does not let one tenant recovering unthrottle another tenant still degraded', async () => {
+    const field = { entityId: 'customers:person', fieldKey: 'national_id' }
+    const recovered = { isEnabled: () => true, getDek: async () => ({ key: fixedKey }) } as any
+
+    await encryptCustomFieldValue('a', 'tenant-1', unresolvableDekService(), undefined, field)
+    await encryptCustomFieldValue('b', 'tenant-2', unresolvableDekService(), undefined, field)
+    expect(warnCalls()).toHaveLength(2)
+
+    await encryptCustomFieldValue('c', 'tenant-1', recovered, undefined, field)
+
+    // tenant-2 never recovered, so its warning stays throttled.
+    await encryptCustomFieldValue('d', 'tenant-2', unresolvableDekService(), undefined, field)
+    expect(warnCalls()).toHaveLength(2)
   })
 })

--- a/packages/shared/src/lib/encryption/customFieldValues.ts
+++ b/packages/shared/src/lib/encryption/customFieldValues.ts
@@ -1,6 +1,9 @@
 import type { EntityManager } from '@mikro-orm/core'
+import { createLogger } from '../logger'
 import { encryptWithAesGcm, decryptWithAesGcm } from './aes'
 import { TenantDataEncryptionService } from './tenantDataEncryptionService'
+
+const logger = createLogger('shared').child({ component: 'encryption' })
 
 /**
  * Custom field kinds that ALWAYS round-trip as a string. The encrypt path
@@ -69,15 +72,80 @@ async function resolveDekKey(
   return key
 }
 
+/**
+ * Whether the caller asked for a write that is supposed to end up encrypted.
+ *
+ * `resolveDekKey` returns `null` for four different situations, three of which
+ * are intentional no-ops: there is no encryption service, the feature is turned
+ * off (`TENANT_DATA_ENCRYPTION`), or the record has no tenant scope. Only when
+ * all three hold and the key STILL comes back empty did key resolution actually
+ * fail, and only then is a plaintext write a degradation worth reporting.
+ */
+function isEncryptionExpected(
+  service: TenantDataEncryptionService | null,
+  tenantId: string | null | undefined,
+): boolean {
+  if (!service || !(tenantId ?? null)) return false
+  return service.isEnabled()
+}
+
+// One warning per tenant/entity/field per process. A KMS outage makes this
+// branch run for every field of every write, and an operator only needs to
+// learn about each degraded field once.
+const PLAINTEXT_FALLBACK_WARN_CAP = 5000
+const plaintextFallbackWarned = new Set<string>()
+
+/** Test seam: the warn-once cache is process-global by design. */
+export function resetEncryptedFieldPlaintextFallbackWarnCache(): void {
+  plaintextFallbackWarned.clear()
+}
+
+function warnOnPlaintextFallback(
+  tenantId: string | null | undefined,
+  options?: EncryptCustomFieldOptions,
+): void {
+  try {
+    const scopedTenantId = tenantId ?? null
+    const entity = options?.entityId ?? null
+    const field = options?.fieldKey ?? null
+    const warnKey = `${scopedTenantId}|${entity ?? 'unknown'}|${field ?? 'unknown'}`
+    if (plaintextFallbackWarned.has(warnKey)) return
+    if (plaintextFallbackWarned.size >= PLAINTEXT_FALLBACK_WARN_CAP) plaintextFallbackWarned.clear()
+    plaintextFallbackWarned.add(warnKey)
+    logger.warn('Custom field configured as encrypted was stored as plaintext', {
+      tenantId: scopedTenantId,
+      entity,
+      field,
+      hint: 'The tenant data encryption key could not be read or created (KMS/Vault unavailable, or DEK creation failed), so the value was written unencrypted. Restore key access and re-save the affected records.',
+    })
+  } catch {
+    // A diagnostic must never break the write it is diagnosing.
+  }
+}
+
+export type EncryptCustomFieldOptions = {
+  /** Entity the value belongs to, e.g. `customers:person`. Used only to identify the field in diagnostics. */
+  entityId?: string | null
+  /** Custom field key, e.g. from `CustomFieldDef.key`. Used only to identify the field in diagnostics. */
+  fieldKey?: string | null
+}
+
 export async function encryptCustomFieldValue(
   value: unknown,
   tenantId: string | null | undefined,
   service: TenantDataEncryptionService | null,
   cache?: Map<string | null, string | null>,
+  options?: EncryptCustomFieldOptions,
 ): Promise<unknown> {
   if (value === undefined || value === null) return value
   const key = await resolveDekKey(service, tenantId, cache, { createIfMissing: true })
-  if (!key) return value
+  if (!key) {
+    // Key resolution failed for a field the operator configured as encrypted.
+    // The write still goes through as plaintext (failing it would drop data on
+    // a transient outage), but it must not be silent — issue #5921.
+    if (isEncryptionExpected(service, tenantId)) warnOnPlaintextFallback(tenantId, options)
+    return value
+  }
   const serialized = typeof value === 'string' ? value : JSON.stringify(value)
   return encryptWithAesGcm(serialized, key).value
 }

--- a/packages/shared/src/lib/encryption/customFieldValues.ts
+++ b/packages/shared/src/lib/encryption/customFieldValues.ts
@@ -2,6 +2,7 @@ import type { EntityManager } from '@mikro-orm/core'
 import { createLogger } from '../logger'
 import { encryptWithAesGcm, decryptWithAesGcm } from './aes'
 import { TenantDataEncryptionService } from './tenantDataEncryptionService'
+import { isTenantDataEncryptionEnabled } from './toggles'
 
 const logger = createLogger('shared').child({ component: 'encryption' })
 
@@ -75,29 +76,52 @@ async function resolveDekKey(
 /**
  * Whether the caller asked for a write that is supposed to end up encrypted.
  *
- * `resolveDekKey` returns `null` for four different situations, three of which
- * are intentional no-ops: there is no encryption service, the feature is turned
- * off (`TENANT_DATA_ENCRYPTION`), or the record has no tenant scope. Only when
- * all three hold and the key STILL comes back empty did key resolution actually
- * fail, and only then is a plaintext write a degradation worth reporting.
+ * `resolveDekKey` returns `null` for several situations. Two are intentional
+ * no-ops — no encryption service is wired, or the record has no tenant scope —
+ * and one is the operator deliberately running unencrypted
+ * (`TENANT_DATA_ENCRYPTION=no`). Anything else means the caller asked for an
+ * encrypted write that could not be performed, which is worth reporting.
+ *
+ * This deliberately checks the `TENANT_DATA_ENCRYPTION` env toggle rather than
+ * `service.isEnabled()`. `isEnabled()` folds the toggle together with KMS
+ * health, and an unreachable Vault with no fallback secret resolves to
+ * `NoopKmsService`, whose `isHealthy()` is false whenever encryption is on — so
+ * gating on it would stay silent during exactly the outage this warning exists
+ * to surface. The env toggle alone expresses the operator's intent.
  */
 function isEncryptionExpected(
   service: TenantDataEncryptionService | null,
   tenantId: string | null | undefined,
 ): boolean {
   if (!service || !(tenantId ?? null)) return false
-  return service.isEnabled()
+  return isTenantDataEncryptionEnabled()
 }
 
-// One warning per tenant/entity/field per process. A KMS outage makes this
-// branch run for every field of every write, and an operator only needs to
-// learn about each degraded field once.
+// One warning per tenant/entity/field per OUTAGE. A key-store outage makes this
+// branch run for every field of every write, so the warning is throttled — but
+// the entries for a tenant are dropped again as soon as one of its writes
+// encrypts successfully. Throttling for the lifetime of the process instead
+// would report the first outage and silently swallow every later one, which is
+// the failure this warning exists to make visible.
 const PLAINTEXT_FALLBACK_WARN_CAP = 5000
 const plaintextFallbackWarned = new Set<string>()
 
 /** Test seam: the warn-once cache is process-global by design. */
 export function resetEncryptedFieldPlaintextFallbackWarnCache(): void {
   plaintextFallbackWarned.clear()
+}
+
+/**
+ * Forget a tenant's plaintext-fallback warnings once its key resolves again, so
+ * a later outage is reported instead of being throttled away by the previous
+ * one. The `size` guard keeps the healthy path — an empty set — at O(1).
+ */
+function clearPlaintextFallbackWarnings(tenantId: string | null | undefined): void {
+  if (!plaintextFallbackWarned.size) return
+  const prefix = `${tenantId ?? null}|`
+  for (const warnKey of plaintextFallbackWarned) {
+    if (warnKey.startsWith(prefix)) plaintextFallbackWarned.delete(warnKey)
+  }
 }
 
 function warnOnPlaintextFallback(
@@ -146,6 +170,7 @@ export async function encryptCustomFieldValue(
     if (isEncryptionExpected(service, tenantId)) warnOnPlaintextFallback(tenantId, options)
     return value
   }
+  clearPlaintextFallbackWarnings(tenantId)
   const serialized = typeof value === 'string' ? value : JSON.stringify(value)
   return encryptWithAesGcm(serialized, key).value
 }


### PR DESCRIPTION
Closes #5921

## 🎯 Goal
A custom field an operator configured as **Encrypted** can no longer be written to the database in cleartext without leaving any trace. When the tenant key cannot be resolved, the write is now reported at WARN level with enough detail to audit and re-save the affected records.

## 🔍 Problem
`encryptCustomFieldValue` silently fell back to a plaintext write whenever the tenant DEK could not be resolved. A KMS/Vault outage, a missing DEK, or any other key-resolution failure therefore stored data the operator believed was encrypted at rest as cleartext, with no operator-facing signal — not even with `TENANT_DATA_ENCRYPTION_DEBUG=yes`, since the branch had no logging statement at all. That directly contradicted the observability promise in `apps/docs/docs/architecture/data-encryption.mdx` ("warning rows emitted when KMS is unavailable"), and left no way to detect the condition after the fact.

## 🔍 Root Cause
`resolveDekKey()` returns `null` for several distinct situations. Two are legitimate no-ops — no encryption service is wired, or the record has no tenant scope — and one is the operator deliberately running unencrypted (`TENANT_DATA_ENCRYPTION=no`). Every remaining case is a genuine key-resolution failure. `encryptCustomFieldValue` collapsed them all into `if (!key) return value`, making the failure indistinguishable from the intentional cases and therefore impossible to log without also spamming deployments that legitimately run unencrypted.

## What Changed
- `packages/shared/src/lib/encryption/customFieldValues.ts` — added an `isEncryptionExpected()` predicate that isolates the key-resolution-failure case, and a throttled `logger.warn('Custom field configured as encrypted was stored as plaintext', { tenantId, entity, field, hint })` on that branch, using the same `createLogger('shared').child({ component: 'encryption' })` facade as `aes.ts` and `kms.ts`. **The field value is never included in the payload.** An optional 5th `options?: { entityId, fieldKey }` parameter lets callers identify the field.
- **The predicate reads the `TENANT_DATA_ENCRYPTION` env toggle, deliberately not `service.isEnabled()`.** `isEnabled()` folds the toggle together with `kms.isHealthy()`, and an unreachable Vault with no fallback secret makes `createKmsService()` return `NoopKmsService`, whose `isHealthy()` is `!isTenantDataEncryptionEnabled()` — false precisely when encryption is on. Gating on it would have stayed silent during exactly the outage in this issue's reproduction steps. The env toggle alone expresses operator intent, so the warning now covers the unhealthy-KMS path, the Vault circuit-breaker window, and a genuinely missing DEK alike.
- **Throttled once per outage, not once per process.** The warning is deduplicated per tenant/entity/field in a capped process-global set, but a tenant's entries are dropped as soon as one of its writes encrypts successfully. Throttling for the process lifetime would report the first outage and hide every later one — the blind spot this warning exists to remove. The `size` guard keeps the healthy path at O(1).
- `packages/core/src/modules/entities/lib/helpers.ts` — both `setCustomFields` call sites (single-value and multi-value) now pass `{ entityId, fieldKey }`, so the warning names the field that degraded rather than just the tenant.
- **Behavior deliberately unchanged:** the fallback still returns the value and the write still succeeds. Failing it would drop user data during a transient outage, and the defect reported is the missing signal, not the return value.
- `apps/docs/docs/user-guide/encryption.mdx` — documents the exact log message under Debugging so operators know what to grep for after a key-store outage.

## 🧪 Tests
- New `packages/shared/src/lib/encryption/__tests__/customFieldValues.plaintext-fallback.test.ts` (9 cases) locks in: the warning fires with the tenant/entity/field payload; the field value never appears in that payload; the unidentified-field case still warns; **the unhealthy-KMS path warns** even though the service reports itself disabled (the issue's own reproduction); **silence** for the genuinely intentional paths (`TENANT_DATA_ENCRYPTION=no`, null/undefined tenant, null service, null value); warn-once dedupe across repeated writes; separate reporting per field and per tenant; a second outage reported after recovery; and one tenant's recovery not unthrottling another still-degraded tenant.
- Verified the tests target the behavior, not the exports: with only the warn call disabled 5 of 6 original cases fail, and with the predicate reverted to `service.isEnabled()` the unhealthy-KMS and intentional-silence cases fail.
- Full configured gate, in order, re-run after the review fixes: `build:packages` ✅ · `generate` ✅ (no drift) · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ (advisory) · `typecheck` ✅ (29 tasks) · `build:app` ✅.
- Tests: `@open-mercato/shared` 2167 passed · `@open-mercato/core` 12110 passed · `@open-mercato/cli` 1865 passed · 28 further packages green.
- Two known-environment items, both confirmed **not** caused by this change: `yarn test` aborts on a `shared` `dynamicLoader.generatedCacheRecovery` failure under turbo's parallel execution (the suite passes standalone, and the package is fully green on its own — every package the abort skipped was re-run individually, as listed above); and `create-mercato-app` fails 80 of 886, with **identical** counts verified against a stashed tree, caused by the absent `codex` CLI (180 occurrences) and typecheck timeouts.

## 💥 Breaking Changes
None. The new `options` parameter is optional and appended, so every existing caller compiles and behaves identically; `resetEncryptedFieldPlaintextFallbackWarnCache` and `EncryptCustomFieldOptions` are additive exports. `BACKWARD_COMPATIBILITY.md` §3 explicitly permits new optional parameters on stable function signatures.

## Follow-up (deliberately not in this PR)
The issue also floats an opt-in **fail-closed** mode (throw instead of writing plaintext). That is a new configuration contract with env, docs, and template-sync obligations plus a behavior change for existing deployments, so it belongs in its own change. The issue's stated expectation is satisfied by either option, and this PR implements the non-breaking one. `decryptCustomFieldValue` has the same `if (!key) return value` shape but returns ciphertext to the caller — visibly broken rather than silently insecure — so it is left untouched here.
