### PR TITLE
fix(encryption): honour TENANT_DATA_ENCRYPTION=no across credentials, session keys and search

### DIFF
--- a/.ai/specs/implemented/2026-05-29-integrations-credentials-encryption-fail-closed.md
+++ b/.ai/specs/implemented/2026-05-29-integrations-credentials-encryption-fail-closed.md
@@ -84,6 +84,30 @@ The public credentials service type and API routes remain stable. The new typed 
 - Sensitive data remains encrypted through AES-GCM and tenant DEKs.
 - The insecure local AES/KMS fallback is removed from integrations credentials.
 
+## Amendment 2026-09-10 — fail closed on outage, not on opt-out
+
+The original rule ("no DEK, no write") was implemented against `getTenantDek()` returning null,
+which conflates two situations that need opposite handling:
+
+- **Vault is down / no fallback secret configured.** Writing a third-party API key in the clear
+  here is exactly the downgrade this spec exists to prevent. Unchanged: still fails closed, still
+  HTTP 503.
+- **The operator set `TENANT_DATA_ENCRYPTION=no`.** Plaintext at rest is the whole point of that
+  setting — emails, the search index and the query index are already stored that way. Failing
+  closed here made integration credentials unsavable on a deployment that had deliberately opted
+  out, with a 503 that pointed at Vault configuration the operator had chosen not to have.
+
+`resolveEncryptionMode(kms)` (`@open-mercato/shared/lib/encryption/kms`) now names the three
+states, and only `unavailable` fails closed. The threat model is unchanged: no local DEK
+derivation, no auth-secret reuse, no hardcoded fallback constant. `disabled` writes the credentials
+object as-is with no `__om_encrypted_credentials_blob_v1` marker, so the on-disk shape stays
+self-describing and re-enabling the toggle re-seals on the next write.
+
+Reads of a blob sealed *before* the toggle was flipped still raise, now with
+`reason: 'sealed-while-disabled'` and a message naming `mercato entities decrypt-database` — the
+previous message pointed at Vault, which is not the remedy for that case.
+
 ## Changelog
 
 - 2026-05-29 - Initial security hardening spec for issue #2251.
+- 2026-09-10 - Amended: `TENANT_DATA_ENCRYPTION=no` degrades to plaintext instead of failing closed; KMS outages are unchanged.

--- a/.ai/specs/implemented/2026-05-29-integrations-credentials-encryption-fail-closed.md
+++ b/.ai/specs/implemented/2026-05-29-integrations-credentials-encryption-fail-closed.md
@@ -104,8 +104,13 @@ object as-is with no `__om_encrypted_credentials_blob_v1` marker, so the on-disk
 self-describing and re-enabling the toggle re-seals on the next write.
 
 Reads of a blob sealed *before* the toggle was flipped still raise, now with
-`reason: 'sealed-while-disabled'` and a message naming `mercato entities decrypt-database` — the
-previous message pointed at Vault, which is not the remedy for that case.
+`reason: 'sealed-while-disabled'`. The previous message pointed at Vault, which is not the remedy
+for that case — and neither is `mercato entities decrypt-database`, which decrypts the columns an
+encryption map covers while this envelope sits *inside* the decrypted `credentials` value. The only
+remedy is re-entering the credentials, so `GET`/`PUT /api/integrations/:id/credentials` catch this
+one reason and degrade to an empty form instead of 503, letting the operator do exactly that. Every
+other unavailable reason still fails closed on both verbs, and adapters reading through the service
+still get the error rather than a silently empty credential set.
 
 ## Changelog
 

--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -189,6 +189,8 @@ yarn mercato entities decrypt-database --tenant <uuid> --confirm <uuid> --deacti
 
 # 3. Rebuild the search/filter indexes.
 yarn mercato query_index reindex --tenant <uuid>
+
+# 4. Re-save every configured integration's credentials from the admin UI (see below).
 ```
 
 **Flipping the flag before step 1 is the mistake to avoid.** Search tokens are hashes of
@@ -220,6 +222,14 @@ the same condition.
   the toggle was flipped cannot be opened by any key. Reads raise
   `CredentialsEncryptionUnavailableError` with `reason: 'sealed-while-disabled'` rather than
   handing an adapter a garbage secret.
+
+  `decrypt-database` does **not** fix this, and step 4 above is not optional: credentials carry a
+  second, service-level envelope under `__om_encrypted_credentials_blob_v1` *inside* the
+  `integration_credentials.credentials` value. The command decrypts the column that the encryption
+  map covers; the envelope inside it survives. **Every integration's credentials must be re-entered
+  once after the flag flips.** The admin credentials form loads as if nothing were configured (the
+  route degrades on this reason specifically), and saving stores them in the clear. Until then the
+  adapter itself fails loudly rather than running with a broken secret.
 - **Ephemeral session API key secrets** (MCP / AI chat) are stored in the clear under `disabled`.
   Sessions minted while encryption was on are unrecoverable afterwards; they expire within 30
   minutes, so re-issuing the session key is the remedy.

--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -172,6 +172,66 @@ production-only encryption map still needs a test.
 - Tenant bootstrap: generate + store DEK when `TENANT_DATA_ENCRYPTION` is enabled; warn otherwise.
 - Health/warning surfacing: warning record when Vault unavailable; telemetry hooks around map cache misses and KMS failures.
 
+## Turning encryption off
+
+`TENANT_DATA_ENCRYPTION=no` is a supported state, but it only governs **new** writes. Rows already
+encrypted stay ciphertext, and the decrypt-on-load hook that used to hide that is gone with the
+toggle. On a database that has never encrypted anything, set the flag and restart. Otherwise the
+order matters:
+
+```bash
+# 1. While encryption is still ON — this needs the DEK.
+yarn mercato entities decrypt-database --tenant <uuid> --confirm <uuid> --dry-run
+yarn mercato entities decrypt-database --tenant <uuid> --confirm <uuid> --deactivate-maps
+
+# 2. Only now flip the flag, and restart every replica (DEK and map caches are in-process).
+#    TENANT_DATA_ENCRYPTION=no
+
+# 3. Rebuild the search/filter indexes.
+yarn mercato query_index reindex --tenant <uuid>
+```
+
+**Flipping the flag before step 1 is the mistake to avoid.** Search tokens are hashes of
+*plaintext* — the indexer decrypts a document before tokenising it, which is what lets the token
+index survive encryption being switched on or off. With the toggle already off there is nothing to
+decrypt with, so a reindex would tokenise ciphertext. The write path detects the envelope by shape
+and preserves the existing tokens rather than replacing them, and logs a warning naming the
+affected fields, but those fields stay unsearchable until you decrypt and reindex properly.
+
+### Three states, not two
+
+Code that branches on encryption must distinguish an operator opt-out from a KMS outage. Use
+`resolveEncryptionMode(kms)` from `@open-mercato/shared/lib/encryption/kms`:
+
+| Mode | Meaning | Correct handling |
+| --- | --- | --- |
+| `disabled` | `TENANT_DATA_ENCRYPTION=no` | Plaintext is the intended outcome — degrade to it. |
+| `active` | Encryption on, DEK reachable | Encrypt. |
+| `unavailable` | Encryption on, no DEK reachable | Fail closed. Never write a secret in the clear. |
+
+Do **not** branch on `kmsService.isHealthy()` alone. `NoopKmsService.isHealthy()` is deliberately
+inverted — it reports healthy exactly when encryption is off, so that `enabled && healthy`
+collapses correctly — which means a bare `if (!kms.isHealthy())` reads the first and third rows as
+the same condition.
+
+### What still needs a decrypted database
+
+- **Integration credentials** are stored in the clear under `disabled`, but a blob sealed *before*
+  the toggle was flipped cannot be opened by any key. Reads raise
+  `CredentialsEncryptionUnavailableError` with `reason: 'sealed-while-disabled'` rather than
+  handing an adapter a garbage secret.
+- **Ephemeral session API key secrets** (MCP / AI chat) are stored in the clear under `disabled`.
+  Sessions minted while encryption was on are unrecoverable afterwards; they expire within 30
+  minutes, so re-issuing the session key is the remedy.
+
+### Search precision is a separate switch
+
+Disabling encryption does not by itself restore exact SQL `ILIKE` on list search. The token rewrite
+is gated on `OM_SEARCH_ENABLED` (default `true`), not on the encryption toggle. To get exact
+matching back on plaintext columns, set `OM_SEARCH_USE_ILIKE_FOR_NON_ENCRYPTED_FIELDS=true` — only
+then does the encryption toggle feed into that decision. `OM_SEARCH_ENABLED=false` turns the token
+machinery off entirely.
+
 ## Operational notes
 
 - Keep `TENANT_DATA_ENCRYPTION=yes` by default. Set `TENANT_DATA_ENCRYPTION=no` only for local dev or when KMS is down during incident response.

--- a/apps/docs/docs/cli/entities-decrypt-database.mdx
+++ b/apps/docs/docs/cli/entities-decrypt-database.mdx
@@ -65,6 +65,12 @@ Flipping the flag first also leaves the search index stranded: tokens are hashes
 with encryption already off a reindex has nothing to decrypt with. The indexer detects the envelope
 by shape and preserves the existing tokens instead of overwriting them with hashes of ciphertext,
 but the affected fields stay unsearchable until you decrypt and reindex in this order.
+
+This command also does not reach **integration credentials**. It decrypts the columns an encryption
+map covers, and those credentials carry a second envelope (`__om_encrypted_credentials_blob_v1`)
+*inside* the decrypted value. After disabling encryption, re-enter each integration's credentials
+from the admin UI once — see
+[Turning encryption off](../architecture/data-encryption#turning-encryption-off).
 :::
 
 After a successful run the following steps are required to complete the transition:

--- a/apps/docs/docs/cli/entities-decrypt-database.mdx
+++ b/apps/docs/docs/cli/entities-decrypt-database.mdx
@@ -59,6 +59,14 @@ Aliases: `--tenantId` for `--tenant`, `--organization`/`--organizationId` for `-
 
 ## Post-decryption steps
 
