### PR TITLE
refactor(customers): extract the triplicated USER_TIMEZONE / isSameDay helpers (#6011)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivitiesCard.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesCard.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { Calendar, CalendarClock, Clock, Mail, Phone, StickyNote, Users } from 'lucide-react'
-import { toZonedTime } from 'date-fns-tz'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
@@ -11,6 +10,7 @@ import { ActivitiesDayStrip } from './ActivitiesDayStrip'
 import { ActivitiesAddNewMenu, type ActivityKind } from './ActivitiesAddNewMenu'
 import type { InteractionSummary } from './types'
 import { isOpenInteractionStatus } from '../../lib/interactionStatus'
+import { isSameDay, toLocalZonedDate } from '../../lib/localDay'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customers')
@@ -43,28 +43,10 @@ const TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   note: StickyNote,
 }
 
-const USER_TIMEZONE = (() => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-  } catch {
-    return 'UTC'
-  }
-})()
-
-// Project a UTC instant to the user's local timezone before extracting day/month/year
-// for "same day" comparisons (issue #1809 — E3 timezone drift).
-function toLocalZonedDate(value: string | Date): Date {
-  return toZonedTime(value, USER_TIMEZONE)
-}
-
 function startOfDay(date: Date): Date {
   const next = new Date(date)
   next.setHours(0, 0, 0, 0)
   return next
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
 }
 
 function isOverdue(activity: InteractionSummary, now: Date): boolean {

--- a/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
@@ -2,12 +2,12 @@
 
 import * as React from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { toZonedTime } from 'date-fns-tz'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import type { InteractionSummary } from './types'
+import { isSameDay, toLocalZonedDate } from '../../lib/localDay'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customers')
@@ -23,23 +23,6 @@ interface ActivitiesDayStripProps {
    * activity list rendered alongside it (issue #1809 — E1 status filter alignment).
    */
   events?: InteractionSummary[]
-}
-
-const USER_TIMEZONE = (() => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-  } catch {
-    return 'UTC'
-  }
-})()
-
-// Project a UTC ISO timestamp to the user's local timezone before comparing
-// "same day" (issue #1809 — E3). The browser's `new Date(iso)` treats the
-// instant correctly, but `getDate()/getMonth()/getFullYear()` reflect the
-// user's local day, so for activities scheduled at e.g. 23:30 local on a UTC
-// boundary the day-strip and list now agree.
-function toLocalZonedDate(value: string | Date): Date {
-  return toZonedTime(value, USER_TIMEZONE)
 }
 
 const VISIBLE_DAYS = 5
