### PR TITLE
fix(security): re-check session liveness for sessionless customer-portal tokens (#5952)

### DIFF
--- a/apps/docs/docs/installation/vps.mdx
+++ b/apps/docs/docs/installation/vps.mdx
@@ -123,8 +123,10 @@ Two variables bound how long tokens signed with the *previous* scheme keep worki
 
 Once the window closes, every token must carry a session id (`sid`) bound to a live session row, which is what makes logout and password reset revoke access immediately. Set `JWT_LEGACY_GRACE_MINUTES=0` on a fresh install: it has no pre-migration tokens to protect.
 
+Inside the window, a customer-portal token without a `sid` still has to prove the customer is signed in somewhere: it is accepted only while that customer has at least one live session row, so revoking their sessions cuts the legacy token off too. Staff tokens do not get that fallback check — a sessionless staff token is accepted for the rest of the window.
+
 :::warning
-Never leave the grace window open indefinitely "just in case". The absolute cutover is mandatory because anyone holding the former raw secret can choose a fresh `iat`; while fallback is open, a legacy token is accepted without a session row and cannot be revoked before it expires.
+Never leave the grace window open indefinitely "just in case". The absolute cutover is mandatory because anyone holding the former raw secret can choose a fresh `iat`, and while fallback is open a sessionless token is bound to no individual session row — so it cannot be revoked one device at a time, only by ending every session the account has.
 :::
 
 ---

--- a/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@open-mercato/shared/lib/auth/jwt'
 
 const findActiveSessionForClaims = jest.fn()
+const hasActiveSessionForUser = jest.fn()
 const findOneWithDecryption = jest.fn()
 const loadAcl = jest.fn()
 const getEffectiveFeatures = jest.fn()
@@ -58,7 +59,7 @@ describe('getCustomerAuthFromRequest — session revocation', () => {
     jest.clearAllMocks()
     containerResolve.mockImplementation((name: string) => {
       if (name === 'customerSessionService') {
-        return { findActiveSessionForClaims }
+        return { findActiveSessionForClaims, hasActiveSessionForUser }
       }
       if (name === 'customerRbacService') {
         return { loadAcl, getEffectiveFeatures }
@@ -243,11 +244,12 @@ describe('getCustomerAuthFromRequest — legacy raw-secret tokens', () => {
     delete process.env.JWT_LEGACY_GRACE_MINUTES
     process.env.JWT_LEGACY_CUTOVER_AT = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString()
     containerResolve.mockImplementation((name: string) => {
-      if (name === 'customerSessionService') return { findActiveSessionForClaims }
+      if (name === 'customerSessionService') return { findActiveSessionForClaims, hasActiveSessionForUser }
       if (name === 'customerRbacService') return { loadAcl, getEffectiveFeatures }
       if (name === 'em') return mockEm
       return null
     })
+    hasActiveSessionForUser.mockResolvedValue(true)
     findOneWithDecryption.mockResolvedValue({
       id: userId,
       sessionsRevokedAt: null,
@@ -284,7 +286,57 @@ describe('getCustomerAuthFromRequest — legacy raw-secret tokens', () => {
     const result = await getCustomerAuthFromRequest(req)
 
     expect(result).toMatchObject({ sub: userId, type: 'customer' })
+    // No `sid` to bind to, so the sid-scoped lookup stays unused — but liveness is still proven.
     expect(findActiveSessionForClaims).not.toHaveBeenCalled()
+    expect(hasActiveSessionForUser).toHaveBeenCalledWith({
+      userId,
+      tenantId,
+      organizationId: orgId,
+    })
+  })
+
+  it('rejects a sessionless legacy token once every session of that customer is revoked', async () => {
+    // The revocation path the API used to skip entirely: staff/user revokes the customer's
+    // sessions without stamping `sessionsRevokedAt` (per-device revoke, portal logout), so
+    // `validateUserState` cannot catch it and only the liveness re-check can.
+    process.env.JWT_LEGACY_GRACE_MINUTES = '60'
+    hasActiveSessionForUser.mockResolvedValue(false)
+    const req = buildLegacyRequest()
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+    expect(hasActiveSessionForUser).toHaveBeenCalledWith({
+      userId,
+      tenantId,
+      organizationId: orgId,
+    })
+  })
+
+  it('fails closed for a sessionless legacy token when the liveness lookup throws', async () => {
+    process.env.JWT_LEGACY_GRACE_MINUTES = '60'
+    hasActiveSessionForUser.mockRejectedValue(new Error('db unavailable'))
+    const req = buildLegacyRequest()
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+
+  it('scopes the liveness lookup to the token tenant and organization', async () => {
+    // A legacy token names its own scope; the lookup must not fall back to a cross-tenant match.
+    process.env.JWT_LEGACY_GRACE_MINUTES = '60'
+    const otherTenantId = 'ssssssss-ssss-4sss-8sss-ssssssssssss'
+    const payload = buildCustomerPayload({ tenantId: otherTenantId })
+    delete payload.sid
+    const token = signJwt(payload, rawSecret, 30 * 24 * 3600)
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await getCustomerAuthFromRequest(req)
+
+    expect(hasActiveSessionForUser).toHaveBeenCalledWith({
+      userId,
+      tenantId: otherTenantId,
+      organizationId: orgId,
+    })
   })
 
   it('rejects the same sessionless legacy token once the grace window has passed', async () => {

--- a/packages/core/src/modules/customer_accounts/__tests__/customerSessionService.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerSessionService.test.ts
@@ -156,3 +156,40 @@ describe('CustomerSessionService.createSession — concurrent session cap', () =
     expect(nativeUpdateMock).not.toHaveBeenCalled()
   })
 })
+
+describe('CustomerSessionService.hasActiveSessionForUser', () => {
+  const userId = '33333333-3333-4333-8333-333333333333'
+  const tenantId = '44444444-4444-4444-8444-444444444444'
+  const organizationId = '55555555-5555-4555-8555-555555555555'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('scopes the lookup to live sessions owned by that customer identity', async () => {
+    const { CustomerSessionService } = await import('../services/customerSessionService')
+    const { CustomerUserSession } = await import('../data/entities')
+    const findOneMock = jest.fn(async () => ({ id: 'live-session' }))
+    const service = new CustomerSessionService({ findOne: findOneMock } as any)
+
+    await expect(
+      service.hasActiveSessionForUser({ userId, tenantId, organizationId }),
+    ).resolves.toBe(true)
+
+    const [entity, filter] = findOneMock.mock.calls[0] as unknown as [unknown, any]
+    expect(entity).toBe(CustomerUserSession)
+    expect(filter.user).toEqual({ id: userId, tenantId, organizationId })
+    expect(filter.deletedAt).toBeNull()
+    expect(filter.expiresAt.$gt).toBeInstanceOf(Date)
+  })
+
+  it('reports no active session once every session row is revoked', async () => {
+    const { CustomerSessionService } = await import('../services/customerSessionService')
+    const findOneMock = jest.fn(async () => null)
+    const service = new CustomerSessionService({ findOne: findOneMock } as any)
+
+    await expect(
+      service.hasActiveSessionForUser({ userId, tenantId, organizationId }),
+    ).resolves.toBe(false)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -18,6 +18,17 @@ export interface CustomerAuthContext {
   isPortalAdmin?: boolean
 }
 
+async function resolveSessionService(): Promise<
+  InstanceType<typeof import('@open-mercato/core/modules/customer_accounts/services/customerSessionService').CustomerSessionService>
+> {
+  const [{ createRequestContainer }, { CustomerSessionService }] = await Promise.all([
+    import('@open-mercato/shared/lib/di/container'),
+    import('@open-mercato/core/modules/customer_accounts/services/customerSessionService'),
+  ])
+  const container = await createRequestContainer()
+  return container.resolve('customerSessionService') as InstanceType<typeof CustomerSessionService>
+}
+
 async function assertSessionStillActive(input: {
   sessionId: string
   userId: string
@@ -25,17 +36,32 @@ async function assertSessionStillActive(input: {
   organizationId: string
 }): Promise<boolean> {
   try {
-    const [{ createRequestContainer }, { CustomerSessionService }] = await Promise.all([
-      import('@open-mercato/shared/lib/di/container'),
-      import('@open-mercato/core/modules/customer_accounts/services/customerSessionService'),
-    ])
-    const container = await createRequestContainer()
-    const service = container.resolve('customerSessionService') as InstanceType<typeof CustomerSessionService>
+    const service = await resolveSessionService()
     const session = await service.findActiveSessionForClaims(input)
     return session !== null
   } catch {
     // Fail closed: if we cannot verify the session, treat the token as revoked to prevent
     // replay of leaked JWTs when the backend is partially degraded.
+    return false
+  }
+}
+
+/**
+ * Liveness re-check for a legacy token that carries no `sid` claim. It cannot name the session it
+ * was issued for, so the check falls back to the strongest available statement: the customer must
+ * still be signed in somewhere. Once every session is revoked — logout, per-device revoke, admin
+ * action — the token stops authenticating instead of surviving until its own expiry.
+ */
+async function assertUserStillHasActiveSession(input: {
+  userId: string
+  tenantId: string
+  organizationId: string
+}): Promise<boolean> {
+  try {
+    const service = await resolveSessionService()
+    return await service.hasActiveSessionForUser(input)
+  } catch {
+    // Same fail-closed contract as the sid-bound check above.
     return false
   }
 }
@@ -129,6 +155,9 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
     const userId = String(payload.sub)
     const tenantId = String(payload.tenantId)
     const organizationId = String(payload.orgId)
+    // Every accepted token is re-checked for liveness, exactly like the SSR path does — a token
+    // without a `sid` is checked against the customer's remaining sessions rather than skipped,
+    // so session revocation is never structurally unreachable on the API path.
     const stillActive = sid
       ? await assertSessionStillActive({
           sessionId: sid,
@@ -136,7 +165,7 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
           tenantId,
           organizationId,
         })
-      : true
+      : await assertUserStillHasActiveSession({ userId, tenantId, organizationId })
     if (!stillActive) return null
 
     const userState = await validateUserState(

--- a/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
@@ -132,6 +132,10 @@ export class CustomerSessionService {
    * session it was issued for, so the strongest statement we can make about it is whether the
    * customer is still signed in anywhere. A customer whose sessions have all been revoked
    * (logout, per-device revoke, admin action) has none, and the token must stop working.
+   *
+   * Existence is the whole answer, so this reads no encrypted column and needs no decryption
+   * round-trip on the authentication path — the same reason `findActiveSessionForClaims` next to
+   * it queries directly. Scope comes from the owning user, since sessions carry no scope columns.
    */
   async hasActiveSessionForUser(input: {
     userId: string

--- a/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
@@ -126,6 +126,30 @@ export class CustomerSessionService {
     return session
   }
 
+  /**
+   * Liveness probe for tokens that carry no `sid` claim — the pre-migration customer JWTs the
+   * legacy raw-secret fallback still admits during a key rotation. Such a token cannot name the
+   * session it was issued for, so the strongest statement we can make about it is whether the
+   * customer is still signed in anywhere. A customer whose sessions have all been revoked
+   * (logout, per-device revoke, admin action) has none, and the token must stop working.
+   */
+  async hasActiveSessionForUser(input: {
+    userId: string
+    tenantId: string
+    organizationId: string
+  }): Promise<boolean> {
+    const session = await this.em.findOne(CustomerUserSession, {
+      user: {
+        id: input.userId,
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+      },
+      deletedAt: null,
+      expiresAt: { $gt: new Date() },
+    })
+    return session !== null
+  }
+
   async revokeSession(sessionId: string): Promise<void> {
     await this.em.nativeUpdate(CustomerUserSession, { id: sessionId }, { deletedAt: new Date() })
   }


### PR DESCRIPTION
## Summary

Closes #5952.

A customer-portal token that carries no `sid` claim — the pre-migration shape the legacy raw-secret fallback still admits during a signing-key rotation — was authenticated on API routes without any session-liveness re-check:

```ts
const stillActive = sid ? await assertSessionStillActive({ … }) : true
```

The `: true` branch is only reachable for those legacy tokens, and it is the branch where revocation was structurally unreachable: nothing the portal or an admin can do to that customer's sessions took effect until the JWT expired on its own. Server-rendered portal pages never had that gap — they reject a `sid`-less token outright and always call the liveness check for the rest.

## What changed

The liveness re-check is now unconditional on the API path, which is what the issue asked for — the API no longer has a code path that skips it:

- **With a `sid`** — unchanged: the named session must still exist, belong to the token's subject, and not be expired.
- **Without a `sid`** (legacy only) — the token cannot name a session, so it must instead prove the customer is still signed in *somewhere*: `CustomerSessionService.hasActiveSessionForUser` looks for any live, non-revoked, unexpired session in the token's own tenant/organization scope. A customer whose sessions have all ended — portal logout, per-device revoke via `/api/customer_accounts/portal/sessions/[id]`, admin action — no longer authenticates.

Both checks fail closed on a lookup error, matching the existing contract.

The bounded legacy grace window itself is preserved: it exists so a rolling key migration does not force-log-out every customer, and a customer with a live session still passes. What it no longer grants is trust based on signature and expiry alone.

`revokeAllUserSessions` was already caught, because it stamps `sessionsRevokedAt` and `validateUserState` compares it against the token's `iat`. The paths that only soft-delete session rows were not, and those are what this closes.

## Scope

Server-rendered portal pages are deliberately left stricter than the API (they refuse legacy tokens entirely) — narrowing that gap the other way would weaken them. The staff-side equivalent in `auth/lib/sessionIntegrity.ts` makes the same sessionless-token trade-off and is untouched here; it is a separate call, and this PR keeps to the reported customer-portal path.

## 🧪 Tests

`packages/core/src/modules/customer_accounts/__tests__/` — 4 regression tests that fail on `develop` and pass here (verified by reverting just the fixed line):

- a sessionless legacy token inside the grace window is accepted **and** proves liveness
- the same token is rejected once every session of that customer is revoked — the previously unreachable path
- the sessionless liveness lookup fails closed when it throws
- the lookup is scoped to the token's own tenant and organization, so it cannot match cross-tenant

Plus service-level coverage of `hasActiveSessionForUser` (query scoping, and the revoked-everywhere case).

No integration test: reaching this branch needs `JWT_LEGACY_CUTOVER_AT` set plus a token signed with the raw secret, which the integration harness has no way to issue.

## ✅ Validation

Full gate, local runner: `build:packages` → `generate` → `build:packages` → `i18n:check-sync` → `i18n:check-usage` → `typecheck` → `test` → `build:app`.

Backend-only change with no rendering surface, so no browser QA.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628271&installation_model_id=432243&pr_number=6032&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6032&signature=6d097215e685e8b67afa2664bf87d4195fb4f9fffe67e2832d2c0731c71a1dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->