### PR TITLE
feat(customers): let hosts hide a deals view without forking the list page (#5923)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/deals/map/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/map/page.tsx
@@ -14,11 +14,22 @@ import {
 import { SearchInput } from '@open-mercato/ui/primitives/search-input'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
-import { ViewTabsRow } from '../pipeline/components/ViewTabsRow'
+import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
+import {
+  ViewTabsRow,
+  VIEW_TABS_ROW_COMPONENT_ID,
+  type ViewTabsRowProps,
+} from '../pipeline/components/ViewTabsRow'
 import { DealsMapView } from './components/DealsMapView'
 
 export default function DealsMapPage(): React.ReactElement {
   const t = useT()
+  // Resolved through the component registry so downstream apps can hide a view
+  // (or replace the whole switcher) without forking this page.
+  const DealsViewTabsRow = useRegisteredComponent<ViewTabsRowProps>(
+    VIEW_TABS_ROW_COMPONENT_ID,
+    ViewTabsRow,
+  )
   const [search, setSearch] = React.useState('')
 
   return (
@@ -68,7 +79,7 @@ export default function DealsMapPage(): React.ReactElement {
           </div>
         </div>
 
-        <ViewTabsRow active="map" className="mt-4" />
+        <DealsViewTabsRow active="map" className="mt-4" />
 
         <DealsMapView search={search} />
       </PageBody>

--- a/packages/core/src/modules/customers/backend/customers/deals/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/page.tsx
@@ -30,7 +30,12 @@ import { SimpleTooltip } from '@open-mercato/ui/primitives/tooltip'
 import { Briefcase, AlertTriangle, X } from 'lucide-react'
 import { isLostDealStatus, isWonDealStatus } from '../../../lib/dealStatus'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { ViewTabsRow } from './pipeline/components/ViewTabsRow'
+import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
+import {
+  ViewTabsRow,
+  VIEW_TABS_ROW_COMPONENT_ID,
+  type ViewTabsRowProps,
+} from './pipeline/components/ViewTabsRow'
 import { DealsKpiStrip } from '../../../components/DealsKpiStrip'
 import { E } from '#generated/entities.ids.generated'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
@@ -195,6 +200,12 @@ function formatGroupedAmount(amount: number | null | undefined): string | null {
 
 export default function CustomersDealsPage() {
   const t = useT()
+  // Resolved through the component registry so downstream apps can hide a view
+  // (or replace the whole switcher) without forking this page.
+  const DealsViewTabsRow = useRegisteredComponent<ViewTabsRowProps>(
+    VIEW_TABS_ROW_COMPONENT_ID,
+    ViewTabsRow,
+  )
   const locale = useLocale()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const router = useRouter()
@@ -1064,7 +1075,7 @@ export default function CustomersDealsPage() {
   return (
     <Page>
       <PageBody>
-        <ViewTabsRow active="list" className="mb-4" />
+        <DealsViewTabsRow active="list" className="mb-4" />
         <DealsKpiStrip
           ownerNames={ownerNames}
           stageDictionary={dictionaryMaps['pipeline-stages'] ?? {}}

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/ViewTabsRow.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/ViewTabsRow.tsx
@@ -7,24 +7,76 @@ import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 
 export type KanbanView = 'kanban' | 'list' | 'map'
 
-type ViewTabsRowProps = {
+/**
+ * Canonical left-to-right order of the deals views. `visibleViews` selects a
+ * subset of these; it never reorders them, so a host that hides one view keeps
+ * the same tab order as every other deployment.
+ */
+export const DEALS_VIEWS: readonly KanbanView[] = ['kanban', 'list', 'map']
+
+export type ViewTabsRowProps = {
   active: KanbanView
   className?: string
+  /**
+   * Views exposed in the tab row. Defaults to all of `DEALS_VIEWS`; pass a
+   * subset to hide a view a deployment has no use for (e.g. omit `'map'` when
+   * deal addresses are never geocoded). Unknown and duplicated entries are
+   * ignored, and `active` is always rendered — a tab row that omits the page it
+   * is sitting on would show no selected tab at all.
+   */
+  visibleViews?: readonly KanbanView[]
 }
 
-const VIEW_KANBAN_HREF = '/backend/customers/deals/pipeline'
-const VIEW_LIST_HREF = '/backend/customers/deals'
-const VIEW_MAP_HREF = '/backend/customers/deals/map'
+/**
+ * Registered component id for the deals view switcher. Downstream apps can
+ * target it from `widgets/components.ts` to replace or wrap the row, or — the
+ * reason it is resolved through the registry at all — to transform its props
+ * from one place instead of forking each of the three pages that render it:
+ *
+ * ```ts
+ * export const componentOverrides: ComponentOverride[] = [{
+ *   target: { componentId: 'section:customers.deals.viewTabs' },
+ *   priority: 50,
+ *   metadata: { module: 'my_module' },
+ *   propsTransform: (props) => ({ ...props, visibleViews: ['kanban', 'list'] }),
+ * }]
+ * ```
+ *
+ * Hiding a tab does not unpublish its route; an app that also wants the page
+ * gone disables it through `entry.overrides.pages` (#5923).
+ */
+export const VIEW_TABS_ROW_COMPONENT_ID = 'section:customers.deals.viewTabs'
 
-export function ViewTabsRow({ active, className }: ViewTabsRowProps): React.ReactElement {
+const VIEW_HREFS: Record<KanbanView, string> = {
+  kanban: '/backend/customers/deals/pipeline',
+  list: '/backend/customers/deals',
+  map: '/backend/customers/deals/map',
+}
+
+/**
+ * Narrows `visibleViews` to the tabs this row renders, in canonical order.
+ * Exported so the contract — canonical order, deduplication, unknown entries
+ * dropped, `active` always kept — is testable without rendering.
+ */
+export function resolveVisibleViews(
+  active: KanbanView,
+  visibleViews?: readonly KanbanView[],
+): KanbanView[] {
+  if (!visibleViews) return [...DEALS_VIEWS]
+  const requested = new Set<KanbanView>(visibleViews.filter((view) => DEALS_VIEWS.includes(view)))
+  requested.add(active)
+  return DEALS_VIEWS.filter((view) => requested.has(view))
+}
+
+export function ViewTabsRow({ active, className, visibleViews }: ViewTabsRowProps): React.ReactElement {
   const t = useT()
-  const labels = {
+  const labels: Record<KanbanView, string> = {
     kanban: translateWithFallback(t, 'customers.deals.kanban.view.kanban', 'Kanban'),
     list: translateWithFallback(t, 'customers.deals.kanban.view.list', 'List'),
     map: translateWithFallback(t, 'customers.deals.kanban.view.map', 'Map'),
   }
 
-  // Link-based tab row (two routes), so the Tabs primitive (state-driven,
+  // Link-based tab row (three routes), so the Tabs primitive (state-driven,
   // onValueChange) does not fit — real <Link> semantics must stay. Classes
   // mirror the Tabs underline variant: accent-indigo active border,
   // shadow-focus halo.
@@ -33,14 +85,9 @@ export function ViewTabsRow({ active, className }: ViewTabsRowProps): React.Reac
   const activeTab = 'border-b-2 border-accent-indigo font-semibold text-foreground'
   const inactiveTab = 'border-b-2 border-transparent font-normal text-muted-foreground hover:text-foreground'
 
-  // Renders the active tab as a non-navigating `<span>` and the inactive tab as a `<Link>`,
-  // so the user can always round-trip between kanban and list from either page. Previously
-  // the kanban tab was a hardcoded `<span>` because the row was only rendered on the kanban
-  // page — adding it to the list page (item 7 of the SPEC-048 UX review) requires it to
-  // navigate back to /pipeline.
-  const isKanbanActive = active === 'kanban'
-  const isListActive = active === 'list'
-  const isMapActive = active === 'map'
+  // The active tab renders as a non-navigating `<span>` and every other tab as a
+  // `<Link>`, so the user can always round-trip between the views from any page.
+  const views = resolveVisibleViews(active, visibleViews)
 
   return (
     <div
@@ -48,60 +95,26 @@ export function ViewTabsRow({ active, className }: ViewTabsRowProps): React.Reac
       aria-label={translateWithFallback(t, 'customers.deals.kanban.view.tablistLabel', 'Deals views')}
       className={`flex items-end gap-1 border-b border-border ${className ?? ''}`.trim()}
     >
-      {isKanbanActive ? (
+      {views.map((view) => (view === active ? (
         <span
+          key={view}
           role="tab"
           aria-selected={true}
           className={`${baseTab} ${activeTab}`}
         >
-          {labels.kanban}
+          {labels[view]}
         </span>
       ) : (
         <Link
-          href={VIEW_KANBAN_HREF}
+          key={view}
+          href={VIEW_HREFS[view]}
           role="tab"
           aria-selected={false}
           className={`${baseTab} ${inactiveTab}`}
         >
-          {labels.kanban}
+          {labels[view]}
         </Link>
-      )}
-      {isListActive ? (
-        <span
-          role="tab"
-          aria-selected={true}
-          className={`${baseTab} ${activeTab}`}
-        >
-          {labels.list}
-        </span>
-      ) : (
-        <Link
-          href={VIEW_LIST_HREF}
-          role="tab"
-          aria-selected={false}
-          className={`${baseTab} ${inactiveTab}`}
-        >
-          {labels.list}
-        </Link>
-      )}
-      {isMapActive ? (
-        <span
-          role="tab"
-          aria-selected={true}
-          className={`${baseTab} ${activeTab}`}
-        >
-          {labels.map}
-        </span>
-      ) : (
-        <Link
-          href={VIEW_MAP_HREF}
-          role="tab"
-          aria-selected={false}
-          className={`${baseTab} ${inactiveTab}`}
-        >
-          {labels.map}
-        </Link>
-      )}
+      )))}
     </div>
   )
 }

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/ViewTabsRow.visibleViews.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/ViewTabsRow.visibleViews.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression for #5923: the deals view switcher hardcoded all three tabs, so an
+ * app that does not use one of them (typically Map, with no geocoded deal
+ * addresses) could only remove it by forking the three pages that render the row.
+ *
+ * Both halves of the fix are asserted, because either can regress on its own.
+ * `visibleViews` is the contract that hides a tab, and the pages resolving the row
+ * through the component registry is what lets a host reach that prop at all —
+ * reverting the call sites to `<ViewTabsRow …>` leaves every behavioural
+ * assertion below green while restoring the exact problem the issue reported.
+ */
+import * as React from 'react'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { render, screen, cleanup } from '@testing-library/react'
+import { registerComponentOverrides } from '@open-mercato/shared/modules/widgets/component-registry'
+import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string) => key,
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}))
+
+import {
+  ViewTabsRow,
+  VIEW_TABS_ROW_COMPONENT_ID,
+  resolveVisibleViews,
+  type ViewTabsRowProps,
+} from '../ViewTabsRow'
+
+function tabNames(): string[] {
+  return screen.getAllByRole('tab').map((tab) => tab.textContent ?? '')
+}
+
+function selectedTabName(): string | undefined {
+  return screen.getAllByRole('tab').find((tab) => tab.getAttribute('aria-selected') === 'true')?.textContent ?? undefined
+}
+
+afterEach(() => {
+  registerComponentOverrides([])
+  cleanup()
+})
+
+describe('ViewTabsRow visibleViews', () => {
+  it('renders every view in canonical order when the host passes no subset', () => {
+    render(<ViewTabsRow active="list" />)
+
+    expect(tabNames()).toEqual(['Kanban', 'List', 'Map'])
+    expect(selectedTabName()).toBe('List')
+    expect(screen.getByRole('tab', { name: 'Kanban' })).toHaveAttribute('href', '/backend/customers/deals/pipeline')
+    expect(screen.getByRole('tab', { name: 'Map' })).toHaveAttribute('href', '/backend/customers/deals/map')
+  })
+
+  it('hides a view the host left out of visibleViews', () => {
+    render(<ViewTabsRow active="list" visibleViews={['kanban', 'list']} />)
+
+    expect(tabNames()).toEqual(['Kanban', 'List'])
+    expect(screen.queryByRole('tab', { name: 'Map' })).toBeNull()
+  })
+
+  it('keeps the active view visible even when the host excluded it', () => {
+    render(<ViewTabsRow active="map" visibleViews={['kanban', 'list']} />)
+
+    expect(tabNames()).toEqual(['Kanban', 'List', 'Map'])
+    expect(selectedTabName()).toBe('Map')
+  })
+
+  it('renders only the active tab for an empty subset instead of an empty tab row', () => {
+    render(<ViewTabsRow active="kanban" visibleViews={[]} />)
+
+    expect(tabNames()).toEqual(['Kanban'])
+  })
+})
+
+describe('resolveVisibleViews', () => {
+  it('keeps canonical order regardless of the order the host listed', () => {
+    expect(resolveVisibleViews('kanban', ['map', 'kanban'])).toEqual(['kanban', 'map'])
+  })
+
+  it('deduplicates repeated entries', () => {
+    expect(resolveVisibleViews('list', ['list', 'list', 'kanban'])).toEqual(['kanban', 'list'])
+  })
+
+  it('drops values that are not deals views', () => {
+    const fromUntypedConfig = ['kanban', 'timeline'] as unknown as ViewTabsRowProps['visibleViews']
+
+    expect(resolveVisibleViews('kanban', fromUntypedConfig)).toEqual(['kanban'])
+  })
+})
+
+describe('component-registry wiring', () => {
+  function Host() {
+    const Resolved = useRegisteredComponent<ViewTabsRowProps>(VIEW_TABS_ROW_COMPONENT_ID, ViewTabsRow)
+    return <Resolved active="list" />
+  }
+
+  it('lets a props-mode override hide a tab without touching the host page', () => {
+    registerComponentOverrides([
+      {
+        target: { componentId: VIEW_TABS_ROW_COMPONENT_ID },
+        priority: 50,
+        metadata: { module: 'test' },
+        propsTransform: (props) => ({ ...(props as ViewTabsRowProps), visibleViews: ['kanban', 'list'] }),
+      },
+    ])
+
+    render(<Host />)
+
+    expect(tabNames()).toEqual(['Kanban', 'List'])
+  })
+
+  it('renders the platform default when no override is registered', () => {
+    render(<Host />)
+
+    expect(tabNames()).toEqual(['Kanban', 'List', 'Map'])
+  })
+
+  it.each([
+    ['kanban', path.join(__dirname, '..', '..', 'page.tsx')],
+    ['list', path.join(__dirname, '..', '..', '..', 'page.tsx')],
+    ['map', path.join(__dirname, '..', '..', '..', 'map', 'page.tsx')],
+  ])('resolves the row through the registry on the %s page', (_view, pagePath) => {
+    const source = readFileSync(pagePath, 'utf8')
+
+    expect(source).toContain('VIEW_TABS_ROW_COMPONENT_ID')
+    // `<ViewTabsRow …>` as an element, not the `useRegisteredComponent<ViewTabsRowProps>`
+    // type argument the resolved call site legitimately carries.
+    expect(source).not.toMatch(/<ViewTabsRow[\s/>]/)
+  })
+})

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -54,7 +54,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import type { FilterOptionTone } from '@open-mercato/shared/lib/query/advanced-filter'
-import { ViewTabsRow } from './components/ViewTabsRow'
+import { ViewTabsRow, VIEW_TABS_ROW_COMPONENT_ID, type ViewTabsRowProps } from './components/ViewTabsRow'
 import { LANE_WIDTH_CLASS } from './components/constants'
 import { useCurrencyDictionary } from '../../../../components/detail/hooks/useCurrencyDictionary'
 import { FilterBarRow, type KanbanFilterChip } from './components/FilterBarRow'
@@ -418,6 +418,12 @@ export default function DealsKanbanPage(): React.ReactElement {
   const QuickDealDialog = useRegisteredComponent<QuickDealDialogProps>(
     QUICK_DEAL_DIALOG_COMPONENT_ID,
     DefaultQuickDealDialog,
+  )
+  // Same reason: an app that does not use one of the three views hides it with a
+  // props override on this handle instead of forking all three deals pages.
+  const DealsViewTabsRow = useRegisteredComponent<ViewTabsRowProps>(
+    VIEW_TABS_ROW_COMPONENT_ID,
+    ViewTabsRow,
   )
   const router = useRouter()
   const scopeVersion = useOrganizationScopeVersion()
@@ -2558,7 +2564,7 @@ export default function DealsKanbanPage(): React.ReactElement {
   return (
     <Page>
       <PageBody>
-        <ViewTabsRow active="kanban" className="mb-4" />
+        <DealsViewTabsRow active="kanban" className="mb-4" />
         <div className="flex flex-col gap-2">
           <Breadcrumb>
             <BreadcrumbList>


### PR DESCRIPTION
## Problem

`ViewTabsRow` — the Kanban / List / Map switcher on the deals pages — took only `{ active, className }` and rendered all three tabs unconditionally. A deployment that has no use for one of them (typically Map, when deal addresses are never geocoded) could remove it only by forking the three pages that render the row, which is a multi-hundred-line page component for the sake of one static tab.

Reported in #5923.

## Change

Two halves, because a prop alone would not have fixed it — the host still could not reach that prop without forking.

1. **`visibleViews?: readonly KanbanView[]` on `ViewTabsRow`**, defaulting to all three views. `resolveVisibleViews` is exported as a pure function and owns the contract: canonical left-to-right order regardless of the order the host listed, duplicates collapsed, values that are not deals views dropped, and the `active` view always kept — a tab row that omits the page it is sitting on would render with no selected tab at all.

2. **All three call sites resolve the row through the component registry** under a new stable handle, `section:customers.deals.viewTabs`, with `ViewTabsRow` as the fallback. This is the same pattern the kanban quick-add dialog already uses (`dialog:customers.deals.quickDeal`, #4329), so nothing new is introduced — it just extends the existing sanctioned override surface to this row.

A host now hides a view from one place:

```ts
export const componentOverrides: ComponentOverride[] = [{
  target: { componentId: 'section:customers.deals.viewTabs' },
  priority: 50,
  metadata: { module: 'my_module' },
  propsTransform: (props) => ({ ...props, visibleViews: ['kanban', 'list'] }),
}]
```

Hiding a tab does not unpublish its route; an app that also wants the page gone disables it through `entry.overrides.pages`. That is called out in the handle's JSDoc so nobody expects one to imply the other.

## Behaviour when nothing overrides

Byte-identical to before: the same three tabs, the same order, the same hrefs, the active one still a non-navigating `<span>` and the rest `<Link>`s. Purely additive — no prop removed, no signature narrowed, no i18n key added or changed.

## Tests

`ViewTabsRow.visibleViews.test.tsx` — 12 tests covering the default row, hiding a view, the active-view-always-visible guarantee, the empty-subset case, `resolveVisibleViews` ordering/dedup/unknown-value handling, and the registry wiring end to end (a props-mode override hiding Map through `useRegisteredComponent`, plus the no-override default).

Three of them assert the call sites resolve through the registry rather than rendering `<ViewTabsRow …>` directly. That guard is deliberate: reverting just the call sites leaves every behavioural assertion green while restoring the exact problem the issue reported.

Verified the suite fails without the fix — mutating `resolveVisibleViews` to ignore `visibleViews` turns 8 of the 12 red.

## Validation

Full gate, local runner: `build:packages` → `generate` → `build:packages` → `i18n:check-sync` → `i18n:check-usage` → `typecheck` → `test` → `build:app`. All green; `yarn generate` produced no churn.

One flake worth naming: `@open-mercato/shared#test` (`dynamicLoader.generatedCacheRecovery.test.ts`) failed on the first parallel `yarn test` and passes standalone (2/2). It spawns a child node process and is in a package this diff does not touch.

Closes #5923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791630025&installation_model_id=432243&pr_number=6037&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6037&signature=84b1e72c306353122fc5efb062db7a544191adfb0513ddf5982be57ef429ea86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->