### PR TITLE
fix(data-sync): validate the recurring-schedule value before submit (#5872)

### DIFF
--- a/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
@@ -6,6 +6,8 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { readOptimisticLockExpected } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { isInvalidScheduleValueError } from '@open-mercato/shared/lib/schedule/invalidScheduleValue'
+import { buildScheduleValueErrorBody } from '../../../lib/schedule-value'
 import { updateSyncScheduleSchema } from '../../../data/validators'
 import type { SyncScheduleService } from '../../../lib/sync-schedule-service'
 import { serializeSchedule } from '../serialize'
@@ -142,6 +144,9 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   } catch (error) {
     if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
+    }
+    if (isInvalidScheduleValueError(error)) {
+      return NextResponse.json(buildScheduleValueErrorBody(error.scheduleType), { status: 422 })
     }
     const message = error instanceof Error ? error.message : 'Failed to update sync schedule'
     return NextResponse.json({ error: message }, { status: 422 })

--- a/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/__tests__/schedule-write-order.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+import { createInvalidScheduleValueError } from '@open-mercato/shared/lib/schedule/invalidScheduleValue'
+
 const mockGetAuthFromRequest = jest.fn()
 
 const mockEm = {
@@ -10,7 +12,11 @@ const mockEm = {
 
 const mockScheduler = {
   register: jest.fn(async () => {
-    throw new Error('Failed to calculate next run time for schedule: some-id')
+    throw createInvalidScheduleValueError(
+      'cron',
+      'not a cron',
+      'Failed to calculate next run time for schedule: some-id',
+    )
   }),
   unregister: jest.fn(async () => undefined),
 }
@@ -46,7 +52,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 import { POST } from '../route'
 
-function request() {
+function request(overrides: Record<string, unknown> = {}) {
   return new Request('http://localhost/api/data_sync/schedules', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -54,11 +60,12 @@ function request() {
       integrationId: 'sync_excel',
       entityType: 'customers.person',
       direction: 'import',
-      scheduleType: 'interval',
-      scheduleValue: '3600',
+      scheduleType: 'cron',
+      scheduleValue: 'not a cron',
       timezone: 'UTC',
       fullSync: false,
       isEnabled: true,
+      ...overrides,
     }),
   })
 }
@@ -73,10 +80,32 @@ describe('data_sync schedule save write ordering', () => {
     const res = await POST(request())
 
     expect(res.status).toBe(422)
-    const body = await res.json()
-    expect(body.error).toContain('Failed to calculate next run time')
 
     expect(mockScheduler.register).toHaveBeenCalledTimes(1)
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+  })
+
+  it('reports a scheduler-rejected value as a scheduleValue field error instead of the internal message', async () => {
+    const res = await POST(request())
+    const body = await res.json()
+
+    expect(body.error).toBe('Invalid payload')
+    expect(body.details.fieldErrors.scheduleValue).toHaveLength(1)
+    expect(JSON.stringify(body)).not.toContain('Failed to calculate next run time')
+    expect(JSON.stringify(body)).not.toContain('some-id')
+  })
+
+  it('rejects an unparseable interval at the schema layer, before the scheduler is reached', async () => {
+    const res = await POST(request({ scheduleType: 'interval', scheduleValue: '3600' }))
+
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toBe('Invalid payload')
+    expect(body.details.fieldErrors.scheduleValue).toHaveLength(1)
+
+    expect(mockScheduler.register).not.toHaveBeenCalled()
     expect(mockEm.create).not.toHaveBeenCalled()
     expect(mockEm.persist).not.toHaveBeenCalled()
     expect(mockEm.flush).not.toHaveBeenCalled()

--- a/packages/core/src/modules/data_sync/api/schedules/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/route.ts
@@ -8,6 +8,8 @@ import type { SyncScheduleService } from '../../lib/sync-schedule-service'
 import { serializeSchedule } from './serialize'
 import { readOptimisticLockExpected } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { isInvalidScheduleValueError } from '@open-mercato/shared/lib/schedule/invalidScheduleValue'
+import { buildScheduleValueErrorBody } from '../../lib/schedule-value'
 import {
   runCrudMutationGuardAfterSuccess,
   validateCrudMutationGuard,
@@ -119,6 +121,9 @@ export async function POST(req: Request) {
   } catch (error) {
     if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
+    }
+    if (isInvalidScheduleValueError(error)) {
+      return NextResponse.json(buildScheduleValueErrorBody(error.scheduleType), { status: 422 })
     }
     const message = error instanceof Error ? error.message : 'Failed to save sync schedule'
     return NextResponse.json({ error: message }, { status: 422 })

--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -30,6 +30,8 @@ import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimi
 import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
+import { isValidScheduleInterval } from '@open-mercato/shared/lib/schedule/interval'
+import { hasScheduleValueFieldError } from '@open-mercato/core/modules/data_sync/lib/schedule-value'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import {
   ArrowRightLeft,
@@ -127,6 +129,8 @@ type SyncScheduleEditorState = {
 
 const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
+const SCHEDULE_VALUE_ERROR_ID = 'data-sync-dashboard-schedule-value-error'
+
 function formatEntityTypeLabel(entityType: string): string {
   return entityType
     .replace(/[_-]+/g, ' ')
@@ -169,6 +173,7 @@ export default function SyncRunsDashboardPage() {
   const [isLoadingSchedule, setIsLoadingSchedule] = React.useState(false)
   const [isSavingSchedule, setIsSavingSchedule] = React.useState(false)
   const [isDeletingSchedule, setIsDeletingSchedule] = React.useState(false)
+  const [hasInvalidScheduleValue, setHasInvalidScheduleValue] = React.useState(false)
   const [reloadToken, setReloadToken] = React.useState(0)
   const scopeVersion = useOrganizationScopeVersion()
   const t = useT()
@@ -337,7 +342,14 @@ export default function SyncRunsDashboardPage() {
 
   const updateScheduleEditor = React.useCallback((changes: Partial<SyncScheduleEditorState>) => {
     setScheduleEditor((current) => ({ ...current, ...changes }))
+    if (changes.scheduleValue !== undefined || changes.scheduleType !== undefined) {
+      setHasInvalidScheduleValue(false)
+    }
   }, [])
+
+  const scheduleValueErrorMessage = scheduleEditor.scheduleType === 'cron'
+    ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a five-field cron expression, for example `0 * * * *`.')
+    : t('data_sync.dashboard.schedule.invalidInterval', 'Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.')
 
   const handleCancel = React.useCallback(async (row: SyncRunRow) => {
     // optimistic-lock-exempt: run lifecycle action endpoint (cancel), not a concurrent record edit
@@ -436,11 +448,19 @@ export default function SyncRunsDashboardPage() {
 
   const handleSaveSchedule = React.useCallback(async () => {
     if (!selectedIntegration || !selectedEntityType) return
-    if (scheduleEditor.scheduleValue.trim().length === 0) {
-      flash(t('data_sync.dashboard.schedule.invalidValue', 'Provide a schedule value before saving.'), 'error')
+    const scheduleValue = scheduleEditor.scheduleValue.trim()
+
+    // The documented interval format is checked here so a value the scheduler
+    // can never run never reaches the API; cron stays server-validated and
+    // comes back through the same inline field error.
+    const isValueAcceptable = scheduleValue.length > 0
+      && (scheduleEditor.scheduleType !== 'interval' || isValidScheduleInterval(scheduleValue))
+    if (!isValueAcceptable) {
+      setHasInvalidScheduleValue(true)
       return
     }
 
+    setHasInvalidScheduleValue(false)
     setIsSavingSchedule(true)
     try {
       const call = await runMutation({
@@ -458,7 +478,7 @@ export default function SyncRunsDashboardPage() {
               entityType: selectedEntityType,
               direction: selectedDirection,
               scheduleType: scheduleEditor.scheduleType,
-              scheduleValue: scheduleEditor.scheduleValue.trim(),
+              scheduleValue,
               timezone: scheduleEditor.timezone.trim() || DEFAULT_TIMEZONE,
               fullSync: scheduleEditor.fullSync,
               isEnabled: scheduleEditor.isEnabled,
@@ -470,7 +490,7 @@ export default function SyncRunsDashboardPage() {
           entityType: selectedEntityType,
           direction: selectedDirection,
           scheduleType: scheduleEditor.scheduleType,
-          scheduleValue: scheduleEditor.scheduleValue.trim(),
+          scheduleValue,
           timezone: scheduleEditor.timezone.trim() || DEFAULT_TIMEZONE,
           fullSync: scheduleEditor.fullSync,
           isEnabled: scheduleEditor.isEnabled,
@@ -483,6 +503,10 @@ export default function SyncRunsDashboardPage() {
       })
 
       if (!call.ok || !call.result) {
+        if (hasScheduleValueFieldError(call.result)) {
+          setHasInvalidScheduleValue(true)
+          return
+        }
         const conflictError = Object.assign(
           new Error((call.result as { error?: string } | null)?.error ?? t('data_sync.dashboard.schedule.error', 'Failed to save recurring schedule')),
           {
@@ -916,7 +940,14 @@ export default function SyncRunsDashboardPage() {
                       onChange={(event) => updateScheduleEditor({ scheduleValue: event.target.value })}
                       disabled={isLoadingSchedule || isSavingSchedule || isDeletingSchedule || !selectedIntegration || !selectedEntityType}
                       placeholder={scheduleEditor.scheduleType === 'cron' ? '0 * * * *' : '1h'}
+                      aria-invalid={hasInvalidScheduleValue || undefined}
+                      aria-describedby={hasInvalidScheduleValue ? SCHEDULE_VALUE_ERROR_ID : undefined}
                     />
+                    {hasInvalidScheduleValue ? (
+                      <p id={SCHEDULE_VALUE_ERROR_ID} className="text-xs text-destructive">
+                        {scheduleValueErrorMessage}
+                      </p>
+                    ) : null}
                     <p className="text-xs text-muted-foreground">
                       {scheduleEditor.scheduleType === 'cron'
                         ? t('data_sync.dashboard.schedule.cronHelp', 'Example: `0 * * * *` runs at the start of every hour.')

--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -131,6 +131,17 @@ const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UT
 
 const SCHEDULE_VALUE_ERROR_ID = 'data-sync-dashboard-schedule-value-error'
 
+type ScheduleValueError = 'empty' | 'format' | null
+
+function detectScheduleValueError(
+  scheduleType: 'cron' | 'interval',
+  scheduleValue: string,
+): ScheduleValueError {
+  if (scheduleValue.length === 0) return 'empty'
+  if (scheduleType === 'interval' && !isValidScheduleInterval(scheduleValue)) return 'format'
+  return null
+}
+
 function formatEntityTypeLabel(entityType: string): string {
   return entityType
     .replace(/[_-]+/g, ' ')
@@ -173,7 +184,7 @@ export default function SyncRunsDashboardPage() {
   const [isLoadingSchedule, setIsLoadingSchedule] = React.useState(false)
   const [isSavingSchedule, setIsSavingSchedule] = React.useState(false)
   const [isDeletingSchedule, setIsDeletingSchedule] = React.useState(false)
-  const [hasInvalidScheduleValue, setHasInvalidScheduleValue] = React.useState(false)
+  const [scheduleValueError, setScheduleValueError] = React.useState<ScheduleValueError>(null)
   const [reloadToken, setReloadToken] = React.useState(0)
   const scopeVersion = useOrganizationScopeVersion()
   const t = useT()
@@ -317,6 +328,7 @@ export default function SyncRunsDashboardPage() {
       }
 
       const record = Array.isArray(call.result?.items) ? call.result?.items[0] : undefined
+      setScheduleValueError(null)
       if (!record) {
         setScheduleEditor(buildDefaultScheduleState(selectedEntityType))
         setIsLoadingSchedule(false)
@@ -343,13 +355,15 @@ export default function SyncRunsDashboardPage() {
   const updateScheduleEditor = React.useCallback((changes: Partial<SyncScheduleEditorState>) => {
     setScheduleEditor((current) => ({ ...current, ...changes }))
     if (changes.scheduleValue !== undefined || changes.scheduleType !== undefined) {
-      setHasInvalidScheduleValue(false)
+      setScheduleValueError(null)
     }
   }, [])
 
-  const scheduleValueErrorMessage = scheduleEditor.scheduleType === 'cron'
-    ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a five-field cron expression, for example `0 * * * *`.')
-    : t('data_sync.dashboard.schedule.invalidInterval', 'Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.')
+  const scheduleValueErrorMessage = scheduleValueError === 'empty'
+    ? t('data_sync.dashboard.schedule.invalidValue', 'Provide a schedule value before saving.')
+    : scheduleEditor.scheduleType === 'cron'
+      ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a cron expression the scheduler can parse, for example `0 * * * *`.')
+      : t('data_sync.dashboard.schedule.invalidInterval', 'Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.')
 
   const handleCancel = React.useCallback(async (row: SyncRunRow) => {
     // optimistic-lock-exempt: run lifecycle action endpoint (cancel), not a concurrent record edit
@@ -453,14 +467,13 @@ export default function SyncRunsDashboardPage() {
     // The documented interval format is checked here so a value the scheduler
     // can never run never reaches the API; cron stays server-validated and
     // comes back through the same inline field error.
-    const isValueAcceptable = scheduleValue.length > 0
-      && (scheduleEditor.scheduleType !== 'interval' || isValidScheduleInterval(scheduleValue))
-    if (!isValueAcceptable) {
-      setHasInvalidScheduleValue(true)
+    const valueError = detectScheduleValueError(scheduleEditor.scheduleType, scheduleValue)
+    if (valueError) {
+      setScheduleValueError(valueError)
       return
     }
 
-    setHasInvalidScheduleValue(false)
+    setScheduleValueError(null)
     setIsSavingSchedule(true)
     try {
       const call = await runMutation({
@@ -504,7 +517,7 @@ export default function SyncRunsDashboardPage() {
 
       if (!call.ok || !call.result) {
         if (hasScheduleValueFieldError(call.result)) {
-          setHasInvalidScheduleValue(true)
+          setScheduleValueError('format')
           return
         }
         const conflictError = Object.assign(
@@ -940,10 +953,10 @@ export default function SyncRunsDashboardPage() {
                       onChange={(event) => updateScheduleEditor({ scheduleValue: event.target.value })}
                       disabled={isLoadingSchedule || isSavingSchedule || isDeletingSchedule || !selectedIntegration || !selectedEntityType}
                       placeholder={scheduleEditor.scheduleType === 'cron' ? '0 * * * *' : '1h'}
-                      aria-invalid={hasInvalidScheduleValue || undefined}
-                      aria-describedby={hasInvalidScheduleValue ? SCHEDULE_VALUE_ERROR_ID : undefined}
+                      aria-invalid={scheduleValueError ? true : undefined}
+                      aria-describedby={scheduleValueError ? SCHEDULE_VALUE_ERROR_ID : undefined}
                     />
-                    {hasInvalidScheduleValue ? (
+                    {scheduleValueError ? (
                       <p id={SCHEDULE_VALUE_ERROR_ID} className="text-xs text-destructive">
                         {scheduleValueErrorMessage}
                       </p>

--- a/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
+++ b/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
@@ -21,7 +21,9 @@ import {
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { Switch } from '@open-mercato/ui/primitives/switch'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
+import { isValidScheduleInterval } from '@open-mercato/shared/lib/schedule/interval'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { hasScheduleValueFieldError } from '../lib/schedule-value'
 import { getSyncSummaryVariant } from '../lib/syncRunStatus'
 import type { RunParameter } from '../lib/adapter'
 import { getApplicableRunParameters } from '../lib/run-parameters'
@@ -122,6 +124,10 @@ function buildScheduleKey(entityType: string, direction: 'import' | 'export'): s
   return `${entityType}:${direction}`
 }
 
+function buildScheduleValueErrorId(scheduleKey: string): string {
+  return `data-sync-schedule-value-error-${scheduleKey.replace(/[^a-zA-Z0-9]+/g, '-')}`
+}
+
 function buildScheduleEditors(
   entityTypes: string[],
   directions: Array<'import' | 'export'>,
@@ -163,6 +169,13 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
   const [runningKey, setRunningKey] = React.useState<string | null>(null)
   const [savingKey, setSavingKey] = React.useState<string | null>(null)
   const [deletingKey, setDeletingKey] = React.useState<string | null>(null)
+  const [invalidValueKeys, setInvalidValueKeys] = React.useState<Record<string, boolean>>({})
+
+  const describeScheduleValueError = React.useCallback((scheduleType: 'cron' | 'interval') => (
+    scheduleType === 'cron'
+      ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a five-field cron expression, for example `0 * * * *`.')
+      : t('data_sync.dashboard.schedule.invalidInterval', 'Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.')
+  ), [t])
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -214,6 +227,9 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
         ...patch,
       },
     }))
+    if (patch.scheduleValue !== undefined || patch.scheduleType !== undefined) {
+      setInvalidValueKeys((current) => (current[key] ? { ...current, [key]: false } : current))
+    }
   }, [])
 
   const handleStartSync = React.useCallback(async (entityType: string, direction: 'import' | 'export', scheduleKey: string) => {
@@ -281,6 +297,19 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
 
   const handleSaveSchedule = React.useCallback(async (entityType: string, direction: 'import' | 'export', scheduleKey: string) => {
     const scheduleState = schedules[scheduleKey] ?? buildDefaultScheduleState(entityType)
+    const scheduleValue = scheduleState.scheduleValue.trim()
+
+    // The documented interval format is checked here so a value the scheduler
+    // can never run never reaches the API; cron stays server-validated and
+    // comes back through the same inline field error.
+    const isValueAcceptable = scheduleValue.length > 0
+      && (scheduleState.scheduleType !== 'interval' || isValidScheduleInterval(scheduleValue))
+    if (!isValueAcceptable) {
+      setInvalidValueKeys((current) => ({ ...current, [scheduleKey]: true }))
+      return
+    }
+
+    setInvalidValueKeys((current) => (current[scheduleKey] ? { ...current, [scheduleKey]: false } : current))
     setSavingKey(scheduleKey)
     try {
       // Keyed upsert (POST). When the server resolves an existing row the save
@@ -297,7 +326,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
               entityType,
               direction,
               scheduleType: scheduleState.scheduleType,
-              scheduleValue: scheduleState.scheduleValue,
+              scheduleValue,
               timezone: scheduleState.timezone,
               fullSync: scheduleState.fullSync,
               isEnabled: scheduleState.isEnabled,
@@ -309,7 +338,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
           entityType,
           direction,
           scheduleType: scheduleState.scheduleType,
-          scheduleValue: scheduleState.scheduleValue,
+          scheduleValue,
           timezone: scheduleState.timezone,
           fullSync: scheduleState.fullSync,
           isEnabled: scheduleState.isEnabled,
@@ -322,6 +351,10 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
       })
 
       if (!call.ok || !call.result) {
+        if (hasScheduleValueFieldError(call.result)) {
+          setInvalidValueKeys((current) => ({ ...current, [scheduleKey]: true }))
+          return
+        }
         const conflictError = Object.assign(
           new Error((call.result as { error?: string } | null)?.error ?? 'Failed to save schedule'),
           {
@@ -498,6 +531,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
                 const isSaving = savingKey === row.key
                 const isDeleting = deletingKey === row.key
                 const controlsDisabled = isRunning || isSaving || isDeleting
+                const hasInvalidValue = invalidValueKeys[row.key] === true
                 return (
                   <tr key={row.key} className="border-t align-top">
                     <td className="px-3 py-3 font-medium">{formatEntityTypeLabel(row.entityType)}</td>
@@ -525,7 +559,17 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
                         onChange={(event) => updateScheduleEditor(row.key, { scheduleValue: event.target.value }, row.entityType)}
                         disabled={controlsDisabled}
                         placeholder={scheduleState.scheduleType === 'cron' ? '0 * * * *' : '1h'}
+                        aria-invalid={hasInvalidValue || undefined}
+                        aria-describedby={hasInvalidValue ? buildScheduleValueErrorId(row.key) : undefined}
+                        aria-label={scheduleState.scheduleType === 'cron'
+                          ? t('data_sync.dashboard.schedule.cronValue', 'Cron expression')
+                          : t('data_sync.dashboard.schedule.intervalValue', 'Interval')}
                       />
+                      {hasInvalidValue ? (
+                        <p id={buildScheduleValueErrorId(row.key)} className="mt-1 text-xs text-destructive">
+                          {describeScheduleValueError(scheduleState.scheduleType)}
+                        </p>
+                      ) : null}
                     </td>
                     <td className="px-3 py-3">
                       <Input

--- a/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
+++ b/packages/core/src/modules/data_sync/components/IntegrationScheduleTab.tsx
@@ -124,8 +124,19 @@ function buildScheduleKey(entityType: string, direction: 'import' | 'export'): s
   return `${entityType}:${direction}`
 }
 
+type ScheduleValueError = 'empty' | 'format' | undefined
+
 function buildScheduleValueErrorId(scheduleKey: string): string {
   return `data-sync-schedule-value-error-${scheduleKey.replace(/[^a-zA-Z0-9]+/g, '-')}`
+}
+
+function detectScheduleValueError(
+  scheduleType: 'cron' | 'interval',
+  scheduleValue: string,
+): ScheduleValueError {
+  if (scheduleValue.length === 0) return 'empty'
+  if (scheduleType === 'interval' && !isValidScheduleInterval(scheduleValue)) return 'format'
+  return undefined
 }
 
 function buildScheduleEditors(
@@ -169,13 +180,17 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
   const [runningKey, setRunningKey] = React.useState<string | null>(null)
   const [savingKey, setSavingKey] = React.useState<string | null>(null)
   const [deletingKey, setDeletingKey] = React.useState<string | null>(null)
-  const [invalidValueKeys, setInvalidValueKeys] = React.useState<Record<string, boolean>>({})
+  const [valueErrors, setValueErrors] = React.useState<Record<string, ScheduleValueError>>({})
 
-  const describeScheduleValueError = React.useCallback((scheduleType: 'cron' | 'interval') => (
-    scheduleType === 'cron'
-      ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a five-field cron expression, for example `0 * * * *`.')
+  const describeScheduleValueError = React.useCallback((
+    valueError: ScheduleValueError,
+    scheduleType: 'cron' | 'interval',
+  ) => {
+    if (valueError === 'empty') return t('data_sync.dashboard.schedule.invalidValue', 'Provide a schedule value before saving.')
+    return scheduleType === 'cron'
+      ? t('data_sync.dashboard.schedule.invalidCron', 'Enter a cron expression the scheduler can parse, for example `0 * * * *`.')
       : t('data_sync.dashboard.schedule.invalidInterval', 'Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.')
-  ), [t])
+  }, [t])
 
   const load = React.useCallback(async () => {
     setIsLoading(true)
@@ -191,6 +206,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
       const supportedEntities = resolvedOption?.supportedEntities ?? []
       const supportedDirections = getSupportedDirections(resolvedOption?.direction)
       setSchedules(buildScheduleEditors(supportedEntities, supportedDirections, schedulesCall.result?.items ?? []))
+      setValueErrors({})
     } catch (error) {
       const message = error instanceof Error ? error.message : t('data_sync.integrationTab.loadError', 'Failed to load sync schedules.')
       flash(message, 'error')
@@ -228,7 +244,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
       },
     }))
     if (patch.scheduleValue !== undefined || patch.scheduleType !== undefined) {
-      setInvalidValueKeys((current) => (current[key] ? { ...current, [key]: false } : current))
+      setValueErrors((current) => (current[key] ? { ...current, [key]: undefined } : current))
     }
   }, [])
 
@@ -302,14 +318,13 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
     // The documented interval format is checked here so a value the scheduler
     // can never run never reaches the API; cron stays server-validated and
     // comes back through the same inline field error.
-    const isValueAcceptable = scheduleValue.length > 0
-      && (scheduleState.scheduleType !== 'interval' || isValidScheduleInterval(scheduleValue))
-    if (!isValueAcceptable) {
-      setInvalidValueKeys((current) => ({ ...current, [scheduleKey]: true }))
+    const valueError = detectScheduleValueError(scheduleState.scheduleType, scheduleValue)
+    if (valueError) {
+      setValueErrors((current) => ({ ...current, [scheduleKey]: valueError }))
       return
     }
 
-    setInvalidValueKeys((current) => (current[scheduleKey] ? { ...current, [scheduleKey]: false } : current))
+    setValueErrors((current) => (current[scheduleKey] ? { ...current, [scheduleKey]: undefined } : current))
     setSavingKey(scheduleKey)
     try {
       // Keyed upsert (POST). When the server resolves an existing row the save
@@ -352,7 +367,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
 
       if (!call.ok || !call.result) {
         if (hasScheduleValueFieldError(call.result)) {
-          setInvalidValueKeys((current) => ({ ...current, [scheduleKey]: true }))
+          setValueErrors((current) => ({ ...current, [scheduleKey]: 'format' }))
           return
         }
         const conflictError = Object.assign(
@@ -531,7 +546,7 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
                 const isSaving = savingKey === row.key
                 const isDeleting = deletingKey === row.key
                 const controlsDisabled = isRunning || isSaving || isDeleting
-                const hasInvalidValue = invalidValueKeys[row.key] === true
+                const valueError = valueErrors[row.key]
                 return (
                   <tr key={row.key} className="border-t align-top">
                     <td className="px-3 py-3 font-medium">{formatEntityTypeLabel(row.entityType)}</td>
@@ -559,15 +574,15 @@ export function IntegrationScheduleTab(props: IntegrationScheduleTabProps) {
                         onChange={(event) => updateScheduleEditor(row.key, { scheduleValue: event.target.value }, row.entityType)}
                         disabled={controlsDisabled}
                         placeholder={scheduleState.scheduleType === 'cron' ? '0 * * * *' : '1h'}
-                        aria-invalid={hasInvalidValue || undefined}
-                        aria-describedby={hasInvalidValue ? buildScheduleValueErrorId(row.key) : undefined}
+                        aria-invalid={valueError ? true : undefined}
+                        aria-describedby={valueError ? buildScheduleValueErrorId(row.key) : undefined}
                         aria-label={scheduleState.scheduleType === 'cron'
                           ? t('data_sync.dashboard.schedule.cronValue', 'Cron expression')
                           : t('data_sync.dashboard.schedule.intervalValue', 'Interval')}
                       />
-                      {hasInvalidValue ? (
+                      {valueError ? (
                         <p id={buildScheduleValueErrorId(row.key)} className="mt-1 text-xs text-destructive">
-                          {describeScheduleValueError(scheduleState.scheduleType)}
+                          {describeScheduleValueError(valueError, scheduleState.scheduleType)}
                         </p>
                       ) : null}
                     </td>

--- a/packages/core/src/modules/data_sync/components/__tests__/IntegrationScheduleTab.scheduleValue.test.tsx
+++ b/packages/core/src/modules/data_sync/components/__tests__/IntegrationScheduleTab.scheduleValue.test.tsx
@@ -121,6 +121,29 @@ describe('IntegrationScheduleTab — schedule value validation', () => {
     expect(runMutationMock.mock.calls[0][0].mutationPayload.scheduleValue).toBe('2h')
   })
 
+  it('distinguishes an empty value from a malformed one', async () => {
+    await renderTab()
+
+    fireEvent.change(intervalInput(), { target: { value: '   ' } })
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(intervalInput()).toHaveAttribute('aria-invalid', 'true'))
+    expect(screen.getByText(/provide a schedule value/i)).toBeInTheDocument()
+    expect(runMutationMock).not.toHaveBeenCalled()
+  })
+
+  it('drops a stale inline error when the tab reloads', async () => {
+    await renderTab()
+
+    fireEvent.change(intervalInput(), { target: { value: '3600' } })
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(intervalInput()).toHaveAttribute('aria-invalid', 'true'))
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+
+    await waitFor(() => expect(intervalInput()).not.toHaveAttribute('aria-invalid'))
+  })
+
   it('renders a server-reported scheduleValue error inline instead of flashing it', async () => {
     runMutationMock.mockResolvedValue({
       ok: false,

--- a/packages/core/src/modules/data_sync/components/__tests__/IntegrationScheduleTab.scheduleValue.test.tsx
+++ b/packages/core/src/modules/data_sync/components/__tests__/IntegrationScheduleTab.scheduleValue.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const apiCallMock = jest.fn()
+const flashMock = jest.fn()
+const runMutationMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  withScopedApiRequestHeaders: (_header: unknown, fn: () => unknown) => fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: runMutationMock, retryLastMutation: jest.fn() }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 0,
+}))
+
+function mockOptions() {
+  apiCallMock.mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.startsWith('/api/data_sync/options')) {
+      return Promise.resolve({
+        ok: true,
+        result: {
+          items: [{
+            integrationId: 'sync_demo',
+            title: 'Demo',
+            direction: 'import',
+            runMode: 'generic',
+            canStartRun: true,
+            supportedEntities: ['orders'],
+            runParameters: [],
+            hasCredentials: true,
+            isEnabled: true,
+          }],
+        },
+      })
+    }
+    return Promise.resolve({ ok: true, result: { items: [] } })
+  })
+}
+
+async function renderTab() {
+  const { IntegrationScheduleTab } = await import('../IntegrationScheduleTab')
+  renderWithProviders(
+    <IntegrationScheduleTab integrationId="sync_demo" hasCredentials isEnabled />,
+  )
+  await waitFor(() => expect(screen.getByText('Orders')).toBeInTheDocument())
+}
+
+function intervalInput() {
+  return screen.getByRole('textbox', { name: /interval/i })
+}
+
+function saveButton() {
+  return screen.getByRole('button', { name: /save recurring schedule/i })
+}
+
+describe('IntegrationScheduleTab — schedule value validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockOptions()
+    runMutationMock.mockResolvedValue({ ok: true, result: null })
+  })
+
+  it('blocks the save and marks the field invalid when the interval has no unit', async () => {
+    await renderTab()
+
+    fireEvent.change(intervalInput(), { target: { value: '3600' } })
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(intervalInput()).toHaveAttribute('aria-invalid', 'true'))
+    expect(screen.getByText(/whole number followed by s, m, h or d/i)).toBeInTheDocument()
+    expect(runMutationMock).not.toHaveBeenCalled()
+    expect(flashMock).not.toHaveBeenCalled()
+  })
+
+  it('clears the inline error once the value is corrected and submits the trimmed value', async () => {
+    runMutationMock.mockResolvedValue({
+      ok: true,
+      result: {
+        id: 'schedule-1',
+        scheduleType: 'interval',
+        scheduleValue: '2h',
+        timezone: 'UTC',
+        fullSync: false,
+        isEnabled: true,
+        lastRunAt: null,
+        updatedAt: null,
+      },
+    })
+    await renderTab()
+
+    fireEvent.change(intervalInput(), { target: { value: '3600' } })
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(intervalInput()).toHaveAttribute('aria-invalid', 'true'))
+
+    fireEvent.change(intervalInput(), { target: { value: ' 2h ' } })
+    expect(intervalInput()).not.toHaveAttribute('aria-invalid')
+
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(runMutationMock).toHaveBeenCalled())
+    expect(runMutationMock.mock.calls[0][0].mutationPayload.scheduleValue).toBe('2h')
+  })
+
+  it('renders a server-reported scheduleValue error inline instead of flashing it', async () => {
+    runMutationMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      result: {
+        error: 'Invalid payload',
+        details: { formErrors: [], fieldErrors: { scheduleValue: ['Cron expression could not be parsed.'] } },
+      },
+    })
+    await renderTab()
+
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(intervalInput()).toHaveAttribute('aria-invalid', 'true'))
+    expect(flashMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/data/__tests__/sync-schedule-validators.test.ts
+++ b/packages/core/src/modules/data_sync/data/__tests__/sync-schedule-validators.test.ts
@@ -34,6 +34,13 @@ describe('createSyncScheduleSchema', () => {
     expect(fieldErrorsFor(result).scheduleValue).toHaveLength(1)
   })
 
+  it('rejects surrounding whitespace, which the scheduler parser would reject later', () => {
+    const result = createSyncScheduleSchema.safeParse({ ...baseCreatePayload, scheduleValue: ' 1h ' })
+
+    expect(result.success).toBe(false)
+    expect(fieldErrorsFor(result).scheduleValue).toHaveLength(1)
+  })
+
   it('leaves cron expressions to the scheduler', () => {
     const result = createSyncScheduleSchema.safeParse({
       ...baseCreatePayload,

--- a/packages/core/src/modules/data_sync/data/__tests__/sync-schedule-validators.test.ts
+++ b/packages/core/src/modules/data_sync/data/__tests__/sync-schedule-validators.test.ts
@@ -1,0 +1,63 @@
+import { createSyncScheduleSchema, updateSyncScheduleSchema } from '../validators'
+
+const baseCreatePayload = {
+  integrationId: 'sync_excel',
+  entityType: 'customers.person',
+  direction: 'import' as const,
+  scheduleType: 'interval' as const,
+  scheduleValue: '1h',
+  timezone: 'UTC',
+}
+
+function fieldErrorsFor(result: ReturnType<typeof createSyncScheduleSchema.safeParse>) {
+  if (result.success) throw new Error('[internal] expected the payload to be rejected')
+  return result.error.flatten().fieldErrors
+}
+
+describe('createSyncScheduleSchema', () => {
+  it('accepts the documented interval format', () => {
+    expect(createSyncScheduleSchema.safeParse(baseCreatePayload).success).toBe(true)
+    expect(createSyncScheduleSchema.safeParse({ ...baseCreatePayload, scheduleValue: '24h' }).success).toBe(true)
+  })
+
+  it('rejects a unitless interval with a scheduleValue field error', () => {
+    const result = createSyncScheduleSchema.safeParse({ ...baseCreatePayload, scheduleValue: '3600' })
+
+    expect(result.success).toBe(false)
+    expect(fieldErrorsFor(result).scheduleValue).toHaveLength(1)
+  })
+
+  it('rejects an interval shorter than the scheduler minimum', () => {
+    const result = createSyncScheduleSchema.safeParse({ ...baseCreatePayload, scheduleValue: '30s' })
+
+    expect(result.success).toBe(false)
+    expect(fieldErrorsFor(result).scheduleValue).toHaveLength(1)
+  })
+
+  it('leaves cron expressions to the scheduler', () => {
+    const result = createSyncScheduleSchema.safeParse({
+      ...baseCreatePayload,
+      scheduleType: 'cron',
+      scheduleValue: '0 * * * *',
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('updateSyncScheduleSchema', () => {
+  it('rejects a unitless interval on a partial update', () => {
+    const result = updateSyncScheduleSchema.safeParse({ scheduleType: 'interval', scheduleValue: '3600' })
+
+    expect(result.success).toBe(false)
+    expect(fieldErrorsFor(result as never).scheduleValue).toHaveLength(1)
+  })
+
+  it('still requires at least one field', () => {
+    expect(updateSyncScheduleSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts an unrelated field on its own', () => {
+    expect(updateSyncScheduleSchema.safeParse({ isEnabled: false }).success).toBe(true)
+  })
+})

--- a/packages/core/src/modules/data_sync/data/validators.ts
+++ b/packages/core/src/modules/data_sync/data/validators.ts
@@ -51,8 +51,10 @@ export const listSyncSchedulesQuerySchema = z.object({
 /**
  * The documented interval format is part of the API contract, so a value the
  * scheduler can never run (`"3600"`) is rejected here instead of surfacing an
- * internal scheduler message from deep inside the write path. Cron is left to
- * the scheduler's own parser, which reports back through the same
+ * internal scheduler message from deep inside the write path. The value is
+ * checked exactly as the scheduler will receive it — surrounding whitespace is
+ * not tolerated here, because the scheduler's anchored parser would reject it
+ * later. Cron is left to that parser, which reports back through the same
  * `scheduleValue` field error.
  */
 function refineScheduleValueFormat(
@@ -60,7 +62,7 @@ function refineScheduleValueFormat(
   ctx: z.RefinementCtx,
 ): void {
   if (value.scheduleType !== 'interval' || typeof value.scheduleValue !== 'string') return
-  if (isValidScheduleInterval(value.scheduleValue.trim())) return
+  if (isValidScheduleInterval(value.scheduleValue)) return
   ctx.addIssue({
     code: 'custom',
     path: [SCHEDULE_VALUE_FIELD],

--- a/packages/core/src/modules/data_sync/data/validators.ts
+++ b/packages/core/src/modules/data_sync/data/validators.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod'
+import { isValidScheduleInterval } from '@open-mercato/shared/lib/schedule/interval'
+import { SCHEDULE_VALUE_FIELD, SCHEDULE_VALUE_FORMAT_MESSAGES } from '../lib/schedule-value'
 
 export const runSyncSchema = z.object({
   integrationId: z.string().min(1),
@@ -46,6 +48,26 @@ export const listSyncSchedulesQuerySchema = z.object({
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
 })
 
+/**
+ * The documented interval format is part of the API contract, so a value the
+ * scheduler can never run (`"3600"`) is rejected here instead of surfacing an
+ * internal scheduler message from deep inside the write path. Cron is left to
+ * the scheduler's own parser, which reports back through the same
+ * `scheduleValue` field error.
+ */
+function refineScheduleValueFormat(
+  value: { scheduleType?: 'cron' | 'interval'; scheduleValue?: string },
+  ctx: z.RefinementCtx,
+): void {
+  if (value.scheduleType !== 'interval' || typeof value.scheduleValue !== 'string') return
+  if (isValidScheduleInterval(value.scheduleValue.trim())) return
+  ctx.addIssue({
+    code: 'custom',
+    path: [SCHEDULE_VALUE_FIELD],
+    message: SCHEDULE_VALUE_FORMAT_MESSAGES.interval,
+  })
+}
+
 export const createSyncScheduleSchema = z.object({
   integrationId: z.string().min(1),
   entityType: z.string().min(1),
@@ -55,7 +77,7 @@ export const createSyncScheduleSchema = z.object({
   timezone: z.string().min(1).default('UTC'),
   fullSync: z.boolean().default(false),
   isEnabled: z.boolean().default(true),
-})
+}).superRefine(refineScheduleValueFormat)
 
 export const updateSyncScheduleSchema = z.object({
   integrationId: z.string().min(1).optional(),
@@ -68,7 +90,7 @@ export const updateSyncScheduleSchema = z.object({
   isEnabled: z.boolean().optional(),
 }).refine((value) => Object.keys(value).length > 0, {
   message: 'At least one field must be updated',
-})
+}).superRefine(refineScheduleValueFormat)
 
 export type CreateSyncScheduleInput = z.infer<typeof createSyncScheduleSchema>
 export type UpdateSyncScheduleInput = z.infer<typeof updateSyncScheduleSchema>

--- a/packages/core/src/modules/data_sync/i18n/de.json
+++ b/packages/core/src/modules/data_sync/i18n/de.json
@@ -31,6 +31,8 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
+  "data_sync.dashboard.schedule.invalidCron": "Geben Sie einen fünfteiligen Cron-Ausdruck an, zum Beispiel `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidInterval": "Geben Sie eine ganze Zahl mit der Einheit s, m, h oder d an (zum Beispiel `15m`, `1h` oder `24h`), mindestens eine Minute lang.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",
   "data_sync.dashboard.schedule.neverRun": "Saved, but no scheduled execution has completed yet.",

--- a/packages/core/src/modules/data_sync/i18n/de.json
+++ b/packages/core/src/modules/data_sync/i18n/de.json
@@ -31,7 +31,7 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
-  "data_sync.dashboard.schedule.invalidCron": "Geben Sie einen fünfteiligen Cron-Ausdruck an, zum Beispiel `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidCron": "Geben Sie einen Cron-Ausdruck an, den der Scheduler verarbeiten kann, zum Beispiel `0 * * * *`.",
   "data_sync.dashboard.schedule.invalidInterval": "Geben Sie eine ganze Zahl mit der Einheit s, m, h oder d an (zum Beispiel `15m`, `1h` oder `24h`), mindestens eine Minute lang.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",

--- a/packages/core/src/modules/data_sync/i18n/en.json
+++ b/packages/core/src/modules/data_sync/i18n/en.json
@@ -31,6 +31,8 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
+  "data_sync.dashboard.schedule.invalidCron": "Enter a five-field cron expression, for example `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidInterval": "Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",
   "data_sync.dashboard.schedule.neverRun": "Saved, but no scheduled execution has completed yet.",

--- a/packages/core/src/modules/data_sync/i18n/en.json
+++ b/packages/core/src/modules/data_sync/i18n/en.json
@@ -31,7 +31,7 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
-  "data_sync.dashboard.schedule.invalidCron": "Enter a five-field cron expression, for example `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidCron": "Enter a cron expression the scheduler can parse, for example `0 * * * *`.",
   "data_sync.dashboard.schedule.invalidInterval": "Enter a whole number followed by s, m, h or d (for example `15m`, `1h` or `24h`), at least one minute long.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",

--- a/packages/core/src/modules/data_sync/i18n/es.json
+++ b/packages/core/src/modules/data_sync/i18n/es.json
@@ -31,6 +31,8 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
+  "data_sync.dashboard.schedule.invalidCron": "Introduce una expresión cron de cinco campos, por ejemplo `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidInterval": "Introduce un número entero seguido de s, m, h o d (por ejemplo `15m`, `1h` o `24h`), de al menos un minuto.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",
   "data_sync.dashboard.schedule.neverRun": "Saved, but no scheduled execution has completed yet.",

--- a/packages/core/src/modules/data_sync/i18n/es.json
+++ b/packages/core/src/modules/data_sync/i18n/es.json
@@ -31,7 +31,7 @@
   "data_sync.dashboard.schedule.interval": "Interval",
   "data_sync.dashboard.schedule.intervalHelp": "Example: `1h`, `6h`, or `24h` for repeating intervals.",
   "data_sync.dashboard.schedule.intervalValue": "Interval",
-  "data_sync.dashboard.schedule.invalidCron": "Introduce una expresión cron de cinco campos, por ejemplo `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidCron": "Introduce una expresión cron que el planificador pueda interpretar, por ejemplo `0 * * * *`.",
   "data_sync.dashboard.schedule.invalidInterval": "Introduce un número entero seguido de s, m, h o d (por ejemplo `15m`, `1h` o `24h`), de al menos un minuto.",
   "data_sync.dashboard.schedule.invalidValue": "Provide a schedule value before saving.",
   "data_sync.dashboard.schedule.lastRun": "Last scheduled run: {value}",

--- a/packages/core/src/modules/data_sync/i18n/ko.json
+++ b/packages/core/src/modules/data_sync/i18n/ko.json
@@ -31,6 +31,8 @@
   "data_sync.dashboard.schedule.interval": "간격",
   "data_sync.dashboard.schedule.intervalHelp": "예: 반복 간격으로 `1h`, `6h`, `24h`를 사용하세요.",
   "data_sync.dashboard.schedule.intervalValue": "간격",
+  "data_sync.dashboard.schedule.invalidCron": "`0 * * * *`와 같이 5개 필드로 구성된 cron 표현식을 입력하세요.",
+  "data_sync.dashboard.schedule.invalidInterval": "`15m`, `1h`, `24h`처럼 정수 뒤에 s, m, h 또는 d를 붙여 1분 이상으로 입력하세요.",
   "data_sync.dashboard.schedule.invalidValue": "저장하기 전에 일정 값을 입력하세요.",
   "data_sync.dashboard.schedule.lastRun": "마지막 예약 실행: {value}",
   "data_sync.dashboard.schedule.neverRun": "저장되었지만 아직 완료된 예약 실행이 없습니다.",

--- a/packages/core/src/modules/data_sync/i18n/ko.json
+++ b/packages/core/src/modules/data_sync/i18n/ko.json
@@ -31,7 +31,7 @@
   "data_sync.dashboard.schedule.interval": "간격",
   "data_sync.dashboard.schedule.intervalHelp": "예: 반복 간격으로 `1h`, `6h`, `24h`를 사용하세요.",
   "data_sync.dashboard.schedule.intervalValue": "간격",
-  "data_sync.dashboard.schedule.invalidCron": "`0 * * * *`와 같이 5개 필드로 구성된 cron 표현식을 입력하세요.",
+  "data_sync.dashboard.schedule.invalidCron": "스케줄러가 해석할 수 있는 cron 표현식을 입력하세요. 예: `0 * * * *`.",
   "data_sync.dashboard.schedule.invalidInterval": "`15m`, `1h`, `24h`처럼 정수 뒤에 s, m, h 또는 d를 붙여 1분 이상으로 입력하세요.",
   "data_sync.dashboard.schedule.invalidValue": "저장하기 전에 일정 값을 입력하세요.",
   "data_sync.dashboard.schedule.lastRun": "마지막 예약 실행: {value}",

--- a/packages/core/src/modules/data_sync/i18n/pl.json
+++ b/packages/core/src/modules/data_sync/i18n/pl.json
@@ -31,6 +31,8 @@
   "data_sync.dashboard.schedule.interval": "Interwał",
   "data_sync.dashboard.schedule.intervalHelp": "Przykład: `1h`, `6h` lub `24h` dla powtarzalnych interwałów.",
   "data_sync.dashboard.schedule.intervalValue": "Interwał",
+  "data_sync.dashboard.schedule.invalidCron": "Podaj pięcioczłonowe wyrażenie cron, na przykład `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidInterval": "Podaj liczbę całkowitą z jednostką s, m, h lub d (na przykład `15m`, `1h` lub `24h`), o długości co najmniej jednej minuty.",
   "data_sync.dashboard.schedule.invalidValue": "Podaj wartość harmonogramu przed zapisaniem.",
   "data_sync.dashboard.schedule.lastRun": "Ostatni zaplanowany przebieg: {value}",
   "data_sync.dashboard.schedule.neverRun": "Zapisano, ale żadne zaplanowane wykonanie jeszcze się nie zakończyło.",

--- a/packages/core/src/modules/data_sync/i18n/pl.json
+++ b/packages/core/src/modules/data_sync/i18n/pl.json
@@ -31,7 +31,7 @@
   "data_sync.dashboard.schedule.interval": "Interwał",
   "data_sync.dashboard.schedule.intervalHelp": "Przykład: `1h`, `6h` lub `24h` dla powtarzalnych interwałów.",
   "data_sync.dashboard.schedule.intervalValue": "Interwał",
-  "data_sync.dashboard.schedule.invalidCron": "Podaj pięcioczłonowe wyrażenie cron, na przykład `0 * * * *`.",
+  "data_sync.dashboard.schedule.invalidCron": "Podaj wyrażenie cron, które scheduler potrafi przetworzyć, na przykład `0 * * * *`.",
   "data_sync.dashboard.schedule.invalidInterval": "Podaj liczbę całkowitą z jednostką s, m, h lub d (na przykład `15m`, `1h` lub `24h`), o długości co najmniej jednej minuty.",
   "data_sync.dashboard.schedule.invalidValue": "Podaj wartość harmonogramu przed zapisaniem.",
   "data_sync.dashboard.schedule.lastRun": "Ostatni zaplanowany przebieg: {value}",

--- a/packages/core/src/modules/data_sync/lib/schedule-value.ts
+++ b/packages/core/src/modules/data_sync/lib/schedule-value.ts
@@ -1,0 +1,45 @@
+import type { ScheduleValueKind } from '@open-mercato/shared/lib/schedule/invalidScheduleValue'
+
+export const SCHEDULE_VALUE_FIELD = 'scheduleValue'
+
+export const SCHEDULE_VALUE_FORMAT_MESSAGES: Record<ScheduleValueKind, string> = {
+  interval: 'Interval must be a whole number followed by s, m, h or d (for example 15m, 1h or 24h) and cover at least one minute.',
+  cron: 'Cron expression could not be parsed. Use the five-field format, for example "0 * * * *".',
+}
+
+export type ScheduleValueErrorBody = {
+  error: string
+  details: {
+    formErrors: string[]
+    fieldErrors: Record<string, string[]>
+  }
+}
+
+/**
+ * Mirrors zod's `flatten()` shape so a scheduler-reported format failure and a
+ * schema-reported one reach the client as the same structured field error
+ * instead of an internal scheduler message.
+ */
+export function buildScheduleValueErrorBody(scheduleType: ScheduleValueKind): ScheduleValueErrorBody {
+  return {
+    error: 'Invalid payload',
+    details: {
+      formErrors: [],
+      fieldErrors: { [SCHEDULE_VALUE_FIELD]: [SCHEDULE_VALUE_FORMAT_MESSAGES[scheduleType]] },
+    },
+  }
+}
+
+/**
+ * Lets a form render its own translated hint next to the field instead of
+ * flashing the API's English message as a toast.
+ */
+export function hasScheduleValueFieldError(payload: unknown): boolean {
+  if (typeof payload !== 'object' || payload === null) return false
+  const details = (payload as { details?: unknown }).details
+  if (typeof details !== 'object' || details === null) return false
+  const fieldErrors = (details as { fieldErrors?: unknown }).fieldErrors
+  if (typeof fieldErrors !== 'object' || fieldErrors === null) return false
+  const messages = (fieldErrors as Record<string, unknown>)[SCHEDULE_VALUE_FIELD]
+  return Array.isArray(messages) && messages.length > 0
+}

--- a/packages/scheduler/src/modules/scheduler/lib/intervalParser.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/intervalParser.ts
@@ -1,27 +1,17 @@
+import {
+  MIN_SCHEDULE_INTERVAL_MS,
+  isValidScheduleInterval,
+  matchScheduleInterval,
+  parseScheduleInterval,
+} from '@open-mercato/shared/lib/schedule/interval'
+
 /**
  * Parse simple interval strings like '15m', '2h', '1d' into milliseconds
  */
-export const MIN_SCHEDULE_INTERVAL_MS = 60 * 1000
+export { MIN_SCHEDULE_INTERVAL_MS }
 
 export function parseInterval(interval: string): number {
-  const regex = /^(\d+)(s|m|h|d)$/
-  const match = interval.match(regex)
-  
-  if (!match) {
-    throw new Error(`Invalid interval format: ${interval}. Expected format: <number><unit> (e.g., 15m, 2h, 1d)`)
-  }
-  
-  const value = parseInt(match[1], 10)
-  const unit = match[2]
-  
-  const multipliers: Record<string, number> = {
-    s: 1000,           // seconds
-    m: 60 * 1000,      // minutes
-    h: 60 * 60 * 1000, // hours
-    d: 24 * 60 * 60 * 1000, // days
-  }
-  
-  return value * multipliers[unit]
+  return parseScheduleInterval(interval)
 }
 
 export function resolveScheduleIntervalMs(interval: string): number {
@@ -43,11 +33,7 @@ export function calculateNextRunFromInterval(
  * Validate an interval string
  */
 export function validateInterval(interval: string): boolean {
-  try {
-    return parseInterval(interval) >= MIN_SCHEDULE_INTERVAL_MS
-  } catch {
-    return false
-  }
+  return isValidScheduleInterval(interval)
 }
 
 /**
@@ -57,15 +43,14 @@ export function validateInterval(interval: string): boolean {
  */
 export function intervalToHuman(interval: string): string {
   try {
-    const regex = /^(\d+)(s|m|h|d)$/
-    const match = interval.match(regex)
-    
-    if (!match) {
+    const parts = matchScheduleInterval(interval)
+
+    if (!parts) {
       return interval
     }
-    
-    const unit = match[2]
-    
+
+    const unit = parts.unit
+
     const ms = parseInterval(interval)
     const seconds = ms / 1000
     

--- a/packages/scheduler/src/modules/scheduler/services/schedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/schedulerService.ts
@@ -4,6 +4,7 @@ import { calculateNextRunForWrite } from '../lib/nextRunCalculator.js'
 import { enforceTenantActiveScheduleLimit } from '../lib/activeScheduleLimits.js'
 import type { BullMQSchedulerService } from './bullmqSchedulerService.js'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { createInvalidScheduleValueError } from '@open-mercato/shared/lib/schedule/invalidScheduleValue'
 
 const logger = createLogger('scheduler')
 
@@ -53,7 +54,11 @@ export class SchedulerService {
     )
     
     if (!nextRunAt) {
-      throw new Error(`Failed to calculate next run time for schedule: ${registration.id}`)
+      throw createInvalidScheduleValueError(
+        registration.scheduleType,
+        registration.scheduleValue,
+        `Failed to calculate next run time for schedule: ${registration.id}`,
+      )
     }
     
     // Check if schedule already exists
@@ -186,7 +191,11 @@ export class SchedulerService {
       )
       : null
     if (scheduleChanged && !nextRunAt) {
-      throw new Error(`Failed to calculate next run time for schedule: ${scheduleId}`)
+      throw createInvalidScheduleValueError(
+        changes.scheduleType ?? schedule.scheduleType,
+        changes.scheduleValue ?? schedule.scheduleValue,
+        `Failed to calculate next run time for schedule: ${scheduleId}`,
+      )
     }
     
     // Apply changes

--- a/packages/shared/src/lib/schedule/__tests__/interval.test.ts
+++ b/packages/shared/src/lib/schedule/__tests__/interval.test.ts
@@ -1,0 +1,37 @@
+import {
+  MIN_SCHEDULE_INTERVAL_MS,
+  isValidScheduleInterval,
+  parseScheduleInterval,
+} from '../interval'
+
+describe('parseScheduleInterval', () => {
+  it('converts each documented unit to milliseconds', () => {
+    expect(parseScheduleInterval('90s')).toBe(90 * 1000)
+    expect(parseScheduleInterval('15m')).toBe(15 * 60 * 1000)
+    expect(parseScheduleInterval('6h')).toBe(6 * 60 * 60 * 1000)
+    expect(parseScheduleInterval('1d')).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('rejects a value that carries no unit', () => {
+    expect(() => parseScheduleInterval('3600')).toThrow('Invalid interval format: 3600')
+  })
+})
+
+describe('isValidScheduleInterval', () => {
+  it.each(['1h', '6h', '24h', '15m', '60s', '1d'])('accepts the documented format %s', (interval) => {
+    expect(isValidScheduleInterval(interval)).toBe(true)
+  })
+
+  it.each(['3600', '', ' 1h', '1h ', '1.5h', '-1h', 'hourly', '1w', '1H'])(
+    'rejects %p, which the scheduler could never run',
+    (interval) => {
+      expect(isValidScheduleInterval(interval)).toBe(false)
+    },
+  )
+
+  it('rejects an interval shorter than the enforced minimum', () => {
+    expect(MIN_SCHEDULE_INTERVAL_MS).toBe(60 * 1000)
+    expect(isValidScheduleInterval('30s')).toBe(false)
+    expect(isValidScheduleInterval('0m')).toBe(false)
+  })
+})

--- a/packages/shared/src/lib/schedule/interval.ts
+++ b/packages/shared/src/lib/schedule/interval.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical interval-format rules for recurring schedules.
+ *
+ * Both the scheduler runtime and the API validators that reject a schedule
+ * before it is persisted read the format from here, so the documented format
+ * (`<number><unit>`, e.g. `15m`, `1h`, `24h`) cannot drift between the layer
+ * that accepts a value and the layer that has to run it.
+ */
+export const MIN_SCHEDULE_INTERVAL_MS = 60 * 1000
+
+export const SCHEDULE_INTERVAL_PATTERN = /^(\d+)(s|m|h|d)$/
+
+const UNIT_MULTIPLIERS: Record<string, number> = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+}
+
+export type ScheduleIntervalUnit = 's' | 'm' | 'h' | 'd'
+
+export type ScheduleIntervalParts = {
+  amount: number
+  unit: ScheduleIntervalUnit
+}
+
+export function matchScheduleInterval(interval: string): ScheduleIntervalParts | null {
+  const match = SCHEDULE_INTERVAL_PATTERN.exec(interval)
+  if (!match) return null
+  return { amount: Number.parseInt(match[1], 10), unit: match[2] as ScheduleIntervalUnit }
+}
+
+export function parseScheduleInterval(interval: string): number {
+  const parts = matchScheduleInterval(interval)
+  if (!parts) {
+    throw new Error(`Invalid interval format: ${interval}. Expected format: <number><unit> (e.g., 15m, 2h, 1d)`)
+  }
+  return parts.amount * UNIT_MULTIPLIERS[parts.unit]
+}
+
+export function isValidScheduleInterval(interval: string): boolean {
+  const parts = matchScheduleInterval(interval)
+  if (!parts) return false
+  return parts.amount * UNIT_MULTIPLIERS[parts.unit] >= MIN_SCHEDULE_INTERVAL_MS
+}

--- a/packages/shared/src/lib/schedule/invalidScheduleValue.ts
+++ b/packages/shared/src/lib/schedule/invalidScheduleValue.ts
@@ -1,0 +1,33 @@
+export const INVALID_SCHEDULE_VALUE_CODE = 'INVALID_SCHEDULE_VALUE'
+
+export type ScheduleValueKind = 'cron' | 'interval'
+
+export type InvalidScheduleValueError = Error & {
+  code: typeof INVALID_SCHEDULE_VALUE_CODE
+  scheduleType: ScheduleValueKind
+  scheduleValue: string
+}
+
+export function createInvalidScheduleValueError(
+  scheduleType: ScheduleValueKind,
+  scheduleValue: string,
+  message: string,
+): InvalidScheduleValueError {
+  return Object.assign(new Error(message), {
+    code: INVALID_SCHEDULE_VALUE_CODE,
+    scheduleType,
+    scheduleValue,
+  } as const)
+}
+
+/**
+ * Structural check rather than `instanceof`: the error crosses a package
+ * boundary (and a production bundle), where a duplicated class identity would
+ * make `instanceof` silently false.
+ */
+export function isInvalidScheduleValueError(error: unknown): error is InvalidScheduleValueError {
+  if (typeof error !== 'object' || error === null) return false
+  const candidate = error as { code?: unknown; scheduleType?: unknown }
+  return candidate.code === INVALID_SCHEDULE_VALUE_CODE
+    && (candidate.scheduleType === 'cron' || candidate.scheduleType === 'interval')
+}


### PR DESCRIPTION
Closes #5872

## 🎯 Goal

Saving a recurring data-sync schedule with a value the scheduler can never run (`3600` instead of `1h`) now fails on the field, before submit, with a translated message — instead of round-tripping to the API and flashing a raw English scheduler error as a toast.

## 🔍 Problem

#5661 fixed three of #5506's four gaps and left the first one open: client-side enforcement of the documented interval format. `createSyncScheduleSchema` / `updateSyncScheduleSchema` declared `scheduleValue: z.string().min(1)`, so `"3600"` was accepted by the API contract and only failed deep inside `calculateNextRunForWrite`. The route returned `{ error: message }` with a 422 and `IntegrationScheduleTab.tsx` rendered that raw string via `flash(message, 'error')` — the field got no `aria-invalid`, and the save button stayed enabled.

## 🔍 Root Cause

Two independent gaps:

1. **No format in the contract.** The documented format (`<number><unit>`) lived only in `packages/scheduler`'s `parseInterval` regex, which nothing upstream of the write path consulted. The zod schemas had no way to reject a value the scheduler would later refuse.
2. **The failure had no field identity.** `SchedulerService.register` threw a bare `Error('Failed to calculate next run time for schedule: <uuid>')`. The route's catch-all could only echo `error.message`, so a scheduler rejection could not be attributed to `scheduleValue` and arrived as an untranslated toast.

## What Changed

- **`packages/shared/src/lib/schedule/interval.ts` (new)** — one canonical implementation of the interval format (`SCHEDULE_INTERVAL_PATTERN`, `MIN_SCHEDULE_INTERVAL_MS`, `parseScheduleInterval`, `isValidScheduleInterval`). `packages/scheduler`'s `intervalParser.ts` now delegates to it rather than keeping its own regex and multiplier table, so the layer that *accepts* a value and the layer that *runs* it cannot drift. Every existing scheduler export keeps its name, signature, and error text.
- **`packages/shared/src/lib/schedule/invalidScheduleValue.ts` (new)** — a coded (`INVALID_SCHEDULE_VALUE`) error carrying `scheduleType` / `scheduleValue`, matched structurally rather than with `instanceof` (which production bundling makes unreliable across a package boundary). `SchedulerService.register` and `updateSchedule` now throw it; the message text is unchanged, so existing scheduler tests and callers are unaffected.
- **`packages/core/.../data_sync/data/validators.ts`** — both schedule schemas gained a shared `superRefine` that rejects a malformed interval on the `scheduleValue` path, so the API answers a structured `422 { error: 'Invalid payload', details: { fieldErrors: { scheduleValue: [...] } } }`. Cron is deliberately left to the scheduler's own parser (core has no cron dependency and duplicating the grammar would reintroduce exactly the drift this PR removes) — it reports back through the same field error.
- **`packages/core/.../data_sync/lib/schedule-value.ts` (new)** — builds that `flatten()`-shaped error body and exposes an isomorphic reader so a form can detect the field error without parsing the payload inline.
- **`.../data_sync/api/schedules/route.ts` + `.../schedules/[id]/route.ts`** — map the coded scheduler error to the same structured 422. The internal message and the record id no longer reach the client.
- **`.../data_sync/components/IntegrationScheduleTab.tsx` and `.../backend/data-sync/page.tsx`** — both schedule forms now block submit on a malformed interval (no request is issued), set `aria-invalid` + `aria-describedby` on the input, render the message inline next to the field instead of as a toast, and route the copy through `useT()`. The error clears as soon as the value or the schedule type changes, and the submitted value is trimmed. A server-reported `scheduleValue` error renders through the same inline path.
- **i18n** — new `data_sync.dashboard.schedule.invalidInterval` / `.invalidCron` keys in all five locales (en, pl, de, es, ko).

## 🧪 Tests

Gate run locally (`node_modules/.bin` on PATH, `TMPDIR=/private/var/tmp`, `--env-mode=loose`):

- `yarn build:packages` ×2 — 29/29 tasks ✅
- `yarn generate` — ✅, no generated-file drift
- `yarn i18n:check-sync` — all 5 locales in sync ✅ · `yarn i18n:check-usage` — exit 0 ✅
- `yarn typecheck` — 29/29 ✅
- `yarn test` — `@open-mercato/core` 12226 passed / 1506 suites, `@open-mercato/shared` 2255 passed / 197 suites, `@open-mercato/scheduler` 466 passed / 25 suites. **One pre-existing local failure:** `create-mercato-app` reports 161 failures across `agent-harness-evaluator`, `agent-harness-release`, `business-writable-oracles` and `writable-ast-oracles` — the documented local-tooling baseline (those suites shell out to the `codex`/`claude` CLIs), the same 161 count measured on clean `develop`, and this PR touches no file under `packages/create-app`.
- `yarn build:app` — ✅

New/updated coverage:

- `packages/shared/src/lib/schedule/__tests__/interval.test.ts` — locks the accepted format, the unit multipliers, and the one-minute floor, including `'3600'`, `' 1h'`, `'1.5h'`, `'1w'`, `'1H'` and `'30s'`.
- `packages/core/.../data_sync/data/__tests__/sync-schedule-validators.test.ts` — the regression itself: `"3600"` is now rejected with a `scheduleValue` field error on both the create and update schemas, a cron value still passes through to the scheduler, and the existing "at least one field" refinement still holds.
- `packages/core/.../data_sync/components/__tests__/IntegrationScheduleTab.scheduleValue.test.tsx` — submit is blocked and `aria-invalid` set for a unitless interval with no request issued and no toast; the error clears on correction and the trimmed value is submitted; a server-reported `scheduleValue` error renders inline rather than flashing. Mutation-checked — all three cases fail when the guards are removed.
- `packages/core/.../api/schedules/__tests__/schedule-write-order.test.ts` — this suite previously drove its write-ordering assertion with `scheduleValue: '3600'`, which the schema now rejects before the service runs. Retargeted at a cron value so it still proves "no row is persisted when the scheduler rejects the value", plus two new cases: the scheduler rejection is reported as a `scheduleValue` field error with neither the internal message nor the record id in the body, and the malformed interval is rejected at the schema layer before the scheduler is reached.

## 💥 Breaking Changes

None. `packages/scheduler`'s public exports (`parseInterval`, `validateInterval`, `intervalToHuman`, `MIN_SCHEDULE_INTERVAL_MS`) keep their names, signatures, and error text; the coded error is additive and its `message` is unchanged. The one API-visible change is intended and is the point of the issue: a malformed `scheduleValue` that previously returned `422 { error: '<internal scheduler message>' }` now returns `422 { error: 'Invalid payload', details: { fieldErrors: { scheduleValue: [...] } } }` — still a 422, now structured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791706109&installation_model_id=432243&pr_number=6053&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6053&signature=f098b25aac904d9500952fdac6272865a26bd0f5db72cd64e2def4f06897e312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->