### PR TITLE
fix(customers): allow re-linking an interaction to a different CRM record (#5938)

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/interactions.relink.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/interactions.relink.test.ts
@@ -1,0 +1,306 @@
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (emInstance: EmLike, entity: unknown, filters: unknown, opts?: unknown) =>
+    emInstance.find(entity, filters, opts),
+  findOneWithDecryption: (emInstance: EmLike, entity: unknown, filters: unknown, opts?: unknown) =>
+    emInstance.findOne(entity, filters, opts),
+}))
+
+import '@open-mercato/core/modules/customers/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import { CustomerDeal, CustomerEntity, CustomerInteraction } from '../../data/entities'
+
+type EmLike = {
+  find: (...args: unknown[]) => Promise<unknown>
+  findOne: (...args: unknown[]) => Promise<unknown>
+}
+
+type EmitCall = {
+  event: string
+  payload: Record<string, unknown>
+}
+
+const TENANT_ID = '99999999-9999-4999-8999-999999999999'
+const ORG_ID = '88888888-8888-4888-8888-888888888888'
+const INTERACTION_ID = '44444444-4444-4444-8444-444444444444'
+const CURRENT_ENTITY_ID = '11111111-1111-4111-8111-111111111111'
+const TARGET_ENTITY_ID = '22222222-2222-4222-8222-222222222222'
+const DEAL_ENTITY_ID = '33333333-3333-4333-8333-333333333333'
+const FOREIGN_ENTITY_ID = '55555555-5555-4555-8555-555555555555'
+
+function createKyselyStub() {
+  const chain: Record<string, unknown> = {}
+  chain.select = jest.fn(() => chain)
+  chain.selectAll = jest.fn(() => chain)
+  chain.where = jest.fn(() => chain)
+  chain.orderBy = jest.fn(() => chain)
+  chain.limit = jest.fn(() => chain)
+  chain.values = jest.fn(() => chain)
+  chain.set = jest.fn(() => chain)
+  chain.onConflict = jest.fn(() => chain)
+  chain.returning = jest.fn(() => chain)
+  chain.executeTakeFirst = jest.fn(async () => undefined)
+  chain.execute = jest.fn(async () => [])
+  return {
+    selectFrom: jest.fn(() => chain),
+    insertInto: jest.fn(() => chain),
+    updateTable: jest.fn(() => chain),
+    deleteFrom: jest.fn(() => chain),
+  }
+}
+
+function createEntity(id: string, kind: string, organizationId = ORG_ID): CustomerEntity {
+  return {
+    id,
+    kind,
+    organizationId,
+    tenantId: TENANT_ID,
+    deletedAt: null,
+  } as unknown as CustomerEntity
+}
+
+function createInteraction(entity: CustomerEntity): CustomerInteraction {
+  return {
+    id: INTERACTION_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    entity,
+    interactionType: 'task',
+    title: 'Follow up',
+    body: null,
+    status: 'planned',
+    scheduledAt: new Date('2026-05-01T10:00:00.000Z'),
+    occurredAt: null,
+    priority: null,
+    authorUserId: null,
+    ownerUserId: null,
+    dealId: null,
+    source: null,
+    appearanceIcon: null,
+    appearanceColor: null,
+    pinned: false,
+    durationMinutes: null,
+    location: null,
+    allDay: null,
+    recurrenceRule: null,
+    recurrenceEnd: null,
+    participants: null,
+    reminderMinutes: null,
+    visibility: null,
+    linkedEntities: null,
+    guestPermissions: null,
+    createdAt: new Date('2026-04-10T08:00:00.000Z'),
+    updatedAt: new Date('2026-04-10T08:00:00.000Z'),
+    deletedAt: null,
+  } as unknown as CustomerInteraction
+}
+
+function createHarness(interaction: CustomerInteraction, entities: CustomerEntity[]) {
+  const emitCalls: EmitCall[] = []
+  const recomputedEntityIds: string[] = []
+
+  const kysely = createKyselyStub()
+  const trackingKysely = {
+    ...kysely,
+    selectFrom: jest.fn((table: string) => {
+      const chain = kysely.selectFrom(table) as Record<string, unknown>
+      const where = chain.where as (...args: unknown[]) => unknown
+      chain.where = jest.fn((column: string, op: string, value: unknown) => {
+        if (table === 'customer_interactions' && column === 'entity_id' && typeof value === 'string') {
+          recomputedEntityIds.push(value)
+        }
+        return where(column, op, value)
+      })
+      return chain
+    }),
+  }
+
+  const em: Record<string, unknown> = {
+    getKysely: jest.fn(() => trackingKysely),
+    findOne: jest.fn(async (ctor: unknown, where: Record<string, unknown>) => {
+      if (ctor === CustomerInteraction) {
+        return where.id === interaction.id ? interaction : null
+      }
+      if (ctor === CustomerEntity) {
+        return (
+          entities.find(
+            (candidate) =>
+              candidate.id === where.id &&
+              candidate.tenantId === where.tenantId &&
+              candidate.organizationId === where.organizationId,
+          ) ?? null
+        )
+      }
+      if (ctor === CustomerDeal) {
+        return where.id === DEAL_ENTITY_ID
+          ? ({ id: DEAL_ENTITY_ID, tenantId: TENANT_ID, organizationId: ORG_ID, deletedAt: null } as unknown)
+          : null
+      }
+      return null
+    }),
+    find: jest.fn(async () => []),
+    nativeDelete: jest.fn(async () => {}),
+    create: jest.fn((ctor: unknown, payload: Record<string, unknown>) => ({ __entity: ctor, ...payload })),
+    persist: jest.fn(() => {}),
+    flush: jest.fn(async () => {}),
+    transactional: jest.fn(async (fn: (inner: unknown) => Promise<unknown>) => fn(em)),
+    begin: jest.fn(async () => {}),
+    commit: jest.fn(async () => {}),
+    rollback: jest.fn(async () => {}),
+    getReference: jest.fn(),
+    remove: jest.fn(),
+  }
+  em.fork = jest.fn(() => em)
+
+  const dataEngine: Pick<DataEngine, 'setCustomFields' | 'emitOrmEntityEvent'> & Record<string, unknown> = {
+    setCustomFields: jest.fn(async () => {}),
+    emitOrmEntityEvent: jest.fn(async () => {}),
+  }
+  dataEngine.markOrmEntityChange = jest.fn(() => {})
+  dataEngine.flushOrmEntityChanges = jest.fn(async () => {})
+
+  const eventBus = {
+    emitEvent: jest.fn(async (event: string, payload: Record<string, unknown>) => {
+      emitCalls.push({ event, payload })
+    }),
+  }
+
+  const container = {
+    resolve: (token: string) => {
+      switch (token) {
+        case 'em':
+          return em
+        case 'dataEngine':
+          return dataEngine
+        case 'eventBus':
+          return eventBus
+        default:
+          throw new Error(`Unexpected dependency: ${token}`)
+      }
+    },
+  }
+
+  const ctx = {
+    container,
+    auth: { sub: null, tenantId: TENANT_ID, orgId: ORG_ID },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: undefined,
+  } as unknown as CommandRuntimeContext
+
+  return { ctx, emitCalls, recomputedEntityIds }
+}
+
+function nextInteractionTargets(emitCalls: EmitCall[]): string[] {
+  return emitCalls
+    .filter((call) => call.event === 'customers.next_interaction.updated')
+    .map((call) => String(call.payload.entityId))
+}
+
+describe('customers.interactions.update — re-linking to a different CRM record (#5938)', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function handler(): CommandHandler {
+    const found = commandRegistry.get('customers.interactions.update') as CommandHandler
+    expect(found).toBeDefined()
+    return found
+  }
+
+  it('re-attaches the interaction to the requested person', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const target = createEntity(TARGET_ENTITY_ID, 'person')
+    const interaction = createInteraction(current)
+    const { ctx } = createHarness(interaction, [current, target])
+
+    await handler().execute!(
+      { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, entityId: TARGET_ENTITY_ID },
+      ctx,
+    )
+
+    expect(interaction.entity).toBe(target)
+  })
+
+  it('recomputes the next interaction for both the old and the new entity', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const target = createEntity(TARGET_ENTITY_ID, 'person')
+    const interaction = createInteraction(current)
+    const { ctx, emitCalls, recomputedEntityIds } = createHarness(interaction, [current, target])
+
+    await handler().execute!(
+      { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, entityId: TARGET_ENTITY_ID },
+      ctx,
+    )
+
+    expect(recomputedEntityIds).toEqual(expect.arrayContaining([CURRENT_ENTITY_ID, TARGET_ENTITY_ID]))
+    expect(nextInteractionTargets(emitCalls).sort()).toEqual([CURRENT_ENTITY_ID, TARGET_ENTITY_ID].sort())
+  })
+
+  it('leaves the link untouched and recomputes once when entityId is omitted', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const interaction = createInteraction(current)
+    const { ctx, emitCalls, recomputedEntityIds } = createHarness(interaction, [current])
+
+    await handler().execute!(
+      { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, title: 'Renamed' },
+      ctx,
+    )
+
+    expect(interaction.entity).toBe(current)
+    expect(interaction.title).toBe('Renamed')
+    expect(recomputedEntityIds).toEqual([CURRENT_ENTITY_ID])
+    expect(nextInteractionTargets(emitCalls)).toEqual([CURRENT_ENTITY_ID])
+  })
+
+  it('treats re-sending the current entityId as a no-op', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const interaction = createInteraction(current)
+    const { ctx, emitCalls } = createHarness(interaction, [current])
+
+    await handler().execute!(
+      { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, entityId: CURRENT_ENTITY_ID },
+      ctx,
+    )
+
+    expect(interaction.entity).toBe(current)
+    expect(nextInteractionTargets(emitCalls)).toEqual([CURRENT_ENTITY_ID])
+  })
+
+  it('rejects an entity that belongs to another organization', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const foreign = createEntity(FOREIGN_ENTITY_ID, 'person', '77777777-7777-4777-8777-777777777777')
+    const interaction = createInteraction(current)
+    const { ctx } = createHarness(interaction, [current, foreign])
+
+    await expect(
+      handler().execute!(
+        { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, entityId: FOREIGN_ENTITY_ID },
+        ctx,
+      ),
+    ).rejects.toBeDefined()
+    expect(interaction.entity).toBe(current)
+  })
+
+  it('rejects re-linking to a deal instead of a person or company', async () => {
+    const current = createEntity(CURRENT_ENTITY_ID, 'company')
+    const interaction = createInteraction(current)
+    const { ctx } = createHarness(interaction, [current])
+
+    await expect(
+      handler().execute!(
+        { id: INTERACTION_ID, tenantId: TENANT_ID, organizationId: ORG_ID, entityId: DEAL_ENTITY_ID },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ status: 422 })
+    expect(interaction.entity).toBe(current)
+  })
+})

