### PR TITLE
refactor(portal): make boundary-crossing portal navigations consistently full page loads (#5958)

### DIFF
--- a/packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts
+++ b/packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts
@@ -38,6 +38,12 @@ const PUBLIC_PORTAL_ROUTES = ['login', 'signup', 'verify', 'reset-password', 'in
 /** The only module allowed to reload the document directly; every portal call site goes through it. */
 const PAGE_RELOAD_HELPER = path.join(REPO_ROOT, 'packages/shared/src/lib/navigation/pageReload.ts')
 
+/** Each helper stands in for one client-router call, and must keep that call's history semantics. */
+const PAGE_RELOAD_HELPER_CONTRACT: Array<{ helper: string; documentApi: string }> = [
+  { helper: 'navigateWithPageReload', documentApi: 'window.location.assign(path)' },
+  { helper: 'replaceWithPageReload', documentApi: 'window.location.replace(path)' },
+]
+
 const CLIENT_NAV = /router\.(push|replace)\(/
 const PORTAL_PATH_LITERAL = /\/portal\//
 const PUBLIC_ROUTE_LITERAL = new RegExp(String.raw`\/portal\/(${PUBLIC_PORTAL_ROUTES.join('|')})\b`)
@@ -122,7 +128,7 @@ describe('portal boundary-crossing navigation guard', () => {
     expect(violations).toEqual([])
   })
 
-  it('routes every portal page reload through navigateWithPageReload', () => {
+  it('routes every portal page reload through the shared helpers', () => {
     const violations = scan(
       portalSourceFiles().filter((file) => file !== PAGE_RELOAD_HELPER),
       ({ line }) => RAW_PAGE_RELOAD.test(line),
@@ -131,7 +137,12 @@ describe('portal boundary-crossing navigation guard', () => {
     expect(violations).toEqual([])
   })
 
-  it('keeps navigateWithPageReload as the single place the document is reloaded', () => {
-    expect(fs.readFileSync(PAGE_RELOAD_HELPER, 'utf8')).toContain('window.location.assign(path)')
-  })
+  it.each(PAGE_RELOAD_HELPER_CONTRACT)(
+    'keeps $helper as the single place the document is reloaded via $documentApi',
+    ({ helper, documentApi }) => {
+      const contents = fs.readFileSync(PAGE_RELOAD_HELPER, 'utf8')
+      expect(contents).toContain(`export function ${helper}(path: string): void {`)
+      expect(contents).toContain(documentApi)
+    },
+  )
 })

--- a/packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts
+++ b/packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts
@@ -1,0 +1,137 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..', '..')
+
+/**
+ * The portal's `(frontend)` layout — the server component that decides the portal chrome and
+ * resolves the customer session — sits above the `[...slug]` segment so portal navigation does not
+ * remount the client subtree. That is a deliberate, permanent performance choice, and it creates a
+ * rule the whole portal depends on:
+ *
+ *   Any navigation that crosses the authenticated/public boundary must be a full page load, so the
+ *   server layout re-runs and recomputes the chrome and the session.
+ *
+ * A client-side `router.push`/`router.replace` across that boundary leaves the previous side's
+ * chrome painted over the new page — authenticated chrome (and the user menu, and the mounted SSE
+ * bridge) over the login page after a logout, or logged-out chrome over the dashboard after a
+ * login. These guards pin the rule so it survives without reviewer vigilance.
+ */
+
+const SCANNED_ROOTS = ['apps', 'packages']
+
+const IGNORED_DIRS = new Set([
+  'node_modules',
+  '.mercato',
+  '.next',
+  'dist',
+  'build',
+  '.turbo',
+  '.yarn',
+  '.git',
+  '.ai',
+])
+
+/** Public, unauthenticated portal routes. Reaching one from an authenticated page crosses the boundary. */
+const PUBLIC_PORTAL_ROUTES = ['login', 'signup', 'verify', 'reset-password', 'invite']
+
+/** The only module allowed to reload the document directly; every portal call site goes through it. */
+const PAGE_RELOAD_HELPER = path.join(REPO_ROOT, 'packages/shared/src/lib/navigation/pageReload.ts')
+
+const CLIENT_NAV = /router\.(push|replace)\(/
+const PORTAL_PATH_LITERAL = /\/portal\//
+const PUBLIC_ROUTE_LITERAL = new RegExp(String.raw`\/portal\/(${PUBLIC_PORTAL_ROUTES.join('|')})\b`)
+const RAW_PAGE_RELOAD = /window\.location\.(assign|replace)\(|window\.location\.href\s*=/
+
+function collectPortalSourceFiles(start: string, out: string[]) {
+  const entries = fs.readdirSync(start, { withFileTypes: true })
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue
+    const full = path.join(start, entry.name)
+    if (entry.isDirectory()) {
+      collectPortalSourceFiles(full, out)
+      continue
+    }
+    if (!entry.isFile()) continue
+    if (!/\.tsx?$/.test(entry.name)) continue
+    const relative = path.relative(REPO_ROOT, full)
+    if (/(^|[\\/])__tests__[\\/]/.test(relative)) continue
+    if (!/[\\/]portal[\\/]/.test(relative)) continue
+    out.push(full)
+  }
+}
+
+function portalSourceFiles(): string[] {
+  const files: string[] = []
+  for (const dir of SCANNED_ROOTS) {
+    const fullDir = path.join(REPO_ROOT, dir)
+    if (fs.existsSync(fullDir)) collectPortalSourceFiles(fullDir, files)
+  }
+  return files
+}
+
+type Violation = { file: string; line: number; snippet: string }
+
+type LineMatcher = (context: { line: string; index: number; lines: string[] }) => boolean
+
+function scan(files: string[], matches: LineMatcher): Violation[] {
+  const violations: Violation[] = []
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf8').split('\n')
+    lines.forEach((line, index) => {
+      if (!matches({ line, index, lines })) return
+      violations.push({
+        file: path.relative(REPO_ROOT, file),
+        line: index + 1,
+        snippet: line.trim().slice(0, 160),
+      })
+    })
+  }
+  return violations
+}
+
+describe('portal boundary-crossing navigation guard', () => {
+  it('finds portal sources to scan', () => {
+    expect(portalSourceFiles().length).toBeGreaterThan(0)
+  })
+
+  it('only client-side navigates to a statically same-side portal target', () => {
+    // A same-side navigation must name its target inline, so this guard can check which side it
+    // lands on. A target hidden behind a variable — `router.push(loginPath)`, the shape that let
+    // the portal's own logout hook drift out of step with `PortalContext` — is unverifiable and is
+    // therefore a violation too: inline the literal, or call `navigateWithPageReload` if the
+    // navigation crosses the public/authenticated boundary.
+    const violations = scan(portalSourceFiles(), ({ line, index, lines }) => {
+      if (!CLIENT_NAV.test(line)) return false
+      const callWindow = lines.slice(index, index + 3).join('\n')
+      if (PUBLIC_ROUTE_LITERAL.test(callWindow)) return true
+      return !PORTAL_PATH_LITERAL.test(callWindow)
+    })
+
+    expect(violations).toEqual([])
+  })
+
+  it('never client-side navigates away from a public auth page', () => {
+    const publicPageDir = new RegExp(String.raw`[\\/]portal[\\/](${PUBLIC_PORTAL_ROUTES.join('|')})[\\/]`)
+
+    const violations = scan(
+      portalSourceFiles().filter((file) => publicPageDir.test(path.relative(REPO_ROOT, file))),
+      ({ line }) => CLIENT_NAV.test(line),
+    )
+
+    expect(violations).toEqual([])
+  })
+
+  it('routes every portal page reload through navigateWithPageReload', () => {
+    const violations = scan(
+      portalSourceFiles().filter((file) => file !== PAGE_RELOAD_HELPER),
+      ({ line }) => RAW_PAGE_RELOAD.test(line),
+    )
+
+    expect(violations).toEqual([])
+  })
+
+  it('keeps navigateWithPageReload as the single place the document is reloaded', () => {
+    expect(fs.readFileSync(PAGE_RELOAD_HELPER, 'utf8')).toContain('window.location.assign(path)')
+  })
+})

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/dashboard/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -47,10 +47,10 @@ export default function PortalDashboardPage({ params }: Props) {
   }
 
   // Leaving an authenticated page for the login page crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   useEffect(() => {
     if (!loading && !user) {
-      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
+      replaceWithPageReload(`/${params.orgSlug}/portal/login`)
     }
   }, [loading, user, params.orgSlug])
 

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/dashboard/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
-import { useRouter } from 'next/navigation'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -29,7 +29,6 @@ function WidgetIcon({ className }: { className?: string }) {
 
 export default function PortalDashboardPage({ params }: Props) {
   const t = useT()
-  const router = useRouter()
   const { auth } = usePortalContext()
   const { user, loading } = auth
 
@@ -47,11 +46,13 @@ export default function PortalDashboardPage({ params }: Props) {
     setHiddenWidgets(user ? loadHiddenWidgets(params.orgSlug, user.id) : new Set())
   }
 
+  // Leaving an authenticated page for the login page crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   useEffect(() => {
     if (!loading && !user) {
-      router.replace(`/${params.orgSlug}/portal/login`)
+      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
     }
-  }, [loading, user, router, params.orgSlug])
+  }, [loading, user, params.orgSlug])
 
   useEffect(() => {
     clearLegacyHiddenWidgetsKey()

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/login/page.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@open-mercato/ui/primitives/empty-state'
 import { SearchX } from 'lucide-react'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { usePortalContext } from '@open-mercato/ui/portal/PortalContext'
 import { InjectionSpot } from '@open-mercato/ui/backend/injection/InjectionSpot'
 
@@ -47,7 +48,7 @@ export default function PortalLoginPage({ params }: Props) {
         })
 
         if (result.ok && result.result?.ok) {
-          window.location.assign(`/${orgSlug}/portal/dashboard`)
+          navigateWithPageReload(`/${orgSlug}/portal/dashboard`)
           return
         }
 

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
 import Link from 'next/link'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -20,10 +20,10 @@ export default function PortalLandingPage({ params }: Props) {
   const { auth, tenant } = usePortalContext()
 
   // Redirect authenticated users to dashboard. This crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   useEffect(() => {
     if (!auth.loading && auth.user) {
-      navigateWithPageReload(`/${orgSlug}/portal/dashboard`)
+      replaceWithPageReload(`/${orgSlug}/portal/dashboard`)
     }
   }, [auth.loading, auth.user, orgSlug])
 

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -16,16 +16,16 @@ type Props = { params: { orgSlug: string } }
 
 export default function PortalLandingPage({ params }: Props) {
   const t = useT()
-  const router = useRouter()
   const orgSlug = params.orgSlug
   const { auth, tenant } = usePortalContext()
 
-  // Redirect authenticated users to dashboard
+  // Redirect authenticated users to dashboard. This crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   useEffect(() => {
     if (!auth.loading && auth.user) {
-      router.replace(`/${orgSlug}/portal/dashboard`)
+      navigateWithPageReload(`/${orgSlug}/portal/dashboard`)
     }
-  }, [auth.loading, auth.user, router, orgSlug])
+  }, [auth.loading, auth.user, orgSlug])
 
   const injectionContext = useMemo(
     () => ({ orgSlug }),

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/profile/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useEffect, useMemo } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
-import { useRouter } from 'next/navigation'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -14,15 +14,16 @@ type Props = { params: { orgSlug: string } }
 
 export default function PortalProfilePage({ params }: Props) {
   const t = useT()
-  const router = useRouter()
   const { auth } = usePortalContext()
   const { user, roles, resolvedFeatures, isPortalAdmin, loading } = auth
 
+  // Leaving an authenticated page for the login page crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   useEffect(() => {
     if (!loading && !user) {
-      router.replace(`/${params.orgSlug}/portal/login`)
+      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
     }
-  }, [loading, user, router, params.orgSlug])
+  }, [loading, user, params.orgSlug])
 
   const injectionContext = useMemo(
     () => ({ orgSlug: params.orgSlug, user, roles, resolvedFeatures, isPortalAdmin }),

--- a/packages/core/src/modules/portal/frontend/[orgSlug]/portal/profile/page.tsx
+++ b/packages/core/src/modules/portal/frontend/[orgSlug]/portal/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useEffect, useMemo } from 'react'
 import { extensionPoints } from '@open-mercato/core/modules/portal/extension-points'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
