### PR TITLE
fix(channel-imap,channel-gmail): warm the lazy mailparser import in jest (#6040)

### DIFF
--- a/packages/channel-gmail/jest.config.cjs
+++ b/packages/channel-gmail/jest.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '^@open-mercato/channel-gmail/(.*)$': '<rootDir>/src/$1',

--- a/packages/channel-gmail/jest.setup.ts
+++ b/packages/channel-gmail/jest.setup.ts
@@ -1,0 +1,13 @@
+// Warm the lazy `mailparser` import before any test body runs (issue #6040).
+//
+// `normalizeInboundGmailMessage` resolves `mailparser` lazily, inside the function, so the whole
+// cold module-graph load is charged to whichever test first reaches it — against jest's default
+// 5000 ms per-test budget. On a contended CI runner that load alone approaches the timeout, which
+// made the first MIME-parsing test in a file fail intermittently while every sibling passed.
+//
+// Paying the load in a root `beforeAll` with an explicit, generous hook budget removes it from
+// every test's budget without raising `testTimeout`, so a genuinely slow adapter regression still
+// trips the 5000 ms default.
+beforeAll(async () => {
+  await import('mailparser')
+}, 60_000)

--- a/packages/channel-gmail/jest.setup.ts
+++ b/packages/channel-gmail/jest.setup.ts
@@ -1,13 +1,22 @@
-// Warm the lazy `mailparser` import before any test body runs (issue #6040).
-//
-// `normalizeInboundGmailMessage` resolves `mailparser` lazily, inside the function, so the whole
-// cold module-graph load is charged to whichever test first reaches it — against jest's default
-// 5000 ms per-test budget. On a contended CI runner that load alone approaches the timeout, which
-// made the first MIME-parsing test in a file fail intermittently while every sibling passed.
-//
-// Paying the load in a root `beforeAll` with an explicit, generous hook budget removes it from
-// every test's budget without raising `testTimeout`, so a genuinely slow adapter regression still
-// trips the 5000 ms default.
+/**
+ * Warm the lazy `mailparser` import before any test body runs (#6040).
+ *
+ * `normalizeInboundGmailMessage` resolves `mailparser` lazily, inside the
+ * function, so the whole cold module-graph load is charged to whichever test
+ * first reaches it — against jest's default 5000 ms per-test budget. On a
+ * contended CI runner that load alone approaches the timeout, which made the
+ * first MIME-parsing test in a file fail intermittently while every sibling
+ * passed.
+ *
+ * Paying the load in a root `beforeAll` with an explicit, generous hook budget
+ * removes it from every test's budget without raising `testTimeout`, so a
+ * genuinely slow adapter regression still trips the 5000 ms default.
+ *
+ * Wired package-wide rather than per test file because it measures free — full
+ * suite 1.04 s → 1.01 s, i.e. noise, since suites run on two workers and the
+ * loads overlap — and it covers every future test file without anyone having
+ * to remember the hook.
+ */
 beforeAll(async () => {
   await import('mailparser')
 }, 60_000)

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/mailparser-warmup.test.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/mailparser-warmup.test.ts
@@ -1,0 +1,12 @@
+// Guards the fix for issue #6040. `normalizeInboundGmailMessage` resolves `mailparser` lazily, so
+// without the root warm-up in jest.setup.ts the cold module-graph load lands inside whichever test
+// first parses a MIME message and competes with jest's default 5000 ms per-test budget.
+//
+// Jest gives every test file its own module registry, and `require.cache` reflects that registry —
+// so an entry for `mailparser` here means the warm-up ran before this test body, which is exactly
+// the property the flaky tests depend on.
+describe('mailparser warm-up', () => {
+  it('resolves mailparser before any test body runs', () => {
+    expect(require.cache[require.resolve('mailparser')]).toBeDefined()
+  })
+})

--- a/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/mailparser-warmup.test.ts
+++ b/packages/channel-gmail/src/modules/channel_gmail/lib/__tests__/mailparser-warmup.test.ts
@@ -1,10 +1,23 @@
-// Guards the fix for issue #6040. `normalizeInboundGmailMessage` resolves `mailparser` lazily, so
-// without the root warm-up in jest.setup.ts the cold module-graph load lands inside whichever test
-// first parses a MIME message and competes with jest's default 5000 ms per-test budget.
-//
-// Jest gives every test file its own module registry, and `require.cache` reflects that registry —
-// so an entry for `mailparser` here means the warm-up ran before this test body, which is exactly
-// the property the flaky tests depend on.
+/**
+ * mailparser warm-up guard (#6040).
+ *
+ * `normalizeInboundGmailMessage` resolves `mailparser` lazily, inside the
+ * function. Without the root warm-up in `jest.setup.ts` the cold module-graph
+ * load therefore lands inside whichever test first parses a MIME message, and
+ * competes with jest's default 5000 ms per-test budget — which is what made
+ * three tests fail intermittently on CI while every sibling passed.
+ *
+ * Jest gives every test file its own module registry, and `require.cache`
+ * reflects that registry. This file imports nothing, so an entry for
+ * `mailparser` can only have been put there by the warm-up — making it a direct
+ * observation of the property the flaky tests depend on, rather than a timing
+ * assertion that would itself be flaky.
+ *
+ * Note this reads the CommonJS registry, which is what ts-jest's transform
+ * produces today. Should that ever emit native ESM dynamic imports, the
+ * warm-up would still work but this assertion would need rewriting — it fails
+ * closed, so the breakage is loud rather than silent.
+ */
 describe('mailparser warm-up', () => {
   it('resolves mailparser before any test body runs', () => {
     expect(require.cache[require.resolve('mailparser')]).toBeDefined()

--- a/packages/channel-imap/jest.config.cjs
+++ b/packages/channel-imap/jest.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   testEnvironment: 'node',
   watchman: false,
   rootDir: '.',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '^@open-mercato/channel-imap/(.*)$': '<rootDir>/src/$1',

--- a/packages/channel-imap/jest.setup.ts
+++ b/packages/channel-imap/jest.setup.ts
@@ -1,13 +1,22 @@
-// Warm the lazy `mailparser` import before any test body runs (issue #6040).
-//
-// `normalizeInboundImapMessage` resolves `mailparser` lazily, inside the function, so the whole
-// cold module-graph load is charged to whichever test first reaches it — against jest's default
-// 5000 ms per-test budget. On a contended CI runner that load alone approaches the timeout, which
-// made the first MIME-parsing test in a file fail intermittently while every sibling passed.
-//
-// Paying the load in a root `beforeAll` with an explicit, generous hook budget removes it from
-// every test's budget without raising `testTimeout`, so a genuinely slow adapter regression still
-// trips the 5000 ms default.
+/**
+ * Warm the lazy `mailparser` import before any test body runs (#6040).
+ *
+ * `normalizeInboundImapMessage` resolves `mailparser` lazily, inside the
+ * function, so the whole cold module-graph load is charged to whichever test
+ * first reaches it — against jest's default 5000 ms per-test budget. On a
+ * contended CI runner that load alone approaches the timeout, which made the
+ * first MIME-parsing test in a file fail intermittently while every sibling
+ * passed.
+ *
+ * Paying the load in a root `beforeAll` with an explicit, generous hook budget
+ * removes it from every test's budget without raising `testTimeout`, so a
+ * genuinely slow adapter regression still trips the 5000 ms default.
+ *
+ * Wired package-wide rather than per test file because it measures free — full
+ * suite 1.06 s → 1.09 s, i.e. noise, since suites run on two workers and the
+ * loads overlap — and it covers every future test file without anyone having
+ * to remember the hook.
+ */
 beforeAll(async () => {
   await import('mailparser')
 }, 60_000)

--- a/packages/channel-imap/jest.setup.ts
+++ b/packages/channel-imap/jest.setup.ts
@@ -1,0 +1,13 @@
+// Warm the lazy `mailparser` import before any test body runs (issue #6040).
+//
+// `normalizeInboundImapMessage` resolves `mailparser` lazily, inside the function, so the whole
+// cold module-graph load is charged to whichever test first reaches it — against jest's default
+// 5000 ms per-test budget. On a contended CI runner that load alone approaches the timeout, which
+// made the first MIME-parsing test in a file fail intermittently while every sibling passed.
+//
+// Paying the load in a root `beforeAll` with an explicit, generous hook budget removes it from
+// every test's budget without raising `testTimeout`, so a genuinely slow adapter regression still
+// trips the 5000 ms default.
+beforeAll(async () => {
+  await import('mailparser')
+}, 60_000)

--- a/packages/channel-imap/src/modules/channel_imap/lib/__tests__/mailparser-warmup.test.ts
+++ b/packages/channel-imap/src/modules/channel_imap/lib/__tests__/mailparser-warmup.test.ts
@@ -1,10 +1,23 @@
-// Guards the fix for issue #6040. `normalizeInboundImapMessage` resolves `mailparser` lazily, so
-// without the root warm-up in jest.setup.ts the cold module-graph load lands inside whichever test
-// first parses a MIME message and competes with jest's default 5000 ms per-test budget.
-//
-// Jest gives every test file its own module registry, and `require.cache` reflects that registry —
-// so an entry for `mailparser` here means the warm-up ran before this test body, which is exactly
-// the property the flaky tests depend on.
+/**
+ * mailparser warm-up guard (#6040).
+ *
+ * `normalizeInboundImapMessage` resolves `mailparser` lazily, inside the
+ * function. Without the root warm-up in `jest.setup.ts` the cold module-graph
+ * load therefore lands inside whichever test first parses a MIME message, and
+ * competes with jest's default 5000 ms per-test budget — which is what made
+ * three tests fail intermittently on CI while every sibling passed.
+ *
+ * Jest gives every test file its own module registry, and `require.cache`
+ * reflects that registry. This file imports nothing, so an entry for
+ * `mailparser` can only have been put there by the warm-up — making it a direct
+ * observation of the property the flaky tests depend on, rather than a timing
+ * assertion that would itself be flaky.
+ *
+ * Note this reads the CommonJS registry, which is what ts-jest's transform
+ * produces today. Should that ever emit native ESM dynamic imports, the
+ * warm-up would still work but this assertion would need rewriting — it fails
+ * closed, so the breakage is loud rather than silent.
+ */
 describe('mailparser warm-up', () => {
   it('resolves mailparser before any test body runs', () => {
     expect(require.cache[require.resolve('mailparser')]).toBeDefined()

--- a/packages/channel-imap/src/modules/channel_imap/lib/__tests__/mailparser-warmup.test.ts
+++ b/packages/channel-imap/src/modules/channel_imap/lib/__tests__/mailparser-warmup.test.ts
@@ -1,0 +1,12 @@
+// Guards the fix for issue #6040. `normalizeInboundImapMessage` resolves `mailparser` lazily, so
+// without the root warm-up in jest.setup.ts the cold module-graph load lands inside whichever test
+// first parses a MIME message and competes with jest's default 5000 ms per-test budget.
+//
+// Jest gives every test file its own module registry, and `require.cache` reflects that registry —
+// so an entry for `mailparser` here means the warm-up ran before this test body, which is exactly
+// the property the flaky tests depend on.
+describe('mailparser warm-up', () => {
+  it('resolves mailparser before any test body runs', () => {
+    expect(require.cache[require.resolve('mailparser')]).toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes #6040

## 🎯 Goal

Stop three `channel-imap` / `channel-gmail` unit tests from failing CI at random. Their pass/fail
was decided by how loaded the runner was, not by the code under test, so every red run they caused
sent someone to re-run a job that was never broken.

## 🔍 Problem

Three tests intermittently tripped jest's default 5000 ms per-test timeout, with identical
signatures and no assertion in common. Every sibling test in the same files passed.

| Package | File | Test |
|---|---|---|
| `channel-imap` | `lib/__tests__/normalize-inbound.test.ts` | `uses the Message-ID header as externalMessageId` |
| `channel-imap` | `lib/__tests__/adapter.test.ts` | `fetchHistory › fetches incremental UID range from the stored cursor` |
| `channel-gmail` | `lib/__tests__/adapter.test.ts` | `fetchHistory › incremental path: fetches added message bodies and updates the cursor` |

## 🔍 Root Cause

`normalizeInboundImapMessage` (`packages/channel-imap/.../normalize-inbound.ts:34`) and
`normalizeInboundGmailMessage` (`packages/channel-gmail/.../normalize-inbound.ts:37`) resolve
`mailparser` **lazily, inside the function**. Jest gives every test file its own module registry, so
the first test in a file to parse a MIME message pays the entire cold `mailparser` module-graph load
— and it is billed to that one test's 5000 ms budget. What made these three special is only
ordering: in each file they are the first test that actually normalizes a message. Neither
`jest.config.base.cjs` nor either package config sets `testTimeout`, so the 5000 ms default applies.

Measured in-jest cold load: **~250 ms** on an idle laptop. #6040 records the same `channel-imap`
suite at **10.8 s** on the failing CI run against **0.77 s** locally, so under runner contention that
single load approaches the timeout on its own.

## What Changed

- **`packages/channel-{imap,gmail}/jest.setup.ts`** (new) — a root `beforeAll` that awaits
  `import('mailparser')`, given its own **60 s hook** budget. The load now happens once per test
  file, before any test body runs.
- **`packages/channel-{imap,gmail}/jest.config.cjs`** — wire that file through
  `setupFilesAfterEnv`, matching how `core`, `ui` and `content` already do it.
- **`.../lib/__tests__/mailparser-warmup.test.ts`** (new, one per package) — the regression guard.

Per-test budgets are untouched. I deliberately did **not** set `testTimeout`: raising it hides the
cold-start cost instead of removing it, and would loosen the budget for the adapter logic itself —
which #6040's second acceptance criterion rules out.

**Why package-wide rather than the per-file `beforeAll` #6040 suggested.** I measured both. Wiring
it once per package costs nothing detectable — full-suite time went `channel-imap` 1.06 s → 1.09 s
and `channel-gmail` 1.04 s → 1.01 s, i.e. noise, because suites run on 2 workers and the loads
overlap. In exchange it covers every existing *and future* test file in these packages, instead of
depending on whoever adds the next MIME-parsing test remembering to add the hook.

## 🧪 Tests

- `mailparser-warmup.test.ts` asserts `mailparser` is already in the test file's module registry
  before any test body runs. Because jest scopes that registry per file, this is the actual property
  the flaky tests depend on rather than a proxy for it — and unlike a timing assertion it is
  deterministic. Both guards confirmed **red without this change, green with it**; the in-test
  `await import('mailparser')` drops from ~56 ms to 0.1 ms.
- `channel-imap` — 110 passed (was 109, +1 guard). `channel-gmail` — 79 passed (was 78, +1 guard).
- Full gate: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`,
  `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all pass.
- `yarn test`: 31 of 32 workspaces green (`core` 12214, `ui` 2067, `cli` 1865, `shared` 2237,
  `documents` 1007, …). Two environment caveats, neither related to this change:
  - turbo does not forward `TMPDIR`, so `@open-mercato/shared#test` aborts in a long in-repo
    worktree path when tsx `listen()`s on its pipe; run standalone with a short `TMPDIR` it is
    2237 passed / 0 failed. Its abort also skips ~15 downstream packages, which were run
    individually instead.
  - `create-mercato-app` is red in any local checkout — its `live Codex` / `live Claude` adapter
    oracles need those CLIs installed, plus one oracle that times out on a scaffolded app's
    `yarn typecheck`.

## Other packages with the same shape

#6040 asked whether any other package lazily imports a heavy dependency inside the unit under test.
I checked all five such sites:

| Site | Exposed? |
|---|---|
| `scheduler` → `bullmq` | No — `jest.mock`ed in the only suite that reaches it |
| `search` → `meilisearch` | No — never actually loaded by a test |
| `channel-imap` → `nodemailer` (`smtp-client.ts`) | No — every test injects a fake SMTP client |
| `channel-apns` → `@parse/node-apn` | **Yes** — `fake-provider.test.ts` really loads it in a test body (confirmed via `require.cache`) |

`channel-apns` is the one genuine analogue, but at ~60 ms cold it is roughly 4× less exposed than
`mailparser` and has no observed CI failure, so I left it out of this diff rather than widening into
a third package. Worth a follow-up if it ever flakes.

## 💥 Breaking Changes

None. Test-only: `jest.setup.ts` sits outside `src/`, so it is neither typechecked nor picked up by
`build-package.mjs`'s `src/**/*.{ts,tsx}` entry-point glob, and the new test files are excluded from
both by the existing `**/__tests__/**` rules. Nothing ships to `dist`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791706021&installation_model_id=432243&pr_number=6052&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6052&signature=3302589dd5e56c2d28c65b868088c5ea65d5429f2884814995f76fc7eaa2f04b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->