### PR TITLE
fix(shared): pass the custom field kind when decrypting index documents (#5968)

### DIFF
--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -10,6 +10,11 @@ import { readCoverageSnapshot, refreshCoverageSnapshot } from './coverage'
 import { createProfiler, shouldEnableProfiler, type Profiler } from '@open-mercato/shared/lib/profiler'
 import type { VectorIndexService } from '@open-mercato/search/vector'
 import { decryptIndexDocCustomFields } from '@open-mercato/shared/lib/encryption/indexDoc'
+import {
+  buildCustomFieldKindMap,
+  type CustomFieldKindMap,
+  type CustomFieldKindRow,
+} from '@open-mercato/shared/lib/custom-fields/kinds'
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import {
   applyJoinFilters,
@@ -200,7 +205,7 @@ function createQueryProfiler(entity: string): Profiler {
 
 export class HybridQueryEngine implements QueryEngine {
   private coverageStatsTtlMs: number
-  private customFieldKeysCache = new Map<string, { expiresAt: number; value: string[] }>()
+  private customFieldDefsCache = new Map<string, { expiresAt: number; value: CustomFieldKindRow[] }>()
   private customFieldKeysTtlMs: number
   private columnCache = new Map<string, boolean>()
   private customEntityCache = new Map<string, boolean>()
@@ -1198,6 +1203,18 @@ export class HybridQueryEngine implements QueryEngine {
       const listCountCapWarning: ListCountCapWarning | undefined = counted.warning
 
       const dekKeyCache = new Map<string | null, string | null>()
+      // Resolved lazily and only once per query: rows share one kind map, and a query whose
+      // rows carry no encrypted custom fields never pays for the lookup.
+      let customFieldKinds: Promise<CustomFieldKindMap> | null = null
+      const resolveCustomFieldKinds = (): Promise<CustomFieldKindMap> => {
+        if (!customFieldKinds) {
+          customFieldKinds = this.resolveCustomFieldKindMap(
+            Array.from(new Set(indexSources.map((src) => String(src.entityId)))),
+            opts.tenantId ?? null,
+          )
+        }
+        return customFieldKinds
+      }
 
       const decryptRow = async (item: Record<string, unknown>): Promise<Record<string, unknown>> => {
         let next = item
@@ -1225,6 +1242,7 @@ export class HybridQueryEngine implements QueryEngine {
                 organizationId: (next?.organization_id ?? next?.organizationId ?? null) as string | null,
               },
               encSvc as any, dekKeyCache,
+              await resolveCustomFieldKinds(),
             )
           } catch { /* keep next as-is */ }
         }
@@ -2171,35 +2189,62 @@ export class HybridQueryEngine implements QueryEngine {
     return !!exists
   }
 
-  private async resolveAvailableCustomFieldKeys(entityIds: string[], tenantId: string | null): Promise<string[]> {
+  private async resolveCustomFieldDefs(
+    entityIds: string[],
+    tenantId: string | null,
+  ): Promise<CustomFieldKindRow[]> {
     if (!entityIds.length) return []
     const cacheKey = this.customFieldKeysCacheKey(entityIds, tenantId)
     const now = Date.now()
-    const cached = this.customFieldKeysCache.get(cacheKey)
+    const cached = this.customFieldDefsCache.get(cacheKey)
     if (cached && cached.expiresAt > now) return cached.value.slice()
 
     const db = this.getDb() as any
     const rows = await db
       .selectFrom('custom_field_defs')
-      .select('key')
+      .select(['key', 'kind'])
       .where('entity_id', 'in', entityIds)
       .where('is_active', '=', true)
       .where((eb: any) => eb.or([
         eb('tenant_id', '=', tenantId),
         eb('tenant_id', 'is', null),
       ]))
-      .execute() as Array<{ key: unknown }>
-    const keys = new Set<string>()
+      .execute() as Array<{ key: unknown; kind: unknown }>
+    const byKey = new Map<string, CustomFieldKindRow>()
     for (const row of rows) {
       const key = row.key
-      if (typeof key === 'string' && key.trim().length) keys.add(key.trim())
-      else if (key != null) keys.add(String(key))
+      const normalized = typeof key === 'string' ? key.trim() : key == null ? '' : String(key)
+      if (!normalized.length) continue
+      if (!byKey.has(normalized)) byKey.set(normalized, { key: normalized, kind: row.kind })
     }
-    const result = Array.from(keys)
+    const result = Array.from(byKey.values())
     if (this.customFieldKeysTtlMs > 0) {
-      this.customFieldKeysCache.set(cacheKey, { expiresAt: now + this.customFieldKeysTtlMs, value: result })
+      this.customFieldDefsCache.set(cacheKey, { expiresAt: now + this.customFieldKeysTtlMs, value: result })
     }
     return result.slice()
+  }
+
+  private async resolveAvailableCustomFieldKeys(entityIds: string[], tenantId: string | null): Promise<string[]> {
+    const defs = await this.resolveCustomFieldDefs(entityIds, tenantId)
+    return defs.map((def) => String(def.key))
+  }
+
+  /**
+   * Kind lookup for the `cf:`/`cf_` keys of an index document, so encrypted string-typed
+   * custom fields keep their type on read instead of being `JSON.parse`d back into numbers
+   * or booleans (issue #5968). Backed by the same TTL cache as the key lookup, so this adds
+   * no round trip on a warm cache and fails open to `{}` on a cold-cache error.
+   */
+  private async resolveCustomFieldKindMap(
+    entityIds: string[],
+    tenantId: string | null,
+  ): Promise<CustomFieldKindMap> {
+    try {
+      return buildCustomFieldKindMap(await this.resolveCustomFieldDefs(entityIds, tenantId))
+    } catch (err) {
+      logger.warn('Failed to resolve custom field kinds', { entityIds, err })
+      return {}
+    }
   }
 
   private async entityHasActiveCustomFields(entityId: string, tenantId: string | null): Promise<boolean> {

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -12,9 +12,11 @@ import type { VectorIndexService } from '@open-mercato/search/vector'
 import { decryptIndexDocCustomFields } from '@open-mercato/shared/lib/encryption/indexDoc'
 import {
   buildCustomFieldKindMap,
+  mergeCustomFieldKindMaps,
   type CustomFieldKindMap,
-  type CustomFieldKindRow,
 } from '@open-mercato/shared/lib/custom-fields/kinds'
+
+type CustomFieldDefRow = { entityId: string; key: string; kind: unknown }
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import {
   applyJoinFilters,
@@ -205,7 +207,7 @@ function createQueryProfiler(entity: string): Profiler {
 
 export class HybridQueryEngine implements QueryEngine {
   private coverageStatsTtlMs: number
-  private customFieldDefsCache = new Map<string, { expiresAt: number; value: CustomFieldKindRow[] }>()
+  private customFieldDefsCache = new Map<string, { expiresAt: number; value: CustomFieldDefRow[] }>()
   private customFieldKeysTtlMs: number
   private columnCache = new Map<string, boolean>()
   private customEntityCache = new Map<string, boolean>()
@@ -2192,7 +2194,7 @@ export class HybridQueryEngine implements QueryEngine {
   private async resolveCustomFieldDefs(
     entityIds: string[],
     tenantId: string | null,
-  ): Promise<CustomFieldKindRow[]> {
+  ): Promise<CustomFieldDefRow[]> {
     if (!entityIds.length) return []
     const cacheKey = this.customFieldKeysCacheKey(entityIds, tenantId)
     const now = Date.now()
@@ -2202,22 +2204,22 @@ export class HybridQueryEngine implements QueryEngine {
     const db = this.getDb() as any
     const rows = await db
       .selectFrom('custom_field_defs')
-      .select(['key', 'kind'])
+      .select(['entity_id', 'key', 'kind'])
       .where('entity_id', 'in', entityIds)
       .where('is_active', '=', true)
       .where((eb: any) => eb.or([
         eb('tenant_id', '=', tenantId),
         eb('tenant_id', 'is', null),
       ]))
-      .execute() as Array<{ key: unknown; kind: unknown }>
-    const byKey = new Map<string, CustomFieldKindRow>()
+      .execute() as Array<{ entity_id: unknown; key: unknown; kind: unknown }>
+    const result: CustomFieldDefRow[] = []
     for (const row of rows) {
       const key = row.key
       const normalized = typeof key === 'string' ? key.trim() : key == null ? '' : String(key)
       if (!normalized.length) continue
-      if (!byKey.has(normalized)) byKey.set(normalized, { key: normalized, kind: row.kind })
+      const entityId = typeof row.entity_id === 'string' ? row.entity_id : String(row.entity_id ?? '')
+      result.push({ entityId, key: normalized, kind: row.kind })
     }
-    const result = Array.from(byKey.values())
     if (this.customFieldKeysTtlMs > 0) {
       this.customFieldDefsCache.set(cacheKey, { expiresAt: now + this.customFieldKeysTtlMs, value: result })
     }
@@ -2226,7 +2228,7 @@ export class HybridQueryEngine implements QueryEngine {
 
   private async resolveAvailableCustomFieldKeys(entityIds: string[], tenantId: string | null): Promise<string[]> {
     const defs = await this.resolveCustomFieldDefs(entityIds, tenantId)
-    return defs.map((def) => String(def.key))
+    return Array.from(new Set(defs.map((def) => def.key)))
   }
 
   /**
@@ -2234,13 +2236,27 @@ export class HybridQueryEngine implements QueryEngine {
    * custom fields keep their type on read instead of being `JSON.parse`d back into numbers
    * or booleans (issue #5968). Backed by the same TTL cache as the key lookup, so this adds
    * no round trip on a warm cache and fails open to `{}` on a cold-cache error.
+   *
+   * `entityIds` MUST arrive in `indexSources` order: `buildCfJsonExprSql` reads a `cf` value
+   * with `coalesce(source0, source1, …)`, so a key defined by several sources has to be typed
+   * by the same source the value came from — hence the priority-ordered merge rather than
+   * whatever order the rows happen to come back in.
    */
   private async resolveCustomFieldKindMap(
     entityIds: string[],
     tenantId: string | null,
   ): Promise<CustomFieldKindMap> {
     try {
-      return buildCustomFieldKindMap(await this.resolveCustomFieldDefs(entityIds, tenantId))
+      const defs = await this.resolveCustomFieldDefs(entityIds, tenantId)
+      const byEntityId = new Map<string, CustomFieldDefRow[]>()
+      for (const def of defs) {
+        const group = byEntityId.get(def.entityId) ?? []
+        group.push(def)
+        byEntityId.set(def.entityId, group)
+      }
+      return mergeCustomFieldKindMaps(
+        entityIds.map((entityId) => buildCustomFieldKindMap(byEntityId.get(entityId) ?? [])),
+      )
     } catch (err) {
       logger.warn('Failed to resolve custom field kinds', { entityIds, err })
       return {}

--- a/packages/search/src/__tests__/presenter-enricher.test.ts
+++ b/packages/search/src/__tests__/presenter-enricher.test.ts
@@ -19,19 +19,31 @@ type IndexRow = {
 
 const mockedDecryptIndexDocForSearch = jest.mocked(decryptIndexDocForSearch)
 
+type CustomFieldDefRow = {
+  entity_id: string
+  key: string
+  kind: string | null
+}
+
 /**
  * Build a minimal Kysely-like mock for `db.selectFrom(...).select(...).where(...).execute()` chains.
  * The presenter enricher only uses selectFrom/select/where/execute on the resolved Kysely instance,
- * so we don't need full coverage here.
+ * so we don't need full coverage here. Rows are routed per table because the enricher reads both
+ * `entity_indexes` (the docs) and `custom_field_defs` (the field kinds, issue #5968).
  */
-function createKyselyMock(rows: IndexRow[]): Kysely<any> {
-  const chain: any = {
-    select: jest.fn(() => chain),
-    where: jest.fn(() => chain),
-    execute: jest.fn().mockResolvedValue(rows),
+function createKyselyMock(rows: IndexRow[], customFieldDefs: CustomFieldDefRow[] = []): Kysely<any> {
+  const createChain = (result: unknown[]) => {
+    const chain: any = {
+      select: jest.fn(() => chain),
+      where: jest.fn(() => chain),
+      execute: jest.fn().mockResolvedValue(result),
+    }
+    return chain
   }
   const db: any = {
-    selectFrom: jest.fn(() => chain),
+    selectFrom: jest.fn((table: string) => (
+      String(table).startsWith('custom_field_defs') ? createChain(customFieldDefs) : createChain(rows)
+    )),
   }
   return db as Kysely<any>
 }
@@ -95,6 +107,7 @@ describe('createPresenterEnricher', () => {
       { tenantId: 'tenant-1', organizationId: 'org-from-doc' },
       expect.anything(),
       expect.any(Map),
+      null,
     )
     expect(buildSource).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -113,6 +126,61 @@ describe('createPresenterEnricher', () => {
     })
     expect(enriched.url).toBe('/backend/customers/person-1')
     expect(enriched.links).toEqual([{ href: '/backend/customers/person-1/edit', label: 'Edit', kind: 'secondary' }])
+  })
+
+  it('forwards each entity type its custom field kinds so encrypted text is not retyped (#5968)', async () => {
+    const doc = { id: 'person-1', organization_id: 'org-1', 'cf:nickname': 'Countess' }
+    mockedDecryptIndexDocForSearch.mockResolvedValue(doc)
+
+    const config = createConfig({ formatResult: async () => ({ title: 'Ada' }) })
+    const db = createKyselyMock(
+      [{ entity_type: 'customers:person', entity_id: 'person-1', doc }],
+      [
+        { entity_id: 'customers:person', key: 'nickname', kind: 'text' },
+        { entity_id: 'customers:person', key: 'visit-count', kind: 'integer' },
+        { entity_id: 'orders:order', key: 'reference', kind: 'text' },
+      ],
+    )
+
+    const enrich = createPresenterEnricher(db, new Map([[config.entityId, config]]), undefined, {} as never)
+    await enrich([createResult()], 'tenant-1', 'org-1')
+
+    expect(mockedDecryptIndexDocForSearch).toHaveBeenCalledWith(
+      'customers:person',
+      doc,
+      expect.anything(),
+      expect.anything(),
+      expect.any(Map),
+      // Only this entity type's definitions, keyed by authored key and sanitized alias.
+      { nickname: 'text', 'visit-count': 'integer', visit_count: 'integer' },
+    )
+  })
+
+  it('degrades to the previous behaviour when the custom field kind lookup fails (#5968)', async () => {
+    const doc = { id: 'person-1', organization_id: 'org-1' }
+    mockedDecryptIndexDocForSearch.mockResolvedValue(doc)
+
+    const db = createKyselyMock([{ entity_type: 'customers:person', entity_id: 'person-1', doc }])
+    const failingDb: any = {
+      selectFrom: jest.fn((table: string) => {
+        if (String(table).startsWith('custom_field_defs')) throw new Error('relation does not exist')
+        return (db as any).selectFrom(table)
+      }),
+    }
+    const config = createConfig({ formatResult: async () => ({ title: 'Ada' }) })
+
+    const enrich = createPresenterEnricher(failingDb, new Map([[config.entityId, config]]), undefined, {} as never)
+    const [enriched] = await enrich([createResult()], 'tenant-1', 'org-1')
+
+    expect(enriched.presenter?.title).toBe('Ada')
+    expect(mockedDecryptIndexDocForSearch).toHaveBeenCalledWith(
+      'customers:person',
+      doc,
+      expect.anything(),
+      expect.anything(),
+      expect.any(Map),
+      null,
+    )
   })
 
   it('replaces empty link arrays with resolved links when url metadata is missing', async () => {

--- a/packages/search/src/lib/presenter-enricher.ts
+++ b/packages/search/src/lib/presenter-enricher.ts
@@ -11,6 +11,7 @@ import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { decryptIndexDocForSearch } from '@open-mercato/shared/lib/encryption/indexDoc'
+import { buildCustomFieldKindMap, type CustomFieldKindMap } from '@open-mercato/shared/lib/custom-fields/kinds'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { extractFallbackPresenter } from './fallback-presenter'
 import { needsSearchResultEnrichment } from './search-result-enrichment'
@@ -33,6 +34,49 @@ function chunk<T>(array: T[], size: number): T[][] {
     chunks.push(array.slice(i, i + size))
   }
   return chunks
+}
+
+/**
+ * Load the `kind` of every active custom field on the entity types in this batch, keyed by
+ * entity type. Without it `decryptIndexDocForSearch` runs `JSON.parse` over decrypted
+ * string-typed values and returns `123` where `"123"` was stored (issue #5968).
+ *
+ * Fails open: a lookup error yields an empty map, which keeps the previous behavior rather
+ * than breaking search.
+ */
+async function fetchCustomFieldKindsByEntityType(
+  db: Kysely<any>,
+  entityTypes: string[],
+  tenantId: string,
+): Promise<Map<string, CustomFieldKindMap>> {
+  const byEntityType = new Map<string, CustomFieldKindMap>()
+  if (!entityTypes.length) return byEntityType
+  try {
+    const rows = await db
+      .selectFrom('custom_field_defs')
+      .select(['entity_id', 'key', 'kind'])
+      .where('entity_id', 'in', entityTypes)
+      .where('is_active', '=', true)
+      .where((eb: any) => eb.or([
+        eb('tenant_id', '=', tenantId),
+        eb('tenant_id', 'is', null),
+      ]))
+      .execute() as Array<{ entity_id: unknown; key: unknown; kind: unknown }>
+    const grouped = new Map<string, Array<{ key: unknown; kind: unknown }>>()
+    for (const row of rows) {
+      const entityType = typeof row.entity_id === 'string' ? row.entity_id : String(row.entity_id ?? '')
+      if (!entityType) continue
+      const group = grouped.get(entityType) ?? []
+      group.push({ key: row.key, kind: row.kind })
+      grouped.set(entityType, group)
+    }
+    for (const [entityType, group] of grouped) {
+      byEntityType.set(entityType, buildCustomFieldKindMap(group))
+    }
+  } catch (err) {
+    logWarning('Failed to resolve custom field kinds', { err })
+  }
+  return byEntityType
 }
 
 /**
@@ -306,7 +350,10 @@ export function createPresenterEnricher(
     }
 
     // Single batch query for all docs across all entity types
-    const rawDocs = await fetchDocsBatch(db, byEntityType, tenantId, organizationId)
+    const [rawDocs, kindsByEntityType] = await Promise.all([
+      fetchDocsBatch(db, byEntityType, tenantId, organizationId),
+      fetchCustomFieldKindsByEntityType(db, Array.from(byEntityType.keys()), tenantId),
+    ])
 
     // Decrypt docs in parallel using DEK cache for efficiency
     const dekCache = new Map<string | null, string | null>()
@@ -326,6 +373,7 @@ export function createPresenterEnricher(
             scope,
             encryptionService ?? null,
             dekCache,
+            kindsByEntityType.get(row.entity_type) ?? null,
           )
           return { ...row, doc: decryptedDoc }
         } catch (err) {

--- a/packages/shared/src/lib/custom-fields/__tests__/kinds.test.ts
+++ b/packages/shared/src/lib/custom-fields/__tests__/kinds.test.ts
@@ -1,4 +1,4 @@
-import { buildCustomFieldKindMap, resolveCustomFieldKind } from '../kinds'
+import { buildCustomFieldKindMap, mergeCustomFieldKindMaps, resolveCustomFieldKind } from '../kinds'
 
 describe('custom-fields/kinds', () => {
   it('indexes a definition under both its authored key and its sanitized alias', () => {
@@ -38,6 +38,33 @@ describe('custom-fields/kinds', () => {
     expect(map['numeric-kind']).toBeNull()
     expect(map['123']).toBe('text')
     expect(Object.keys(map)).not.toContain('')
+  })
+
+  it('lets the earliest source win when several define the same key', () => {
+    // The query engine reads a cf value with `coalesce(source0, source1, ...)`, so the kind
+    // has to come from the same source the value did.
+    const base = buildCustomFieldKindMap([{ key: 'code', kind: 'text' }])
+    const joined = buildCustomFieldKindMap([
+      { key: 'code', kind: 'integer' },
+      { key: 'extra', kind: 'boolean' },
+    ])
+
+    expect(mergeCustomFieldKindMaps([base, joined])).toEqual({ code: 'text', extra: 'boolean' })
+    expect(mergeCustomFieldKindMaps([joined, base])).toEqual({ code: 'integer', extra: 'boolean' })
+  })
+
+  it('ignores absent sources when merging', () => {
+    const map = buildCustomFieldKindMap([{ key: 'code', kind: 'text' }])
+
+    expect(mergeCustomFieldKindMaps([null, map, undefined, {}])).toEqual({ code: 'text' })
+    expect(mergeCustomFieldKindMaps([])).toEqual({})
+  })
+
+  it('keeps a null kind from an earlier source instead of falling through', () => {
+    const base = buildCustomFieldKindMap([{ key: 'code' }])
+    const joined = buildCustomFieldKindMap([{ key: 'code', kind: 'integer' }])
+
+    expect(mergeCustomFieldKindMaps([base, joined]).code).toBeNull()
   })
 
   it('resolves both index-document key shapes', () => {

--- a/packages/shared/src/lib/custom-fields/__tests__/kinds.test.ts
+++ b/packages/shared/src/lib/custom-fields/__tests__/kinds.test.ts
@@ -1,0 +1,65 @@
+import { buildCustomFieldKindMap, resolveCustomFieldKind } from '../kinds'
+
+describe('custom-fields/kinds', () => {
+  it('indexes a definition under both its authored key and its sanitized alias', () => {
+    const map = buildCustomFieldKindMap([{ key: 'order-ref', kind: 'text' }])
+
+    expect(map).toEqual({ 'order-ref': 'text', order_ref: 'text' })
+  })
+
+  it('lets an authored key win over an alias another definition sanitizes to', () => {
+    const aliasFirst = buildCustomFieldKindMap([
+      { key: 'order-ref', kind: 'text' },
+      { key: 'order_ref', kind: 'integer' },
+    ])
+    const authoredFirst = buildCustomFieldKindMap([
+      { key: 'order_ref', kind: 'integer' },
+      { key: 'order-ref', kind: 'text' },
+    ])
+
+    expect(aliasFirst.order_ref).toBe('integer')
+    expect(authoredFirst.order_ref).toBe('integer')
+  })
+
+  it('normalizes rows with blank, non-string, or missing values', () => {
+    const map = buildCustomFieldKindMap([
+      { key: '  padded  ', kind: 'text' },
+      { key: 'no-kind' },
+      { key: 'null-kind', kind: null },
+      { key: 'numeric-kind', kind: 7 },
+      { key: '   ' },
+      { key: null },
+      { key: 123, kind: 'text' },
+    ])
+
+    expect(map.padded).toBe('text')
+    expect(map['no-kind']).toBeNull()
+    expect(map['null-kind']).toBeNull()
+    expect(map['numeric-kind']).toBeNull()
+    expect(map['123']).toBe('text')
+    expect(Object.keys(map)).not.toContain('')
+  })
+
+  it('resolves both index-document key shapes', () => {
+    const map = buildCustomFieldKindMap([{ key: 'note', kind: 'multiline' }])
+
+    expect(resolveCustomFieldKind(map, 'cf:note')).toBe('multiline')
+    expect(resolveCustomFieldKind(map, 'cf_note')).toBe('multiline')
+  })
+
+  it('resolves a sanitized document key back to its authored definition', () => {
+    const map = buildCustomFieldKindMap([{ key: 'order-ref', kind: 'text' }])
+
+    expect(resolveCustomFieldKind(map, 'cf_order_ref')).toBe('text')
+    expect(resolveCustomFieldKind(map, 'cf:order-ref')).toBe('text')
+  })
+
+  it('returns null for an unknown key, an absent map, or a bare prefix', () => {
+    const map = buildCustomFieldKindMap([{ key: 'note', kind: 'text' }])
+
+    expect(resolveCustomFieldKind(map, 'cf:missing')).toBeNull()
+    expect(resolveCustomFieldKind(null, 'cf:note')).toBeNull()
+    expect(resolveCustomFieldKind(undefined, 'cf:note')).toBeNull()
+    expect(resolveCustomFieldKind(map, 'cf:')).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/custom-fields/kinds.ts
+++ b/packages/shared/src/lib/custom-fields/kinds.ts
@@ -54,6 +54,22 @@ export function buildCustomFieldKindMap(rows: Iterable<CustomFieldKindRow>): Cus
 }
 
 /**
+ * Merges per-source maps into one, with earlier maps winning. Callers pass their sources in
+ * the same priority order the value itself resolves in, so a key defined by more than one
+ * source is typed by the source the value actually came from.
+ */
+export function mergeCustomFieldKindMaps(maps: Array<CustomFieldKindMap | null | undefined>): CustomFieldKindMap {
+  const merged: CustomFieldKindMap = {}
+  for (const map of maps) {
+    if (!map) continue
+    for (const [key, kind] of Object.entries(map)) {
+      if (!(key in merged)) merged[key] = kind
+    }
+  }
+  return merged
+}
+
+/**
  * Resolves the `kind` for a `cf:`/`cf_`-prefixed index-document key. Returns `null` when the
  * key has no active definition — callers then keep the historical no-`kind` behavior rather
  * than guessing, so an unresolved lookup degrades instead of corrupting the value.

--- a/packages/shared/src/lib/custom-fields/kinds.ts
+++ b/packages/shared/src/lib/custom-fields/kinds.ts
@@ -1,0 +1,72 @@
+/**
+ * Custom-field `kind` lookup for the `cf:`/`cf_` keys carried by a query-index document.
+ *
+ * `decryptCustomFieldValue` cannot recover a value's original JS type from the ciphertext
+ * alone: the encrypt path stores a raw string unwrapped and JSON-stringifies everything
+ * else, so the string `"123"` and the number `123` produce the same plaintext. The field's
+ * `kind` is the only disambiguator, which is why every index-document read path has to
+ * resolve it before decrypting (issue #5968).
+ */
+export type CustomFieldKindMap = Record<string, string | null>
+
+export type CustomFieldKindRow = {
+  key: unknown
+  kind?: unknown
+}
+
+const CF_KEY_PREFIX = /^cf[:_]/
+
+/**
+ * Mirrors `HybridQueryEngine.sanitize()`, which aliases the doc key `cf:my-field` as the
+ * SQL-safe column alias `cf_my_field`. The transform is lossy, so a map keyed only by the
+ * authored key would never match a sanitized alias.
+ */
+function sanitizeKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9_]/g, '_')
+}
+
+function normalizeKey(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (value == null) return ''
+  return String(value).trim()
+}
+
+/**
+ * Builds a lookup keyed by both the authored field key and its sanitized alias. Authored
+ * keys take precedence, so a literal `my_field` definition is never shadowed by the alias
+ * a `my-field` definition also sanitizes to.
+ */
+export function buildCustomFieldKindMap(rows: Iterable<CustomFieldKindRow>): CustomFieldKindMap {
+  const map: CustomFieldKindMap = {}
+  const aliases: CustomFieldKindMap = {}
+  for (const row of rows) {
+    const key = normalizeKey(row.key)
+    if (!key) continue
+    const kind = typeof row.kind === 'string' && row.kind.length ? row.kind : null
+    map[key] = kind
+    const alias = sanitizeKey(key)
+    if (alias !== key && !(alias in aliases)) aliases[alias] = kind
+  }
+  for (const [alias, kind] of Object.entries(aliases)) {
+    if (!(alias in map)) map[alias] = kind
+  }
+  return map
+}
+
+/**
+ * Resolves the `kind` for a `cf:`/`cf_`-prefixed index-document key. Returns `null` when the
+ * key has no active definition — callers then keep the historical no-`kind` behavior rather
+ * than guessing, so an unresolved lookup degrades instead of corrupting the value.
+ */
+export function resolveCustomFieldKind(
+  kinds: CustomFieldKindMap | null | undefined,
+  docKey: string,
+): string | null {
+  if (!kinds) return null
+  const bare = docKey.replace(CF_KEY_PREFIX, '')
+  if (!bare) return null
+  if (bare in kinds) return kinds[bare] ?? null
+  const alias = sanitizeKey(bare)
+  if (alias !== bare && alias in kinds) return kinds[alias] ?? null
+  return null
+}

--- a/packages/shared/src/lib/encryption/__tests__/indexDoc.custom-field-kinds.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/indexDoc.custom-field-kinds.test.ts
@@ -1,0 +1,119 @@
+import { decryptIndexDocCustomFields, decryptIndexDocForSearch } from '../indexDoc'
+import { encryptCustomFieldValue } from '../customFieldValues'
+import { buildCustomFieldKindMap } from '../../custom-fields/kinds'
+
+/**
+ * Regression coverage for issue #5968: the query-index and search read paths decrypted
+ * `cf:`/`cf_` values without the field's `kind`, so `decryptCustomFieldValue` fell through
+ * to `JSON.parse` and retyped every string-typed custom field whose plaintext looked like
+ * JSON. Unlike the sibling `indexDoc.test.ts`, this suite does NOT mock
+ * `decryptCustomFieldValue` — the defect lives in the argument the helpers pass to it, so a
+ * mocked value would hide it.
+ */
+
+const fixedKey = Buffer.alloc(32, 7).toString('base64')
+
+const service = {
+  isEnabled: () => true,
+  getDek: async () => ({ key: fixedKey }),
+} as any
+
+const scope = { tenantId: 'tenant-1', organizationId: 'org-1' }
+
+async function encrypt(value: unknown): Promise<unknown> {
+  return encryptCustomFieldValue(value, scope.tenantId, service, new Map())
+}
+
+describe('encryption/indexDoc custom field kinds (#5968)', () => {
+  it.each([
+    ['123', 'text'],
+    ['0042', 'multiline'],
+    ['true', 'select'],
+    ['false', 'text'],
+    ['null', 'text'],
+    ['{"nested":1}', 'multiline'],
+    ['[1,2,3]', 'text'],
+    ['1.5e3', 'currency'],
+  ])('keeps the string %p verbatim for a %s field', async (plaintext, kind) => {
+    const doc = { id: '1', 'cf:note': await encrypt(plaintext) }
+    const kinds = buildCustomFieldKindMap([{ key: 'note', kind }])
+
+    const out = await decryptIndexDocCustomFields(doc, scope, service, new Map(), kinds)
+
+    expect(out['cf:note']).toBe(plaintext)
+  })
+
+  it('still coerces numeric and boolean kinds through the JSON round trip', async () => {
+    const doc = {
+      id: '1',
+      'cf:count': await encrypt(42),
+      'cf:ratio': await encrypt(3.14),
+      'cf:flag': await encrypt(true),
+    }
+    const kinds = buildCustomFieldKindMap([
+      { key: 'count', kind: 'integer' },
+      { key: 'ratio', kind: 'float' },
+      { key: 'flag', kind: 'boolean' },
+    ])
+
+    const out = await decryptIndexDocCustomFields(doc, scope, service, new Map(), kinds)
+
+    expect(out['cf:count']).toBe(42)
+    expect(out['cf:ratio']).toBe(3.14)
+    expect(out['cf:flag']).toBe(true)
+  })
+
+  it('applies the kind to every entry of a multi-value field', async () => {
+    const doc = { id: '1', 'cf:codes': [await encrypt('1'), await encrypt('2')] }
+    const kinds = buildCustomFieldKindMap([{ key: 'codes', kind: 'text' }])
+
+    const out = await decryptIndexDocCustomFields(doc, scope, service, new Map(), kinds)
+
+    expect(out['cf:codes']).toEqual(['1', '2'])
+  })
+
+  it('resolves the sanitized `cf_` alias the hybrid query engine emits', async () => {
+    // `HybridQueryEngine.sanitize()` turns the doc key `cf:order-ref` into `cf_order_ref`,
+    // so a map keyed only by the authored key would miss it.
+    const doc = { id: '1', cf_order_ref: await encrypt('900') }
+    const kinds = buildCustomFieldKindMap([{ key: 'order-ref', kind: 'text' }])
+
+    const out = await decryptIndexDocCustomFields(doc, scope, service, new Map(), kinds)
+
+    expect(out.cf_order_ref).toBe('900')
+  })
+
+  it('falls back to the legacy JSON round trip when the kind cannot be resolved', async () => {
+    const doc = { id: '1', 'cf:unknown': await encrypt('123') }
+
+    const withoutMap = await decryptIndexDocCustomFields(doc, scope, service, new Map())
+    const withEmptyMap = await decryptIndexDocCustomFields(doc, scope, service, new Map(), {})
+
+    expect(withoutMap['cf:unknown']).toBe(123)
+    expect(withEmptyMap['cf:unknown']).toBe(123)
+  })
+
+  it('threads the kind map through decryptIndexDocForSearch', async () => {
+    const searchService = {
+      ...service,
+      isEnabled: () => true,
+      decryptEntityPayload: async () => ({ title: 'Plain' }),
+    } as any
+    const doc = { id: '1', title: 'Encrypted', 'cf:note': await encrypt('123') }
+    const kinds = buildCustomFieldKindMap([{ key: 'note', kind: 'text' }])
+
+    const out = await decryptIndexDocForSearch('example:todo', doc, scope, searchService, new Map(), kinds)
+
+    expect(out.title).toBe('Plain')
+    expect(out['cf:note']).toBe('123')
+  })
+
+  it('threads the kind map through decryptIndexDocForSearch without an entity payload decryptor', async () => {
+    const doc = { id: '1', 'cf:note': await encrypt('true') }
+    const kinds = buildCustomFieldKindMap([{ key: 'note', kind: 'text' }])
+
+    const out = await decryptIndexDocForSearch('example:todo', doc, scope, service, new Map(), kinds)
+
+    expect(out['cf:note']).toBe('true')
+  })
+})

--- a/packages/shared/src/lib/encryption/__tests__/indexDoc.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/indexDoc.test.ts
@@ -39,6 +39,45 @@ describe('encryption/indexDoc', () => {
     expect(decryptCustomFieldValueMock).toHaveBeenCalled()
   })
 
+  test('decryptIndexDocCustomFields passes each key its resolved kind (#5968)', async () => {
+    const doc = { id: '1', 'cf:note': 'enc', 'cf:count': 'enc', cf_order_ref: 'enc' }
+    const kinds = { note: 'text', count: 'integer', 'order-ref': 'text', order_ref: 'text' }
+
+    await decryptIndexDocCustomFields(doc, { tenantId: 't1', organizationId: 'org1' }, {} as any, undefined, kinds)
+
+    expect(decryptCustomFieldValueMock).toHaveBeenCalledTimes(3)
+    const kindsPassed = decryptCustomFieldValueMock.mock.calls.map((call) => call[4]?.kind).sort()
+    expect(kindsPassed).toEqual(['integer', 'text', 'text'])
+  })
+
+  test('decryptIndexDocCustomFields passes a null kind when no map is supplied (#5968)', async () => {
+    const doc = { id: '1', 'cf:note': 'enc' }
+
+    await decryptIndexDocCustomFields(doc, { tenantId: 't1', organizationId: 'org1' }, {} as any)
+
+    expect(decryptCustomFieldValueMock).toHaveBeenCalledWith('enc', 't1', {}, undefined, { kind: null })
+  })
+
+  test('decryptIndexDocForSearch forwards the kind map to the cf decryption (#5968)', async () => {
+    const service = {
+      isEnabled: () => true,
+      decryptEntityPayload: jest.fn(async () => ({})),
+    }
+
+    await decryptIndexDocForSearch(
+      'example:todo',
+      { id: '1', 'cf:note': 'enc' },
+      { tenantId: 't1', organizationId: 'org1' },
+      service as any,
+      undefined,
+      { note: 'multiline' },
+    )
+
+    expect(decryptCustomFieldValueMock).toHaveBeenCalledWith(
+      'enc', 't1', service, undefined, { kind: 'multiline' },
+    )
+  })
+
   test('decryptIndexDocForSearch merges decrypted entity payload and decrypts cf keys', async () => {
     decryptCustomFieldValueMock.mockImplementation(async (value: unknown) => (value === 'enc' ? 'dec' : value))
 

--- a/packages/shared/src/lib/encryption/indexDoc.ts
+++ b/packages/shared/src/lib/encryption/indexDoc.ts
@@ -1,4 +1,5 @@
 import { decryptCustomFieldValue } from './customFieldValues'
+import { resolveCustomFieldKind, type CustomFieldKindMap } from '../custom-fields/kinds'
 import type { TenantDataEncryptionService } from './tenantDataEncryptionService'
 
 export type IndexDocScope = {
@@ -10,12 +11,15 @@ async function decryptValue(
   value: unknown,
   scope: IndexDocScope,
   service: TenantDataEncryptionService | null,
-  cache?: Map<string | null, string | null>,
+  cache: Map<string | null, string | null> | undefined,
+  kind: string | null,
 ): Promise<unknown> {
   if (Array.isArray(value)) {
-    return Promise.all(value.map((entry) => decryptCustomFieldValue(entry, scope.tenantId, service, cache)))
+    return Promise.all(
+      value.map((entry) => decryptCustomFieldValue(entry, scope.tenantId, service, cache, { kind })),
+    )
   }
-  return decryptCustomFieldValue(value, scope.tenantId, service, cache)
+  return decryptCustomFieldValue(value, scope.tenantId, service, cache, { kind })
 }
 
 export async function decryptIndexDocCustomFields(
@@ -23,6 +27,7 @@ export async function decryptIndexDocCustomFields(
   scope: IndexDocScope,
   service: TenantDataEncryptionService | null,
   cache?: Map<string | null, string | null>,
+  kinds?: CustomFieldKindMap | null,
 ): Promise<Record<string, unknown>> {
   // HybridQueryEngine aliases cf keys as `cf_<key>` (sanitized), while index docs use `cf:<key>`.
   // Support both shapes to keep decryption consistent across query paths.
@@ -33,7 +38,10 @@ export async function decryptIndexDocCustomFields(
   await Promise.all(
     keys.map(async (key) => {
       try {
-        working[key] = await decryptValue(working[key], scope, service, cache)
+        // Without the field's kind, `decryptCustomFieldValue` falls back to `JSON.parse` and
+        // retypes string-typed values whose plaintext looks like JSON — `"123"` becomes 123
+        // and `"true"` becomes true (issue #5968). An unresolved kind keeps the legacy path.
+        working[key] = await decryptValue(working[key], scope, service, cache, resolveCustomFieldKind(kinds, key))
       } catch {
         // ignore; keep original value
       }
@@ -48,12 +56,13 @@ export async function decryptIndexDocForSearch(
   scope: IndexDocScope,
   service: TenantDataEncryptionService | null,
   cache?: Map<string | null, string | null>,
+  kinds?: CustomFieldKindMap | null,
 ): Promise<Record<string, unknown>> {
   if (!service || typeof service.decryptEntityPayload !== 'function') {
-    return decryptIndexDocCustomFields(doc, scope, service, cache)
+    return decryptIndexDocCustomFields(doc, scope, service, cache, kinds)
   }
   if (service.isEnabled?.() === false) {
-    return decryptIndexDocCustomFields(doc, scope, service, cache)
+    return decryptIndexDocCustomFields(doc, scope, service, cache, kinds)
   }
 
   let working: Record<string, unknown> = doc
@@ -72,7 +81,7 @@ export async function decryptIndexDocForSearch(
     await decryptEntity('customers:customer_entity')
   }
 
-  return decryptIndexDocCustomFields(working, scope, service, cache)
+  return decryptIndexDocCustomFields(working, scope, service, cache, kinds)
 }
 
 export async function encryptIndexDocForStorage(


### PR DESCRIPTION
## Summary

Reading an encrypted, string-typed custom field back through the query index or full-text search returned a **different type than was saved**. A field holding `"123"` came back as the number `123`; `"true"` came back as the boolean `true`. The same value read through the canonical (non-indexed) custom-field loader was correct, so the corruption depended entirely on which read path a request happened to take.

The consequence is worse than a display glitch: consumers that check `typeof value === 'string'` treat the field as empty or invalid and can null it out on the next save, silently destroying the stored text.

Fixes #5968

## Root cause

`decryptCustomFieldValue` only preserves a decrypted string verbatim when it is told the field's `kind`; otherwise it runs `JSON.parse` over the plaintext. `decryptIndexDocCustomFields` and `decryptIndexDocForSearch` never passed that argument — they were the last two callers still omitting it.

This cannot be recovered from the ciphertext alone. The encrypt path stores a raw string unwrapped but JSON-stringifies everything else, so the stored plaintext for the string `"123"` and the number `123` is byte-identical. The field's `kind` is the only disambiguator.

## What changed

- **`packages/shared/src/lib/custom-fields/kinds.ts`** (new) — an index of every candidate `custom_field_defs` row per `cf:`/`cf_` document key (authored key and sanitized alias alike), resolved to the map that applies to one row **through the same `selectDefinitionForRecord` scope precedence** (organization ▸ tenant ▸ global) the canonical, non-indexed custom-field loader already uses per record. `custom_field_defs` has no unique constraint on `(entity_id, key)` — an organization can override an inherited definition with a different `kind` — so the index keeps every scope's definition and lets the caller resolve the winner against the row it is actually decrypting, rather than collapsing to one tenant-wide map.
- **`packages/shared/src/lib/encryption/indexDoc.ts`** — both helpers accept an optional trailing `kinds` map and pass each key's resolved kind through to `decryptCustomFieldValue`.
- **`packages/core/src/modules/query_index/lib/engine.ts`** — resolves the per-key candidate index once per query (reusing the existing TTL-cached `custom_field_defs` lookup, so a warm cache adds **no extra query**), then flattens it to the map for each row's own `organization_id`/`tenant_id` — the same scope the row is already decrypted with — memoized so rows sharing a scope pay for the flatten once.
- **`packages/search/src/lib/presenter-enricher.ts`** — same per-row scope resolution for search results, via one batched, fail-open query per entity type; skipped entirely when no encryption service is active, since search is a hot path and the lookup would be dead weight.

## Why not the cheaper alternative

The report offered a second option: restrict the no-`kind` `JSON.parse` fallback to text starting with `{` or `[`. That would regress this same read path for `integer`, `float`, and `boolean` custom fields, which rely on the JSON round trip and would start coming back as strings. The no-`kind` fallback is also the documented backward-compatibility contract, so it is left untouched.

## Scope note

Three other callers (`query_index/lib/indexer.ts`, `lib/reindexer.ts`, `cli.ts`) also omit the kind. They are deliberately left unwired here to keep this fix minimal — **not** because it is a no-op: the search tokenizer (`search-tokens.ts`'s `shouldIndexField`) actually **drops** non-string, non-array values rather than stringifying them, so an unwired encrypted string-typed field whose plaintext looks like JSON silently produces zero search tokens today. That is a real, pre-existing gap, tracked separately in #6081 rather than folded into this read-path fix, since closing it also requires a reindex for existing rows to pick up new tokens.

## Testing

Every change is covered, and the coverage was verified to actually catch the bug: with the resolved kind neutralized, tests fail reproducing the reported symptom exactly; all pass with the fix.

- Round-trip tests over the real encrypt/decrypt helpers (not mocks — the defect is in the *argument*, so a mocked value would hide it) across the string-typed kinds, including `"123"`, `"true"`, `"null"`, and object/array-shaped strings.
- Assertions that `integer`/`float`/`boolean` still coerce, that multi-value fields apply the kind per entry, that the sanitized `cf_` alias resolves, and that an unresolved kind degrades to the previous behavior.
- Scope-resolution tests reproducing the re-review's M1 scenario directly: two organizations with colliding `kind` overrides on the same key, asserting the resolved map is keyed by the row's own organization and is independent of the order rows come back from the database, plus tenant/global fallback and a deterministic same-scope tiebreak.
- Caller-level tests that the query engine and presenter enricher forward the right per-row, per-organization map, plus a fail-open test for a failing lookup.

**Validation gate:** `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app`, `yarn test` all green against the current `develop` merge base.

## Compatibility

No breaking changes. Both exported signatures gain a trailing **optional** parameter, so existing callers compile and behave identically. No schema change and no migration — documents already written to `entity_indexes` need no rewrite, since only the read side changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791618908&installation_model_id=432243&pr_number=6027&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6027&signature=1b2b2c3a8eb5c028be5a60a6cb30605c42299ca5d4ac662d971f996706be32f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
