### PR TITLE
fix(entities): make the custom-field encrypted flag declarative and install-safe (#5920)

### DIFF
--- a/apps/docs/docs/framework/database/data-extensibility.mdx
+++ b/apps/docs/docs/framework/database/data-extensibility.mdx
@@ -78,6 +78,18 @@ export const entities = [
   - If the `id` is not a system entity, the installer automatically creates/updates a corresponding row in `custom_entities` so the entity shows up in the UI and can store records.
   - All entries are processed per tenant by default; mark an entry with `global: true` to install it once with `tenant_id = null`.
 
+#### Declaring a field as encrypted
+
+Set `encrypted: true` to store a field's values encrypted with the tenant key, the same way `required` or `listVisible` are declared:
+
+```ts
+export const entities = [
+  { id: 'crm:contact', fields: [ { key: 'national_id', kind: 'text', label: 'National ID', encrypted: true } ] },
+]
+```
+
+The declaration is idempotent — re-running `entities install` keeps the flag. A field an administrator encrypted through the admin UI also keeps its flag when the declaration omits `encrypted`, because clearing it would leave stored ciphertext that the read path no longer decrypts. To turn encryption off, declare `encrypted: false` explicitly (existing values stay encrypted at rest and must be migrated separately).
+
 ### Declaring fields via DSL (legacy) — deprecated
 ```ts
 import { defineFields, entityId, cf } from '@/modules/dsl'

--- a/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
@@ -83,6 +83,92 @@ describe('ensureCustomFieldDefinitions (issue #1399)', () => {
     expect(notes.configJson.priority).toBeUndefined()
   })
 
+  it('passes a declared encrypted flag through to configJson (#5920)', async () => {
+    const em = createMockEm()
+    const sets = [
+      {
+        entity: 'a:one',
+        fields: [
+          { key: 'ssn', kind: 'text' as const, encrypted: true },
+          { key: 'notes', kind: 'text' as const },
+        ],
+      },
+    ]
+
+    await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    const [ssn, notes] = em.persisted as Array<{ key: string; configJson: Record<string, unknown> }>
+    expect(ssn.key).toBe('ssn')
+    expect(ssn.configJson.encrypted).toBe(true)
+    expect(notes.configJson.encrypted).toBeUndefined()
+  })
+
+  it('keeps a declared encrypted flag idempotent across reinstalls (#5920)', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'ssn', kind: 'text', configJson: { encrypted: true }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [{ entity: 'a:one', fields: [{ key: 'ssn', kind: 'text' as const, encrypted: true }] }]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect(result).toEqual({ created: 0, updated: 0, unchanged: 1 })
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('preserves an admin-enabled encryption flag the declaration omits (#5920)', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'ssn', kind: 'text', configJson: { label: 'SSN', encrypted: true }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [{ entity: 'a:one', fields: [{ key: 'ssn', kind: 'text' as const, label: 'Social security number' }] }]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    // The label is rebuilt from the declaration, but dropping `encrypted` would leave
+    // stored ciphertext that the read path no longer decrypts.
+    expect(result).toEqual({ created: 0, updated: 1, unchanged: 0 })
+    expect(existing[0].configJson).toEqual({ label: 'Social security number', encrypted: true })
+  })
+
+  it('reports no change when only the preserved encryption flag would be re-added (#5920)', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'ssn', kind: 'text', configJson: { label: 'SSN', encrypted: true }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [{ entity: 'a:one', fields: [{ key: 'ssn', kind: 'text' as const, label: 'SSN' }] }]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect(result).toEqual({ created: 0, updated: 0, unchanged: 1 })
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('lets an explicit encrypted: false in the declaration turn encryption off (#5920)', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'ssn', kind: 'text', configJson: { encrypted: true }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [{ entity: 'a:one', fields: [{ key: 'ssn', kind: 'text' as const, encrypted: false }] }]
+
+    const result = await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect(result).toEqual({ created: 0, updated: 1, unchanged: 0 })
+    expect(existing[0].configJson).toEqual({ encrypted: false })
+  })
+
+  it('does not resurrect encryption for a definition that never had it (#5920)', async () => {
+    const existing = [
+      { entityId: 'a:one', key: 'notes', kind: 'text', configJson: { encrypted: false }, isActive: true, deletedAt: null },
+    ]
+    const em = createMockEm(existing)
+    const sets = [{ entity: 'a:one', fields: [{ key: 'notes', kind: 'text' as const, label: 'Notes' }] }]
+
+    await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    expect((existing[0].configJson as Record<string, unknown>).encrypted).toBeUndefined()
+  })
+
   it('does not query or flush on a dry run', async () => {
     const em = createMockEm()
     const sets = [{ entity: 'a:one', fields: [{ key: 'foo', kind: 'text' as const }] }]

--- a/packages/core/src/modules/entities/lib/__tests__/install-from-ce.checksum.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/install-from-ce.checksum.test.ts
@@ -1,0 +1,79 @@
+import type { CustomFieldDefinition } from '@open-mercato/shared/modules/entities'
+
+const getModules = jest.fn()
+const ensureCustomFieldDefinitions = jest.fn(async () => ({ created: 0, updated: 1, unchanged: 0 }))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({ getModules: () => getModules() }))
+jest.mock('@open-mercato/shared/lib/encryption/entityIds', () => ({ getEntityIds: () => ({}) }))
+jest.mock('@open-mercato/core/modules/directory/data/entities', () => ({ Tenant: class Tenant {} }))
+jest.mock('../register', () => ({ upsertCustomEntity: jest.fn(async () => 'unchanged') }))
+jest.mock('../../api/definitions.cache', () => ({ invalidateDefinitionsCache: jest.fn(async () => {}) }))
+jest.mock('../field-definitions', () => ({
+  ensureCustomFieldDefinitions: (...args: unknown[]) => ensureCustomFieldDefinitions(...(args as [])),
+}))
+
+import { installCustomEntitiesFromModules } from '../install-from-ce'
+
+const entityId = 'a:one'
+
+function declareField(field: CustomFieldDefinition) {
+  getModules.mockReturnValue([
+    {
+      id: 'a',
+      customEntities: [{ id: entityId, label: 'One', global: true }],
+      customFieldSets: [{ entity: entityId, fields: [field] }],
+    },
+  ])
+}
+
+function createCache() {
+  const store = new Map<string, string>()
+  return {
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => {
+      store.set(key, value)
+    }),
+  }
+}
+
+const em = {} as never
+
+describe('installCustomEntitiesFromModules checksum (#5920)', () => {
+  beforeEach(() => {
+    ensureCustomFieldDefinitions.mockClear()
+  })
+
+  it('skips a reinstall when the declaration is unchanged', async () => {
+    const cache = createCache()
+    declareField({ key: 'ssn', kind: 'text' })
+
+    const first = await installCustomEntitiesFromModules(em, cache as never)
+    expect(first.synchronized).toBe(1)
+    expect(ensureCustomFieldDefinitions).toHaveBeenCalledTimes(1)
+
+    const second = await installCustomEntitiesFromModules(em, cache as never)
+    expect(second.skipped).toBe(1)
+    expect(ensureCustomFieldDefinitions).toHaveBeenCalledTimes(1)
+  })
+
+  it('reinstalls when a declaration turns encryption on', async () => {
+    const cache = createCache()
+    declareField({ key: 'ssn', kind: 'text' })
+    await installCustomEntitiesFromModules(em, cache as never)
+    expect(ensureCustomFieldDefinitions).toHaveBeenCalledTimes(1)
+
+    // Without `encrypted` in the checksum payload the cached checksum still matches,
+    // so the declared change never reaches the definitions writer.
+    declareField({ key: 'ssn', kind: 'text', encrypted: true })
+    const result = await installCustomEntitiesFromModules(em, cache as never)
+
+    expect(result.skipped).toBe(0)
+    expect(result.synchronized).toBe(1)
+    expect(ensureCustomFieldDefinitions).toHaveBeenCalledTimes(2)
+    const [, sets] = ensureCustomFieldDefinitions.mock.calls[1] as unknown as [
+      unknown,
+      Array<{ fields: CustomFieldDefinition[] }>,
+    ]
+    expect(sets[0].fields[0].encrypted).toBe(true)
+  })
+})

--- a/packages/core/src/modules/entities/lib/field-definitions.ts
+++ b/packages/core/src/modules/entities/lib/field-definitions.ts
@@ -36,6 +36,7 @@ const CONFIG_PASSTHROUGH_KEYS: Array<keyof CustomFieldDefinition> = [
   'formEditable',
   'listVisible',
   'indexed',
+  'encrypted',
   'priority',
   'editor',
   'input',
@@ -63,6 +64,12 @@ function normalizeValue(value: unknown): unknown {
 
 function configEquals(a: unknown, b: unknown): boolean {
   return JSON.stringify(normalizeValue(a ?? null)) === JSON.stringify(normalizeValue(b ?? null))
+}
+
+function hasEncryptionEnabled(definition: CustomFieldDef | null): boolean {
+  const config = definition?.configJson
+  if (!config || typeof config !== 'object') return false
+  return (config as Record<string, unknown>).encrypted === true
 }
 
 export async function ensureCustomFieldDefinitions(
@@ -101,6 +108,14 @@ export async function ensureCustomFieldDefinitions(
       for (const key of CONFIG_PASSTHROUGH_KEYS) {
         const value = field[key]
         if (value !== undefined) configJson[key] = value as unknown
+      }
+
+      // configJson is rebuilt from the declaration, so a field encrypted through the
+      // definitions API would lose the flag on the next install while its stored
+      // values stay ciphertext the read path no longer decrypts. Keep an enabled flag
+      // unless the declaration turns it off with an explicit `encrypted: false`.
+      if (configJson.encrypted === undefined && hasEncryptionEnabled(existing)) {
+        configJson.encrypted = true
       }
 
       if (!existing) {

--- a/packages/core/src/modules/entities/lib/install-from-ce.ts
+++ b/packages/core/src/modules/entities/lib/install-from-ce.ts
@@ -49,6 +49,7 @@ const FIELD_DETAIL_KEYS: Array<keyof CustomFieldDefinition> = [
   'formEditable',
   'listVisible',
   'indexed',
+  'encrypted',
   'priority',
   'editor',
   'input',

--- a/packages/shared/src/modules/entities.ts
+++ b/packages/shared/src/modules/entities.ts
@@ -66,6 +66,11 @@ export type CustomFieldDefinition = {
   formEditable?: boolean
   indexed?: boolean
   listVisible?: boolean
+  // Store the value encrypted with the tenant key. Declaring it here keeps the
+  // flag idempotent across `entities install` runs; an admin-enabled flag is
+  // never downgraded by an install that omits it (turn it off explicitly with
+  // `encrypted: false`).
+  encrypted?: boolean
   // Display order within a form/card; lower renders first. When omitted, the
   // installer derives it from the declaration order of the field set.
   priority?: number


### PR DESCRIPTION
Closes #5920

## 🎯 Goal
A module can now declare `encrypted: true` on a custom field in its `ce.ts`, and that declaration survives every `entities install` run — as does an encryption flag an administrator set through the admin UI.

## 🔍 Problem
`configJson.encrypted` is already honored end to end at runtime: the definitions API validator accepts it (`packages/shared/src/modules/entities/validators.ts`), the write path encrypts on it (`entities/lib/helpers.ts`), and the read path decrypts on it (`shared/lib/crud/custom-fields.ts`). Only the declarative layer never carried it, so the flag could be set exclusively through the admin UI — and `entities install` then silently discarded it. That is worse than losing a cosmetic config key: the stored values stay ciphertext in `value_text` while the read path stops decrypting them, so users start seeing ciphertext.

## 🔍 Root Cause
Three separate gaps, all in the declaration → install path:

1. `CustomFieldDefinition` (`packages/shared/src/modules/entities.ts`) had no `encrypted` property, so `ce.ts` could not express it.
2. `CONFIG_PASSTHROUGH_KEYS` (`entities/lib/field-definitions.ts`) omitted `'encrypted'`. `ensureCustomFieldDefinitions` rebuilds `configJson` from the declaration and assigns it wholesale, so any existing flag was dropped.
3. `FIELD_DETAIL_KEYS` (`entities/lib/install-from-ce.ts`) omitted it too. That list feeds the install checksum, so even once the flag were declarable, flipping it in `ce.ts` would produce an identical checksum and `entities install` would short-circuit before reaching the definitions writer.

Gap 3 is not mentioned in the issue but would have made the suggested fix silently ineffective on a warm cache.

## What Changed
- `packages/shared/src/modules/entities.ts` — `CustomFieldDefinition` gains `encrypted?: boolean`. The `cf.*` DSL helpers derive their options from this type, so `cf.text('national_id', { encrypted: true })` works with no further change.
- `packages/core/src/modules/entities/lib/field-definitions.ts` — `'encrypted'` added to `CONFIG_PASSTHROUGH_KEYS`, so a declared flag is written to `configJson` and is idempotent across reinstalls. Additionally, when an existing definition has `configJson.encrypted === true` and the declaration omits `encrypted`, the flag is preserved rather than dropped — an admin-enabled field is never silently downgraded into unreadable ciphertext. An explicit `encrypted: false` in the declaration still wins, so turning encryption off stays possible and stays declarative.
- `packages/core/src/modules/entities/lib/install-from-ce.ts` — `'encrypted'` added to `FIELD_DETAIL_KEYS` so a declaration that flips the flag changes the install checksum and is actually applied.
- `apps/docs/docs/framework/database/data-extensibility.mdx` — documents declaring an encrypted field and the preserve/override semantics.

## 🧪 Tests
- `yarn workspace @open-mercato/core test` — 16 passed in the touched suites; 8 new cases. Reverting only the three production files makes 6 of them fail, so they lock in the fix rather than the status quo.
- New cases in `entities/lib/__tests__/field-definitions.test.ts`: a declared flag reaches `configJson`; a reinstall of the same declaration reports `unchanged` (no write churn); an admin-enabled flag survives a declaration that omits it; re-adding only the preserved flag still reports `unchanged`; an explicit `encrypted: false` turns it off; a definition that never had encryption does not acquire it.
- New `entities/lib/__tests__/install-from-ce.checksum.test.ts`: an unchanged declaration still skips on a warm cache, and a declaration that turns encryption on is no longer skipped.
- Full gate run (all 8 configured commands): `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`. The aggregate `yarn test` step aborted in `@open-mercato/cli` on the two known location/`TMPDIR`-dependent suites (`resolver.enterprise`, `resolve-environment`); re-run standalone they pass 16/16. Because turbo's abort also skips every remaining package, all 18 skipped packages were then run individually — all green, including `@open-mercato/core` 12,222 passed and `@open-mercato/shared` 2,237 passed.

## 💥 Breaking Changes
None. Both additions are additive per `BACKWARD_COMPATIBILITY.md`: a new optional property on a public type, and new entries in two private allowlists. No DB schema, API route, or response shape changes.

One behavioral note for reviewers: preserving an admin-enabled `encrypted` makes that key asymmetric with the other passthrough keys, which an install still rebuilds from the declaration. That asymmetry is deliberate — clearing `encrypted` corrupts reads of already-encrypted data, whereas clearing a label does not.

## Follow-up (not in this PR)
`FIELD_DETAIL_KEYS` still diverges from `CONFIG_PASSTHROUGH_KEYS` on `fieldset`, `fieldsets`, `group`, `dictionaryId`, `dictionaryInlineCreate`, and `sourceMetadata`. Those keys are persisted to `configJson` but are not part of the install checksum, so changing one of them in `ce.ts` can be skipped on a warm cache the same way `encrypted` was. Left out of scope here; worth its own issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791714596&installation_model_id=432243&pr_number=6059&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6059&signature=2691f966e49905ceabb99f6e8accbdd004ec69972f3b969e8f88f453e7f18a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->