@@ -18,10 +18,10 @@ export default function PortalProfilePage({ params }: Props) {
   const { user, roles, resolvedFeatures, isPortalAdmin, loading } = auth
 
   // Leaving an authenticated page for the login page crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   useEffect(() => {
     if (!loading && !user) {
-      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
+      replaceWithPageReload(`/${params.orgSlug}/portal/login`)
     }
   }, [loading, user, params.orgSlug])
 

--- a/packages/core/src/modules/portal/lib/navigation.ts
+++ b/packages/core/src/modules/portal/lib/navigation.ts
@@ -1,3 +1,8 @@
-export function navigateWithPageReload(path: string): void {
-  window.location.assign(path)
-}
+/**
+ * Portal-local import path for the boundary-crossing navigation helper.
+ *
+ * The implementation lives in `@open-mercato/shared/lib/navigation/pageReload` so `@open-mercato/ui`
+ * — which does not depend on `@open-mercato/core` — can reach it from the portal shell and hooks.
+ * This re-export keeps the published import path stable for existing callers.
+ */
+export { navigateWithPageReload } from '@open-mercato/shared/lib/navigation/pageReload'

--- a/packages/core/src/modules/portal/lib/navigation.ts
+++ b/packages/core/src/modules/portal/lib/navigation.ts
@@ -1,8 +1,8 @@
 /**
- * Portal-local import path for the boundary-crossing navigation helper.
+ * Portal-local import path for the boundary-crossing navigation helpers.
  *
  * The implementation lives in `@open-mercato/shared/lib/navigation/pageReload` so `@open-mercato/ui`
  * — which does not depend on `@open-mercato/core` — can reach it from the portal shell and hooks.
  * This re-export keeps the published import path stable for existing callers.
  */
