### PR TITLE
fix(sales): preserve line catalog snapshots when another line is saved (#5911)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/documents.line-carried-columns.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.line-carried-columns.test.ts
@@ -1,0 +1,311 @@
+/** @jest-environment node */
+
+/**
+ * Carry-through coverage for the columns the calculation engine never reads —
+ * `catalog_snapshot`, `promotion_snapshot` and `status_entry_id` (issue #5911).
+ *
+ * A line write rebuilds *every* line of the document from
+ * `map{Quote,Order}LineEntityToSnapshot` and then `Object.assign`s the result
+ * back onto the existing rows. Any column that mapper drops is therefore not
+ * merely missing from the recalculation — it is written back as `null` over the
+ * stored value of lines the caller never touched. Saving line 2 destroyed the
+ * catalog snapshot of lines 1 and 3, and nothing about the totals changed, so
+ * the arithmetic tests could not see it.
+ *
+ * These tests drive the real upsert and delete commands so the assertion is on
+ * what the row ends up holding, not on the mapper's return value in isolation.
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { DefaultSalesCalculationService } from '../../services/salesCalculationService'
+import { SalesOrder, SalesQuote, SalesShipment, SalesShipmentItem } from '../../data/entities'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string, fallback?: string) => fallback ?? key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => ({
+  invalidateCrudCache: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const QUOTE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const ORDER_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const FIRST_LINE_ID = '11111111-1111-4111-8111-111111111111'
+const MIDDLE_LINE_ID = '22222222-2222-4222-8222-222222222222'
+const LAST_LINE_ID = '33333333-3333-4333-8333-333333333333'
+const STATUS_ENTRY_ID = '44444444-4444-4444-8444-444444444444'
+
+type PersistedLine = Record<string, unknown> & { id: string }
+
+function buildLine(overrides: Partial<PersistedLine> & { id: string }): PersistedLine {
+  return {
+    lineNumber: 1,
+    kind: 'product',
+    productId: null,
+    productVariantId: null,
+    name: 'Line',
+    description: null,
+    comment: null,
+    quantityUnit: null,
+    normalizedQuantity: null,
+    normalizedUnit: null,
+    uomSnapshot: null,
+    currencyCode: 'USD',
+    taxRate: '0',
+    taxAmount: null,
+    configuration: null,
+    promotionCode: null,
+    metadata: null,
+    customFieldSetId: null,
+    statusEntryId: null,
+    catalogSnapshot: null,
+    promotionSnapshot: null,
+    updatedAt: new Date(),
+    quantity: '1',
+    unitPriceNet: '10',
+    unitPriceGross: '10',
+    discountAmount: '0',
+    discountPercent: '0',
+    totalNetAmount: '10',
+    totalGrossAmount: '10',
+    ...overrides,
+  }
+}
+
+function setWorld(lines: PersistedLine[]) {
+  const document = {
+    id: QUOTE_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    deletedAt: null,
+    currencyCode: 'USD',
+    shippingMethodSnapshot: null,
+    paymentMethodSnapshot: null,
+    shippingMethodId: null,
+    paymentMethodId: null,
+    shippingMethodCode: null,
+    paymentMethodCode: null,
+    paidTotalAmount: '0',
+    refundedTotalAmount: '0',
+    updatedAt: new Date('2026-09-07T00:00:00.000Z'),
+  }
+  const order = { ...document, id: ORDER_ID }
+  ;(globalThis as any).__carriedColumnsWorld = { quote: document, order, lines }
+}
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (_em: unknown, entityClass: unknown) => {
+    const world = (globalThis as any).__carriedColumnsWorld
+    if (entityClass === SalesQuote) return world.quote
+    if (entityClass === SalesOrder) return world.order
+    return null
+  }),
+  findWithDecryption: jest.fn(async (_em: unknown, entityClass: unknown) => {
+    const world = (globalThis as any).__carriedColumnsWorld
+    const entityName = (entityClass as { name?: string })?.name ?? ''
+    if (entityName === 'SalesQuoteLine' || entityName === 'SalesOrderLine') return [...world.lines]
+    if (entityClass === SalesShipment) return []
+    if (entityClass === SalesShipmentItem) return []
+    return []
+  }),
+}))
+
+function makeEm() {
+  const world = () => (globalThis as any).__carriedColumnsWorld
+  const em: any = {
+    fork: function () {
+      return this
+    },
+    transactional: async (cb: (tx: unknown) => Promise<unknown>) => cb(em),
+    find: jest.fn(async (entityClass: unknown) => {
+      const entityName = (entityClass as { name?: string })?.name ?? ''
+      if (entityName === 'SalesQuoteLine' || entityName === 'SalesOrderLine') return [...world().lines]
+      return []
+    }),
+    findOne: jest.fn(async () => null),
+    count: jest.fn(async () => 0),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn(async () => {}),
+    begin: jest.fn(async () => {}),
+    commit: jest.fn(async () => {}),
+    rollback: jest.fn(async () => {}),
+    isInTransaction: jest.fn(() => false),
+    getUnitOfWork: jest.fn(() => ({
+      getChangeSets: () => [],
+      computeChangeSets: () => {},
+    })),
+    getReference: jest.fn((_entity: unknown, id: string) => ({ id })),
+    getConnection: () => ({ execute: jest.fn(async () => [{ value: 1 }]) }),
+  }
+  return em
+}
+
+function makeCtx(em: unknown) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({
+    em: asValue(em),
+    dataEngine: asValue({ markOrmEntityChange: jest.fn() }),
+    salesCalculationService: asValue(new DefaultSalesCalculationService(null)),
+  })
+  return {
+    container,
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: new Request('https://example.test/api/sales/quote-lines', { method: 'PUT' }),
+  }
+}
+
+/**
+ * The commands mutate the same line objects the world holds, so reading them
+ * back afterwards is reading the persisted state.
+ */
+async function runCommand(commandId: string, body: Record<string, unknown>) {
+  const handler = commandRegistry.get(commandId)!
+  await handler.execute({ body } as never, makeCtx(makeEm()) as never)
+  const world = (globalThis as any).__carriedColumnsWorld
+  return new Map<string, PersistedLine>(world.lines.map((line: PersistedLine) => [line.id, line]))
+}
+
+function threeQuoteLines() {
+  return [
+    buildLine({
+      id: FIRST_LINE_ID,
+      lineNumber: 1,
+      catalogSnapshot: { sku: 'HB-1' },
+      promotionSnapshot: { campaign: 'spring' },
+      statusEntryId: STATUS_ENTRY_ID,
+    }),
+    buildLine({ id: MIDDLE_LINE_ID, lineNumber: 2, catalogSnapshot: { sku: 'HB-2' } }),
+    buildLine({
+      id: LAST_LINE_ID,
+      lineNumber: 3,
+      catalogSnapshot: { sku: 'HB-3' },
+      promotionSnapshot: { campaign: 'summer' },
+      statusEntryId: STATUS_ENTRY_ID,
+    }),
+  ]
+}
+
+describe('sales line writes — carried columns (#5911)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).__carriedColumnsWorld
+  })
+
+  it('leaves the catalog snapshots of the other quote lines alone when the middle line is edited', async () => {
+    setWorld(threeQuoteLines())
+
+    const lines = await runCommand('sales.quotes.lines.upsert', {
+      id: MIDDLE_LINE_ID,
+      quoteId: QUOTE_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      currencyCode: 'USD',
+      kind: 'product',
+      quantity: 2,
+      unitPriceNet: 10,
+      unitPriceGross: 10,
+      taxRate: 0,
+    })
+
+    expect(lines.get(FIRST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-1' })
+    expect(lines.get(LAST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-3' })
+  })
+
+  it('carries the promotion snapshot and status entry of untouched quote lines through the rebuild', async () => {
+    // Same mapper, same write-back, same data loss: a fix that only restores
+    // the catalog snapshot leaves these two silently nulled.
+    setWorld(threeQuoteLines())
+
+    const lines = await runCommand('sales.quotes.lines.upsert', {
+      id: MIDDLE_LINE_ID,
+      quoteId: QUOTE_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      currencyCode: 'USD',
+      kind: 'product',
+      quantity: 2,
+      unitPriceNet: 10,
+      unitPriceGross: 10,
+      taxRate: 0,
+    })
+
+    expect(lines.get(FIRST_LINE_ID)!.promotionSnapshot).toEqual({ campaign: 'spring' })
+    expect(lines.get(FIRST_LINE_ID)!.statusEntryId).toBe(STATUS_ENTRY_ID)
+    expect(lines.get(LAST_LINE_ID)!.promotionSnapshot).toEqual({ campaign: 'summer' })
+    expect(lines.get(LAST_LINE_ID)!.statusEntryId).toBe(STATUS_ENTRY_ID)
+  })
+
+  it('keeps the edited quote line’s own catalog snapshot when the caller does not resend it', async () => {
+    setWorld(threeQuoteLines())
+
+    const lines = await runCommand('sales.quotes.lines.upsert', {
+      id: MIDDLE_LINE_ID,
+      quoteId: QUOTE_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      currencyCode: 'USD',
+      kind: 'product',
+      quantity: 5,
+      unitPriceNet: 10,
+      unitPriceGross: 10,
+      taxRate: 0,
+    })
+
+    expect(lines.get(MIDDLE_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-2' })
+  })
+
+  it('leaves the surviving quote lines’ catalog snapshots alone when another line is deleted', async () => {
+    setWorld(threeQuoteLines())
+
+    const lines = await runCommand('sales.quotes.lines.delete', {
+      id: MIDDLE_LINE_ID,
+      quoteId: QUOTE_ID,
+    })
+
+    expect(lines.get(FIRST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-1' })
+    expect(lines.get(LAST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-3' })
+  })
+
+  it('leaves the catalog snapshots of the other order lines alone when the middle line is edited', async () => {
+    // The order upsert shares the mapper and the write-back, so it lost the
+    // same columns even though the report only named quotes.
+    setWorld(threeQuoteLines())
+
+    const lines = await runCommand('sales.orders.lines.upsert', {
+      id: MIDDLE_LINE_ID,
+      orderId: ORDER_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      currencyCode: 'USD',
+      kind: 'product',
+      quantity: 2,
+      unitPriceNet: 10,
+      unitPriceGross: 10,
+      taxRate: 0,
+    })
+
+    expect(lines.get(FIRST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-1' })
+    expect(lines.get(LAST_LINE_ID)!.catalogSnapshot).toEqual({ sku: 'HB-3' })
+  })
+})

--- a/packages/core/src/modules/sales/lib/__tests__/lineSnapshots.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/lineSnapshots.test.ts
@@ -91,6 +91,45 @@ describe('entity-to-snapshot mappers', () => {
     expect(snapshot.unitPriceNet).toBe(85)
   })
 
+  it.each([
+    ['order', mapOrderLineEntityToSnapshot],
+    ['quote', mapQuoteLineEntityToSnapshot],
+  ])('carries the %s line columns the engine never reads (issue #5911)', (_kind, map) => {
+    // The write paths rebuild every line of the document from this snapshot and
+    // assign the result back onto the row, so a column missing here is written
+    // back as null over the stored value of a line nobody edited.
+    const snapshot = (map as (line: never) => ReturnType<typeof mapOrderLineEntityToSnapshot>)(
+      persistedLine({
+        statusEntryId: 'status-1',
+        catalogSnapshot: { sku: 'HB-1' },
+        promotionSnapshot: { campaign: 'spring' },
+      }) as never,
+    )
+
+    expect(snapshot.statusEntryId).toBe('status-1')
+    expect(snapshot.catalogSnapshot).toEqual({ sku: 'HB-1' })
+    expect(snapshot.promotionSnapshot).toEqual({ campaign: 'spring' })
+  })
+
+  it('clones the carried snapshots so the row cannot be mutated through them', () => {
+    const line = persistedLine({ catalogSnapshot: { sku: 'HB-1' }, promotionSnapshot: { campaign: 'spring' } })
+    const snapshot = mapQuoteLineEntityToSnapshot(line as unknown as SalesQuoteLine)
+
+    ;(snapshot.catalogSnapshot as Record<string, unknown>).sku = 'mutated'
+    ;(snapshot.promotionSnapshot as Record<string, unknown>).campaign = 'mutated'
+
+    expect(line.catalogSnapshot).toEqual({ sku: 'HB-1' })
+    expect(line.promotionSnapshot).toEqual({ campaign: 'spring' })
+  })
+
+  it('maps absent carried columns to null rather than undefined', () => {
+    const snapshot = mapQuoteLineEntityToSnapshot(persistedLine() as unknown as SalesQuoteLine)
+
+    expect(snapshot.statusEntryId).toBeNull()
+    expect(snapshot.catalogSnapshot).toBeNull()
+    expect(snapshot.promotionSnapshot).toBeNull()
+  })
+
   it('coerces a non-finite stored value to zero rather than propagating NaN', () => {
     const snapshot = mapQuoteLineEntityToSnapshot(
       persistedLine({ discountAmount: 'not-a-number' }) as unknown as SalesQuoteLine,

--- a/packages/core/src/modules/sales/lib/lineSnapshots.ts
+++ b/packages/core/src/modules/sales/lib/lineSnapshots.ts
@@ -11,9 +11,28 @@ function toNumeric(value: unknown): number {
   return 0
 }
 
-function mapPersistedLine(line: SalesOrderLine | SalesQuoteLine): SalesLineSnapshot {
+/**
+ * A snapshot rebuilt from a persisted row, plus the columns the calculation
+ * engine never reads but the write paths must carry back to the row.
+ *
+ * The line upsert, line delete and adjustment write paths all rebuild *every*
+ * line of the document from these snapshots and then `Object.assign` the result
+ * onto the existing entities. Anything the mapper drops is therefore not merely
+ * absent from the calculation — it is written back as `null` over the stored
+ * value of lines the caller never touched (#5911).
+ */
+export type SalesPersistedLineSnapshot = SalesLineSnapshot & {
+  statusEntryId: string | null
+  catalogSnapshot: Record<string, unknown> | null
+  promotionSnapshot: Record<string, unknown> | null
+}
+
+function mapPersistedLine(line: SalesOrderLine | SalesQuoteLine): SalesPersistedLineSnapshot {
   return {
     id: line.id,
+    statusEntryId: line.statusEntryId ?? null,
+    catalogSnapshot: line.catalogSnapshot ? cloneJson(line.catalogSnapshot) : null,
+    promotionSnapshot: line.promotionSnapshot ? cloneJson(line.promotionSnapshot) : null,
     lineNumber: line.lineNumber,
     kind: line.kind,
     productId: line.productId ?? null,
@@ -60,11 +79,11 @@ function mapPersistedLine(line: SalesOrderLine | SalesQuoteLine): SalesLineSnaps
  * two files used to carry byte-identical copies, and that duplication is why
  * the return flows kept the discount defect after the order flows were fixed.
  */
-export function mapOrderLineEntityToSnapshot(line: SalesOrderLine): SalesLineSnapshot {
+export function mapOrderLineEntityToSnapshot(line: SalesOrderLine): SalesPersistedLineSnapshot {
   return mapPersistedLine(line)
 }
 
-export function mapQuoteLineEntityToSnapshot(line: SalesQuoteLine): SalesLineSnapshot {
+export function mapQuoteLineEntityToSnapshot(line: SalesQuoteLine): SalesPersistedLineSnapshot {
   return mapPersistedLine(line)
 }
 


### PR DESCRIPTION
Closes #5911

## 🎯 Goal
- Saving one line of a quote or order no longer destroys the catalog snapshot of the other lines on that document. The stored product snapshot is what the quote shows and what it is meant to preserve for the record, so today an ordinary second edit silently empties it.

## 🔍 Problem
`sales.quotes.lines.upsert` cleared `catalog_snapshot` on every untouched line whenever another line on the same quote was created or edited, as reported. Two columns next to it — `promotion_snapshot` and `status_entry_id` — were lost by exactly the same write, and `sales.orders.lines.upsert` plus both adjustment write paths shared the defect, because they all go through the same rebuild.

## 🔍 Root Cause
`mapPersistedLine` in `packages/core/src/modules/sales/lib/lineSnapshots.ts` rebuilds a calculation snapshot from a persisted row, but it only carried the columns the calculation engine reads. The line upsert, line delete and adjustment write paths rebuild *every* line of the document from that snapshot and then `Object.assign` the result back onto the existing rows — so a column the mapper omits is not merely absent from the recalculation, it is written back as `null` over the stored value. The call sites already asked for the data (`catalogSnapshot: (line as any).catalogSnapshot ?? null`); the mapper simply never supplied it, so the expression was always `null`.

The quote-line *delete* path was the one exception, and only because it re-adds all three columns by hand immediately after calling the same mapper — which is what showed the preservation behaviour was intended.

## What Changed
- `packages/core/src/modules/sales/lib/lineSnapshots.ts` — `mapPersistedLine` now carries `statusEntryId`, `catalogSnapshot` and `promotionSnapshot`, cloning the two JSONB values the way `uomSnapshot` and `metadata` already are so a snapshot handed out cannot be mutated back into the row. The mappers' return type is a new exported `SalesPersistedLineSnapshot` (`SalesLineSnapshot` plus those three fields); `SalesLineSnapshot` itself is untouched, so the calculation engine's input contract is unchanged.
- Fixing the mapper rather than the individual call sites repairs every path that rebuilds lines: both line upserts, both line deletes, and the four adjustment write paths. It also fixes the edited line's own snapshot, which was lost whenever the caller did not resend it.

## 🧪 Tests
- `packages/core/src/modules/sales/commands/__tests__/documents.line-carried-columns.test.ts` (new) — drives the real `sales.quotes.lines.upsert`, `sales.quotes.lines.delete` and `sales.orders.lines.upsert` commands over a three-line document, edits the middle line, and asserts the first and third lines keep their `catalog_snapshot`, `promotion_snapshot` and `status_entry_id`, plus that the edited line keeps its own snapshot when the caller does not resend it.
- `packages/core/src/modules/sales/lib/__tests__/lineSnapshots.test.ts` — mapper-level coverage for the three carried columns on both document kinds, the clone guarantee, and `null` (not `undefined`) for absent values.
- Verified the coverage is real: **8 of these tests fail against the unpatched mapper** and all pass with the fix.
- Gate: `build:packages` (×2), `generate`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app` — all green. `turbo run test --continue` — 32/36 packages green, including `@open-mercato/core` (**1505 suites / 12223 tests passed**). The 4 red packages are pre-existing environment failures in this checkout, unrelated to the diff: `ai-assistant` (`command not found: jest`), `shared` (`tsx` IPC pipe `EINVAL` under the sandbox TMPDIR — passes standalone, 2237 tests), `cli` (5 location-dependent env-resolution failures), `create-app` (stale `source-link-inventory.json`, which indexes no `sales/` paths).

## 💥 Breaking Changes
- None. No schema change, no API shape change, no change to `SalesLineSnapshot`. `SalesPersistedLineSnapshot` is an additive export and the mappers' return type only widens.
- Note for anyone triaging the original report: this stops further loss, but rows whose snapshots were already nulled cannot be reconstructed from the data that remains.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791705379&installation_model_id=432243&pr_number=6051&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6051&signature=1a79bf30cc1fcf12d1451487758cdcb3e727509d9b5d2bf3717af75ab09bfe63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->