### PR TITLE
feat(ai-assistant): add Atlas Cloud provider

### DIFF
--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -45,6 +45,10 @@ Files like `AGENTS.md` and `CLAUDE.md` use UPPERCASE names and are not numberedâ
 
 ### Pending Specifications
 
+Implemented provider additions:
+
+- [Atlas Cloud AI Provider](implemented/2026-09-11-atlas-cloud-ai-provider.md) - Optional OpenAI-compatible Atlas Cloud preset for the AI Assistant.
+
 Specs awaiting implementation or partially complete. Focus here for actionable work.
 
 | SPEC | Date | Title | Description |

--- a/.ai/specs/implemented/2026-09-11-atlas-cloud-ai-provider.md
+++ b/.ai/specs/implemented/2026-09-11-atlas-cloud-ai-provider.md
@@ -1,0 +1,21 @@
+# Atlas Cloud AI Provider
+
+## Status
+
+Implemented.
+
+## Context
+
+The AI Assistant already registers OpenAI-compatible services from data-only presets. Atlas Cloud exposes the same protocol and can therefore use the existing adapter without a new runtime dependency or route.
+
+## Decision
+
+- Register `atlas-cloud` as an optional built-in provider.
+- Read credentials from `ATLASCLOUD_API_KEY` and an optional endpoint override from `ATLASCLOUD_BASE_URL`.
+- Use `https://api.atlascloud.ai/v1` as the default endpoint.
+- Seed the catalog with `Qwen/Qwen3-235B-A22B-Instruct-2507`, whose live Atlas catalog entry supports tools and a 131072-token context window.
+- Preserve the existing provider order and default-selection behavior; Atlas Cloud is selected only when configured or explicitly requested.
+
+## Verification
+
+Provider bootstrap and preset tests cover registration, credentials, endpoint resolution, and default model metadata without making network requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Features
+
+- Add Atlas Cloud as an optional OpenAI-compatible AI Assistant provider.
+
 # 0.7.0 (2026-08-26)
 
 ## Highlights

--- a/packages/ai-assistant/README.md
+++ b/packages/ai-assistant/README.md
@@ -121,6 +121,7 @@ curl http://localhost:4096/mcp
 | `OPENAI_API_KEY` | If using OpenAI | - | OpenAI API key |
 | `GOOGLE_GENERATIVE_AI_API_KEY` | If using Google | - | Google Generative AI API key |
 | `DEEPINFRA_API_KEY` | If using DeepInfra | - | DeepInfra API key (OpenAI-compatible preset) |
+| `ATLASCLOUD_API_KEY` | If using Atlas Cloud | - | Atlas Cloud API key (OpenAI-compatible preset) |
 | `GROQ_API_KEY` | If using Groq | - | Groq API key (OpenAI-compatible preset) |
 | `TOGETHER_API_KEY` | If using Together | - | Together AI API key |
 | `FIREWORKS_API_KEY` | If using Fireworks | - | Fireworks AI API key |
@@ -139,7 +140,7 @@ curl http://localhost:4096/mcp
 
 ### Built-in Providers
 
-The registry ships 10 built-in providers via the ports & adapters
+The registry ships 14 built-in providers via the ports & adapters
 architecture (see [`.ai/specs/implemented/2026-04-14-llm-provider-ports-and-adapters.md`](../../.ai/specs/implemented/2026-04-14-llm-provider-ports-and-adapters.md)).
 
 Native protocol adapters:
@@ -156,6 +157,7 @@ OpenAI-compatible presets (all share one protocol adapter with different
 |-------------|----------|---------------|---------|
 | `openai` | `api.openai.com` | `gpt-5-mini` | 128K |
 | `deepinfra` | `api.deepinfra.com/v1/openai` | `zai-org/GLM-5.1` | 202K |
+| `atlas-cloud` | `api.atlascloud.ai/v1` | `Qwen/Qwen3-235B-A22B-Instruct-2507` | 131K |
 | `groq` | `api.groq.com/openai/v1` | `llama-3.3-70b-versatile` | 131K |
 | `together` | `api.together.xyz/v1` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | 131K |
 | `fireworks` | `api.fireworks.ai/inference/v1` | `llama-v3p3-70b-instruct` | 131K |

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-adapters-openai.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-adapters-openai.test.ts
@@ -66,7 +66,7 @@ describe('OpenAIAdapter (OpenAI-compatible provider factory)', () => {
     )
     expect(flagged).toEqual(new Set(['openrouter', 'requesty', 'litellm']))
     // Non-gateway backends stay unflagged.
-    for (const id of ['openai', 'deepinfra', 'together', 'fireworks', 'groq', 'azure']) {
+    for (const id of ['openai', 'deepinfra', 'atlas-cloud', 'together', 'fireworks', 'groq', 'azure']) {
       const preset = OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === id)!
       expect(preset.usesVendorPrefixedModelIds).toBeFalsy()
     }
@@ -150,6 +150,13 @@ describe('OpenAIAdapter (OpenAI-compatible provider factory)', () => {
     expect(preset.baseURLEnvKeys).toContain('DEEPINFRA_BASE_URL')
   })
 
+  it('atlas-cloud preset declares its endpoint and env keys', () => {
+    const preset = OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === 'atlas-cloud')!
+    expect(preset.baseURL).toBe('https://api.atlascloud.ai/v1')
+    expect(preset.baseURLEnvKeys).toContain('ATLASCLOUD_BASE_URL')
+    expect(preset.envKeys).toContain('ATLASCLOUD_API_KEY')
+  })
+
   it('groq preset declares GROQ_BASE_URL in baseURLEnvKeys', () => {
     const preset = OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === 'groq')!
     expect(preset.baseURLEnvKeys).toContain('GROQ_BASE_URL')
@@ -195,6 +202,7 @@ describe('OPENAI_COMPATIBLE_PRESETS built-in catalog', () => {
     const ids = OPENAI_COMPATIBLE_PRESETS.map((p) => p.id)
     expect(ids).toContain('openai')
     expect(ids).toContain('deepinfra')
+    expect(ids).toContain('atlas-cloud')
     expect(ids).toContain('groq')
     expect(ids).toContain('together')
     expect(ids).toContain('fireworks')

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-bootstrap.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-bootstrap.test.ts
@@ -21,6 +21,7 @@ describe('llm-bootstrap — built-in provider registration', () => {
     // OpenAI-compatible presets.
     expect(ids).toContain('openai')
     expect(ids).toContain('deepinfra')
+    expect(ids).toContain('atlas-cloud')
     expect(ids).toContain('groq')
     expect(ids).toContain('together')
     expect(ids).toContain('fireworks')
@@ -69,6 +70,14 @@ describe('llm-bootstrap — built-in provider registration', () => {
     const modelIds = deepinfra?.defaultModels.map((m) => m.id) ?? []
     expect(modelIds).toContain('zai-org/GLM-5.1')
     expect(modelIds).toContain('Qwen/Qwen3-235B-A22B-Instruct-2507')
+  })
+
+  it('atlas-cloud provider comes from the OpenAI-compatible preset', () => {
+    registerBuiltInLlmProviders()
+    const atlasCloud = llmProviderRegistry.get('atlas-cloud')
+    expect(atlasCloud).not.toBeNull()
+    expect(atlasCloud?.envKeys).toEqual(['ATLASCLOUD_API_KEY'])
+    expect(atlasCloud?.defaultModel).toBe('Qwen/Qwen3-235B-A22B-Instruct-2507')
   })
 
   it('resolveFirstConfigured picks a configured provider from the registry', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/openai-compatible-presets.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/openai-compatible-presets.ts
@@ -108,6 +108,26 @@ const DEEPINFRA_PRESET: OpenAICompatiblePreset = {
 }
 
 /**
+ * Atlas Cloud — OpenAI-compatible access to a curated model catalog.
+ */
+const ATLAS_CLOUD_PRESET: OpenAICompatiblePreset = {
+  id: 'atlas-cloud',
+  name: 'Atlas Cloud',
+  baseURL: 'https://api.atlascloud.ai/v1',
+  baseURLEnvKeys: ['ATLASCLOUD_BASE_URL'],
+  envKeys: ['ATLASCLOUD_API_KEY'],
+  defaultModel: 'Qwen/Qwen3-235B-A22B-Instruct-2507',
+  defaultModels: [
+    {
+      id: 'Qwen/Qwen3-235B-A22B-Instruct-2507',
+      name: 'Qwen3 235B Instruct',
+      contextWindow: 131072,
+      tags: ['flagship'],
+    },
+  ],
+}
+
+/**
  * Groq — specializes in low-latency inference on LPU hardware.
  * Best suited for snappy tool-use and routing, less so for long reasoning.
  */
@@ -326,6 +346,7 @@ const LM_STUDIO_PRESET: OpenAICompatiblePreset = {
 export const OPENAI_COMPATIBLE_PRESETS: readonly OpenAICompatiblePreset[] = [
   OPENAI_PRESET,
   DEEPINFRA_PRESET,
+  ATLAS_CLOUD_PRESET,
   GROQ_PRESET,
   TOGETHER_PRESET,
   FIREWORKS_PRESET,


### PR DESCRIPTION
## Summary

- register Atlas Cloud as an optional OpenAI-compatible AI Assistant provider
- expose `ATLASCLOUD_API_KEY` and `ATLASCLOUD_BASE_URL` configuration
- seed the provider with a tool-capable Qwen3 model from the live Atlas catalog
- document the provider contract and configuration

The existing provider order and defaults remain unchanged; Atlas Cloud is used only when configured or explicitly selected.

## Validation

- `yarn jest --config packages/ai-assistant/jest.config.cjs --runInBand packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-bootstrap.test.ts packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-adapters-openai.test.ts` (46 passed)
- `yarn workspace @open-mercato/ai-assistant build`
- `yarn agents:check-budget`
- `git diff --check`
- one live Atlas Cloud Chat Completions smoke request returned `OK` with no retry

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791652434&installation_model_id=432243&pr_number=6044&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6044&signature=a57fbe551fa4cb3f205530a73eab039923d6a30a2165679d1989fa9279146b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->