--- a/packages/core/src/modules/customers/commands/interactions.ts
+++ b/packages/core/src/modules/customers/commands/interactions.ts
@@ -638,7 +638,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(interactionUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const { interaction, entityId, nextInteractionId } = await runInTransaction(em, async (trx) => {
+    const { interaction, projections } = await runInTransaction(em, async (trx) => {
       const interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: parsed.id, deletedAt: null })
       if (!interaction) {
         enforceRecordGoneIsConflict({ resourceKind: 'customers.interaction', resourceId: parsed.id, request: ctx.request ?? null })
@@ -688,12 +688,27 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
         }
       }
 
+      // Re-link to a different person/company (#5938). Resolved before any scalar
+      // mutation below so the lookup never lands between a mutation and `trx.flush()`
+      // (packages/core/AGENTS.md → Entity Update Safety). `requireTimelineParentEntity`
+      // applies the same tenant/organization scoping and person-or-company check the
+      // create path uses, so a cross-tenant or deal id cannot be attached here.
+      const previousEntityId = typeof interaction.entity === 'string' ? interaction.entity : interaction.entity.id
+      const nextEntity =
+        parsed.entityId !== undefined && parsed.entityId !== previousEntityId
+          ? await requireTimelineParentEntity(trx, parsed.entityId, {
+              tenantId: interaction.tenantId,
+              organizationId: interaction.organizationId,
+            })
+          : null
+
       if (parsed.dealId !== undefined) {
         if (parsed.dealId) {
           await requireDealInScope(trx, parsed.dealId, interaction.tenantId, interaction.organizationId)
         }
         interaction.dealId = parsed.dealId ?? null
       }
+      if (nextEntity) interaction.entity = nextEntity
       if (parsed.interactionType !== undefined) interaction.interactionType = parsed.interactionType
       if (parsed.title !== undefined) interaction.title = parsed.title ?? null
       if (parsed.body !== undefined) interaction.body = parsed.body ?? null
@@ -729,8 +744,18 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
       )
 
       const projection = await recomputeNextInteraction(trx, entityId)
+      const projections: InteractionProjectionMutation[] = [
+        { entityId, nextInteractionId: projection.nextInteractionId },
+      ]
+      // A re-link changes which timeline the interaction belongs to, so the record it
+      // just left needs its own "next interaction" recomputed too — otherwise the old
+      // person/company keeps pointing at an activity that is no longer theirs (#5938).
+      if (previousEntityId !== entityId) {
+        const previousProjection = await recomputeNextInteraction(trx, previousEntityId)
+        projections.push({ entityId: previousEntityId, nextInteractionId: previousProjection.nextInteractionId })
+      }
 
-      return { interaction, entityId, nextInteractionId: projection.nextInteractionId }
+      return { interaction, projections }
     })
 
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
@@ -747,11 +772,13 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
       indexer: interactionCrudIndexer,
       events: interactionCrudEvents,
     })
