### PR TITLE
fix(app): apply widgets.components overrides on the client so they survive hydration (#5864)

### DIFF
--- a/apps/docs/docs/framework/modules/overrides.mdx
+++ b/apps/docs/docs/framework/modules/overrides.mdx
@@ -192,10 +192,15 @@ in both the entries registry and every injection table that places it, so you ne
 need to list both — and neither is reported as a stale override.
 
 The dispatcher must also run in the browser. `ClientBootstrap` re-registers the
-injection, dashboard and notification registries after hydration, so an app that
-forks it MUST call `applyModuleOverridesFromEnabledModules(enabledModules, { domains: ['widgets', 'notifications'] })`
+injection, dashboard and notification registries after hydration, and
+`ComponentOverridesBootstrap` re-registers the component overrides, so an app that
+forks either one MUST call `applyModuleOverridesFromEnabledModules(enabledModules, { domains: ['widgets', 'notifications'] })`
 before those registrations — otherwise the raw generated registries overwrite the
-filtered ones and a disabled widget reappears once hydration finishes.
+filtered ones and a disabled widget or component override reappears once hydration
+finishes. Each of those browser registrations MUST also run its own domain filter
+(`applyInjectionWidgetOverridesToEntries`, `applyComponentOverridesToEntries`, …)
+before registering, exactly as the server bootstrap does; dispatching alone only
+fills the override stores, it does not filter anything.
 
 :::warning Keep client-side overrides off server-only env gates
 

--- a/apps/mercato/src/components/ComponentOverridesBootstrap.tsx
+++ b/apps/mercato/src/components/ComponentOverridesBootstrap.tsx
@@ -5,7 +5,7 @@ import type { ComponentOverride } from '@open-mercato/shared/modules/widgets/com
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { ComponentOverrideProvider } from '@open-mercato/ui/backend/injection/ComponentOverrideProvider'
 import type { ClientBootstrapProfile } from '@/components/ClientBootstrap'
-import { profileUsesComponentOverrides } from '@/components/ClientBootstrap'
+import { ensureModuleOverridesApplied, profileUsesComponentOverrides } from '@/components/ClientBootstrap'
 
 const logger = createLogger('app').child({ component: 'ComponentOverridesBootstrap' })
 const EMPTY_OVERRIDES: ComponentOverride[] = []
@@ -16,11 +16,27 @@ type LoadedOverrides = {
 
 let overridePromise: Promise<LoadedOverrides> | null = null
 
+/**
+ * The server registers these entries through `applyComponentOverridesToEntries`
+ * (`@open-mercato/shared/lib/bootstrap/factory`). Registering the raw generated list
+ * in the browser would overwrite that filtered registration, so a `widgets.components`
+ * override declared in `src/modules.ts` holds while server-rendered and is undone on
+ * hydration (#5864 — the #5152 defect, one key over). Awaiting the same dispatch the
+ * override-dependent registry groups await fills the component override store before
+ * the filter reads it; the dispatch is fail-soft, so a failure there degrades to the
+ * unfiltered list rather than leaving the page with no overrides at all.
+ */
 function loadOverrides(): Promise<LoadedOverrides> {
   if (overridePromise) return overridePromise
-  const pending = import('@/.mercato/generated/component-overrides.generated').then((generated) => ({
-    overrides: generated.componentOverrideEntries.flatMap((entry) => entry.componentOverrides ?? []),
-  }))
+  const pending = (async () => {
+    await ensureModuleOverridesApplied()
+    const [generated, overrides] = await Promise.all([
+      import('@/.mercato/generated/component-overrides.generated'),
+      import('@open-mercato/shared/modules/overrides'),
+    ])
+    const finalEntries = overrides.applyComponentOverridesToEntries(generated.componentOverrideEntries)
+    return { overrides: finalEntries.flatMap((entry) => entry.componentOverrides ?? []) }
+  })()
   const retryable = pending.catch((err) => {
     if (overridePromise === retryable) overridePromise = null
     throw err

--- a/apps/mercato/src/components/__tests__/ComponentOverridesBootstrap.test.tsx
+++ b/apps/mercato/src/components/__tests__/ComponentOverridesBootstrap.test.tsx
@@ -11,12 +11,31 @@ import { ComponentOverridesBootstrap } from '../ComponentOverridesBootstrap'
 
 jest.mock('@/.mercato/generated/component-overrides.generated', () => ({
   componentOverrideEntries: [{
-    componentOverrides: [{
-      target: { componentId: 'test' },
-      priority: 1,
-      propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
-    }],
+    componentOverrides: [
+      {
+        target: { componentId: 'test' },
+        priority: 1,
+        propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
+      },
+      {
+        target: { componentId: 'disabled-test' },
+        priority: 1,
+        propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
+      },
+    ],
   }],
+}))
+
+jest.mock('@/modules', () => ({
+  enabledModules: [{
+    id: 'app',
+    from: '@app',
+    overrides: { widgets: { components: { 'disabled-test': null } } },
+  }],
+}))
+
+jest.mock('@/.mercato/generated/enabled-module-ids.generated', () => ({
+  enabledModuleIds: ['app'],
 }))
 
 describe('ComponentOverridesBootstrap', () => {
@@ -46,6 +65,33 @@ describe('ComponentOverridesBootstrap', () => {
 
     expect(screen.getByText('Override active')).toBeInTheDocument()
     expect(screen.queryByText('Fallback active')).not.toBeInTheDocument()
+  })
+
+  it('keeps a modules.ts widgets.components disable applied after hydration', async () => {
+    // Without the client-side filter the browser re-registers the raw generated
+    // entries and the disabled override comes back on hydration (#5864).
+    function Label({ label }: { label: string }) {
+      return <span>{label}</span>
+    }
+
+    function Consumer() {
+      const ResolvedLabel = useRegisteredComponent<{ label: string }>('disabled-test', Label)
+      return <ResolvedLabel label="Fallback active" />
+    }
+
+    await act(async () => {
+      render(
+        <React.Suspense fallback={<span>Loading overrides</span>}>
+          <ComponentOverridesBootstrap profile="login">
+            <Consumer />
+          </ComponentOverridesBootstrap>
+        </React.Suspense>,
+      )
+    })
+
+    expect(getComponentOverrides('disabled-test')).toHaveLength(0)
+    expect(screen.getByText('Fallback active')).toBeInTheDocument()
+    expect(getComponentOverrides('test')).toHaveLength(1)
   })
 
   it('preserves child state and updates mounted consumers when asynchronous overrides activate', async () => {

--- a/packages/create-app/template/src/components/ComponentOverridesBootstrap.tsx
+++ b/packages/create-app/template/src/components/ComponentOverridesBootstrap.tsx
@@ -5,7 +5,7 @@ import type { ComponentOverride } from '@open-mercato/shared/modules/widgets/com
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { ComponentOverrideProvider } from '@open-mercato/ui/backend/injection/ComponentOverrideProvider'
 import type { ClientBootstrapProfile } from '@/components/ClientBootstrap'
-import { profileUsesComponentOverrides } from '@/components/ClientBootstrap'
+import { ensureModuleOverridesApplied, profileUsesComponentOverrides } from '@/components/ClientBootstrap'
 
 const logger = createLogger('app').child({ component: 'ComponentOverridesBootstrap' })
 const EMPTY_OVERRIDES: ComponentOverride[] = []
@@ -16,11 +16,27 @@ type LoadedOverrides = {
 
 let overridePromise: Promise<LoadedOverrides> | null = null
 
+/**
+ * The server registers these entries through `applyComponentOverridesToEntries`
+ * (`@open-mercato/shared/lib/bootstrap/factory`). Registering the raw generated list
+ * in the browser would overwrite that filtered registration, so a `widgets.components`
+ * override declared in `src/modules.ts` holds while server-rendered and is undone on
+ * hydration (#5864 — the #5152 defect, one key over). Awaiting the same dispatch the
+ * override-dependent registry groups await fills the component override store before
+ * the filter reads it; the dispatch is fail-soft, so a failure there degrades to the
+ * unfiltered list rather than leaving the page with no overrides at all.
+ */
 function loadOverrides(): Promise<LoadedOverrides> {
   if (overridePromise) return overridePromise
-  const pending = import('@/.mercato/generated/component-overrides.generated').then((generated) => ({
-    overrides: generated.componentOverrideEntries.flatMap((entry) => entry.componentOverrides ?? []),
-  }))
+  const pending = (async () => {
+    await ensureModuleOverridesApplied()
+    const [generated, overrides] = await Promise.all([
+      import('@/.mercato/generated/component-overrides.generated'),
+      import('@open-mercato/shared/modules/overrides'),
+    ])
+    const finalEntries = overrides.applyComponentOverridesToEntries(generated.componentOverrideEntries)
+    return { overrides: finalEntries.flatMap((entry) => entry.componentOverrides ?? []) }
+  })()
   const retryable = pending.catch((err) => {
     if (overridePromise === retryable) overridePromise = null
     throw err

--- a/packages/create-app/template/src/components/__tests__/ComponentOverridesBootstrap.test.tsx
+++ b/packages/create-app/template/src/components/__tests__/ComponentOverridesBootstrap.test.tsx
@@ -11,12 +11,31 @@ import { ComponentOverridesBootstrap } from '../ComponentOverridesBootstrap'
 
 jest.mock('@/.mercato/generated/component-overrides.generated', () => ({
   componentOverrideEntries: [{
-    componentOverrides: [{
-      target: { componentId: 'test' },
-      priority: 1,
-      propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
-    }],
+    componentOverrides: [
+      {
+        target: { componentId: 'test' },
+        priority: 1,
+        propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
+      },
+      {
+        target: { componentId: 'disabled-test' },
+        priority: 1,
+        propsTransform: (props: { label: string }) => ({ ...props, label: 'Override active' }),
+      },
+    ],
   }],
+}))
+
+jest.mock('@/modules', () => ({
+  enabledModules: [{
+    id: 'app',
+    from: '@app',
+    overrides: { widgets: { components: { 'disabled-test': null } } },
+  }],
+}))
+
+jest.mock('@/.mercato/generated/enabled-module-ids.generated', () => ({
+  enabledModuleIds: ['app'],
 }))
 
 describe('ComponentOverridesBootstrap', () => {
@@ -46,6 +65,33 @@ describe('ComponentOverridesBootstrap', () => {
 
     expect(screen.getByText('Override active')).toBeInTheDocument()
     expect(screen.queryByText('Fallback active')).not.toBeInTheDocument()
+  })
+
+  it('keeps a modules.ts widgets.components disable applied after hydration', async () => {
+    // Without the client-side filter the browser re-registers the raw generated
+    // entries and the disabled override comes back on hydration (#5864).
+    function Label({ label }: { label: string }) {
+      return <span>{label}</span>
+    }
+
+    function Consumer() {
+      const ResolvedLabel = useRegisteredComponent<{ label: string }>('disabled-test', Label)
+      return <ResolvedLabel label="Fallback active" />
+    }
+
+    await act(async () => {
+      render(
+        <React.Suspense fallback={<span>Loading overrides</span>}>
+          <ComponentOverridesBootstrap profile="login">
+            <Consumer />
+          </ComponentOverridesBootstrap>
+        </React.Suspense>,
+      )
+    })
+
+    expect(getComponentOverrides('disabled-test')).toHaveLength(0)
+    expect(screen.getByText('Fallback active')).toBeInTheDocument()
+    expect(getComponentOverrides('test')).toHaveLength(1)
   })
 
   it('preserves child state and updates mounted consumers when asynchronous overrides activate', async () => {


### PR DESCRIPTION
Closes #5864

## 🎯 Goal
A `widgets.components` override declared in an app's `src/modules.ts` now stays applied after the page hydrates. Before this change it was honoured in the server-rendered HTML and then silently undone in the browser, so a component an app had disabled or replaced flickered back to the module's version with nothing logged to explain it.

## 🔍 Problem
The server and browser register component overrides through different paths, and only the server consulted the override map. `packages/shared/src/lib/bootstrap/factory.ts:96-99` runs the generated entries through `applyComponentOverridesToEntries` before `registerComponentOverrides`; `apps/mercato/src/components/ComponentOverridesBootstrap.tsx` imported the generated file and flattened the **raw** entries, and `ComponentOverrideProvider` registered exactly that — overwriting the filtered server registration on hydration.

## 🔍 Root Cause
`applyComponentOverridesToEntries` (`packages/shared/src/modules/overrides.ts:1370`) had no client-side caller anywhere in the repo. The store it reads *was* already populated in the browser: PR #5829 (issue #5152) added `ensureModuleOverridesApplied()`, which dispatches the `widgets` domain, and that domain's applier fills `componentOverrideStore` alongside the injection store (`overrides.ts:1656`). The `components` half of that dispatch simply had no reader — the same defect class as #5152, one key over.

## What Changed
- `apps/mercato/src/components/ComponentOverridesBootstrap.tsx` — `loadOverrides()` now awaits `ensureModuleOverridesApplied()` (the same fail-soft dispatch `ClientBootstrap`'s override-dependent registry groups await) and runs the generated entries through `applyComponentOverridesToEntries` before flattening them for `ComponentOverrideProvider`. Both imports stay dynamic, so no new module is pulled into the profiles that do not use component overrides, and the existing retryable-promise handling is untouched — a transient chunk-load failure still clears the cached promise. Because the dispatch is fail-soft, a failure there degrades to the previous unfiltered behavior rather than leaving the page with no overrides.
- `packages/create-app/template/src/components/ComponentOverridesBootstrap.tsx` — byte-identical mirror; `yarn template:sync` passes.

The constraint documented for #5829 carries over unchanged: an `enabledModules` entry gated on a non-`NEXT_PUBLIC_` env var must not carry `widgets` overrides, because the browser cannot evaluate the gate. `ClientBootstrap`'s existing development warning already reports that case.

## 🧪 Tests
- New regression case in both `ComponentOverridesBootstrap` suites (app + template): a `modules.ts` entry disabling one of two generated overrides leaves that component unoverridden after the client registration settles, while the sibling override still registers — so the filter is proven targeted, not blanket. Verified it fails on the unfixed tree (`Expected length: 0, Received length: 1`) and passes with the fix.
- Full configured gate run locally, in order: `build:packages` ✅ · `generate` ✅ · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ · `typecheck` ✅ (29/29) · `test` · `build:app` ✅.
- Test results: `@open-mercato/app` 579 passed / 93 suites ✅ · `@open-mercato/shared` 2158 passed ✅ · `@open-mercato/ai-assistant` 1482 passed ✅ · all other packages ✅.
- Two packages fail for environment reasons unrelated to this diff and on an untouched tree: `@open-mercato/cli` (5 failures in `resolve-environment.test.ts` / `resolver.enterprise.test.ts`, which depend on the checkout location) and `create-mercato-app` (81 standalone-harness oracle/sandbox failures that require the `codex`/`claude` CLIs).

## 💥 Breaking Changes
None. No exported signature, route, event, or schema changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791622844&installation_model_id=432243&pr_number=6031&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6031&signature=aeac6f57e9c9504612d2dbd724eb6e75ee04419897cef26da839a5b11ef036a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->