-export { navigateWithPageReload } from '@open-mercato/shared/lib/navigation/pageReload'
+export { navigateWithPageReload, replaceWithPageReload } from '@open-mercato/shared/lib/navigation/pageReload'

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/[id]/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/[id]/page.tsx
@@ -2,8 +2,8 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { ArrowLeft, Check, CircleAlert, Info, Paperclip, RefreshCw, ShieldCheck, Trash2, TriangleAlert } from 'lucide-react'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT, type TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { localizeDictionaryLabel } from '@open-mercato/core/modules/warranty_claims/lib/dictionaryLabels'
 import { formatQuantity } from '@open-mercato/core/modules/warranty_claims/lib/quantity'
@@ -330,7 +330,6 @@ const DARK_BUTTON_CLASS = 'rounded-md px-3 py-2 text-sm font-medium'
 export default function WarrantyClaimPortalDetailPage({ params }: Props) {
   const t = useT()
   const locale = useLocale()
-  const router = useRouter()
   const { auth } = usePortalContext()
   const { user, loading } = auth
   const guardedMutation = useGuardedMutation<Record<string, unknown>>({
@@ -354,11 +353,13 @@ export default function WarrantyClaimPortalDetailPage({ params }: Props) {
   const replacementInputRef = React.useRef<HTMLInputElement | null>(null)
   const replacementTargetRef = React.useRef<PortalAttachment | null>(null)
 
+  // Leaving an authenticated page for the login page crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      router.replace(`/${params.orgSlug}/portal/login`)
+      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
     }
-  }, [loading, user, router, params.orgSlug])
+  }, [loading, user, params.orgSlug])
 
   const refreshEvents = React.useCallback(async (claimId: string) => {
     const result = await apiCall<EventResponse>(`/api/warranty_claims/portal/events?claimId=${encodeURIComponent(claimId)}`)

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/[id]/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/[id]/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Check, CircleAlert, Info, Paperclip, RefreshCw, ShieldCheck, Trash2, TriangleAlert } from 'lucide-react'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT, type TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { localizeDictionaryLabel } from '@open-mercato/core/modules/warranty_claims/lib/dictionaryLabels'
 import { formatQuantity } from '@open-mercato/core/modules/warranty_claims/lib/quantity'
@@ -354,10 +354,10 @@ export default function WarrantyClaimPortalDetailPage({ params }: Props) {
   const replacementTargetRef = React.useRef<PortalAttachment | null>(null)
 
   // Leaving an authenticated page for the login page crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
+      replaceWithPageReload(`/${params.orgSlug}/portal/login`)
     }
   }, [loading, user, params.orgSlug])
 

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/new/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/new/page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, ArrowRight, FileText, Plus, Send, Trash2 } from 'lucide-react'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
@@ -307,11 +308,13 @@ export default function WarrantyClaimPortalNewPage({ params }: Props) {
   const serialLookupTimers = React.useRef<Record<string, number>>({})
   const isMountedRef = React.useRef(true)
 
+  // Leaving an authenticated page for the login page crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      router.replace(`/${params.orgSlug}/portal/login`)
+      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
     }