-    await emitNextInteractionUpdatedEvent(ctx, { entityId, nextInteractionId }, {
-      id: interaction.id,
-      organizationId: interaction.organizationId,
-      tenantId: interaction.tenantId,
-    })
+    for (const projection of projections) {
+      await emitNextInteractionUpdatedEvent(ctx, projection, {
+        id: interaction.id,
+        organizationId: interaction.organizationId,
+        tenantId: interaction.tenantId,
+      })
+    }
 
     return { interactionId: interaction.id }
   },
@@ -787,7 +814,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
+    const { interaction, projections } = await runInTransaction(em, async (trx) => {
       let interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: before.interaction.id })
       const entity = await requireTimelineParentEntity(trx, before.interaction.entityId, { tenantId: before.interaction.tenantId, organizationId: before.interaction.organizationId })
 
@@ -853,6 +880,16 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
 
       await trx.flush()
       const projection = await recomputeNextInteraction(trx, before.interaction.entityId)
+      const projections: InteractionProjectionMutation[] = [
+        { entityId: before.interaction.entityId, nextInteractionId: projection.nextInteractionId },
+      ]
+      // Undoing a re-link (#5938) moves the interaction back off the entity the update
+      // attached it to, so that entity's projection is stale until it is recomputed too.
+      const reattachedEntityId = payload?.after?.interaction.entityId
+      if (reattachedEntityId && reattachedEntityId !== before.interaction.entityId) {
+        const reattachedProjection = await recomputeNextInteraction(trx, reattachedEntityId)
+        projections.push({ entityId: reattachedEntityId, nextInteractionId: reattachedProjection.nextInteractionId })
+      }
 
       const resetValues = buildCustomFieldResetMap(before.custom, payload?.after?.custom)
       if (Object.keys(resetValues).length) {
@@ -869,7 +906,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
 
       return {
         interaction,
-        nextInteractionId: projection.nextInteractionId,
+        projections,
       }
     })
 
