### PR TITLE
fix(shared,core): stop dry-run encryption previews from provisioning a tenant DEK (#5950)

### DIFF
--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -161,6 +161,7 @@ production-only encryption map still needs a test.
 - **Rotation** – future addition: new version stored under suffix `tenant_key_<tenantId>_v2` with dual-read, single-write strategy; current design keeps a single active DEK per tenant.
 - **Caching** – DEKs cached with TTL (e.g., 15 minutes) and proactive refresh on expiry; invalidated if KMS returns a new version.
 - **Derived-key fallback** – when running without Vault and with a dedicated fallback secret, the derived KMS hashes the chosen secret to a root key and produces per-tenant DEKs with PBKDF2-SHA512 using the tenant id as salt, encoded base64. The key stays stable for a tenant while the secret is unchanged.
+- **Lazy provisioning is a state change** – `encryptEntityPayload` provisions the tenant's DEK on first use, which writes real key material to Vault. Callers that only preview or check ("would this row be encrypted?") MUST pass `{ createMissingDek: false }` so KMS stays untouched; the payload then comes back unchanged, exactly as when KMS declines a key. `getDek(keyId)` is the read-only probe for "does a key exist yet", and `resolveEncryptionKeyId(entityId, keyScope, tenantId)` derives the id a map's payloads are sealed under (`system:<entityId>` for system-scoped maps). The `--dry-run` modes of `mercato entities rotate-encryption-key` and `mercato entities backfill-system-encryption` use this path, so they report the rows a real run would rewrite without creating a key (#5950).
 
 ## Integration points to implement
 

--- a/packages/core/src/modules/entities/__tests__/cli-backfill-system-encryption.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-backfill-system-encryption.test.ts
@@ -10,6 +10,8 @@ registerEntityIds({
 const execute = jest.fn()
 const isEnabled = jest.fn(() => true)
 const encryptEntityPayload = jest.fn()
+const getDek = jest.fn()
+const defaultGetDek = async (keyId: string) => ({ tenantId: keyId, key: 'system-key', fetchedAt: 0 })
 const systemMaps = [
   {
     entityId: 'onboarding:onboarding_request',
@@ -34,10 +36,12 @@ jest.mock('@open-mercato/shared/modules/registry', () => ({
 jest.mock('@open-mercato/shared/lib/encryption/tenantDataEncryptionService', () => ({
   TenantDataEncryptionService: jest.fn().mockImplementation(() => ({
     isEnabled: () => isEnabled(),
-    getDek: jest.fn(async () => ({ tenantId: 'system:onboarding:onboarding_request', key: 'system-key', fetchedAt: 0 })),
+    getDek: (...args: unknown[]) => getDek(...args),
     encryptEntityPayload: (...args: unknown[]) => encryptEntityPayload(...args),
   })),
   parseDecryptedFieldValue: (decrypted: string) => decrypted,
+  resolveEncryptionKeyId: (entityId: string, keyScope: string | undefined, tenantId: string | null | undefined) =>
+    (keyScope === 'system' ? `system:${entityId}` : tenantId ?? null),
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -89,6 +93,7 @@ describe('entities backfill-system-encryption CLI', () => {
     jest.clearAllMocks()
     process.env.TENANT_DATA_ENCRYPTION = 'yes'
     isEnabled.mockReturnValue(true)
+    getDek.mockImplementation(defaultGetDek)
     encryptEntityPayload.mockImplementation(async (_entityId: string, payload: Record<string, unknown>) => {
       const next: Record<string, unknown> = { ...payload }
       for (const rule of systemMaps[0]!.fields) {
@@ -146,6 +151,50 @@ describe('entities backfill-system-encryption CLI', () => {
 
     expect(execute.mock.calls.filter(([sql]) => String(sql).startsWith('update'))).toHaveLength(0)
     expect(logSpy.mock.calls.flat().join('\n')).toContain('[dry-run] onboarding:onboarding_request: scanned 1, encrypted 1')
+  })
+
+  // Regression for #5950: encrypting is what provisions the system DEK, so a dry run
+  // against an entity that has none must not reach the encrypt call at all.
+  it('provisions no system DEK on --dry-run, and still reports the rows it would encrypt', async () => {
+    getDek.mockResolvedValue(null)
+    queueSelects([{ id: 'row-1', email: 'ada@example.com', email_hash: null, first_name: 'Ada' }])
+
+    await loadCommand().run(['--dry-run'])
+
+    expect(getDek).toHaveBeenCalledWith('system:onboarding:onboarding_request')
+    expect(encryptEntityPayload).not.toHaveBeenCalled()
+    expect(execute.mock.calls.filter(([sql]) => String(sql).startsWith('update'))).toHaveLength(0)
+    expect(warnSpy.mock.calls.flat().join('\n')).toContain('no key material was provisioned')
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('[dry-run] onboarding:onboarding_request: scanned 1, encrypted 1')
+  })
+
+  it('asks the encryption service not to create a missing system DEK while dry-running', async () => {
+    queueSelects([{ id: 'row-1', email: 'ada@example.com', email_hash: null, first_name: 'Ada' }])
+
+    await loadCommand().run(['--dry-run'])
+
+    expect(encryptEntityPayload).toHaveBeenCalledWith(
+      'onboarding:onboarding_request',
+      expect.anything(),
+      null,
+      null,
+      { createMissingDek: false },
+    )
+  })
+
+  it('allows system DEK provisioning on a real run', async () => {
+    queueSelects([{ id: 'row-1', email: 'ada@example.com', email_hash: null, first_name: 'Ada' }])
+
+    await loadCommand().run([])
+
+    expect(getDek).not.toHaveBeenCalled() // no probe needed when provisioning is allowed
+    expect(encryptEntityPayload).toHaveBeenCalledWith(
+      'onboarding:onboarding_request',
+      expect.anything(),
+      null,
+      null,
+      { createMissingDek: true },
+    )
   })
 
   it('pages through rows with a keyset cursor', async () => {

--- a/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
@@ -117,21 +117,7 @@ describe('entities rotate-encryption-key CLI', () => {
     const rotate = cli.find((c: any) => c.command === 'rotate-encryption-key')!
     const encryptedValue = 'iv:cipher:tag:v1'
 
-    find.mockImplementation(async (entity: any) => {
-      if (entity === EncryptionMap) {
-        return [{
-          entityId: 'audit_logs:access_log',
-          tenantId: 'tenant-1',
-          organizationId: 'org-1',
-          fieldsJson: [{ field: 'resource_id' }, { field: 'context_json' }],
-          deletedAt: null,
-        }]
-      }
-      if (entity === Organization) {
-        return [{ id: 'org-1', tenantId: 'tenant-1' }]
-      }
-      return []
-    })
+    singleMapFixture()
 
     execute.mockResolvedValueOnce([
       { id: 'row-1', resource_id: encryptedValue, context_json: encryptedValue },

--- a/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
@@ -23,22 +23,30 @@ jest.mock('@open-mercato/shared/lib/encryption/aes', () => ({
   decryptWithAesGcm: jest.fn(),
 }))
 
+const getDek = jest.fn()
+const encryptEntityPayload = jest.fn()
+
+const defaultGetDek = async (tenantId: string) => ({ tenantId, key: 'new-key', fetchedAt: 0 })
+const defaultEncryptEntityPayload = async (_entityId: string, payload: Record<string, unknown>) => {
+  const next: Record<string, unknown> = { ...payload }
+  Object.entries(payload).forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      next[key] = `enc:${value}`
+    } else {
+      next[key] = `enc:${JSON.stringify(value)}`
+    }
+  })
+  return next
+}
+
 jest.mock('@open-mercato/shared/lib/encryption/tenantDataEncryptionService', () => ({
   TenantDataEncryptionService: jest.fn().mockImplementation(() => ({
     isEnabled: () => true,
-    getDek: jest.fn(async (tenantId: string) => ({ tenantId, key: 'new-key', fetchedAt: 0 })),
-    encryptEntityPayload: jest.fn(async (_entityId: string, payload: Record<string, unknown>) => {
-      const next: Record<string, unknown> = { ...payload }
-      Object.entries(payload).forEach(([key, value]) => {
-        if (typeof value === 'string') {
-          next[key] = `enc:${value}`
-        } else {
-          next[key] = `enc:${JSON.stringify(value)}`
-        }
-      })
-      return next
-    }),
+    getDek: (...args: unknown[]) => getDek(...args),
+    encryptEntityPayload: (...args: unknown[]) => encryptEntityPayload(...args),
   })),
+  resolveEncryptionKeyId: (entityId: string, keyScope: string | undefined, tenantId: string | null | undefined) =>
+    (keyScope === 'system' ? `system:${entityId}` : tenantId ?? null),
   parseDecryptedFieldValue: (decrypted: string) => {
     if (decrypted.length === 0) return decrypted
     const first = decrypted[0]
@@ -83,9 +91,27 @@ describe('entities rotate-encryption-key CLI', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    getDek.mockImplementation(defaultGetDek)
+    encryptEntityPayload.mockImplementation(defaultEncryptEntityPayload)
     process.env.TENANT_DATA_ENCRYPTION = 'yes'
     cli = require('@open-mercato/core/modules/entities/cli').default
   })
+
+  const singleMapFixture = () => {
+    find.mockImplementation(async (entity: any) => {
+      if (entity === EncryptionMap) {
+        return [{
+          entityId: 'audit_logs:access_log',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          fieldsJson: [{ field: 'resource_id' }, { field: 'context_json' }],
+          deletedAt: null,
+        }]
+      }
+      if (entity === Organization) return [{ id: 'org-1', tenantId: 'tenant-1' }]
+      return []
+    })
+  }
 
   it('rotates mapped fields with old key and updates rows', async () => {
     const rotate = cli.find((c: any) => c.command === 'rotate-encryption-key')!
@@ -125,5 +151,73 @@ describe('entities rotate-encryption-key CLI', () => {
       '"enc:{\\"note\\":\\"hello\\"}"',
       'row-1',
     ]))
+  })
+
+  // Regression for #5950: encryptEntityPayload provisions a tenant DEK in KMS/Vault
+  // the first time it runs for a tenant, so a dry run against a tenant that has none
+  // used to create real key material as a side effect.
+  it('provisions no DEK on --dry-run when the tenant has none, and still reports the pending rows', async () => {
+    const rotate = cli.find((c: any) => c.command === 'rotate-encryption-key')!
+    singleMapFixture()
+    getDek.mockResolvedValue(null)
+    execute.mockResolvedValueOnce([
+      { id: 'row-1', resource_id: 'plain-value', context_json: null },
+    ])
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await rotate.run(['--tenant', 'tenant-1', '--org', 'org-1', '--dry-run'])
+
+    expect(encryptEntityPayload).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledTimes(1) // the select only — no update was issued
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no key material was provisioned'))
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[dry-run] Encrypted 1 record(s)'))
+
+    logSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
+  it('asks the encryption service not to create a missing DEK while dry-running', async () => {
+    const rotate = cli.find((c: any) => c.command === 'rotate-encryption-key')!
+    singleMapFixture()
+    execute.mockResolvedValueOnce([
+      { id: 'row-1', resource_id: 'plain-value', context_json: null },
+    ])
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await rotate.run(['--tenant', 'tenant-1', '--org', 'org-1', '--dry-run'])
+
+    expect(encryptEntityPayload).toHaveBeenCalledWith(
+      'audit_logs:access_log',
+      expect.anything(),
+      'tenant-1',
+      'org-1',
+      { createMissingDek: false },
+    )
+    expect(execute).toHaveBeenCalledTimes(1) // still no update on a dry run
+
+    logSpy.mockRestore()
+  })
+
+  it('allows DEK provisioning on a real run', async () => {
+    const rotate = cli.find((c: any) => c.command === 'rotate-encryption-key')!
+    singleMapFixture()
+    execute.mockResolvedValueOnce([
+      { id: 'row-1', resource_id: 'plain-value', context_json: null },
+    ])
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await rotate.run(['--tenant', 'tenant-1', '--org', 'org-1'])
+
+    expect(encryptEntityPayload).toHaveBeenCalledWith(
+      'audit_logs:access_log',
+      expect.anything(),
+      'tenant-1',
+      'org-1',
+      { createMissingDek: true },
+    )
+    expect(execute).toHaveBeenCalledTimes(2) // select + update
+
+    logSpy.mockRestore()
   })
 })

--- a/packages/core/src/modules/entities/__tests__/cli-system-scope-guards.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-system-scope-guards.test.ts
@@ -44,6 +44,8 @@ jest.mock('@open-mercato/shared/lib/encryption/tenantDataEncryptionService', () 
     encryptEntityPayload: jest.fn(async (_entityId: string, payload: Record<string, unknown>) => payload),
   })),
   parseDecryptedFieldValue: (decrypted: string) => decrypted,
+  resolveEncryptionKeyId: (entityId: string, keyScope: string | undefined, tenantId: string | null | undefined) =>
+    (keyScope === 'system' ? `system:${entityId}` : tenantId ?? null),
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({

--- a/packages/core/src/modules/entities/cli.ts
+++ b/packages/core/src/modules/entities/cli.ts
@@ -554,6 +554,10 @@ const rotateEncryptionKey: ModuleCli = {
     // persists a tenant DEK in KMS/Vault the first time it runs for a tenant, so a
     // read-only preview would silently mutate KMS state (#5950). Probe read-only
     // once per tenant instead, and report what a real run would rewrite.
+    //
+    // The tenant id IS the key id here: this command skips every system-scoped
+    // entity above, and its service is built without `defaultEncryptionMaps`, so
+    // no map it sees can resolve to a `system:<entityId>` key.
     const dekAvailability = new Map<string, boolean>()
     const hasExistingDek = async (tenantId: string): Promise<boolean> => {
       const cached = dekAvailability.get(tenantId)

--- a/packages/core/src/modules/entities/cli.ts
+++ b/packages/core/src/modules/entities/cli.ts
@@ -22,6 +22,7 @@ import {
 import {
   TenantDataEncryptionService,
   parseDecryptedFieldValue,
+  resolveEncryptionKeyId,
 } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { resolveEntityIdFromMetadata } from '@open-mercato/shared/lib/encryption/entityIds'
 import { listEntityMetadata } from '@open-mercato/shared/lib/db/entityMetadata'
@@ -549,6 +550,23 @@ const rotateEncryptionKey: ModuleCli = {
     }
 
     const oldDekCache = new Map<string, TenantDek | null>()
+    // A dry run must not provision key material. `encryptEntityPayload` creates and
+    // persists a tenant DEK in KMS/Vault the first time it runs for a tenant, so a
+    // read-only preview would silently mutate KMS state (#5950). Probe read-only
+    // once per tenant instead, and report what a real run would rewrite.
+    const dekAvailability = new Map<string, boolean>()
+    const hasExistingDek = async (tenantId: string): Promise<boolean> => {
+      const cached = dekAvailability.get(tenantId)
+      if (cached !== undefined) return cached
+      const available = Boolean(await encryptionService.getDek(tenantId))
+      dekAvailability.set(tenantId, available)
+      if (!available) {
+        console.warn(
+          `[dry-run] Tenant ${tenantId} has no data-encryption key yet. Reporting the rows a real run would encrypt; no key material was provisioned.`,
+        )
+      }
+      return available
+    }
     const processScope = async (
       entityId: string,
       meta: any,
@@ -576,6 +594,7 @@ const rotateEncryptionKey: ModuleCli = {
       const rows = await conn.execute(selectSql, [scope.tenantId, scope.organizationId])
       const list = Array.isArray(rows) ? rows : []
       if (!list.length) return 0
+      const dekAvailable = dryRun ? await hasExistingDek(scope.tenantId) : true
       let updated = 0
       for (const row of list) {
         const payload: Record<string, unknown> = {}
@@ -611,11 +630,26 @@ const rotateEncryptionKey: ModuleCli = {
             payload[rule.field] = parseDecryptedFieldValue(decrypted)
           }
         }
+        if (!dekAvailable) {
+          // Nothing was encrypted because no key exists and this run refuses to
+          // create one. Count the rows a real run would rewrite by applying the
+          // same plaintext/ciphertext filters the update path uses below.
+          const wouldChange = fields.some((rule) => {
+            const col = resolveProperty(meta, rule.field)?.columnName
+            if (!col) return false
+            const value = row[col]
+            if (value === null || value === undefined) return false
+            return rotate ? isEncryptedPayload(value) : !isEncryptedPayload(value)
+          })
+          if (wouldChange) updated += 1
+          continue
+        }
         const encrypted = await encryptionService.encryptEntityPayload(
           entityId,
           payload,
           scope.tenantId,
           scope.organizationId,
+          { createMissingDek: !dryRun },
         )
         const updates: Record<string, unknown> = {}
         for (const rule of fields) {
@@ -1129,6 +1163,17 @@ const backfillSystemEncryption: ModuleCli = {
       const columnList = Array.from(columns)
       const selectList = columnList.map((column) => `"${column}"`).join(', ')
 
+      // Same dry-run guarantee as rotate-encryption-key: previewing must not make
+      // the KMS provision this entity's system DEK as a side effect (#5950).
+      const systemDekAvailable = dryRun
+        ? Boolean(await encryptionService.getDek(resolveEncryptionKeyId(entityId, 'system', null)))
+        : true
+      if (!systemDekAvailable) {
+        console.warn(
+          `[dry-run] ${entityId} has no system data-encryption key yet. Reporting the rows a real run would encrypt; no key material was provisioned.`,
+        )
+      }
+
       let cursor: unknown = null
       let entityRowsScanned = 0
       let entityRowsUpdated = 0
@@ -1160,8 +1205,19 @@ const backfillSystemEncryption: ModuleCli = {
             }
           }
           if (!hasPlaintext) continue
+          if (!systemDekAvailable) {
+            // `hasPlaintext` already means a real run would rewrite this row.
+            entityRowsUpdated += 1
+            continue
+          }
 
-          const encrypted = await encryptionService.encryptEntityPayload(entityId, payload, null, null)
+          const encrypted = await encryptionService.encryptEntityPayload(
+            entityId,
+            payload,
+            null,
+            null,
+            { createMissingDek: !dryRun },
+          )
           const updates: Record<string, unknown> = {}
           for (const rule of map.fields) {
             const resolved = resolveProperty(meta, rule.field)

--- a/packages/shared/src/lib/encryption/__tests__/dek-lifecycle.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/dek-lifecycle.test.ts
@@ -174,6 +174,42 @@ describe('TenantDataEncryptionService DEK lifecycle (issue #2746)', () => {
     expect((kms.getTenantDek as jest.Mock)).toHaveBeenCalledTimes(2) // expired → re-fetch
   })
 
+  it('provisions no DEK when the caller opts out, so a preview leaves KMS untouched', async () => {
+    const { kms, created } = makeCreatingKms()
+    const service = new TenantDataEncryptionService({} as never, { kms })
+    jest.spyOn(service, 'isEnabled').mockReturnValue(true)
+    ;(service as unknown as { getMap: () => Promise<{ entityId: string; fields: { field: string }[] }> }).getMap =
+      jest.fn(async () => ({ entityId, fields: [{ field: 'secret' }] }))
+    const tenantId = uniqueTenant('no-create')
+
+    const row = await service.encryptEntityPayload(
+      entityId,
+      { secret: 'value' },
+      tenantId,
+      null,
+      { createMissingDek: false },
+    )
+
+    expect((kms.createTenantDek as jest.Mock)).not.toHaveBeenCalled()
+    expect(created).toHaveLength(0)
+    expect(row.secret).toBe('value') // returned unchanged, exactly as when the KMS declines a key
+    expect(await service.getDek(tenantId)).toBeNull()
+  })
+
+  it('still provisions on the default path so existing write callers are unaffected', async () => {
+    const { kms, created } = makeCreatingKms()
+    const service = new TenantDataEncryptionService({} as never, { kms })
+    jest.spyOn(service, 'isEnabled').mockReturnValue(true)
+    ;(service as unknown as { getMap: () => Promise<{ entityId: string; fields: { field: string }[] }> }).getMap =
+      jest.fn(async () => ({ entityId, fields: [{ field: 'secret' }] }))
+    const tenantId = uniqueTenant('default-create')
+
+    const row = await service.encryptEntityPayload(entityId, { secret: 'value' }, tenantId)
+
+    expect((kms.createTenantDek as jest.Mock)).toHaveBeenCalledTimes(1)
+    expect(decryptWithAesGcm(String(row.secret), created[0])).toBe('value')
+  })
+
   it('invalidateDek clears both the service cache and the KMS cache', async () => {
     const { kms } = makeFetchingKms()
     const kmsInvalidate = jest.fn()

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -134,6 +134,21 @@ function readEncryptedFieldsJson(row: Record<string, unknown>): EncryptedFieldRu
   return []
 }
 
+/**
+ * The KMS key id an encryption map's payloads are sealed under: a system-scoped map
+ * uses a per-entity key that exists before any tenant does, everything else uses the
+ * tenant's own key. Exported so callers that need to probe key availability without
+ * encrypting (the encryption CLIs) derive the same id instead of re-spelling the
+ * `system:` convention (#5950).
+ */
+export function resolveEncryptionKeyId(
+  entityId: string,
+  keyScope: EncryptionKeyScope | undefined,
+  tenantId: string | null | undefined
+): string | null {
+  return keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+}
+
 function getSqlConnection(em: EntityManager): SqlConnection | null {
   const source = em as { getConnection?: () => unknown }
   const conn = source.getConnection?.()
@@ -198,9 +213,23 @@ export class TenantDataEncryptionService {
     return dek
   }
 
-  private async resolveDekForEncrypt(tenantId: string | null): Promise<TenantDek | null> {
+  /**
+   * Resolves the DEK an encrypt call should seal under, provisioning one when the
+   * tenant has none yet.
+   *
+   * Provisioning writes real key material to the KMS/Vault backend, so it is a
+   * state change — not a cache fill. Callers whose intent is only to preview or
+   * check ("would this row be encrypted?") pass `createIfMissing: false` to get a
+   * `null` instead, leaving KMS untouched (issue #5950). The default stays `true`
+   * so every existing write path keeps provisioning on first use.
+   */
+  private async resolveDekForEncrypt(
+    tenantId: string | null,
+    options?: { createIfMissing?: boolean }
+  ): Promise<TenantDek | null> {
     const existing = await this.getDek(tenantId)
     if (existing || !tenantId) return existing ?? null
+    if (options?.createIfMissing === false) return null
     if (typeof this.kms.createTenantDek !== 'function') return existing ?? null
     // Dedupe concurrent first-time creation within this process so two callers
     // can't each generate a distinct DEK and overwrite one another (#2746).
@@ -455,11 +484,22 @@ export class TenantDataEncryptionService {
     return clone
   }
 
+  /**
+   * Encrypts the fields an entity's encryption map covers.
+   *
+   * `options.createMissingDek` (default `true`) controls whether a tenant without
+   * a DEK gets one provisioned as a side effect. Preview/check callers — most
+   * notably `mercato entities rotate-encryption-key --dry-run` — pass `false` so a
+   * read-only invocation cannot write key material to KMS (issue #5950). With
+   * `false` and no existing DEK the payload is returned unchanged, exactly as it
+   * is when the KMS declines to issue a key.
+   */
   async encryptEntityPayload(
     entityId: string,
     payload: Record<string, unknown>,
     tenantId: string | null | undefined,
-    organizationId?: string | null
+    organizationId?: string | null,
+    options?: { createMissingDek?: boolean }
   ): Promise<Record<string, unknown>> {
     if (!this.isEnabled()) {
       debug('⚪️ encrypt.skip.disabled', { entityId, tenantId })
@@ -470,8 +510,8 @@ export class TenantDataEncryptionService {
       debug('⚪️ encrypt.skip.no-map', { entityId, tenantId })
       return payload
     }
-    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
-    const dek = await this.resolveDekForEncrypt(keyId)
+    const keyId = resolveEncryptionKeyId(entityId, map.keyScope, tenantId)
+    const dek = await this.resolveDekForEncrypt(keyId, { createIfMissing: options?.createMissingDek !== false })
     if (!dek) {
       debug('⚠️ encrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })
       return payload
@@ -495,7 +535,7 @@ export class TenantDataEncryptionService {
       debug('⚪️ decrypt.skip.no-map', { entityId, tenantId })
       return payload
     }
-    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+    const keyId = resolveEncryptionKeyId(entityId, map.keyScope, tenantId)
     const dek = await this.getDek(keyId)
     if (!dek) {
       debug('⚠️ decrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })


### PR DESCRIPTION
Closes #5950

## 🎯 Goal
`mercato entities rotate-encryption-key --dry-run` no longer creates key material. Previewing a rotation against a tenant that has never been encrypted used to provision and persist a real DEK in Vault, so "dry run" quietly changed KMS state — the one thing a dry run is supposed to guarantee it will not do.

## 🔍 Problem
`resolveDekForEncrypt` is the only way `encryptEntityPayload` obtains a tenant DEK, and it had no read-only mode: when the tenant had no key it called `kms.createTenantDek(tenantId)` and persisted the result. Any caller whose intent was to check or preview — not to provision — therefore wrote key material as a side effect. The `rotate-encryption-key` command made that concrete: it called `encryptEntityPayload` for **every** scanned row unconditionally and gated only the subsequent `UPDATE` on `!dryRun`. `backfill-system-encryption` had the identical shape under the `system:<entityId>` key.

## 🔍 Root Cause
`packages/shared/src/lib/encryption/tenantDataEncryptionService.ts` — lazy DEK provisioning was unconditional and invisible to callers. `HashicorpVaultKmsService.createTenantDek` writes to Vault, so this was a genuine state change rather than a cache fill. Worth noting that `packages/core/src/modules/auth/cli.ts` already returns early on `if (dryRun)` before encrypting: "a dry run performs no encryption" was the established convention, and the entities CLI had drifted from it.

## What Changed
- **`packages/shared/src/lib/encryption/tenantDataEncryptionService.ts`** — `encryptEntityPayload` takes an optional trailing `{ createMissingDek }` (default `true`), threaded into `resolveDekForEncrypt` as `createIfMissing`. With `false` and no existing key, the payload comes back unchanged, exactly as it already does when the KMS declines to issue one. Every existing write path — the ORM subscriber, the query indexer, audit logs, SSO, api_keys, integrations — keeps today's behavior byte for byte. Also exports `resolveEncryptionKeyId(entityId, keyScope, tenantId)`, replacing three inline copies of the `system:<entityId>` convention so a caller probing key availability cannot drift from the key the service actually seals under.
- **`packages/core/src/modules/entities/cli.ts`** — `rotate-encryption-key` and `backfill-system-encryption` probe read-only with the already-public `getDek` once per tenant (resp. per entity) while dry-running, and pass `{ createMissingDek: !dryRun }` to the encrypt call. When no key exists they warn that none was provisioned and still count the rows a real run would rewrite, applying the same plaintext/ciphertext filters the update path uses. Without that counting branch a dry run against a fresh tenant would report "all mapped entity fields already encrypted" — the opposite of the truth, and a worse bug than the one being fixed.
- **`apps/docs/docs/architecture/data-encryption.mdx`** — documents that lazy provisioning is a state change and names the read-only path for preview callers.

## 🧪 Tests
- 7 new/changed cases, each verified to fail on the unfixed code and pass with it (checked by reverting only the two production files: 6 CLI failures + 1 shared failure). They lock in that a dry run provisions no DEK yet still reports the pending row count, that dry-run passes `createMissingDek: false` while a real run passes `true`, and that the shared service both honors the opt-out and still provisions on the default path.
- Full validation gate run locally in order — `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`. `@open-mercato/core` 12,116 passed; `@open-mercato/shared` 2,160 passed; `@open-mercato/ui` 1,970 passed; `build:app` green.
- Two failures are pre-existing and unrelated, both reproducing independently of this branch and touching no encryption code: `@open-mercato/cli`'s `resolver.enterprise` / `resolve-environment` suites (5 checkout-location-dependent failures), and `@open-mercato/shared`'s `dynamicLoader.generatedCacheRecovery` suite, which crashes a child process only under turbo's 1 GB heap cap and passes standalone.

## 💥 Breaking Changes
None. Both additions are additive-only — a new optional trailing parameter on a STABLE signature and a new named export — so no deprecation bridge is required per `BACKWARD_COMPATIBILITY.md`. No schema, API, event, or UI surface changes, and no migration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628689&installation_model_id=432243&pr_number=6033&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6033&signature=8e00e9d06ed868432c4915a895eccbbd0c69b1f547ebc1619f3ed148d1693786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->