### PR TITLE
fix(auth): preserve resolved tenant context through password reset and login redirect (#5901)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/reset-confirm.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/reset-confirm.test.ts
@@ -157,7 +157,6 @@ describe('POST /api/auth/reset/confirm — tenant continuity in the success redi
     const res = await POST(makeConfirmRequest())
     const { redirect } = await res.json() as { redirect: string }
 
-    expect(redirect).toBe('/login?tenant=a%26b%3Dc')
     const parsed = new URL(redirect, 'https://app.example.com')
     expect(parsed.pathname).toBe('/login')
     expect([...parsed.searchParams.keys()]).toEqual(['tenant'])

--- a/packages/core/src/modules/auth/api/__tests__/reset-confirm.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/reset-confirm.test.ts
@@ -49,10 +49,11 @@ jest.mock('@open-mercato/core/modules/auth/events', () => ({
 
 import { POST } from '@open-mercato/core/modules/auth/api/reset/confirm'
 
-function makeConfirmRequest(): Request {
+function makeConfirmRequest(extraFields: Record<string, string> = {}): Request {
   const body = new URLSearchParams()
   body.set('token', 'reset-token-1')
   body.set('password', 'Str0ng-Passw0rd!')
+  for (const [key, value] of Object.entries(extraFields)) body.set(key, value)
   return new Request('https://app.example.com/api/auth/reset/confirm', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -109,6 +110,75 @@ describe('POST /api/auth/reset/confirm — auth.password.reset.completed event',
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body).toEqual({ ok: true, redirect: '/login' })
+    expect(body).toEqual({ ok: true, redirect: '/login?tenant=tenant-1' })
+  })
+})
+
+describe('POST /api/auth/reset/confirm — tenant continuity in the success redirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null })
+    mockConfirmPasswordReset.mockResolvedValue({
+      id: 'user-1',
+      email: 'staff@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+
+  test('sends a tenant-bound user back to the tenant login entry', async () => {
+    const res = await POST(makeConfirmRequest())
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true, redirect: '/login?tenant=tenant-1' })
+  })
+
+  test('leaves a tenantless user on the generic login page', async () => {
+    mockConfirmPasswordReset.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'staff@example.com',
+      tenantId: null,
+      organizationId: null,
+    })
+
+    const res = await POST(makeConfirmRequest())
+
+    expect(await res.json()).toEqual({ ok: true, redirect: '/login' })
+  })
+
+  test('encodes a tenant id that would otherwise alter the redirect', async () => {
+    mockConfirmPasswordReset.mockResolvedValueOnce({
+      id: 'user-1',
+      email: 'staff@example.com',
+      tenantId: 'a&b=c',
+      organizationId: 'org-1',
+    })
+
+    const res = await POST(makeConfirmRequest())
+    const { redirect } = await res.json() as { redirect: string }
+
+    expect(redirect).toBe('/login?tenant=a%26b%3Dc')
+    const parsed = new URL(redirect, 'https://app.example.com')
+    expect(parsed.pathname).toBe('/login')
+    expect([...parsed.searchParams.keys()]).toEqual(['tenant'])
+    expect(parsed.searchParams.get('tenant')).toBe('a&b=c')
+  })
+
+  test('ignores a tenant supplied by the caller and uses the resolved user instead', async () => {
+    const res = await POST(makeConfirmRequest({ tenant: 'forged-tenant' }))
+    const body = await res.json() as { redirect: string }
+
+    expect(body.redirect).toBe('/login?tenant=tenant-1')
+    expect(body.redirect).not.toContain('forged-tenant')
+  })
+
+  test('returns no redirect at all for an invalid or expired token', async () => {
+    mockConfirmPasswordReset.mockResolvedValueOnce(null)
+
+    const res = await POST(makeConfirmRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body).toEqual({ ok: false, error: 'Invalid or expired token' })
   })
 })

--- a/packages/core/src/modules/auth/api/__tests__/reset.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/reset.test.ts
@@ -241,4 +241,74 @@ describe('POST /api/auth/reset', () => {
     expect(body).toEqual({ ok: true })
     expect(mockRequestPasswordReset).toHaveBeenCalledWith('staff@example.com')
   })
+
+  describe('tenant continuity in the reset link', () => {
+    function resolveTenantBoundUser(tenantId: unknown) {
+      mockRequestPasswordReset.mockResolvedValueOnce({
+        user: { id: 'user-1', email: 'staff@example.com', tenantId, organizationId: 'org-1' },
+        token: 'reset-token-1',
+      })
+    }
+
+    test('carries the resolved tenant so the link lands on the tenant login entry', async () => {
+      resolveTenantBoundUser('tenant-1')
+
+      await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+
+      expect(mockResetPasswordEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resetUrl: 'https://app.example.com/reset/reset-token-1?tenant=tenant-1',
+        }),
+      )
+    })
+
+    test('leaves a tenantless user on the generic reset link', async () => {
+      await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+
+      expect(mockResetPasswordEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resetUrl: 'https://app.example.com/reset/reset-token-1',
+        }),
+      )
+    })
+
+    test('escapes a tenant id that would otherwise alter the link', async () => {
+      resolveTenantBoundUser('a&b=c')
+
+      await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+
+      const { resetUrl } = mockResetPasswordEmail.mock.calls[0]?.[0] as { resetUrl: string }
+      const parsed = new URL(resetUrl)
+      expect(parsed.pathname).toBe('/reset/reset-token-1')
+      expect([...parsed.searchParams.keys()]).toEqual(['tenant'])
+      expect(parsed.searchParams.get('tenant')).toBe('a&b=c')
+    })
+
+    test('ignores a tenant supplied by the caller and uses the resolved user instead', async () => {
+      resolveTenantBoundUser('tenant-1')
+      const body = new URLSearchParams()
+      body.set('email', 'staff@example.com')
+      body.set('tenant', 'forged-tenant')
+
+      await POST(new Request('https://app.example.com/api/auth/reset?tenant=forged-tenant', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      }))
+
+      const { resetUrl } = mockResetPasswordEmail.mock.calls[0]?.[0] as { resetUrl: string }
+      expect(new URL(resetUrl).searchParams.get('tenant')).toBe('tenant-1')
+      expect(resetUrl).not.toContain('forged-tenant')
+    })
+
+    test('keeps the generic response for an unknown account without sending mail', async () => {
+      mockRequestPasswordReset.mockResolvedValueOnce(null)
+
+      const res = await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: true })
+      expect(mockSendEmail).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -14,6 +14,7 @@ import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { mapSecurityEmailUrlError, toSecurityEmailUrl } from '@open-mercato/shared/lib/url'
+import { withTenantHintUrl } from '@open-mercato/core/modules/auth/lib/tenantHint'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { emitAuthEvent } from '@open-mercato/core/modules/auth/events'
 