@@ -82,10 +65,6 @@ function endOfDay(date: Date): Date {
   const next = new Date(date)
   next.setHours(23, 59, 59, 999)
   return next
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
 }
 
 function isWeekend(date: Date): boolean {

--- a/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
+++ b/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
@@ -9,6 +9,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import type { InteractionSummary } from './types'
 import { loadLegacyActivitiesInRange } from './legacyActivities'
+import { isSameDay } from '../../lib/localDay'
 
 interface MiniWeekCalendarProps {
   entityId: string
@@ -28,10 +29,6 @@ function getWeekDays(baseDate: Date): Date[] {
     days.push(d)
   }
   return days
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
 }
 
 function getDayLabels(t: ReturnType<typeof useT>): string[] {

--- a/packages/core/src/modules/customers/components/detail/PlannedActivitiesSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/PlannedActivitiesSection.tsx
@@ -7,6 +7,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { Popover, PopoverContent, PopoverTrigger } from '@open-mercato/ui/primitives/popover'
 import type { InteractionSummary } from './types'
+import { isSameDay } from '../../lib/localDay'
 
 const TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   call: Phone,
@@ -245,7 +246,7 @@ function formatScheduledDate(isoString: string): string {
     const dateStr = date.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
     const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
 
-    if (date.toDateString() === tomorrow.toDateString()) {
+    if (isSameDay(date, tomorrow)) {
       return `Tomorrow ${timeStr}`
     }
     return `${dayName}, ${dateStr} · ${timeStr}`

--- a/packages/core/src/modules/customers/components/detail/schedule/DateTimeFields.tsx
+++ b/packages/core/src/modules/customers/components/detail/schedule/DateTimeFields.tsx
@@ -16,6 +16,7 @@ import {
 } from '@open-mercato/ui/primitives/select'
 import type { ActivityType, ScheduleFieldId } from './fieldConfig'
 import { isVisible, getFieldLabel } from './fieldConfig'
+import { USER_TIMEZONE } from '../../../lib/localDay'
 
 function parseIsoDate(value: string): Date | null {
   if (!value) return null
@@ -193,7 +194,7 @@ export function DateTimeFields({
           <span className="text-muted-foreground">&middot;</span>
           <span className="flex items-center gap-1.5">
             <Globe className="size-3.5" />
-            {Intl.DateTimeFormat().resolvedOptions().timeZone} (GMT{new Date().getTimezoneOffset() <= 0 ? '+' : '-'}{String(Math.abs(Math.floor(new Date().getTimezoneOffset() / 60))).padStart(1, '0')})
+            {USER_TIMEZONE} (GMT{new Date().getTimezoneOffset() <= 0 ? '+' : '-'}{String(Math.abs(Math.floor(new Date().getTimezoneOffset() / 60))).padStart(1, '0')})
           </span>
           {showRecurrence && (
             <>

--- a/packages/core/src/modules/customers/lib/__tests__/localDay.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/localDay.test.ts
@@ -1,0 +1,63 @@
+import { USER_TIMEZONE, isSameDay, toLocalZonedDate } from '../localDay'
+
+describe('USER_TIMEZONE', () => {
+  it('resolves to a non-empty IANA zone the platform accepts', () => {
+    expect(USER_TIMEZONE).toEqual(expect.any(String))
+    expect(USER_TIMEZONE.length).toBeGreaterThan(0)
+    expect(() => new Intl.DateTimeFormat(undefined, { timeZone: USER_TIMEZONE })).not.toThrow()
+  })
+})
+
+describe('isSameDay', () => {
+  it('is true for two instants on the same calendar day', () => {
+    expect(isSameDay(new Date(2026, 3, 10, 0, 0, 0), new Date(2026, 3, 10, 23, 59, 59))).toBe(true)
+  })
+
+  it('is false one millisecond across a local midnight', () => {
+    expect(isSameDay(new Date(2026, 3, 10, 23, 59, 59, 999), new Date(2026, 3, 11, 0, 0, 0, 0))).toBe(false)
+  })
+
+  it('compares the day rather than the elapsed distance', () => {
+    const lateEvening = new Date(2026, 3, 10, 23, 30)
+    const earlyNextMorning = new Date(2026, 3, 11, 0, 30)
+    expect(earlyNextMorning.getTime() - lateEvening.getTime()).toBe(60 * 60 * 1000)
+    expect(isSameDay(lateEvening, earlyNextMorning)).toBe(false)
+  })
+
+  it('distinguishes the same day number in a different month or year', () => {
+    expect(isSameDay(new Date(2026, 3, 10), new Date(2026, 4, 10))).toBe(false)
+    expect(isSameDay(new Date(2026, 3, 10), new Date(2027, 3, 10))).toBe(false)
+  })
+
+  it('is false when either operand is an invalid date', () => {
+    expect(isSameDay(new Date('nope'), new Date(2026, 3, 10))).toBe(false)
+    expect(isSameDay(new Date('nope'), new Date('nope'))).toBe(false)
+  })
+})
+
+describe('toLocalZonedDate', () => {
+  it('accepts an ISO string and a Date and yields the same projection', () => {
+    const iso = '2026-04-10T21:30:00.000Z'
+    expect(toLocalZonedDate(iso).getTime()).toBe(toLocalZonedDate(new Date(iso)).getTime())
+  })
+
+  it('projects an instant onto the calendar day the reader would name', () => {
+    // The projected wall-clock fields are what the day comparison reads, so they must
+    // agree with what `Intl` renders for the same instant in USER_TIMEZONE — this is
+    // the property that keeps the day strip and the activity list on the same day for
+    // late-evening activities near a UTC boundary (issue #1809 — E3).
+    const instant = new Date('2026-04-10T21:30:00.000Z')
+    const projected = toLocalZonedDate(instant)
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: USER_TIMEZONE,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    }).formatToParts(instant)
+    const partValue = (type: string) => Number(parts.find((part) => part.type === type)?.value)
+
+    expect(projected.getFullYear()).toBe(partValue('year'))
+    expect(projected.getMonth() + 1).toBe(partValue('month'))
+    expect(projected.getDate()).toBe(partValue('day'))
+  })
+})

--- a/packages/core/src/modules/customers/lib/localDay.ts
+++ b/packages/core/src/modules/customers/lib/localDay.ts
@@ -1,0 +1,36 @@
+// Single source of truth for "what timezone is the reader in, and is this the same
+// calendar day" across the customers detail components.
+//
+// Every activity surface in `components/detail/` answers the same two questions, and
+// until issue #6011 each answered them with its own byte-identical copy. They are kept
+// together here because they are one decision, not two: `isSameDay` is only meaningful
+// once both operands have been projected into the same zone, which is what
+// `toLocalZonedDate` does with `USER_TIMEZONE`.
+//
+// The zone is deliberately the reader's own runtime zone. Host/tenant-configured
+// display timezones are planned in `.ai/specs/2026-05-18-date-locale-settings.md`
+// (issue #1964); when that lands, threading a configured zone through the detail
+// components is an edit to this file rather than a hunt through every component.
+
+import { toZonedTime } from 'date-fns-tz'
+
+export const USER_TIMEZONE = (() => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+})()
+
+// Project a UTC instant to the user's local timezone before extracting day/month/year
+// for "same day" comparisons (issue #1809 — E3 timezone drift). The browser's
+// `new Date(iso)` treats the instant correctly, but `getDate()/getMonth()/getFullYear()`
+// reflect the user's local day, so an activity scheduled at e.g. 23:30 local on a UTC
+// boundary lands on the day the reader would call it.
+export function toLocalZonedDate(value: string | Date): Date {
+  return toZonedTime(value, USER_TIMEZONE)
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+}


### PR DESCRIPTION
## What

`components/detail/` carried the same "what timezone is the reader in, and is this the same calendar day" construct in several byte-identical copies. This extracts it into one module and points every call site at it.

New: `packages/core/src/modules/customers/lib/localDay.ts` exporting

- `USER_TIMEZONE` — the single `Intl.DateTimeFormat().resolvedOptions().timeZone` resolution, with the existing `'UTC'` fallback;
- `isSameDay(a, b)` — the `getFullYear`/`getMonth`/`getDate` comparison;
- `toLocalZonedDate(value)` — the `toZonedTime(value, USER_TIMEZONE)` wrapper.

`toLocalZonedDate` is extracted alongside the two the issue names because it is the only consumer of `USER_TIMEZONE` in both activity components. Exporting the constant without it would have left an identical two-line wrapper duplicated in each file, which defeats the "one edit when #1964 lands" rationale the issue gives.

Net: **47 lines deleted, 7 added** across the call sites. Pure refactor — no behaviour change. All five sites keep resolving the day in the reader's own runtime timezone exactly as before; moving off the browser timezone stays #1964's job (`.ai/specs/2026-05-18-date-locale-settings.md`), and this extraction is what makes that a one-file change.

## Call sites updated

| File | Was | Now imports |
|---|---|---|
| `ActivitiesCard.tsx` | own `USER_TIMEZONE`, `toLocalZonedDate`, `isSameDay` | `isSameDay`, `toLocalZonedDate` |
| `ActivitiesDayStrip.tsx` | own `USER_TIMEZONE`, `toLocalZonedDate`, `isSameDay` | `isSameDay`, `toLocalZonedDate` |
| `MiniWeekCalendar.tsx` | own `isSameDay` | `isSameDay` |
| `PlannedActivitiesSection.tsx` | `date.toDateString() === tomorrow.toDateString()` | `isSameDay` |
| `schedule/DateTimeFields.tsx` | inline `resolvedOptions().timeZone` in JSX | `USER_TIMEZONE` |

## Scope note — the state of `develop` differs from the issue body

The issue describes the *post-#5976* picture. On `develop` today:

- `PlannedActivitiesSection.tsx` has **no** `isSameDay` yet — it arrives with #5976. Its `formatScheduledDate` used `toDateString()` string equality, which is the same predicate by another spelling (both compare local Y/M/D), so it is converted here and the file is an import site as acceptance criterion 1 requires.
- A **fourth** byte-identical `isSameDay` lived in `MiniWeekCalendar.tsx`, and a **fifth** inline `resolvedOptions().timeZone` in `schedule/DateTimeFields.tsx`. Neither is named in the issue; both are covered so acceptance criterion 2 holds for the whole folder rather than for three files out of five.

⚠️ **Overlap with open PR #5976:** that PR edits the same `formatScheduledDate` hunk. Whichever of the two merges second needs a one-hunk rebase — keep #5976's `t(...)` translation and this PR's shared `isSameDay` import. Flagged on #5976.

## Acceptance criteria

- [x] `USER_TIMEZONE` and `isSameDay` defined once and imported by `ActivitiesCard.tsx`, `ActivitiesDayStrip.tsx` and `PlannedActivitiesSection.tsx` (plus `MiniWeekCalendar.tsx` and `schedule/DateTimeFields.tsx`).
- [x] `grep -rn "resolvedOptions().timeZone" packages/core/src/modules/customers/components/detail/` returns **0** hits — the single remaining hit in the module is the extracted constant in `lib/localDay.ts`.
- [x] The extracted helper has its own unit test — `lib/__tests__/localDay.test.ts`, 8 tests covering the zone resolution, the midnight boundary, same-day-number-different-month/year, invalid dates, and that the projection agrees with `Intl` for the same instant.
- [x] The existing suites for all touched components pass unchanged — no assertion edited. `ActivitiesCard`, `ActivitiesDayStrip`, `PlannedActivitiesSection`, `MiniWeekCalendar` and `DateTimeFields` suites are untouched by this diff.

## Testing

- New unit test is mutation-verified: deleting the `getFullYear` term from `isSameDay` fails the suite, so the test is load-bearing rather than decorative.
- Configured validation gate, run locally (no container runtime on this machine): `build:packages` ✅ · `generate` ✅ (no generated drift) · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ · `typecheck` ✅ · `test` ⚠️ (below) · `build:app` ✅.
- `test` with `--continue`: **33 of 36 packages pass**, including the two that matter here — `@open-mercato/core` (1505 suites / 12222 tests) and `@open-mercato/ui` (244 suites / 2067 tests).
- Three packages fail, none touched by this diff: `@open-mercato/shared`, `@open-mercato/cli`, `create-mercato-app`. **`@open-mercato/shared` was verified pre-existing** — the identical failure (`bootstrap runner reported no result (status 1)`, cascading into an `fs.rmSync(undefined)` in `afterEach`) reproduces on a pristine `develop` tree with this branch's changes reverted, and the suite passes when run standalone outside turbo. The `cli` failures are the known location-dependent `resolveEnvironment` / enterprise-toggle env suites; `create-mercato-app`'s are the harness oracle suites. CI is the authority on all three.

Manual QA is still pending — the diff touches `.tsx` files, so the automated-verification exemption does not apply even though the change is behaviour-preserving.

Fixes #6011

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708081&installation_model_id=432243&pr_number=6056&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6056&signature=9b0805b0d3a5f545c4680ca9cce8a67985b027dbc00c105f9a3c233bb936ebdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->