-  }, [loading, user, router, params.orgSlug])
+  }, [loading, user, params.orgSlug])
 
   React.useEffect(() => {
     isMountedRef.current = true

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/new/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/new/page.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, ArrowRight, FileText, Plus, Send, Trash2 } from 'lucide-react'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
@@ -309,10 +309,10 @@ export default function WarrantyClaimPortalNewPage({ params }: Props) {
   const isMountedRef = React.useRef(true)
 
   // Leaving an authenticated page for the login page crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
+      replaceWithPageReload(`/${params.orgSlug}/portal/login`)
     }
   }, [loading, user, params.orgSlug])
 

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
 import { ChevronRight, Plus, ShieldCheck } from 'lucide-react'
-import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
+import { replaceWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -74,10 +74,10 @@ export default function WarrantyClaimsPortalListPage({ params }: Props) {
   const [tabCounts, setTabCounts] = React.useState<Partial<Record<'all' | 'open' | 'resolved', number>>>({})
 
   // Leaving an authenticated page for the login page crosses the public/authenticated
-  // boundary, so it must be a full page load — see `navigateWithPageReload`.
+  // boundary, so it must be a full page load — see `replaceWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
+      replaceWithPageReload(`/${params.orgSlug}/portal/login`)
     }
   }, [loading, user, params.orgSlug])
 

--- a/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/page.tsx
+++ b/packages/core/src/modules/warranty_claims/frontend/[orgSlug]/portal/claims/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
 import { ChevronRight, Plus, ShieldCheck } from 'lucide-react'
+import { navigateWithPageReload } from '@open-mercato/core/modules/portal/lib/navigation'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -72,11 +73,13 @@ export default function WarrantyClaimsPortalListPage({ params }: Props) {
   const [stateGroup, setStateGroup] = React.useState<'all' | 'open' | 'resolved'>('all')
   const [tabCounts, setTabCounts] = React.useState<Partial<Record<'all' | 'open' | 'resolved', number>>>({})
 
+  // Leaving an authenticated page for the login page crosses the public/authenticated
+  // boundary, so it must be a full page load — see `navigateWithPageReload`.
   React.useEffect(() => {
     if (!loading && !user) {
-      router.replace(`/${params.orgSlug}/portal/login`)
+      navigateWithPageReload(`/${params.orgSlug}/portal/login`)
     }
-  }, [loading, user, router, params.orgSlug])
+  }, [loading, user, params.orgSlug])
 
   const statusFilter = typeof filterValues.status === 'string' ? filterValues.status : ''
 