@@ -57,7 +58,7 @@ export async function POST(req: Request) {
   const resReq = await auth.requestPasswordReset(parsed.data.email)
   if (!resReq) return NextResponse.json({ ok: true })
   const { user, token } = resReq
-  const resetUrl = resetUrlTemplate.replace('__token__', token)
+  const resetUrl = withTenantHintUrl(resetUrlTemplate.replace('__token__', token), user.tenantId)
   void emitAuthEvent('auth.password.reset.requested', {
     id: String(user.id),
     tenantId: user.tenantId ? String(user.tenantId) : null,

--- a/packages/core/src/modules/auth/api/reset/confirm.ts
+++ b/packages/core/src/modules/auth/api/reset/confirm.ts
@@ -12,6 +12,7 @@ import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { emitAuthEvent } from '@open-mercato/core/modules/auth/events'
+import { withTenantHintPath } from '@open-mercato/core/modules/auth/lib/tenantHint'
 
 const logger = createLogger('auth').child({ component: 'reset-confirm' })
 
@@ -60,7 +61,7 @@ export async function POST(req: Request) {
   } catch (err) {
     logger.error('Failed to create notification', { err })
   }
-  return NextResponse.json({ ok: true, redirect: '/login' })
+  return NextResponse.json({ ok: true, redirect: withTenantHintPath('/login', user.tenantId) })
 }
 
 export const metadata = { requireAuth: false }
@@ -81,7 +82,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     POST: {
       summary: 'Complete password reset',
-      description: 'Validates the reset token and updates the user password.',
+      description: 'Validates the reset token and updates the user password. The returned `redirect` carries the resolved user\'s tenant as a navigation hint (`/login?tenant=...`) so a tenant-bound user lands on the tenant login entry; tenantless users get `/login`.',
       requestBody: {
         contentType: 'application/x-www-form-urlencoded',
         schema: confirmPasswordResetSchema,

--- a/packages/core/src/modules/auth/lib/__tests__/tenantHint.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/tenantHint.test.ts
@@ -1,0 +1,53 @@
+import { withTenantHintPath, withTenantHintUrl } from '@open-mercato/core/modules/auth/lib/tenantHint'
+
+describe('withTenantHintUrl', () => {
+  test('appends the tenant hint to a reset link', () => {
+    expect(withTenantHintUrl('https://app.example.com/reset/reset-token-1', 'tenant-1'))
+      .toBe('https://app.example.com/reset/reset-token-1?tenant=tenant-1')
+  })
+
+  test('leaves the link untouched for a tenantless user', () => {
+    expect(withTenantHintUrl('https://app.example.com/reset/reset-token-1', null))
+      .toBe('https://app.example.com/reset/reset-token-1')
+    expect(withTenantHintUrl('https://app.example.com/reset/reset-token-1', undefined))
+      .toBe('https://app.example.com/reset/reset-token-1')
+    expect(withTenantHintUrl('https://app.example.com/reset/reset-token-1', '   '))
+      .toBe('https://app.example.com/reset/reset-token-1')
+  })
+
+  test('escapes a tenant id that would otherwise alter the query string', () => {
+    const url = withTenantHintUrl('https://app.example.com/reset/reset-token-1', 'a&b=c d')
+
+    expect(new URL(url).searchParams.get('tenant')).toBe('a&b=c d')
+    expect(url).toBe('https://app.example.com/reset/reset-token-1?tenant=a%26b%3Dc+d')
+  })
+
+  test('replaces rather than duplicates an existing tenant parameter', () => {
+    expect(withTenantHintUrl('https://app.example.com/reset/tok?tenant=forged', 'tenant-1'))
+      .toBe('https://app.example.com/reset/tok?tenant=tenant-1')
+  })
+
+  test('returns the original value when the url cannot be parsed', () => {
+    expect(withTenantHintUrl('not-a-url', 'tenant-1')).toBe('not-a-url')
+  })
+})
+
+describe('withTenantHintPath', () => {
+  test('appends the tenant hint to the login redirect', () => {
+    expect(withTenantHintPath('/login', 'tenant-1')).toBe('/login?tenant=tenant-1')
+  })
+
+  test('leaves the redirect untouched for a tenantless user', () => {
+    expect(withTenantHintPath('/login', null)).toBe('/login')
+    expect(withTenantHintPath('/login', '')).toBe('/login')
+  })
+
+  test('encodes a tenant id containing url-significant characters', () => {
+    expect(withTenantHintPath('/login', 'a&b=c d')).toBe('/login?tenant=a%26b%3Dc%20d')
+  })
+
+  test('joins onto a path that already carries a query string', () => {
+    expect(withTenantHintPath('/login?next=%2Fbackend', 'tenant-1'))
+      .toBe('/login?next=%2Fbackend&tenant=tenant-1')
+  })
+})

--- a/packages/core/src/modules/auth/lib/__tests__/tenantHint.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/tenantHint.test.ts
@@ -43,11 +43,26 @@ describe('withTenantHintPath', () => {
   })
 
   test('encodes a tenant id containing url-significant characters', () => {
-    expect(withTenantHintPath('/login', 'a&b=c d')).toBe('/login?tenant=a%26b%3Dc%20d')
+    const redirect = withTenantHintPath('/login', 'a&b=c d')
+    const parsed = new URL(redirect, 'https://app.example.com')
+
+    expect([...parsed.searchParams.keys()]).toEqual(['tenant'])
+    expect(parsed.searchParams.get('tenant')).toBe('a&b=c d')
   })
 
   test('joins onto a path that already carries a query string', () => {
     expect(withTenantHintPath('/login?next=%2Fbackend', 'tenant-1'))
       .toBe('/login?next=%2Fbackend&tenant=tenant-1')
+  })
+
+  test('replaces rather than duplicates an existing tenant parameter', () => {
+    expect(withTenantHintPath('/login?tenant=forged', 'tenant-1')).toBe('/login?tenant=tenant-1')
+  })
+
+  test('encodes both helpers identically for the same tenant id', () => {
+    const fromUrl = new URL(withTenantHintUrl('https://app.example.com/reset/tok', 'a&b=c d')).search
+    const fromPath = withTenantHintPath('/login', 'a&b=c d').slice('/login'.length)
+
+    expect(fromPath).toBe(fromUrl)
   })
 })

--- a/packages/core/src/modules/auth/lib/tenantHint.ts
+++ b/packages/core/src/modules/auth/lib/tenantHint.ts
@@ -1,0 +1,45 @@
+/**
+ * Tenant continuity hints for unauthenticated auth navigation.
+ *
+ * The `tenant` query parameter is a navigation hint only — it tells the login
+ * entry which tenant the user was already resolved to so it can show tenant
+ * branding instead of the generic form. It is never authorization, and it must
+ * only ever be derived from a server-resolved user, never from request input.
+ */
+
+const TENANT_HINT_PARAM = 'tenant'
+
+function normalizeTenantHint(tenantId: unknown): string | null {
+  if (tenantId == null) return null
+  const value = String(tenantId).trim()
+  return value.length > 0 ? value : null
+}
+
+/**
+ * Adds the tenant hint to an absolute URL (password reset and invitation email
+ * links). Returns the URL unchanged for tenantless users or an unparsable URL,
+ * so a hint can never cost a user their working link.
+ */
+export function withTenantHintUrl(url: string, tenantId: unknown): string {
+  const tenant = normalizeTenantHint(tenantId)
+  if (!tenant) return url
+  try {
+    const parsed = new URL(url)
+    parsed.searchParams.set(TENANT_HINT_PARAM, tenant)
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Adds the tenant hint to an app-relative path (the redirect handed back to the
+ * browser after a successful reset). Returns the path unchanged for tenantless
+ * users.
+ */
+export function withTenantHintPath(path: string, tenantId: unknown): string {
+  const tenant = normalizeTenantHint(tenantId)
+  if (!tenant) return path
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}${TENANT_HINT_PARAM}=${encodeURIComponent(tenant)}`
+}

--- a/packages/core/src/modules/auth/lib/tenantHint.ts
+++ b/packages/core/src/modules/auth/lib/tenantHint.ts
@@ -9,10 +9,11 @@
 
 const TENANT_HINT_PARAM = 'tenant'
 
-function normalizeTenantHint(tenantId: unknown): string | null {
-  if (tenantId == null) return null
-  const value = String(tenantId).trim()
-  return value.length > 0 ? value : null
+export type TenantHintSource = string | null | undefined
+
+function normalizeTenantHint(tenantId: TenantHintSource): string | null {
+  const value = tenantId?.trim()
+  return value ? value : null
 }
 
 /**
@@ -20,7 +21,7 @@ function normalizeTenantHint(tenantId: unknown): string | null {
  * links). Returns the URL unchanged for tenantless users or an unparsable URL,
  * so a hint can never cost a user their working link.
  */
-export function withTenantHintUrl(url: string, tenantId: unknown): string {
+export function withTenantHintUrl(url: string, tenantId: TenantHintSource): string {
   const tenant = normalizeTenantHint(tenantId)
   if (!tenant) return url
   try {
@@ -35,11 +36,14 @@ export function withTenantHintUrl(url: string, tenantId: unknown): string {
 /**
  * Adds the tenant hint to an app-relative path (the redirect handed back to the
  * browser after a successful reset). Returns the path unchanged for tenantless
- * users.
+ * users. Encoding and replace-don't-duplicate semantics match
+ * {@link withTenantHintUrl}.
  */
-export function withTenantHintPath(path: string, tenantId: unknown): string {
+export function withTenantHintPath(path: string, tenantId: TenantHintSource): string {
   const tenant = normalizeTenantHint(tenantId)
   if (!tenant) return path
-  const separator = path.includes('?') ? '&' : '?'
-  return `${path}${separator}${TENANT_HINT_PARAM}=${encodeURIComponent(tenant)}`
+  const [pathname, existingQuery = ''] = path.split('?')
+  const params = new URLSearchParams(existingQuery)
+  params.set(TENANT_HINT_PARAM, tenant)
+  return `${pathname}?${params.toString()}`
 }


### PR DESCRIPTION
Fixes #5901

## What changed for users

A user who belongs to a tenant can now finish a password reset and land on **their** tenant's login entry — with the tenant banner and branding the login page already renders — instead of the generic login form. Before this change the tenant was silently dropped somewhere between the reset email and the post-reset redirect, so the user arrived at `/login` with no idea which tenant they had just reset a password for. Users with no tenant see exactly what they saw before.

| | Before | After |
|---|---|---|
| Reset email link | `https://app.example.com/reset/<token>` | `https://app.example.com/reset/<token>?tenant=<tenantId>` |
| Reset completed | `{ "ok": true, "redirect": "/login" }` | `{ "ok": true, "redirect": "/login?tenant=<tenantId>" }` |
| Tenantless user | unchanged | unchanged |

## Root cause

Both routes already had the resolved user's tenant in hand — `api/reset.ts` reads `user.tenantId` for the `auth.password.reset.requested` payload and the email scope two lines after building the URL, and `api/reset/confirm.ts` reads it for the completion event — but neither applied it to the navigation targets they hand back to the browser. `reset.ts` built `resetUrl` from `toSecurityEmailUrl(req, '/reset/__token__')`, which strips any query string from the validated base, and `confirm.ts` returned a hard-coded `{ ok: true, redirect: '/login' }`. That redirect is authoritative: the reset page does `router.replace(result?.redirect || '/login')`.

The receiving end was never the problem — `frontend/login.tsx` already reads `?tenant=`, persists it to `om_login_tenant` plus the tenant cookie, and shows the "You're logging in to {tenant}" banner. It only falls back to that cookie when the parameter is absent, so a user opening the reset link on a fresh device got no tenant at all.

## Approach

A new `auth/lib/tenantHint.ts` — alongside the module's other single-purpose helpers — exposes `withTenantHintUrl` for absolute email links and `withTenantHintPath` for app-relative redirects. The two routes each gain one call.

**The tenant is read only from the service-resolved user object, never from request input.** A `tenant` field in the form body or query string is ignored, so the parameter remains a navigation hint and can never be used to point a reset at a different tenant — there is a regression test for exactly that. Origin validation, the generic unknown-account `{ ok: true }` response, token checks, rate limiting, and all event and notification behavior are untouched.

Keeping the logic in a shared helper means the invitation-link gap noted below becomes a one-line change.

## Tests

- `lib/__tests__/tenantHint.test.ts` — 9 cases: append, tenantless no-op for `null` / `undefined` / whitespace, escaping, replacing rather than duplicating an existing parameter, unparsable-URL passthrough, joining onto an existing query string.
- `api/__tests__/reset.test.ts` and `api/__tests__/reset-confirm.test.ts` — tenant-bound and tenantless users, URL-encoding safety, a forged caller-supplied tenant ignored in favour of the resolved user, the generic unknown-account response with no mail sent, and an expired token still returning 400 with no redirect.

**Mutation-verified:** reverting the two production call sites makes 7 of the new assertions fail; restoring them turns all green. The existing `reset-confirm.test.ts:112` assertion encoded the bug (`redirect: '/login'` for a `tenant-1` fixture) and was updated.

## Validation

Full configured gate run locally: `build:packages` ✅ · `generate` ✅ · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ (advisory) · `typecheck` ✅ 29/29 · `build:app` ✅. `yarn lint` reports 0 errors.

`yarn test` under turbo aborted on 5 pre-existing `@open-mercato/cli` temp-directory failures unrelated to this change (that package passes 99 suites / 1865 tests standalone). Because turbo's abort skips every remaining package, they were run directly: **core 1487 suites / 12130 tests ✅**, ui 240 / 2011 ✅, app 95 / 584 ✅, shared 193 / 2195 ✅.

## Compatibility and follow-up

**No breaking change.** The `{ ok: true, redirect: string }` response shape is unchanged; only the value differs, and only for tenant-bound users. The tenant id now appears in an emailed URL and in browser history — it is already exposed as a login query parameter and a client-readable cookie, so this adds no new disclosure class, and it carries no authority: `/api/directory/tenants/lookup` and the login POST still authorize independently.

Two deliberate scope limits, both worth a follow-up:

- **Invitation links** (`api/users/resend-invite/route.ts:164`, `${base}/reset/${rawToken}`) have the identical gap. The issue explicitly asks for these to be audited separately, so they are untouched here; `withTenantHintUrl` makes that fix a one-liner.
- **The `/reset/<token>` page itself does not yet read `?tenant=`.** The immediate user-visible improvement in this PR comes from the confirm redirect. Forwarding the hint to the page's "Back to login" and "Request a new link" links would make the emailed parameter useful on the expired-token path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629327&installation_model_id=432243&pr_number=6036&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6036&signature=0955bac0341a8e420933e08c843be30f0147c0bdd25ce87744d6228a4ed751a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->