@@ -887,14 +924,13 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
       indexer: interactionCrudIndexer,
       events: interactionCrudEvents,
     })
-    await emitNextInteractionUpdatedEvent(ctx, {
-      entityId: before.interaction.entityId,
-      nextInteractionId,
-    }, {
-      id: interaction.id,
-      organizationId: interaction.organizationId,
-      tenantId: interaction.tenantId,
-    })
+    for (const projection of projections) {
+      await emitNextInteractionUpdatedEvent(ctx, projection, {
+        id: interaction.id,
+        organizationId: interaction.organizationId,
+        tenantId: interaction.tenantId,
+      })
+    }
   },
 }
 

--- a/packages/core/src/modules/customers/data/__tests__/interactionSchemas.test.ts
+++ b/packages/core/src/modules/customers/data/__tests__/interactionSchemas.test.ts
@@ -113,6 +113,48 @@ describe('interaction validators — extended scheduling fields', () => {
     expect(parsed.guestPermissions).toBeNull()
   })
 
+  test('interactionUpdateSchema accepts entityId so an interaction can be re-linked', () => {
+    const parsed = interactionUpdateSchema.parse({
+      id: interactionId,
+      tenantId,
+      organizationId: orgId,
+      entityId,
+    })
+    expect(parsed.entityId).toBe(entityId)
+  })
+
+  test('interactionUpdateSchema leaves entityId undefined when it is not sent', () => {
+    const parsed = interactionUpdateSchema.parse({
+      id: interactionId,
+      tenantId,
+      organizationId: orgId,
+      title: 'Just title',
+    })
+    expect(parsed.entityId).toBeUndefined()
+  })
+
+  test('interactionUpdateSchema rejects a non-uuid entityId', () => {
+    expect(() =>
+      interactionUpdateSchema.parse({
+        id: interactionId,
+        tenantId,
+        organizationId: orgId,
+        entityId: 'not-a-uuid',
+      }),
+    ).toThrow()
+  })
+
+  test('interactionUpdateSchema rejects a null entityId because the relation is required', () => {
+    expect(() =>
+      interactionUpdateSchema.parse({
+        id: interactionId,
+        tenantId,
+        organizationId: orgId,
+        entityId: null,
+      }),
+    ).toThrow()
+  })
+
   test('interactionUpdateSchema rejects invalid linked entity type', () => {
     expect(() =>
       interactionUpdateSchema.parse({

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -560,6 +560,11 @@ const interactionUpdateBaseSchema = z
   .merge(
     scopedSchema
       .extend({
+        // Re-link an existing interaction to a different person/company, the same way
+        // `dealId` below already re-links it to a different deal (#5938). Not nullable:
+        // `CustomerInteraction.entity` is a required relation, so there is no "detach"
+        // state to express — that depends on #5935 making the column nullable first.
+        entityId: z.string().uuid().optional(),
         interactionType: z.string().trim().min(1).max(100).optional(),
         title: z.string().trim().max(500).optional().nullable(),
         body: z.string().trim().max(10000).optional().nullable(),


### PR DESCRIPTION
Closes #5938

## 🎯 Goal

Let an interaction (activity / task / meeting) be moved to a different CRM record after it was created. `PUT /api/customers/interactions` already accepts `dealId` to change which deal an activity belongs to; it now accepts `entityId` the same way, so "I picked the wrong contact" has a correction path that keeps the activity's history, attachments and calendar placement.

## 🔍 Problem

`interactionUpdateBaseSchema` (`packages/core/src/modules/customers/data/validators.ts`) lists every editable field of an existing interaction — including `dealId` — but never declared `entityId`. Zod strips unrecognised keys, so the reproducer from the issue:

```
PUT /api/customers/interactions
{ "id": "<uuid>", "entityId": "<person-or-company-uuid>" }
```

returned `200` while silently discarding `entityId`. The person/company link was effectively immutable through the API, and the only correction was delete-and-recreate.

Nothing enforced that immutability on purpose: there is no guard, comment, or test asserting the entity link is fixed. `entityId` is simply the one relationship the update schema was never extended to cover.

## What Changed

- **`data/validators.ts`** — `interactionUpdateBaseSchema` gains `entityId: z.string().uuid().optional()`. Because the route's OpenAPI document is generated from this schema, the published contract updates automatically.
- **`commands/interactions.ts`** — `customers.interactions.update` acts on it:
  - The new entity is resolved through `requireTimelineParentEntity`, the same helper the create path uses. That applies tenant/organization scoping and the person-or-company check, so a cross-tenant id yields `404` and a deal id yields `422` — a re-link cannot smuggle an activity across a tenant boundary.
  - The lookup runs **before** any scalar mutation, so it never lands between a mutation and `trx.flush()` (`packages/core/AGENTS.md` → Entity Update Safety).
  - Sending the entity the interaction is already attached to is a no-op — no redundant lookup, no extra event.
  - `recomputeNextInteraction` now runs for **both** timelines on a re-link. Without this the record the activity left keeps advertising it as its "next interaction". The same applies when the change is undone, so `undo` recomputes the entity the update had attached it to as well.

**Not** nullable, deliberately — the issue suggested `.optional().nullable()`, but `CustomerInteraction.entity` is a required `@ManyToOne` relation, so `null` has no representable meaning yet and would only fail at the database. Detaching an interaction from every CRM record depends on #5935 making the column nullable first; a `null` `entityId` is rejected by validation today, with a test pinning that.

The `/api/customers/activities` and `/api/customers/todos` bridges build explicit allow-listed command inputs and never forward `entityId`, so no existing caller starts re-linking implicitly.

## 🧪 Tests

Ten new cases, all of which fail without this change (verified by reverting the schema field: 7 failures across the two suites, 0 with the fix).

`commands/__tests__/interactions.relink.test.ts` (new, 6 cases) drives the real command through the registry:

- re-attaches the interaction to the requested person;
- recomputes and emits `customers.next_interaction.updated` for **both** the old and the new entity;
- leaves the link untouched and recomputes once when `entityId` is omitted;
- treats re-sending the current `entityId` as a no-op;
- rejects an entity belonging to another organization, leaving the link unchanged;
- rejects a deal id with `422`, leaving the link unchanged.

`data/__tests__/interactionSchemas.test.ts` (4 added cases): `entityId` survives parsing, stays `undefined` when not sent, and is rejected when it is a non-uuid or `null`.

## 💥 Breaking Changes

**None.** Accepting a previously-ignored input field is additive: every payload that validated before still validates, and no previously-accepted request is now rejected. Per `BACKWARD_COMPATIBILITY.md` this is an ADDITIVE-ONLY change to the API-route contract surface. No database change is involved.

The one behavior change worth a reviewer's eye: a caller that was already sending `entityId` expecting it to be ignored will now have it applied. The bridges in this repo do not; an external caller echoing a whole interaction record back would send the record's own current `entityId`, which the equality guard treats as a no-op.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791705241&installation_model_id=432243&pr_number=6050&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6050&signature=13b52cb714473a2b16730bbf5c3f34e145fa38a884dfa4f1f07011bf5458ab90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->