--- a/packages/shared/src/lib/navigation/__tests__/pageReload.test.ts
+++ b/packages/shared/src/lib/navigation/__tests__/pageReload.test.ts
@@ -1,0 +1,58 @@
+/**
+ * These helpers exist so a boundary-crossing portal navigation re-runs the server layout that
+ * computes the portal chrome and the session. Which document API each one uses is the whole
+ * contract: `assign` keeps the current page in session history, `replace` does not, so they are
+ * the document-loading counterparts of `router.push` and `router.replace` respectively. Swapping
+ * one for the other is invisible on screen and only surfaces as a broken Back button, so pin both.
+ *
+ * This runs in the node environment on purpose: jsdom exposes `window.location` as a
+ * non-configurable getter whose `assign`/`replace` are non-writable, so the real navigation calls
+ * cannot be observed there. A synthetic `window` lets the helper bodies run for real.
+ */
+
+const assign = jest.fn()
+const replace = jest.fn()
+
+describe('page reload navigation helpers', () => {
+  let navigateWithPageReload: (path: string) => void
+  let replaceWithPageReload: (path: string) => void
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: { location: { assign, replace } },
+    })
+    // Imported after the synthetic window exists, so the module resolves against it.
+    const helpers = require('../pageReload')
+    navigateWithPageReload = helpers.navigateWithPageReload
+    replaceWithPageReload = helpers.replaceWithPageReload
+  })
+
+  afterAll(() => {
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  beforeEach(() => {
+    assign.mockReset()
+    replace.mockReset()
+  })
+
+  describe('navigateWithPageReload', () => {
+    it('loads the path and keeps the current page in session history', () => {
+      navigateWithPageReload('/acme/portal/dashboard')
+
+      expect(assign).toHaveBeenCalledWith('/acme/portal/dashboard')
+      expect(replace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('replaceWithPageReload', () => {
+    it('loads the path without leaving the redirecting page in session history', () => {
+      replaceWithPageReload('/acme/portal/login')
+
+      expect(replace).toHaveBeenCalledWith('/acme/portal/login')
+      expect(assign).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/shared/src/lib/navigation/pageReload.ts
+++ b/packages/shared/src/lib/navigation/pageReload.ts
@@ -27,10 +27,16 @@ export function navigateWithPageReload(path: string): void {
  * Full page load that replaces the current session-history entry — the document-loading
  * counterpart of `router.replace`.
  *
- * Use this for redirects the user should not be able to navigate back into: an auth guard sending
- * an unauthenticated visitor to the login page, or the portal landing page forwarding a signed-in
- * customer to the dashboard. `navigateWithPageReload` would leave the redirecting page in history,
- * so pressing Back would land on it and immediately bounce forward again.
+ * Use this where the client-router call being replaced was a `router.replace`: an auth guard
+ * sending an unauthenticated visitor to the login page, or the portal landing page forwarding a
+ * signed-in customer to the dashboard.
+ *
+ * Note that for those call sites specifically, `navigateWithPageReload` was measured to behave
+ * identically: they redirect from an effect during page load, and a browser treats a navigation
+ * started then as a client redirect, replacing the entry rather than pushing it whichever method
+ * is used. This helper exists so the call site states which semantics it means instead of relying
+ * on that heuristic — and so a redirect that later moves behind a user gesture, where the
+ * distinction does bite, keeps the behaviour it was written with.
  */
 export function replaceWithPageReload(path: string): void {
   window.location.replace(path)

--- a/packages/shared/src/lib/navigation/pageReload.ts
+++ b/packages/shared/src/lib/navigation/pageReload.ts
@@ -1,5 +1,6 @@
 /**
- * Navigates by reloading the document instead of handing the route to the client router.
+ * Boundary-crossing navigation helpers: they reload the document instead of handing the route to
+ * the client router.
  *
  * The portal's `(frontend)` layout — the server component that decides the portal chrome and
  * resolves the customer session — sits *above* the `[...slug]` segment so portal navigation does
@@ -8,10 +9,29 @@
  * keep rendering chrome computed for the page it came from: authenticated chrome over the login
  * page after a logout, or logged-out chrome over the dashboard after a login.
  *
- * Use this helper for every boundary-crossing navigation (login, logout, signup completion,
+ * Use these helpers for every boundary-crossing navigation (login, logout, signup completion,
  * invite acceptance, auth guards redirecting to login) so the layout re-runs and recomputes both
  * the chrome and the session. Same-side navigation should keep using the client router.
+ *
+ * Pick the one that matches the client-router call it stands in for, so session history behaves
+ * the same way: `navigateWithPageReload` for `router.push`, `replaceWithPageReload` for
+ * `router.replace`.
  */
+
+/** Full page load that adds a session-history entry — the document-loading counterpart of `router.push`. */
 export function navigateWithPageReload(path: string): void {
   window.location.assign(path)
+}
+
+/**
+ * Full page load that replaces the current session-history entry — the document-loading
+ * counterpart of `router.replace`.
+ *
+ * Use this for redirects the user should not be able to navigate back into: an auth guard sending
+ * an unauthenticated visitor to the login page, or the portal landing page forwarding a signed-in
+ * customer to the dashboard. `navigateWithPageReload` would leave the redirecting page in history,
+ * so pressing Back would land on it and immediately bounce forward again.
+ */
+export function replaceWithPageReload(path: string): void {
+  window.location.replace(path)
 }

--- a/packages/shared/src/lib/navigation/pageReload.ts
+++ b/packages/shared/src/lib/navigation/pageReload.ts
@@ -1,0 +1,17 @@
+/**
+ * Navigates by reloading the document instead of handing the route to the client router.
+ *
+ * The portal's `(frontend)` layout — the server component that decides the portal chrome and
+ * resolves the customer session — sits *above* the `[...slug]` segment so portal navigation does
+ * not remount the client subtree. A client-side `router.push`/`router.replace` therefore never
+ * re-runs that layout, and any navigation that crosses the public/authenticated boundary would
+ * keep rendering chrome computed for the page it came from: authenticated chrome over the login
+ * page after a logout, or logged-out chrome over the dashboard after a login.
+ *
+ * Use this helper for every boundary-crossing navigation (login, logout, signup completion,
+ * invite acceptance, auth guards redirecting to login) so the layout re-runs and recomputes both
+ * the chrome and the session. Same-side navigation should keep using the client router.
+ */
+export function navigateWithPageReload(path: string): void {
+  window.location.assign(path)
+}

--- a/packages/ui/src/portal/PortalContext.tsx
+++ b/packages/ui/src/portal/PortalContext.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react'
 import type { CustomerAuthResult } from '@open-mercato/shared/modules/customer-auth'
 import type { CustomerAuthContext } from '@open-mercato/shared/modules/customer-auth'
+import { navigateWithPageReload } from '@open-mercato/shared/lib/navigation/pageReload'
 import { apiCall } from '../backend/utils/apiCall'
 
 /* ------------------------------------------------------------------ */
@@ -155,7 +156,7 @@ export function PortalProvider({ orgSlug, children, initialAuth, initialTenant }
     }
     profileEnrichedRef.current = false
     setAuthState({ user: null, roles: [], resolvedFeatures: [], isPortalAdmin: false, loading: false, error: null })
-    window.location.assign(`/${orgSlug}/portal/login`)
+    navigateWithPageReload(`/${orgSlug}/portal/login`)
   }, [orgSlug])
 
   /* ---- Tenant state ---- */

--- a/packages/ui/src/portal/__tests__/logoutPageReload.test.tsx
+++ b/packages/ui/src/portal/__tests__/logoutPageReload.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import type { CustomerAuthContext } from '@open-mercato/shared/modules/customer-auth'
+import { PortalProvider, usePortalContext } from '../PortalContext'
+import { useCustomerAuth } from '../hooks/useCustomerAuth'
+
+const apiCallMock = jest.fn()
+const navigateWithPageReloadMock = jest.fn()
+const routerPushMock = jest.fn()
+const routerReplaceMock = jest.fn()
+
+jest.mock('../../backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/navigation/pageReload', () => ({
+  navigateWithPageReload: (...args: unknown[]) => navigateWithPageReloadMock(...args),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPushMock, replace: routerReplaceMock }),
+}))
+
+function makeAuth(): CustomerAuthContext {
+  return {
+    sub: 'user-1',
+    email: 'user@example.com',
+    displayName: 'User One',
+    tenantId: 't-1',
+    orgId: 'o-1',
+    resolvedFeatures: ['portal.view'],
+    customerEntityId: null,
+    personEntityId: null,
+  } as unknown as CustomerAuthContext
+}
+
+/**
+ * The portal layout that computes `authenticated` and the customer session sits above the
+ * `[...slug]` segment, so it only re-runs on a document load. Both logout paths must therefore
+ * leave the authenticated side with a full page load; a client-side navigation would strand
+ * authenticated chrome over the login page. See `navigateWithPageReload`.
+ */
+describe('portal logout crosses the auth boundary with a full page load', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    apiCallMock.mockResolvedValue({ ok: true, status: 200, result: { ok: true } })
+    navigateWithPageReloadMock.mockReset()
+    routerPushMock.mockReset()
+    routerReplaceMock.mockReset()
+  })
+
+  describe('useCustomerAuth().logout', () => {
+    function LogoutProbe({ orgSlug }: { orgSlug?: string }) {
+      const { logout } = useCustomerAuth(orgSlug)
+      return <button type="button" onClick={() => { void logout() }}>logout</button>
+    }
+
+    it('reloads the page onto the org-scoped login route', async () => {
+      const { getByText } = render(<LogoutProbe orgSlug="acme" />)
+
+      await act(async () => { getByText('logout').click() })
+
+      await waitFor(() => {
+        expect(navigateWithPageReloadMock).toHaveBeenCalledWith('/acme/portal/login')
+      })
+      expect(routerPushMock).not.toHaveBeenCalled()
+      expect(routerReplaceMock).not.toHaveBeenCalled()
+    })
+
+    it('reloads the page onto the unscoped login route when no org slug is known', async () => {
+      const { getByText } = render(<LogoutProbe />)
+
+      await act(async () => { getByText('logout').click() })
+
+      await waitFor(() => {
+        expect(navigateWithPageReloadMock).toHaveBeenCalledWith('/portal/login')
+      })
+    })
+
+    it('still reloads when the logout request fails', async () => {
+      apiCallMock.mockRejectedValue(new Error('[internal] network down'))
+      const { getByText } = render(<LogoutProbe orgSlug="acme" />)
+
+      await act(async () => { getByText('logout').click() })
+
+      await waitFor(() => {
+        expect(navigateWithPageReloadMock).toHaveBeenCalledWith('/acme/portal/login')
+      })
+    })
+  })
+
+  describe('PortalContext logout', () => {
+    function ContextLogoutProbe() {
+      const { auth } = usePortalContext()
+      return <button type="button" onClick={() => { void auth.logout() }}>logout</button>
+    }
+
+    it('reloads the page onto the login route', async () => {
+      const { getByText } = render(
+        <PortalProvider orgSlug="acme" initialAuth={makeAuth()}>
+          <ContextLogoutProbe />
+        </PortalProvider>,
+      )
+
+      await act(async () => { getByText('logout').click() })
+
+      await waitFor(() => {
+        expect(navigateWithPageReloadMock).toHaveBeenCalledWith('/acme/portal/login')
+      })
+      expect(routerPushMock).not.toHaveBeenCalled()
+      expect(routerReplaceMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/ui/src/portal/hooks/useCustomerAuth.ts
+++ b/packages/ui/src/portal/hooks/useCustomerAuth.ts
@@ -1,7 +1,7 @@
 "use client"
 import { useCallback, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import type { CustomerUser, CustomerRole, CustomerAuthResult } from '@open-mercato/shared/modules/customer-auth'
+import { navigateWithPageReload } from '@open-mercato/shared/lib/navigation/pageReload'
 import { apiCall } from '../../backend/utils/apiCall'
 
 export type { CustomerUser, CustomerRole, CustomerAuthResult }
@@ -27,7 +27,6 @@ export type { CustomerUser, CustomerRole, CustomerAuthResult }
  * ```
  */
 export function useCustomerAuth(orgSlug?: string) {
-  const router = useRouter()
   const [state, setState] = useState<CustomerAuthResult>({
     user: null,
     roles: [],
@@ -90,8 +89,8 @@ export function useCustomerAuth(orgSlug?: string) {
       loading: false,
       error: null,
     })
-    router.push(loginPath)
-  }, [router, loginPath])
+    navigateWithPageReload(loginPath)
+  }, [loginPath])
 
   return { ...state, logout }
 }

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -97,6 +97,10 @@ export const REPO_WIDE_GUARDS = [
         scans: 'packages/ and apps/ — CRUD indexer configuration',
       },
       {
+        path: 'src/modules/portal/__tests__/boundaryNavigation.test.ts',
+        scans: 'every portal source tree under packages/ and apps/ — boundary-crossing portal navigations must be full page loads. The rule exists because the portal (frontend) layout sits above [...slug], so a client-side navigation across the public/authenticated line leaves the previous side\'s chrome painted over the new page (#5678). The guard lives in core while the call sites it protects include packages/ui (the portal shell and hooks) and any module contributing portal pages, so the turbo filter would skip it on exactly the PRs that break it (#5958).',
+      },
+      {
         path: 'src/modules/design_system/gallery/__tests__/gallery-coverage.test.ts',
         scans: 'packages/ui/src/primitives — design-system gallery coverage',
       },


### PR DESCRIPTION
## Summary

Fixes #5958.

The portal's `(frontend)` layout — the server component that computes the portal chrome and resolves the customer session — sits **above** the `[...slug]` segment so portal navigation does not remount the client subtree. That deliberate performance choice creates a rule the whole portal depends on:

> Any navigation that crosses the authenticated/public boundary must be a full page load, so the server layout re-runs and recomputes the chrome and the session.

Until now nothing enforced that rule. This PR makes every boundary-crossing portal navigation a full page load, gives the helper that expresses the rule a single home and a doc comment, and adds the guard test the issue asked for so the constraint survives without reviewer vigilance.

## What changed

**1. The helper moved to a package the portal shell can actually import, and gained a `replace` counterpart.**

`navigateWithPageReload` lived in `@open-mercato/core`, but two of the call sites that need it (`useCustomerAuth`, `PortalContext`) live in `@open-mercato/ui`, which does **not** depend on `@open-mercato/core`. The implementation now lives in `packages/shared/src/lib/navigation/pageReload.ts` (`@open-mercato/shared` is already a declared peer dependency of `@open-mercato/ui`), carrying the doc comment that states the layout-position rule it exists to satisfy.

There are now **two** helpers, because a full page load has to preserve the session-history semantics of the client-router call it stands in for:

| Helper | Document API | Stands in for |
|---|---|---|
| `navigateWithPageReload` | `window.location.assign` | `router.push` — keeps the current page in history |
| `replaceWithPageReload` | `window.location.replace` | `router.replace` — does not |

Each converted call site keeps the semantics it had. **This is intent-preserving, not a bug fix** — see the correction comment on this PR: for these six redirects, which fire from an effect during page load, `assign` and `replace` were measured to behave identically, because a browser treats a navigation started during load as a client redirect and replaces the entry either way. The pair exists so a call site declares which semantics it means rather than depending on that heuristic. A reviewer who considers the second helper unnecessary API surface has a fair case; collapsing to one is a small change.

`packages/core/src/modules/portal/lib/navigation.ts` is kept as a re-export, so the published import path — a contract surface under `BACKWARD_COMPATIBILITY.md` — is unchanged for existing callers such as `invite/page.tsx`.

**2. `useCustomerAuth().logout` now does a full page load** (issue item 1). It ended with `router.push(loginPath)` while its sibling in `PortalContext` ended with a document reload. For any portal surface logging out through the hook, the layout never re-ran, leaving authenticated chrome — the user menu and the mounted SSE bridge included — painted over the login page after the session was gone. `useRouter` had no other consumer in the hook and was dropped.

**3. Every remaining boundary-crossing call site routes through the helper** (issue item 2, plus what the guard surfaced). The issue named two open-coded `window.location.assign` sites; writing the guard test turned up **five more** client-side `router.replace` calls across the same boundary:

| Call site | Was | Now |
|---|---|---|
| `ui/portal/hooks/useCustomerAuth.ts` | `router.push(loginPath)` | `navigateWithPageReload` |
| `ui/portal/PortalContext.tsx` | inline `window.location.assign` | `navigateWithPageReload` |
| `portal/…/login/page.tsx` | inline `window.location.assign` | `navigateWithPageReload` |
| `portal/…/portal/page.tsx` | `router.replace(…/dashboard)` | `replaceWithPageReload` |
| `portal/…/dashboard/page.tsx` | `router.replace(…/login)` | `replaceWithPageReload` |
| `portal/…/profile/page.tsx` | `router.replace(…/login)` | `replaceWithPageReload` |
| `warranty_claims/…/claims/page.tsx` | `router.replace(…/login)` | `replaceWithPageReload` |
| `warranty_claims/…/claims/new/page.tsx` | `router.replace(…/login)` | `replaceWithPageReload` |
| `warranty_claims/…/claims/[id]/page.tsx` | `router.replace(…/login)` | `replaceWithPageReload` |

Same-side navigations were left on the client router, which is correct — the two `router.push` calls into `/portal/claims/<id>` still use it.

**4. The guard test** (`packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts`) scans every portal source file under `apps/` and `packages/` and asserts:

- no client-side navigation targets a public auth route (`login`, `signup`, `verify`, `reset-password`, `invite`);
- no client-side navigation has an **unverifiable** target. `router.push(loginPath)` — the exact shape that let the logout hook drift out of step with `PortalContext` — passes a regex looking for path literals, so a `router.push`/`router.replace` whose target is not named inline is a violation too: inline the literal, or use the helper;
- public auth pages perform no client-side navigation at all;
- no portal file reloads the document directly — that is the helpers' job;
- each helper still uses the document API its name promises, so the `assign`/`replace` pair cannot be silently swapped.

## Testing

- `packages/core/src/modules/portal/__tests__/boundaryNavigation.test.ts` — 6 cases (new).
- `packages/ui/src/portal/__tests__/logoutPageReload.test.tsx` — 4 cases (new): both logout paths reload onto the login route, the hook handles the unscoped-org path, and logout still reloads when the logout request fails.
- `packages/shared/src/lib/navigation/__tests__/pageReload.test.ts` — 2 cases (new): each helper calls the document API its contract promises. It runs in the node environment against a synthetic `window` on purpose — jsdom exposes `window.location` as a non-configurable getter whose `assign`/`replace` are non-writable, so the real calls cannot be observed there.

Every suite was verified to **fail** with the source reverted, mutant by mutant:

- reverting only `useCustomerAuth.ts` trips the guard — the first draft of it did **not**, which is what motivated the unverifiable-target rule above;
- reverting the two open-coded `window.location.assign` sites trips the raw-reload guard;
- swapping `replace` for `assign` inside the helper trips both the helper test and the guard's contract case.

**No integration test ships with this PR, deliberately.** One was written, got green, and was then removed because mutation testing showed it detected nothing — the history assertions are vacuous for the reason above, and the chrome assertion is masked by `PortalContext.logout` resetting `user: null` in React state before it navigates. The reasoning, and the browser evidence behind it, are in the correction comment.

UI verification was run in a real browser against a disposable environment (screenshots in the QA evidence comment): logged-out chrome on the login page, authenticated chrome after signing in, and no authenticated chrome surviving on the login page after logout with the session genuinely gone.

## Risk

Behavioural in one direction only: navigations that were client-side are now document loads. That is the intended change and the slower path, but it is confined to auth-boundary crossings (login, logout, and auth-guard redirects), which already re-render the whole shell. Session-history behaviour is unchanged — each call site kept the push/replace semantics it had, and for the six guard redirects the two were measured to be equivalent anyway.

No API, schema, or contract surface changes; the existing `@open-mercato/core` import path for the helper is preserved as a re-export and now exports both helpers.