+:::warning Run this command BEFORE disabling encryption
+The command needs the tenant DEK, so it must run while `TENANT_DATA_ENCRYPTION` is still on.
+Flipping the flag first also leaves the search index stranded: tokens are hashes of plaintext, and
+with encryption already off a reindex has nothing to decrypt with. The indexer detects the envelope
+by shape and preserves the existing tokens instead of overwriting them with hashes of ciphertext,
+but the affected fields stay unsearchable until you decrypt and reindex in this order.
+:::
+
 After a successful run the following steps are required to complete the transition:
 
 1. Set `TENANT_DATA_ENCRYPTION=false` in your environment / secrets.

--- a/packages/core/src/modules/api_keys/__tests__/apiKeyService.sessionSecret.test.ts
+++ b/packages/core/src/modules/api_keys/__tests__/apiKeyService.sessionSecret.test.ts
@@ -1,0 +1,129 @@
+/**
+ * MCP and the AI chat authenticate by session token, and that only works if the ephemeral key's
+ * secret can be handed back later — `session_secret_encrypted` exists for no other reason.
+ *
+ * It used to be written only when a DEK was reachable, which is never true under
+ * `TENANT_DATA_ENCRYPTION=no`. The column stayed null, `findSessionApiKeyWithSecret` returned null,
+ * and the only trace was a debug-level log: MCP session auth was simply off for anyone who had
+ * disabled encryption, with nothing to point at.
+ */
+
+const mockCreateKmsService = jest.fn()
+
+// `resolveEncryptionMode` stays real — it is the disabled/unavailable split under test.
+jest.mock('@open-mercato/shared/lib/encryption/kms', () => ({
+  ...jest.requireActual('@open-mercato/shared/lib/encryption/kms'),
+  createKmsService: (...args: unknown[]) => mockCreateKmsService(...args),
+}))
+
+import { generateDek, looksLikeEncryptedPayload } from '@open-mercato/shared/lib/encryption/aes'
+import { createSessionApiKey, findSessionApiKeyWithSecret } from '../services/apiKeyService'
+
+const TENANT = 'tenant-1'
+const previousToggle = process.env.TENANT_DATA_ENCRYPTION
+
+function mockKms(dek: string | null) {
+  mockCreateKmsService.mockReturnValue({
+    isHealthy: () => Boolean(dek),
+    getTenantDek: jest.fn(async (tenantId: string) => (dek ? { tenantId, key: dek, fetchedAt: Date.now() } : null)),
+    createTenantDek: jest.fn(async (tenantId: string) => (dek ? { tenantId, key: dek, fetchedAt: Date.now() } : null)),
+  })
+}
+
+function buildEm() {
+  const created: Array<Record<string, unknown>> = []
+  const flush = jest.fn().mockResolvedValue(undefined)
+  const em = {
+    create: jest.fn((_Entity: unknown, data: Record<string, unknown>) => {
+      const row = { id: `key-${created.length + 1}`, ...data }
+      created.push(row)
+      return row
+    }),
+    persist: jest.fn(() => ({ flush })),
+    flush,
+    // `findApiKeyBySessionToken` reads the row back through the plain EntityManager.
+    findOne: jest.fn(async () => created[0] ?? null),
+  }
+  return { em, created }
+}
+
+/** Round-trip a freshly minted session key through storage and back out again. */
+async function roundTrip(): Promise<{ stored: unknown; recovered: string | null }> {
+  const { em, created } = buildEm()
+  await createSessionApiKey(em as never, {
+    sessionToken: 'sess_alice',
+    userId: 'user-alice',
+    userRoles: ['admin'],
+    tenantId: TENANT,
+    organizationId: 'org-1',
+  })
+  const row = created[0]
+  const result = await findSessionApiKeyWithSecret(em as never, 'sess_alice')
+  return { stored: row.sessionSecretEncrypted, recovered: result?.secret ?? null }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+afterEach(() => {
+  if (previousToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+  else process.env.TENANT_DATA_ENCRYPTION = previousToggle
+})
+
+describe('session secret storage', () => {
+  it('seals the secret when encryption is active', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    mockKms(generateDek())
+
+    const { stored, recovered } = await roundTrip()
+
+    expect(looksLikeEncryptedPayload(stored)).toBe(true)
+    expect(recovered).toEqual(expect.any(String))
+    expect(recovered).not.toEqual(stored)
+  })
+
+  it('round-trips the secret in the clear when the operator disabled encryption', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+    mockKms(null)
+
+    const { stored, recovered } = await roundTrip()
+
+    expect(stored).toEqual(expect.any(String))
+    expect(looksLikeEncryptedPayload(stored)).toBe(false)
+    expect(recovered).toBe(stored)
+  })
+
+  it('still refuses to store a secret in the clear when the KMS is merely unreachable', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    mockKms(null)
+
+    const { stored, recovered } = await roundTrip()
+
+    // A Vault outage must not silently downgrade a secret nobody asked to store in plaintext.
+    expect(stored).toBeNull()
+    expect(recovered).toBeNull()
+  })
+
+  it('gives up honestly on a secret sealed before the toggle was flipped off', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    mockKms(generateDek())
+    const { em, created } = buildEm()
+    await createSessionApiKey(em as never, {
+      sessionToken: 'sess_alice',
+      userId: 'user-alice',
+      userRoles: ['admin'],
+      tenantId: TENANT,
+      organizationId: 'org-1',
+    })
+    const sealed = created[0]
+
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+    mockKms(null)
+    expect(sealed.sessionSecretEncrypted).toEqual(expect.any(String))
+
+    // Handing the envelope back as if it were the secret would authenticate nothing and look like
+    // a wrong password; null at least routes the caller to re-issue the session key.
+    await expect(findSessionApiKeyWithSecret(em as never, 'sess_alice')).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/api_keys/services/apiKeyService.ts
+++ b/packages/core/src/modules/api_keys/services/apiKeyService.ts
@@ -4,8 +4,8 @@ import { hash, compare } from 'bcryptjs'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { Role } from '@open-mercato/core/modules/auth/data/entities'
 import { ApiKey } from '../data/entities'
-import { createKmsService } from '@open-mercato/shared/lib/encryption/kms'
-import { encryptWithAesGcm, decryptWithAesGcm } from '@open-mercato/shared/lib/encryption/aes'
+import { createKmsService, resolveEncryptionMode } from '@open-mercato/shared/lib/encryption/kms'
+import { encryptWithAesGcm, decryptWithAesGcm, looksLikeEncryptedPayload } from '@open-mercato/shared/lib/encryption/aes'
 import { getSharedApiKeyAuthCache } from '@open-mercato/shared/lib/auth/apiKeyAuthCache'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -19,8 +19,16 @@ const BCRYPT_COST = 10
 // =============================================================================
 
 /**
- * Encrypt an API key secret for storage.
- * Uses tenant-specific DEK if available, otherwise returns null.
+ * Seal an ephemeral session API key secret for storage in `session_secret_encrypted`.
+ *
+ * Returns null when the secret cannot be stored at all, which costs the caller MCP session-token
+ * auth (the secret is unrecoverable and `findSessionApiKeyWithSecret` gives up).
+ *
+ * Under `TENANT_DATA_ENCRYPTION=no` the secret is stored as-is. That is the same bargain the rest
+ * of the system already strikes in that mode -- emails, integration credentials and the search
+ * index all sit in plaintext -- and it is what keeps the AI chat working when an operator opts
+ * out. A DEK that is merely unreachable is a different situation and still yields null: writing a
+ * secret in the clear because Vault happens to be down is not a downgrade anyone asked for.
  */
 async function encryptSessionSecret(
   secret: string,
@@ -29,7 +37,16 @@ async function encryptSessionSecret(
   if (!tenantId) return null
 
   const kms = createKmsService()
-  if (!kms.isHealthy()) return null
+  const mode = resolveEncryptionMode(kms)
+  if (mode === 'disabled') return secret
+  if (mode === 'unavailable') {
+    logger.warn(
+      'Tenant data encryption is enabled but no DEK is reachable; session secret not stored. '
+        + 'MCP session-token auth will fail until the KMS recovers.',
+      { tenantId },
+    )
+    return null
+  }
 
   const dek = await kms.getTenantDek(tenantId)
   if (!dek) {
@@ -45,22 +62,31 @@ async function encryptSessionSecret(
 }
 
 /**
- * Decrypt an API key secret from storage.
- * Returns null if decryption fails or no DEK available.
+ * Recover a session API key secret written by {@link encryptSessionSecret}.
+ * Returns null if it cannot be recovered.
  */
 async function decryptSessionSecret(
-  encrypted: string,
+  stored: string,
   tenantId: string | null
 ): Promise<string | null> {
-  if (!tenantId || !encrypted) return null
+  if (!tenantId || !stored) return null
 
   const kms = createKmsService()
-  if (!kms.isHealthy()) return null
+  const mode = resolveEncryptionMode(kms)
+  if (mode === 'disabled') {
+    // Written in the clear by the branch above -- unless it predates the toggle being flipped, in
+    // which case it is a sealed envelope no key can open and null is the honest answer.
+    return looksLikeEncryptedPayload(stored) ? null : stored
+  }
+  if (mode === 'unavailable') {
+    logger.warn('Tenant data encryption is enabled but no DEK is reachable; cannot recover session secret', { tenantId })
+    return null
+  }
 
   const dek = await kms.getTenantDek(tenantId)
   if (!dek) return null
 
-  return decryptWithAesGcm(encrypted, dek.key)
+  return decryptWithAesGcm(stored, dek.key)
 }
 
 export type CreateApiKeyInput = {

--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -9,6 +9,7 @@ import { emitIntegrationsEvent } from '../../../events'
 import { saveCredentialsSchema } from '../../../data/validators'
 import {
   isCredentialsEncryptionUnavailableError,
+  isCredentialsSealedWhileDisabledError,
   type CredentialsService,
 } from '../../../lib/credentials-service'
 import { collectCredentialUrlValidationErrors } from '../../../lib/credentials-field-validation'
@@ -22,8 +23,30 @@ import {
   runIntegrationMutationGuards,
 } from '../../guards'
 import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
+
+const logger = createLogger('integrations').child({ component: 'credentials-route' })
+
+/**
+ * Credentials sealed before `TENANT_DATA_ENCRYPTION` was switched off cannot be opened by any key,
+ * and nothing unseals them for the operator: `mercato entities decrypt-database` decrypts the
+ * columns an encryption map covers, while this envelope sits *inside* the decrypted `credentials`
+ * value. Re-entering them is the only remedy, so the admin surface has to stay usable — a 503 on
+ * both the read and the save would leave the integration permanently unfixable from the UI.
+ *
+ * The form therefore loads as if nothing were configured. Adapters keep seeing the error, since
+ * they read through the service directly.
+ */
+function reportSealedCredentials(integrationId: string, tenantId: string): void {
+  logger.warn(
+    'Integration credentials are sealed under an encryption key that is no longer available '
+      + '(TENANT_DATA_ENCRYPTION was switched off after they were saved). The admin form will show '
+      + 'them as unconfigured; re-save the credentials to store them in the clear.',
+    { integrationId, tenantId },
+  )
+}
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.credentials.manage'] },
@@ -74,10 +97,15 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
     values = await credentialsService.resolve(integration.id, scope)
     updatedAt = await credentialsService.resolveUpdatedAt(integration.id, scope)
   } catch (error) {
-    if (isCredentialsEncryptionUnavailableError(error)) {
+    if (isCredentialsSealedWhileDisabledError(error)) {
+      reportSealedCredentials(integration.id, auth.tenantId)
+      values = null
+      updatedAt = await credentialsService.resolveUpdatedAt(integration.id, scope)
+    } else if (isCredentialsEncryptionUnavailableError(error)) {
       return NextResponse.json({ error: 'Integration credentials encryption is unavailable' }, { status: 503 })
+    } else {
+      throw error
     }
-    throw error
   }
 
   const schema = credentialsService.getSchema(integration.id)
@@ -183,7 +211,15 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   }
 
   try {
-    const existing = await credentialsService.resolve(integration.id, scope)
+    let existing: Record<string, unknown> | null = null
+    try {
+      existing = await credentialsService.resolve(integration.id, scope)
+    } catch (error) {
+      // Nothing to merge against, but the save itself must go through: this is the state the
+      // re-entry is meant to escape from.
+      if (!isCredentialsSealedWhileDisabledError(error)) throw error
+      reportSealedCredentials(integration.id, auth.tenantId)
+    }
     const credentialsToSave = mergeMaskedSecretCredentials(
       schema,
       payloadData.credentials,

--- a/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
+++ b/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../guards'
 import { GET, PUT } from '../[id]/credentials/route'
 import { MASKED_SECRET_VALUE } from '../../lib/credentials-masking'
+import { CredentialsEncryptionUnavailableError } from '../../lib/credentials-service'
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn(),
@@ -235,5 +236,86 @@ describe('integrations credentials route — secret masking (issue #2253)', () =
       { clientSecret: '' },
       { organizationId: 'o1', tenantId: 't1' },
     )
+  })
+})
+
+/**
+ * Credentials sealed while `TENANT_DATA_ENCRYPTION` was on, read back after it was switched off.
+ * No key can open that blob, and no command unseals it — `mercato entities decrypt-database`
+ * decrypts the columns an encryption map covers, while this envelope sits inside the decrypted
+ * value. Re-entering the credentials is the only remedy, so both halves of the admin round-trip
+ * have to survive the error: a 503 on the read and a 503 on the save would leave the integration
+ * unfixable from the UI forever.
+ *
+ * A KMS that is merely unreachable is the opposite case and must keep failing closed.
+ */
+describe('integrations credentials route — credentials sealed before the encryption toggle flipped', () => {
+  const saveMock = jest.fn()
+  const resolveMock = jest.fn()
+
+  function sealedWhileDisabled(): CredentialsEncryptionUnavailableError {
+    return new CredentialsEncryptionUnavailableError('t1', 'sealed-while-disabled')
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    saveMock.mockReset()
+    resolveMock.mockReset()
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: 't1', orgId: 'o1', sub: 'u1' })
+    ;(getIntegration as jest.Mock).mockReturnValue({ id: 'sync_akeneo', title: 'Akeneo PIM' })
+    ;(runIntegrationMutationGuards as jest.Mock).mockResolvedValue({ ok: true })
+    ;(createRequestContainer as jest.Mock).mockResolvedValue({
+      resolve: (key: string) => {
+        if (key === 'integrationCredentialsService') {
+          return { getSchema: () => secretSchema, save: saveMock, resolve: resolveMock, resolveUpdatedAt: jest.fn().mockResolvedValue(null) }
+        }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    })
+  })
+
+  it('GET loads the form as unconfigured instead of failing the page', async () => {
+    resolveMock.mockRejectedValue(sealedWhileDisabled())
+    const response = await GET(
+      new Request('http://localhost/api/integrations/sync_akeneo/credentials'),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.credentials).toEqual({})
+    expect(body.secretFieldsConfigured).toEqual({ clientSecret: false })
+  })
+
+  it('PUT stores the re-entered credentials rather than 503-ing on the merge read', async () => {
+    resolveMock.mockRejectedValue(sealedWhileDisabled())
+    const response = await PUT(
+      buildRequest({ apiUrl: 'https://akeneo.example', clientSecret: 'freshly-typed' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(200)
+    expect(saveMock).toHaveBeenCalledWith(
+      'sync_akeneo',
+      { apiUrl: 'https://akeneo.example', clientSecret: 'freshly-typed' },
+      { organizationId: 'o1', tenantId: 't1' },
+    )
+  })
+
+  it('GET still fails closed when encryption is on and the KMS is unreachable', async () => {
+    resolveMock.mockRejectedValue(new CredentialsEncryptionUnavailableError('t1', 'no-dek'))
+    const response = await GET(
+      new Request('http://localhost/api/integrations/sync_akeneo/credentials'),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(503)
+  })
+
+  it('PUT still fails closed when encryption is on and the KMS is unreachable', async () => {
+    resolveMock.mockRejectedValue(new CredentialsEncryptionUnavailableError('t1', 'no-dek'))
+    const response = await PUT(
+      buildRequest({ apiUrl: 'https://akeneo.example', clientSecret: 'freshly-typed' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(503)
+    expect(saveMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
@@ -18,7 +18,10 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: jest.fn(),
 }))
 
+// `resolveEncryptionMode` stays real: it is the function under test on the disabled/unavailable
+// split, and it reads only the env toggle plus the mocked KMS's `isHealthy()`.
 jest.mock('@open-mercato/shared/lib/encryption/kms', () => ({
+  ...jest.requireActual('@open-mercato/shared/lib/encryption/kms'),
   createKmsService: jest.fn(),
 }))
 
@@ -194,6 +197,90 @@ describe('integration credentials service encryption', () => {
       'utf8',
     )
     expect(source).not.toContain('om-emergency-fallback-rotate-me')
+  })
+})
+
+/**
+ * `TENANT_DATA_ENCRYPTION=no` is a supported deployment, not an outage.
+ *
+ * Both states hand the KMS factory a service that produces no DEK, which is why this path used to
+ * answer 503 for an operator who had simply opted out: `getTenantDek` returning null looks the
+ * same either way. The distinction is the env toggle, and only the outage half may fail closed —
+ * degrading a secret to plaintext because Vault blinked is the downgrade the fail-closed rule
+ * exists to prevent (spec 2026-05-29, security finding #7).
+ */
+describe('integration credentials with tenant data encryption disabled', () => {
+  const previousToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+  })
+
+  afterEach(() => {
+    if (previousToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = previousToggle
+  })
+
+  it('stores credentials as plaintext instead of answering 503', async () => {
+    mockKms(null)
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    const { em, persisted } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await service.save('gateway_test', { apiKey: 'sk_test_secret' }, scope)
+
+    const credentialsRow = persisted.find((row) =>
+      typeof row === 'object'
+      && row !== null
+      && (row as { integrationId?: unknown }).integrationId === 'gateway_test'
+    ) as { credentials?: Record<string, unknown> } | undefined
+
+    expect(credentialsRow?.credentials).toEqual({ apiKey: 'sk_test_secret' })
+    expect(credentialsRow?.credentials).not.toHaveProperty(encryptedBlobKey)
+  })
+
+  it('round-trips a plaintext blob through getRaw', async () => {
+    mockKms(null)
+    mockFindOneWithDecryption.mockResolvedValue({
+      credentials: { apiKey: 'sk_test_secret' },
+    } as never)
+    const { em } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    await expect(service.getRaw('gateway_test', scope)).resolves.toEqual({ apiKey: 'sk_test_secret' })
+  })
+
+  it('still refuses to guess at a blob sealed before the toggle was flipped', async () => {
+    const dek = generateDek()
+    const encrypted = encryptWithAesGcm(JSON.stringify({ apiKey: 'sk_test_secret' }), dek).value
+    mockKms(null)
+    mockFindOneWithDecryption.mockResolvedValue({
+      credentials: { [encryptedBlobKey]: encrypted },
+    } as never)
+    const { em } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    // Returning the envelope, or an empty credential set, would hand the adapter a silently broken
+    // secret. The operator skipped `decrypt-database`; say so.
+    const error = await service.getRaw('gateway_test', scope).catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(CredentialsEncryptionUnavailableError)
+    expect((error as CredentialsEncryptionUnavailableError).reason).toBe('sealed-while-disabled')
+    expect((error as Error).message).toContain('decrypt-database')
+  })
+
+  it('keeps failing closed when encryption is ON but the KMS is merely unreachable', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    mockKms(null)
+    const { em, persisted } = createMockEntityManager()
+    const service = createCredentialsService(em as never)
+
+    const error = await service
+      .save('gateway_test', { apiKey: 'sk_test_secret' }, scope)
+      .catch((err: unknown) => err)
+    expect(error).toBeInstanceOf(CredentialsEncryptionUnavailableError)
+    expect((error as CredentialsEncryptionUnavailableError).reason).toBe('no-dek')
+    expect(persisted).toEqual([])
   })
 })
 

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-service.test.ts
@@ -262,11 +262,15 @@ describe('integration credentials with tenant data encryption disabled', () => {
     const service = createCredentialsService(em as never)
 
     // Returning the envelope, or an empty credential set, would hand the adapter a silently broken
-    // secret. The operator skipped `decrypt-database`; say so.
+    // secret. Say what happened instead -- and name a remedy that exists: `decrypt-database` does
+    // NOT unseal this blob (it decrypts the columns an encryption map covers, and this envelope
+    // sits inside the decrypted value), so an operator who follows that advice lands right back
+    // here. Re-entering the credentials is what actually works.
     const error = await service.getRaw('gateway_test', scope).catch((err: unknown) => err)
     expect(error).toBeInstanceOf(CredentialsEncryptionUnavailableError)
     expect((error as CredentialsEncryptionUnavailableError).reason).toBe('sealed-while-disabled')
-    expect((error as Error).message).toContain('decrypt-database')
+    expect((error as Error).message).toContain('re-enter the credentials')
+    expect((error as Error).message).toContain('does not reach this blob')
   })
 
   it('keeps failing closed when encryption is ON but the KMS is merely unreachable', async () => {

--- a/packages/core/src/modules/integrations/lib/credentials-service.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-service.ts
@@ -29,8 +29,10 @@ const CREDENTIALS_ENCRYPTION_REMEDY: Record<CredentialsEncryptionUnavailableReas
     'set TENANT_DATA_ENCRYPTION_FALLBACK_KEY in the environment.',
   'sealed-while-disabled':
     'they were sealed while TENANT_DATA_ENCRYPTION was on and it is now off, so no key can open ' +
-    'them. Re-enable TENANT_DATA_ENCRYPTION, or run `mercato entities decrypt-database` before ' +
-    'disabling it.',
+    'them. Re-enable TENANT_DATA_ENCRYPTION to read them again, or re-enter the credentials — ' +
+    'saving them while the toggle is off stores them in the clear. Note that ' +
+    '`mercato entities decrypt-database` does not reach this blob: it decrypts the columns an ' +
+    'encryption map covers, and this envelope sits inside the decrypted value.',
 }
 
 export class CredentialsEncryptionUnavailableError extends Error {
@@ -48,6 +50,16 @@ export class CredentialsEncryptionUnavailableError extends Error {
 
 export function isCredentialsEncryptionUnavailableError(error: unknown): error is CredentialsEncryptionUnavailableError {
   return error instanceof CredentialsEncryptionUnavailableError
+}
+
+/**
+ * The one unavailable-reason an operator can act on without restoring a key: the blob predates
+ * `TENANT_DATA_ENCRYPTION=no` and no key exists to open it, so re-entering the credentials is the
+ * only way forward. The admin credentials route degrades to an empty form on this so that the
+ * re-entry is possible at all; `no-dek` (encryption on, KMS unreachable) still fails closed.
+ */
+export function isCredentialsSealedWhileDisabledError(error: unknown): boolean {
+  return isCredentialsEncryptionUnavailableError(error) && error.reason === 'sealed-while-disabled'
 }
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {
@@ -169,8 +181,9 @@ export function createCredentialsService(em: EntityManager) {
 
     // A sealed blob written before encryption was switched off. There is no key to open it with,
     // and returning the envelope as if it were the credentials would hand an adapter a garbage
-    // secret, so this stays an error even in `disabled` mode -- the remedy is
-    // `mercato entities decrypt-database`, not a silent empty credential set.
+    // secret, so this stays an error even in `disabled` mode rather than a silent empty credential
+    // set. The remedy is re-entering the credentials (see the reason's message); the admin route
+    // catches this specific reason so the form can load empty and accept them.
     const dek = await resolveCredentialsDek(scope)
     if (!dek) throw new CredentialsEncryptionUnavailableError(scope.tenantId, 'sealed-while-disabled')
 

--- a/packages/core/src/modules/integrations/lib/credentials-service.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-service.ts
@@ -1,7 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { decryptWithAesGcm, encryptWithAesGcm } from '@open-mercato/shared/lib/encryption/aes'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { createKmsService } from '@open-mercato/shared/lib/encryption/kms'
+import { createKmsService, resolveEncryptionMode } from '@open-mercato/shared/lib/encryption/kms'
 import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import {
   getBundle,
@@ -21,15 +21,28 @@ const ENCRYPTED_CREDENTIALS_BLOB_KEY = '__om_encrypted_credentials_blob_v1'
  * configured. The credentials path deliberately fails closed instead of using
  * a hardcoded fallback secret; see security tracker finding #7.
  */
+export type CredentialsEncryptionUnavailableReason = 'no-dek' | 'sealed-while-disabled'
+
+const CREDENTIALS_ENCRYPTION_REMEDY: Record<CredentialsEncryptionUnavailableReason, string> = {
+  'no-dek':
+    'no tenant DEK is available. Configure Vault (VAULT_ADDR/VAULT_TOKEN) or ' +
+    'set TENANT_DATA_ENCRYPTION_FALLBACK_KEY in the environment.',
+  'sealed-while-disabled':
+    'they were sealed while TENANT_DATA_ENCRYPTION was on and it is now off, so no key can open ' +
+    'them. Re-enable TENANT_DATA_ENCRYPTION, or run `mercato entities decrypt-database` before ' +
+    'disabling it.',
+}
+
 export class CredentialsEncryptionUnavailableError extends Error {
   readonly code = 'CREDENTIALS_ENCRYPTION_UNAVAILABLE'
-  constructor(tenantId: string) {
+  readonly reason: CredentialsEncryptionUnavailableReason
+  constructor(tenantId: string, reason: CredentialsEncryptionUnavailableReason = 'no-dek') {
     super(
       `Cannot encrypt or decrypt integration credentials for tenant ${tenantId}: ` +
-        `no tenant DEK is available. Configure Vault (VAULT_ADDR/VAULT_TOKEN) or ` +
-        `set TENANT_DATA_ENCRYPTION_FALLBACK_KEY in the environment.`,
+        CREDENTIALS_ENCRYPTION_REMEDY[reason],
     )
     this.name = 'CredentialsEncryptionUnavailableError'
+    this.reason = reason
   }
 }
 
@@ -112,8 +125,21 @@ export function createCredentialsService(em: EntityManager) {
     existing.isActive = true
   }
 
-  async function resolveCredentialsDek(scope: IntegrationScope): Promise<string> {
+  /**
+   * Resolve the DEK this tenant's credentials blob is sealed with, or `null` when the operator
+   * has switched tenant data encryption off.
+   *
+   * The `null` is the whole point of going through {@link resolveEncryptionMode} rather than
+   * asking the KMS directly. Under `TENANT_DATA_ENCRYPTION=no` the KMS is a noop and hands back
+   * nothing, which is indistinguishable — to `getTenantDek` alone — from Vault being down. Those
+   * two need opposite answers: an operator who turned encryption off expects plaintext, whereas a
+   * Vault outage must not silently downgrade a secret that is supposed to be sealed. So only
+   * `unavailable` throws.
+   */
+  async function resolveCredentialsDek(scope: IntegrationScope): Promise<string | null> {
     const kms = createKmsService()
+    if (resolveEncryptionMode(kms) === 'disabled') return null
+
     const existing = await kms.getTenantDek(scope.tenantId)
     if (existing?.key) return existing.key
 
@@ -128,6 +154,7 @@ export function createCredentialsService(em: EntityManager) {
     scope: IntegrationScope,
   ): Promise<Record<string, unknown>> {
     const dek = await resolveCredentialsDek(scope)
+    if (!dek) return credentials
     const payload = encryptWithAesGcm(JSON.stringify(credentials), dek)
     return { [ENCRYPTED_CREDENTIALS_BLOB_KEY]: payload.value }
   }
@@ -140,7 +167,13 @@ export function createCredentialsService(em: EntityManager) {
     const encrypted = credentials[ENCRYPTED_CREDENTIALS_BLOB_KEY]
     if (typeof encrypted !== 'string' || !encrypted) return credentials
 
+    // A sealed blob written before encryption was switched off. There is no key to open it with,
+    // and returning the envelope as if it were the credentials would hand an adapter a garbage
+    // secret, so this stays an error even in `disabled` mode -- the remedy is
+    // `mercato entities decrypt-database`, not a silent empty credential set.
     const dek = await resolveCredentialsDek(scope)
+    if (!dek) throw new CredentialsEncryptionUnavailableError(scope.tenantId, 'sealed-while-disabled')
+
     const decryptedRaw = decryptWithAesGcm(encrypted, dek)
     if (!decryptedRaw) return {}
 

--- a/packages/core/src/modules/query_index/__tests__/search-tokens-ciphertext-guard.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-tokens-ciphertext-guard.test.ts
@@ -1,0 +1,330 @@
+import type { Kysely } from 'kysely'
+import { encryptWithAesGcm, generateDek } from '@open-mercato/shared/lib/encryption/aes'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
+import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import {
+  buildSearchTokenRows,
+  replaceSearchTokensForBatch,
+  replaceSearchTokensForRecord,
+  resetCiphertextSkipWarnings,
+} from '../lib/search-tokens'
+
+const warn = jest.fn()
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const mocked = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => warn(...args),
+    error: jest.fn(),
+    child: jest.fn(),
+  }
+  mocked.child.mockImplementation(() => mocked)
+  return { createLogger: jest.fn(() => mocked) }
+})
+
+type StoredRow = {
+  id: number
+  entity_type: string
+  entity_id: string
+  organization_id: string | null
+  tenant_id: string | null
+  field: string
+  token_hash: string
+  token: string | null
+}
+
+type Matcher = (row: StoredRow) => boolean
+type RawBuilderLike = { toOperationNode: () => { sqlFragments: string[]; parameters: Array<{ value?: unknown }> } }
+
+const columnOf = (row: StoredRow, column: string): unknown => (row as unknown as Record<string, unknown>)[column]
+
+/**
+ * Minimal in-memory `search_tokens`, kin to the stores in `search-tokens-record-unchanged-skip`
+ * and `search-tokens-unchanged-skip`. Rows carry a synthetic `id` because that is the only thing
+ * that distinguishes "left alone" from "deleted and re-inserted with identical content", and the
+ * whole point of this guard is that the existing rows are never deleted.
+ */
+function createStore() {
+  const rows: StoredRow[] = []
+  let nextId = 1
+
+  const expressionBuilder = () => {
+    const eb: any = (column: string, operator: string, value: unknown): Matcher => {
+      if (operator !== '=') throw new Error(`[internal] unsupported eb operator: ${operator}`)
+      return (row) => String(columnOf(row, column)) === String(value)
+    }
+    eb.and = (matchers: Matcher[]): Matcher => (row) => matchers.every((matches) => matches(row))
+    eb.or = (matchers: Matcher[]): Matcher => (row) => matchers.some((matches) => matches(row))
+    return eb
+  }
+
+  const buildPredicate = (args: unknown[]): Matcher => {
+    if (args.length === 1) {
+      const arg = args[0]
+      if (typeof arg === 'function') return (arg as (eb: unknown) => Matcher)(expressionBuilder())
+      const node = (arg as RawBuilderLike).toOperationNode()
+      const column = String(node.sqlFragments[0]).trim().split(/\s+/)[0]
+      const expected = node.parameters[0]?.value ?? null
+      return (row) => (columnOf(row, column) ?? null) === expected
+    }
+    const [column, operator, value] = args as [string, string, unknown]
+    if (operator === '=') return (row) => String(columnOf(row, column)) === String(value)
+    if (operator === 'in') {
+      const allowed = new Set((value as unknown[]).map(String))
+      return (row) => allowed.has(String(columnOf(row, column)))
+    }
+    throw new Error(`[internal] unsupported where operator: ${operator}`)
+  }
+
+  const selectChain = () => (_table: unknown) => {
+    const predicates: Matcher[] = []
+    let columns: string[] | null = null
+    let limit: number | null = null
+    let grouped = false
+    const chain: any = {
+      select: (selection: unknown) => {
+        columns = Array.isArray(selection) ? selection.filter((col) => typeof col === 'string').map(String) : null
+        return chain
+      },
+      where: (...args: unknown[]) => {
+        predicates.push(buildPredicate(args))
+        return chain
+      },
+      groupBy: () => {
+        grouped = true
+        return chain
+      },
+      limit: (count: number) => {
+        limit = count
+        return chain
+      },
+      execute: async () => {
+        const matched = rows.filter((row) => predicates.every((matches) => matches(row)))
+        if (grouped) {
+          const counts = new Map<string, number>()
+          for (const row of matched) counts.set(row.entity_id, (counts.get(row.entity_id) ?? 0) + 1)
+          return Array.from(counts, ([entity_id, token_count]) => ({ entity_id, token_count: String(token_count) }))
+        }
+        if (!columns) return [{ token_count: String(matched.length) }]
+        const limited = limit === null ? matched : matched.slice(0, limit)
+        return limited.map((row) => Object.fromEntries(columns!.map((column) => [column, columnOf(row, column)])))
+      },
+    }
+    return chain
+  }
+
+  const deleteChain = (_table: unknown) => {
+    const predicates: Matcher[] = []
+    const chain: any = {
+      where: (...args: unknown[]) => {
+        predicates.push(buildPredicate(args))
+        return chain
+      },
+      execute: async () => {
+        const kept = rows.filter((row) => !predicates.every((matches) => matches(row)))
+        rows.length = 0
+        rows.push(...kept)
+        return []
+      },
+    }
+    return chain
+  }
+
+  const insertChain = (_table: unknown) => {
+    const chain: any = {
+      values: (values: any[]) => {
+        for (const value of values) {
+          rows.push({
+            id: nextId++,
+            entity_type: String(value.entity_type),
+            entity_id: String(value.entity_id),
+            organization_id: value.organization_id ?? null,
+            tenant_id: value.tenant_id ?? null,
+            field: String(value.field),
+            token_hash: String(value.token_hash),
+            token: value.token ?? null,
+          })
+        }
+        return chain
+      },
+      execute: async () => [],
+    }
+    return chain
+  }
+
+  const executor = () => ({ selectFrom: selectChain(), deleteFrom: deleteChain, insertInto: insertChain })
+
+  const db = {
+    ...executor(),
+    transaction: () => ({
+      execute: async (callback: (trx: unknown) => Promise<void>) => callback(executor()),
+    }),
+  } as unknown as Kysely<any>
+
+  return {
+    db,
+    rows,
+    insertRaw: (row: Omit<StoredRow, 'id'>) => {
+      rows.push({ ...row, id: nextId++ })
+    },
+    idsFor: (field: string) => rows.filter((row) => row.field === field).map((row) => row.id).sort((a, b) => a - b),
+    fields: () => Array.from(new Set(rows.map((row) => row.field))).sort(),
+  }
+}
+
+const ENTITY_TYPE = 'customers:customer_deal'
+const SCOPE = { organizationId: 'org-1', tenantId: 'tenant-1' }
+const hashOf = (word: string): string => tokenizeText(word, resolveSearchConfig()).hashes[0]
+
+const storedRow = (recordId: string, field: string, tokenHash: string): Omit<StoredRow, 'id'> => ({
+  entity_type: ENTITY_TYPE,
+  entity_id: recordId,
+  organization_id: SCOPE.organizationId,
+  tenant_id: SCOPE.tenantId,
+  field,
+  token_hash: tokenHash,
+  token: null,
+})
+
+const ciphertext = () => String(encryptWithAesGcm('Renewal for ACME Ltd', generateDek()).value)
+
+beforeEach(() => {
+  warn.mockClear()
+  resetCiphertextSkipWarnings()
+})
+
+/**
+ * The failure this guards against is not "search degrades while encryption is off" — it is
+ * permanent, silent data loss.
+ *
+ * Tokens are hashes of PLAINTEXT: the indexer decrypts a document before tokenising it, which is
+ * what lets the token index survive encryption being switched on or off. That decrypt step becomes
+ * a no-op under `TENANT_DATA_ENCRYPTION=no`, so an operator who flips the toggle before running
+ * `mercato entities decrypt-database` feeds ciphertext to the tokeniser. Writing those tokens is
+ * merely useless; DELETING the good ones to make room for them is unrecoverable without a reindex
+ * that itself cannot run until the data is decrypted.
+ */
+describe('search tokens refuse to index ciphertext', () => {
+  it('emits no token rows for a field holding an AES-GCM envelope', () => {
+    const rows = buildSearchTokenRows({
+      entityType: ENTITY_TYPE,
+      recordId: 'deal-1',
+      ...SCOPE,
+      doc: { title: ciphertext(), status: 'open' },
+    })
+
+    expect(new Set(rows.map((row) => row.field))).toEqual(new Set(['status']))
+  })
+
+  it('indexes the plaintext siblings of a ciphertext field normally', () => {
+    const rows = buildSearchTokenRows({
+      entityType: ENTITY_TYPE,
+      recordId: 'deal-1',
+      ...SCOPE,
+      doc: { title: ciphertext(), description: 'quarterly renewal' },
+    })
+
+    expect(rows.length).toBeGreaterThan(0)
+    expect(new Set(rows.map((row) => row.field))).toEqual(new Set(['description']))
+  })
+
+  it('skips an array field as soon as any entry is an envelope', () => {
+    const rows = buildSearchTokenRows({
+      entityType: ENTITY_TYPE,
+      recordId: 'deal-1',
+      ...SCOPE,
+      doc: { tags: ['plaintext', ciphertext()] },
+    })
+
+    expect(rows).toEqual([])
+  })
+
+  it('tells the operator which fields and what to do about it, once per entity type', () => {
+    const doc = { title: ciphertext(), description: ciphertext() }
+    buildSearchTokenRows({ entityType: ENTITY_TYPE, recordId: 'deal-1', ...SCOPE, doc })
+    buildSearchTokenRows({ entityType: ENTITY_TYPE, recordId: 'deal-2', ...SCOPE, doc })
+
+    // Once per entity type per process: a full reindex would otherwise emit this per record.
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(String(warn.mock.calls[0][0])).toContain('decrypt-database')
+    expect(warn.mock.calls[0][1]).toEqual({ entityType: ENTITY_TYPE, fields: ['description', 'title'] })
+  })
+})
+
+describe('replaceSearchTokensForRecord preserves tokens for ciphertext fields', () => {
+  it('leaves the encrypted field’s existing rows untouched while rewriting its siblings', async () => {
+    const store = createStore()
+    store.insertRaw(storedRow('deal-1', 'title', hashOf('renewal')))
+    store.insertRaw(storedRow('deal-1', 'description', hashOf('stale')))
+    const preservedIds = store.idsFor('title')
+
+    await replaceSearchTokensForRecord(store.db, {
+      entityType: ENTITY_TYPE,
+      recordId: 'deal-1',
+      ...SCOPE,
+      doc: { title: ciphertext(), description: 'quarterly renewal' },
+    })
+
+    // Same row ids => never deleted. A delete-then-reinsert would renumber them.
+    expect(store.idsFor('title')).toEqual(preservedIds)
+    expect(store.rows.filter((row) => row.field === 'title').map((row) => row.token_hash))
+      .toEqual([hashOf('renewal')])
+    // The plaintext sibling still gets its normal rewrite.
+    expect(store.rows.some((row) => row.field === 'description' && row.token_hash === hashOf('quarterly')))
+      .toBe(true)
+    expect(store.rows.some((row) => row.token_hash === hashOf('stale'))).toBe(false)
+  })
+
+  it('does not strand a record whose every indexable field is ciphertext', async () => {
+    const store = createStore()
+    store.insertRaw(storedRow('deal-1', 'title', hashOf('renewal')))
+    const preservedIds = store.idsFor('title')
+
+    await replaceSearchTokensForRecord(store.db, {
+      entityType: ENTITY_TYPE,
+      recordId: 'deal-1',
+      ...SCOPE,
+      doc: { title: ciphertext() },
+    })
+
+    expect(store.idsFor('title')).toEqual(preservedIds)
+  })
+})
+
+describe('replaceSearchTokensForBatch preserves tokens for ciphertext records', () => {
+  it('drops the affected record from the rewrite and still processes its neighbours', async () => {
+    const store = createStore()
+    store.insertRaw(storedRow('deal-encrypted', 'title', hashOf('renewal')))
+    store.insertRaw(storedRow('deal-plain', 'title', hashOf('outdated')))
+    const preservedIds = store.idsFor('title').slice(0, 1)
+
+    await replaceSearchTokensForBatch(store.db, [
+      { entityType: ENTITY_TYPE, recordId: 'deal-encrypted', ...SCOPE, doc: { title: ciphertext() } },
+      { entityType: ENTITY_TYPE, recordId: 'deal-plain', ...SCOPE, doc: { title: 'quarterly renewal' } },
+    ])
+
+    const encryptedRows = store.rows.filter((row) => row.entity_id === 'deal-encrypted')
+    expect(encryptedRows.map((row) => row.id)).toEqual(preservedIds)
+    expect(encryptedRows.map((row) => row.token_hash)).toEqual([hashOf('renewal')])
+
+    const plainHashes = store.rows.filter((row) => row.entity_id === 'deal-plain').map((row) => row.token_hash)
+    expect(plainHashes).toContain(hashOf('quarterly'))
+    expect(plainHashes).not.toContain(hashOf('outdated'))
+  })
+
+  it('does not purge a batch of nothing-but-ciphertext records', async () => {
+    const store = createStore()
+    store.insertRaw(storedRow('deal-1', 'title', hashOf('renewal')))
+    store.insertRaw(storedRow('deal-2', 'title', hashOf('expansion')))
+    const before = store.rows.map((row) => row.id).sort((a, b) => a - b)
+
+    // The `!rows.length` branch purges every id in the batch. Reaching it with these records would
+    // wipe exactly the tokens that are still good.
+    await replaceSearchTokensForBatch(store.db, [
+      { entityType: ENTITY_TYPE, recordId: 'deal-1', ...SCOPE, doc: { title: ciphertext() } },
+      { entityType: ENTITY_TYPE, recordId: 'deal-2', ...SCOPE, doc: { title: ciphertext() } },
+    ])
+
+    expect(store.rows.map((row) => row.id).sort((a, b) => a - b)).toEqual(before)
+  })
+})

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -6,6 +6,7 @@ import {
   type SearchConfig,
 } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import { looksLikeEncryptedPayload } from '@open-mercato/shared/lib/encryption/aes'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
@@ -68,6 +69,51 @@ function collectTextValues(value: unknown): string[] {
   return []
 }
 
+/**
+ * Fields whose value is an AES-GCM envelope rather than the text it is supposed to hold.
+ *
+ * Search tokens are hashes of PLAINTEXT: the indexer decrypts a document before tokenising it
+ * (`indexer.ts` -> `decryptIndexDocForSearch`), which is what lets the token index survive
+ * encryption being switched on or off. That decrypt step is a no-op once
+ * `TENANT_DATA_ENCRYPTION=no`, so an operator who flips the toggle before running
+ * `mercato entities decrypt-database` starts feeding ciphertext into the tokeniser. The tokens
+ * that come out are hashes of base64 noise and match nothing, and because a write REPLACES a
+ * record's tokens, the good plaintext tokens already in the table would be deleted to make room
+ * for them -- turning a recoverable misordering into permanent search loss.
+ *
+ * Detecting the envelope by shape (no DEK is reachable in that state, so decryption cannot be the
+ * test) lets the write skip those fields and leave what is already indexed alone.
+ */
+function ciphertextFieldsOf(doc: Record<string, unknown> | null | undefined): Set<string> {
+  const fields = new Set<string>()
+  if (!doc) return fields
+  for (const [field, value] of Object.entries(doc)) {
+    const values = collectTextValues(value)
+    if (values.length && values.some((text) => looksLikeEncryptedPayload(text))) fields.add(field)
+  }
+  return fields
+}
+
+const warnedCiphertextEntities = new Set<string>()
+
+function warnCiphertextSkipped(entityType: string, fields: Set<string>): void {
+  if (!fields.size) return
+  // Once per entity type per process: a full reindex would otherwise emit this per record.
+  if (warnedCiphertextEntities.has(entityType)) return
+  warnedCiphertextEntities.add(entityType)
+  logger.warn(
+    'Search indexing skipped ciphertext fields and preserved their existing tokens. '
+      + 'This means TENANT_DATA_ENCRYPTION was switched off while encrypted data was still at rest. '
+      + 'Run `mercato entities decrypt-database` and reindex; until then these fields are not searchable.',
+    { entityType, fields: Array.from(fields).sort((left, right) => left.localeCompare(right)) },
+  )
+}
+
+/** Test seam: the warning above fires once per entity type per process. */
+export function resetCiphertextSkipWarnings(): void {
+  warnedCiphertextEntities.clear()
+}
+
 function shouldIndexField(
   field: string,
   value: unknown,
@@ -97,9 +143,12 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
   const limits = resolveSearchTokenLimits(config)
   const recordLimit = limits.maxTokensPerRecord > 0 ? limits.maxTokensPerRecord : Number.POSITIVE_INFINITY
   const fieldLimit = limits.maxTokensPerField > 0 ? limits.maxTokensPerField : Number.POSITIVE_INFINITY
+  const ciphertextFields = ciphertextFieldsOf(params.doc)
+  warnCiphertextSkipped(params.entityType, ciphertextFields)
 
   for (const [field, rawValue] of Object.entries(params.doc)) {
     if (tokens.length >= recordLimit) break
+    if (ciphertextFields.has(field)) continue
     if (!shouldIndexField(field, rawValue, config, params.entityType)) continue
     const values = collectTextValues(rawValue)
     const seen = new Set<string>()
@@ -149,11 +198,18 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
   return tokens
 }
 
-function buildFieldPairs(recordId: string, doc?: Record<string, unknown> | null): EntityFieldPair[] {
+function buildFieldPairs(
+  recordId: string,
+  doc?: Record<string, unknown> | null,
+  skipFields?: Set<string>,
+): EntityFieldPair[] {
   if (!doc) return []
   const pairs: EntityFieldPair[] = []
   const dedupe = new Set<string>()
   for (const field of Object.keys(doc)) {
+    // The delete below is scoped to these pairs, so omitting a field here is what preserves the
+    // tokens already stored for it rather than merely declining to write new ones.
+    if (skipFields?.has(field)) continue
     const key = `${recordId}|${field}`
     if (dedupe.has(key)) continue
     dedupe.add(key)
@@ -226,7 +282,16 @@ export async function replaceSearchTokensForRecord(
   if (!config.enabled) return
   const organizationId = params.organizationId ?? null
   const tenantId = params.tenantId ?? null
-  const fieldPairs = buildFieldPairs(String(params.recordId), params.doc)
+  const ciphertextFields = ciphertextFieldsOf(params.doc)
+  const fieldPairs = buildFieldPairs(String(params.recordId), params.doc, ciphertextFields)
+
+  // An empty pair list normally means the document is gone, and the delete below then purges the
+  // record wholesale. It can now also mean every field was skipped as ciphertext, where a purge
+  // would destroy precisely the tokens the skip exists to protect. Distinguish the two.
+  if (params.doc && ciphertextFields.size && !fieldPairs.length) {
+    debug('record.preserve-ciphertext', { entityType: params.entityType, recordId: params.recordId })
+    return
+  }
 
   // Same comparison #5402 gave the batch path, over the scope this path actually writes: the
   // delete below is narrowed to the document's own `(entity_id, field)` pairs, so the comparison
@@ -325,11 +390,27 @@ export async function deleteSearchTokensForRecord(
 
 export async function replaceSearchTokensForBatch(
   db: Kysely<any>,
-  payloads: Array<BuildTokenOptions & { doc: Record<string, unknown> }>
+  allPayloads: Array<BuildTokenOptions & { doc: Record<string, unknown> }>
 ): Promise<void> {
-  if (!payloads.length) return
+  if (!allPayloads.length) return
   const config = resolveSearchConfig()
   if (!config.enabled) return
+
+  // A record carrying ciphertext drops out of the batch entirely, rather than being rewritten
+  // without its encrypted fields. This path deletes by `entity_id` -- it cannot express "replace
+  // these fields and leave those alone" the way the per-record path can -- so partial handling
+  // here would still delete the tokens we are trying to protect. Skipping the record leaves every
+  // one of its tokens, encrypted-field and plaintext-field alike, exactly as it was. The state is
+  // transient by construction: `decrypt-database` followed by a reindex rebuilds all of it.
+  const preservedRecordIds = new Set<string>()
+  const payloads = allPayloads.filter((payload) => {
+    const ciphertextFields = ciphertextFieldsOf(payload.doc)
+    if (!ciphertextFields.size) return true
+    warnCiphertextSkipped(payload.entityType, ciphertextFields)
+    preservedRecordIds.add(String(payload.recordId))
+    return false
+  })
+  if (!payloads.length) return
 
   const rows = payloads.flatMap((payload) => buildSearchTokenRows({ ...payload, config }))
   if (!rows.length) {
@@ -438,6 +519,7 @@ export async function replaceSearchTokensForBatch(
     entityType: payloads[0].entityType,
     recordCount: payloads.length,
     changedCount: changedRecordKeys.size,
+    preservedCiphertextRecordCount: preservedRecordIds.size,
   })
   if (!changedRecordKeys.size) return
 

--- a/packages/shared/src/lib/encryption/__tests__/encryptionMode.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/encryptionMode.test.ts
@@ -1,0 +1,72 @@
+import { encryptWithAesGcm, generateDek, looksLikeEncryptedPayload } from '../aes'
+import { NoopKmsService, resolveEncryptionMode } from '../kms'
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+/**
+ * Once encryption is switched off the KMS is a noop, so `decryptWithAesGcm` cannot tell ciphertext
+ * from plaintext — it returns null for both. Every caller that has to answer "is this column still
+ * holding an envelope?" in that state depends on the shape check instead.
+ */
+describe('looksLikeEncryptedPayload', () => {
+  it('recognises what encryptWithAesGcm produces', () => {
+    const payload = encryptWithAesGcm('sk_live_secret', generateDek()).value
+    expect(looksLikeEncryptedPayload(payload)).toBe(true)
+  })
+
+  it.each([
+    ['plain text', 'Renewal for ACME Ltd'],
+    ['empty string', ''],
+    ['a colon-separated value with the wrong arity', 'a:b:v1'],
+    ['a four-part value with the wrong version', 'aaaaaaaaaaaaaaaa:Y2lwaGVy:aaaaaaaaaaaaaaaaaaaaaaaa:v2'],
+    ['a time-like string', '12:30:00:v1'],
+    ['non-base64 components of the right length', '****************:Y2lwaGVy:************************:v1'],
+    ['an empty ciphertext component', 'YWJjZGVmZ2hpamtsbW5v:' + ':YWJjZGVmZ2hpamtsbW5vcHFyc3R1:v1'],
+  ])('rejects %s', (_label, value) => {
+    expect(looksLikeEncryptedPayload(value)).toBe(false)
+  })
+
+  it.each([[null], [undefined], [42], [{}], [[]]])('rejects the non-string %p', (value) => {
+    expect(looksLikeEncryptedPayload(value)).toBe(false)
+  })
+})
+
+/**
+ * The distinction this type exists to make. `NoopKmsService.isHealthy()` is deliberately inverted
+ * — it reports healthy exactly when encryption is OFF — so that `enabled && healthy` collapses
+ * correctly. The cost is that a bare `if (!kms.isHealthy())` reads "operator opted out" and "Vault
+ * is down" as the same condition, and they need opposite handling.
+ */
+describe('resolveEncryptionMode', () => {
+  it('reports disabled when the operator opted out, however the KMS answers', () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+    expect(resolveEncryptionMode(new NoopKmsService())).toBe('disabled')
+    expect(resolveEncryptionMode({ isHealthy: () => true })).toBe('disabled')
+    expect(resolveEncryptionMode({ isHealthy: () => false })).toBe('disabled')
+  })
+
+  it('reports active when encryption is on and a DEK is reachable', () => {
+    delete process.env.TENANT_DATA_ENCRYPTION
+    expect(resolveEncryptionMode({ isHealthy: () => true })).toBe('active')
+  })
+
+  it('separates an unreachable KMS from an operator opt-out', () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+    expect(resolveEncryptionMode({ isHealthy: () => false })).toBe('unavailable')
+    // Same KMS object, same `isHealthy()` answer, opposite mode — the toggle is what differs.
+    expect(new NoopKmsService().isHealthy()).toBe(false)
+    process.env.TENANT_DATA_ENCRYPTION = 'no'
+    expect(new NoopKmsService().isHealthy()).toBe(true)
+    expect(resolveEncryptionMode(new NoopKmsService())).toBe('disabled')
+  })
+
+  it('defaults to encrypting when the toggle is unset', () => {
+    delete process.env.TENANT_DATA_ENCRYPTION
+    expect(resolveEncryptionMode({ isHealthy: () => true })).toBe('active')
+    expect(resolveEncryptionMode({ isHealthy: () => false })).toBe('unavailable')
+  })
+})

--- a/packages/shared/src/lib/encryption/aes.ts
+++ b/packages/shared/src/lib/encryption/aes.ts
@@ -27,6 +27,31 @@ export class TenantDataEncryptionError extends Error {
   }
 }
 
+const BASE64_PART = /^[A-Za-z0-9+/]+={0,2}$/
+
+/**
+ * Keyless structural check for the `base64(iv):base64(ciphertext):base64(tag):v1` envelope
+ * {@link encryptWithAesGcm} emits.
+ *
+ * Answers "is this column holding ciphertext?" without a DEK, which is the only question
+ * available once encryption has been switched off — the KMS is a noop by then, so
+ * {@link decryptWithAesGcm} cannot distinguish ciphertext from plaintext. A 12-byte IV and a
+ * 16-byte tag encode to exactly 16 and 24 base64 characters, so the shape is specific enough
+ * that plaintext colliding with it is not a practical concern.
+ */
+export function looksLikeEncryptedPayload(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  const parts = value.split(':')
+  if (parts.length !== 4 || parts[3] !== 'v1') return false
+  const [iv, ciphertext, tag] = parts as [string, string, string, string]
+  return iv.length === 16
+    && tag.length === 24
+    && ciphertext.length > 0
+    && BASE64_PART.test(iv)
+    && BASE64_PART.test(ciphertext)
+    && BASE64_PART.test(tag)
+}
+
 export function generateDek(): string {
   return crypto.randomBytes(32).toString('base64')
 }

--- a/packages/shared/src/lib/encryption/kms.ts
+++ b/packages/shared/src/lib/encryption/kms.ts
@@ -423,6 +423,28 @@ function logDerivedKeyFallbackBanner(opts: DerivedSecret): void {
   })
 }
 
+/**
+ * What the runtime should do about tenant data encryption right now.
+ *
+ * `isHealthy()` alone cannot answer this: {@link NoopKmsService} reports healthy precisely when
+ * encryption is switched OFF, so `enabled && healthy` collapses correctly but a bare
+ * `if (!kms.isHealthy())` guard reads the two opposite situations as the same one. They call for
+ * opposite handling, so name them:
+ *
+ * - `disabled`    — the operator set `TENANT_DATA_ENCRYPTION=no`. Plaintext is the intended
+ *                   outcome; degrade to it rather than failing.
+ * - `active`      — encryption is on and a DEK is reachable. Encrypt.
+ * - `unavailable` — encryption is on but no DEK is reachable (Vault down, no fallback secret).
+ *                   Data that is meant to be ciphertext MUST NOT be written as plaintext; callers
+ *                   holding secrets fail closed here (spec 2026-05-29, security finding #7).
+ */
+export type TenantDataEncryptionMode = 'disabled' | 'active' | 'unavailable'
+
+export function resolveEncryptionMode(kms: Pick<KmsService, 'isHealthy'>): TenantDataEncryptionMode {
+  if (!isTenantDataEncryptionEnabled()) return 'disabled'
+  return kms.isHealthy() ? 'active' : 'unavailable'
+}
+
 export function createKmsService(): KmsService {
   if (!isTenantDataEncryptionEnabled()) return new NoopKmsService()
   const primary = new HashicorpVaultKmsService()


### PR DESCRIPTION
## Problem

`TENANT_DATA_ENCRYPTION` is documented as a master toggle — "when false, encryption hooks no-op but validation still runs so the system can be toggled on later". Three paths never consulted it, so disabling encryption broke them:

| | Symptom today with `TENANT_DATA_ENCRYPTION=no` |
| --- | --- |
| **Integration credentials** | `POST /api/integrations/<id>/credentials` answers **HTTP 503**. Credentials cannot be saved at all. |
| **MCP / AI-chat session auth** | Silently stops working. The ephemeral key's secret is never stored, so `findSessionApiKeyWithSecret` returns null — behind a *debug*-level log. |
| **Search index** | A reindex can **destroy the token index permanently**. |

All three branch on `kmsService.isHealthy()`, which cannot answer the question they are actually asking. `NoopKmsService.isHealthy()` is deliberately inverted — it reports healthy exactly when encryption is OFF — so that `enabled && healthy` collapses correctly. The cost is that a bare `if (!kms.isHealthy())` reads *"the operator opted out"* and *"Vault is down"* as the same condition. They need opposite handling.

### The search one is data loss, not degradation

Search tokens are hashes of **plaintext**: the indexer decrypts a document before tokenising it (`indexer.ts` → `decryptIndexDocForSearch`). That is what lets the token index survive encryption being switched on *or* off, and it is why search is otherwise orthogonal to this toggle.

Flip the toggle before running `mercato entities decrypt-database` and that decrypt step becomes a no-op, so a reindex tokenises ciphertext. Writing those tokens is merely useless. **Deleting the good ones to make room for them is not recoverable** — a write replaces a record's tokens, and the repair (decrypt, then reindex) cannot run in the state that caused it. Two paths purge wholesale: `replaceSearchTokensForRecord` falls back to deleting by `entity_id` when its field-pair list is empty, and `replaceSearchTokensForBatch` purges every id in the batch when no rows are built. A fully-encrypted record hits both.

## Solution

`resolveEncryptionMode(kms)` names the three states, and the three callers route through it:

| Mode | Meaning | Handling |
| --- | --- | --- |
| `disabled` | `TENANT_DATA_ENCRYPTION=no` | Plaintext is the intended outcome — degrade to it. |
| `active` | Encryption on, DEK reachable | Encrypt. |
| `unavailable` | Encryption on, no DEK reachable | Fail closed. |

**Integration credentials** — only `unavailable` fails closed now. The threat model from `.ai/specs/implemented/2026-05-29-integrations-credentials-encryption-fail-closed.md` is unchanged: no local DEK derivation, no auth-secret reuse, no hardcoded fallback constant. Degrading to plaintext because Vault blinked is exactly what that spec exists to prevent, and still cannot happen. A blob sealed *before* the toggle was flipped still raises rather than handing an adapter a garbage secret, now with `reason: 'sealed-while-disabled'`. The spec carries an amendment recording the refinement.

*What that one reason needed on top (second commit).* `decrypt-database` is **not** its remedy: that command decrypts the columns an encryption map covers, while the credentials carry a second envelope (`__om_encrypted_credentials_blob_v1`) *inside* the decrypted value. An operator following that advice lands back on the same error. And there was no other way out — `GET` 503s so the admin form never loads, and `PUT` reads the existing credentials to merge masked secrets, so it 503s too. Any deployment that had ever saved credentials with encryption on found them permanently unfixable from the UI the moment the flag flipped, including one that followed the documented `decrypt-database` → flip → reindex order. Both verbs now catch that one reason and degrade to an empty form, so the credentials can be re-entered — the only remedy that exists. Every other unavailable reason still fails closed on both verbs, and adapters reading through the service still get the error rather than a silently empty credential set.

**Session API key secrets** — round-trip in the clear under `disabled` (the same bargain emails, credentials and the query index already strike in that mode); still refused under `unavailable`, now at warn level instead of debug.

**Search tokens** — `looksLikeEncryptedPayload` detects the envelope by shape, which is the only test available once the KMS is a noop. Ciphertext fields are skipped *and* excluded from the delete scope, so their stored tokens are preserved rather than replaced; both wholesale-purge branches are guarded. One warning per entity type per process names the affected fields and the remedy.

## Verification

`yarn build:packages → generate → i18n:check-sync → i18n:check-usage → typecheck → test → build:app` all green locally (36/36 test tasks, 12 128 core tests). `yarn lint`: 0 errors.

New coverage:
- `packages/shared/.../encryptionMode.test.ts` — envelope detector; mode resolver, including the same KMS object resolving to opposite modes on the toggle alone.
- `credentials-service.test.ts` — plaintext save/read under `disabled`; `sealed-while-disabled` on legacy ciphertext, asserting the message names a remedy that exists; **still fails closed when encryption is ON but the KMS is unreachable** (the regression that would undo the security fix).
- `credentials-route.test.ts` — the admin round-trip out of `sealed-while-disabled`: `GET` loads the form as unconfigured, `PUT` stores what was re-entered, and both still 503 on `no-dek`.
- `search-tokens-ciphertext-guard.test.ts` — asserts preservation by **row id**, the only thing that distinguishes "left alone" from "deleted and re-inserted with identical content". Covers the per-record path, the batch path, and the all-ciphertext record that hits the purge branches.
- `apiKeyService.sessionSecret.test.ts` — secret round-trip across all three modes.

The repo's own `explicit-sort-comparators` guard caught a bare `.sort()` in the new warning path; fixed.

## Notes for review

- `resetCiphertextSkipWarnings()` is exported from `search-tokens.ts` purely as a test seam for the once-per-process warning. Happy to swap it for `jest.isolateModules` if you would rather not have it in the public surface.
- `ciphertextFieldsOf` runs on every indexed document. It is a `split(':')` plus a length check per string value, ahead of tokenisation which is far more expensive — but it is a hot path, so worth a second opinion.
- The batch path drops an affected record from the rewrite *entirely* rather than handling it per-field. It deletes by `entity_id` and cannot express "replace these fields, leave those alone", so partial handling there would still delete the tokens being protected. The per-record path does handle it per-field.
- Docs now give the required order (`decrypt-database` → flag → reindex) and note that search *precision* is a separate switch: the token rewrite is gated on `OM_SEARCH_ENABLED`, not on encryption, so disabling encryption does not by itself restore exact `ILIKE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791608321&installation_model_id=432243&pr_number=6025&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6025&signature=5ca47386002bbe9c0f40ed01142157bbbd1c2da763f314fc391ecb5a39739fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
