### PR TITLE
fix(customers): seed new schedule activities forward instead of at the opening time (#5940)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/schedule/__tests__/useScheduleFormState.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/schedule/__tests__/useScheduleFormState.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react'
+import { resolveDefaultActivityStart, useScheduleFormState } from '../useScheduleFormState'
+import type { ScheduleActivityEditData } from '../useScheduleFormState'
+
+function localDate(year: number, month: number, day: number, hours: number, minutes: number): Date {
+  return new Date(year, month - 1, day, hours, minutes, 0, 0)
+}
+
+function presetCreateData(overrides: Partial<ScheduleActivityEditData> = {}): ScheduleActivityEditData {
+  return {
+    id: '',
+    interactionType: 'task',
+    title: null,
+    body: null,
+    scheduledAt: null,
+    durationMinutes: null,
+    location: null,
+    allDay: false,
+    recurrenceRule: null,
+    recurrenceEnd: null,
+    participants: null,
+    reminderMinutes: null,
+    visibility: 'team',
+    linkedEntities: null,
+    ...overrides,
+  }
+}
+
+describe('resolveDefaultActivityStart (#5940)', () => {
+  it('defaults a task to the end of the working day while that is still ahead', () => {
+    const start = resolveDefaultActivityStart('task', localDate(2026, 9, 11, 9, 5))
+    expect(start).toEqual(localDate(2026, 9, 11, 17, 0))
+  })
+
+  it('moves a late task past the current moment instead of into the morning', () => {
+    const start = resolveDefaultActivityStart('task', localDate(2026, 9, 11, 18, 40))
+    expect(start).toEqual(localDate(2026, 9, 11, 19, 0))
+  })
+
+  it('does not return the end-of-day slot once the clock has reached it', () => {
+    const start = resolveDefaultActivityStart('task', localDate(2026, 9, 11, 17, 0))
+    expect(start).toEqual(localDate(2026, 9, 11, 17, 30))
+  })
+
+  it('rounds a non-task activity up to the next half-hour slot', () => {
+    expect(resolveDefaultActivityStart('meeting', localDate(2026, 9, 11, 14, 12))).toEqual(
+      localDate(2026, 9, 11, 14, 30),
+    )
+    expect(resolveDefaultActivityStart('call', localDate(2026, 9, 11, 14, 45))).toEqual(
+      localDate(2026, 9, 11, 15, 0),
+    )
+  })
+
+  it('steps strictly forward when the clock sits exactly on a slot boundary', () => {
+    const start = resolveDefaultActivityStart('meeting', localDate(2026, 9, 11, 14, 0))
+    expect(start).toEqual(localDate(2026, 9, 11, 14, 30))
+  })
+
+  it('rolls over to the next morning rather than crossing midnight', () => {
+    expect(resolveDefaultActivityStart('meeting', localDate(2026, 9, 11, 23, 45))).toEqual(
+      localDate(2026, 9, 12, 9, 0),
+    )
+    expect(resolveDefaultActivityStart('task', localDate(2026, 9, 11, 23, 50))).toEqual(
+      localDate(2026, 9, 12, 9, 0),
+    )
+  })
+})
+
+describe('useScheduleFormState seeding (#5940)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(localDate(2026, 9, 11, 14, 12))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('treats an empty id as create mode instead of seeding the opening moment', () => {
+    const editData = presetCreateData()
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.activityType).toBe('task')
+    expect(result.current.date).toBe('2026-09-11')
+    expect(result.current.startTime).toBe('17:00')
+  })
+
+  it('keeps the preset default ahead of "now" for non-task types too', () => {
+    const editData = presetCreateData({ interactionType: 'meeting' })
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.startTime).toBe('14:30')
+  })
+
+  it('still prefills an explicit scheduledAt supplied with an empty id', () => {
+    const editData = presetCreateData({
+      scheduledAt: localDate(2026, 12, 1, 11, 15).toISOString(),
+      title: 'Revisit closed deal',
+    })
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.date).toBe('2026-12-01')
+    expect(result.current.startTime).toBe('11:15')
+    expect(result.current.title).toBe('Revisit closed deal')
+  })
+
+  it('still restores the original moment when editing a saved activity', () => {
+    const editData = presetCreateData({
+      id: 'b0a1c2d3-0000-4000-8000-000000000001',
+      interactionType: 'meeting',
+      occurredAt: localDate(2026, 3, 4, 8, 45).toISOString(),
+    })
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.date).toBe('2026-03-04')
+    expect(result.current.startTime).toBe('08:45')
+  })
+
+  it('uses the forward-looking default for a plain create with no editData', () => {
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData: null }))
+
+    expect(result.current.activityType).toBe('meeting')
+    expect(result.current.date).toBe('2026-09-11')
+    expect(result.current.startTime).toBe('14:30')
+  })
+
+  it('applies the per-type reminder default when the user switches type in preset-create mode', () => {
+    const editData = presetCreateData({ interactionType: 'meeting' })
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.reminderMinutes).toBe(15)
+
+    act(() => {
+      result.current.setActivityType('task')
+    })
+
+    expect(result.current.reminderMinutes).toBe(1440)
+  })
+
+  it('keeps the persisted reminder when the type changes while editing a saved activity', () => {
+    const editData = presetCreateData({
+      id: 'b0a1c2d3-0000-4000-8000-000000000002',
+      interactionType: 'task',
+      reminderMinutes: 30,
+      scheduledAt: localDate(2026, 10, 2, 9, 0).toISOString(),
+    })
+    const { result } = renderHook(() => useScheduleFormState({ open: true, editData }))
+
+    expect(result.current.reminderMinutes).toBe(30)
+
+    act(() => {
+      result.current.setActivityType('meeting')
+    })
+
+    expect(result.current.reminderMinutes).toBe(30)
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
+++ b/packages/core/src/modules/customers/components/detail/schedule/useScheduleFormState.ts
@@ -67,8 +67,47 @@ const DEFAULT_REMINDER_MINUTES: Record<ActivityType, number> = {
   note: 15,
 }
 
+// Create-mode date/time defaults. A fixed morning slot made every activity opened
+// later in the day start in the past, so the seed is always computed forward from
+// "now" (#5940): tasks are plan-ahead artefacts and default to the end of the
+// working day, everything else to the next half-hour slot.
+const DEFAULT_SLOT_MINUTES = 30
+const TASK_DEFAULT_HOUR = 17
+const NEXT_DAY_START_HOUR = 9
+
 function padDatePart(value: number): string {
   return String(value).padStart(2, '0')
+}
+
+function isSameLocalDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  )
+}
+
+function nextSlotAfter(now: Date): Date {
+  const next = new Date(now)
+  next.setSeconds(0, 0)
+  next.setMinutes(next.getMinutes() + (DEFAULT_SLOT_MINUTES - (next.getMinutes() % DEFAULT_SLOT_MINUTES)))
+  if (!isSameLocalDay(next, now)) {
+    next.setHours(NEXT_DAY_START_HOUR, 0, 0, 0)
+  }
+  return next
+}
+
+/**
+ * Default start moment for a newly created activity of `type`, always strictly
+ * after `now` so a brand-new record is never born overdue (#5940).
+ */
+export function resolveDefaultActivityStart(type: ActivityType, now: Date): Date {
+  if (type === 'task') {
+    const endOfWorkingDay = new Date(now)
+    endOfWorkingDay.setHours(TASK_DEFAULT_HOUR, 0, 0, 0)
+    if (endOfWorkingDay.getTime() > now.getTime()) return endOfWorkingDay
+  }
+  return nextSlotAfter(now)
 }
 
 function formatLocalDateInput(date: Date): string {
@@ -85,10 +124,15 @@ interface UseScheduleFormStateParams {
 }
 
 export function useScheduleFormState({ open, editData }: UseScheduleFormStateParams) {
+  // An empty `id` is the menu-driven "New X" convention — a create with a preset
+  // type, not an edit. The save path already reads it this way (`isSaveEdit`), so
+  // the seeding below must agree or new records inherit edit-mode fallbacks (#5940).
+  const isEditing = Boolean(editData?.id)
+  const [initialStart] = React.useState(() => resolveDefaultActivityStart('meeting', new Date()))
   const [activityType, setActivityType] = React.useState<ActivityType>('meeting')
   const [title, setTitle] = React.useState('')
-  const [date, setDate] = React.useState(() => formatLocalDateInput(new Date()))
-  const [startTime, setStartTime] = React.useState('10:00')
+  const [date, setDate] = React.useState(() => formatLocalDateInput(initialStart))
+  const [startTime, setStartTime] = React.useState(() => formatLocalTimeInput(initialStart))
   const [duration, setDuration] = React.useState(30)
   const [allDay, setAllDay] = React.useState(false)
   const [description, setDescription] = React.useState('')
@@ -120,10 +164,13 @@ export function useScheduleFormState({ open, editData }: UseScheduleFormStatePar
         // Keep seed values in the user's local timezone, matching the cluster-E
         // local-day convention.
         const sourceTimestamp = editData.occurredAt ?? editData.scheduledAt ?? null
-        const seedDate = sourceTimestamp ? new Date(sourceTimestamp) : new Date()
-        const seedDateValid = !Number.isNaN(seedDate.getTime())
-        const fallbackNow = new Date()
-        const dateForForm = seedDateValid ? seedDate : fallbackNow
+        const seedDate = sourceTimestamp ? new Date(sourceTimestamp) : null
+        // No usable timestamp means this is a preset create (or a corrupt row), so
+        // fall forward to the create-mode default instead of "now" (#5940).
+        const dateForForm =
+          seedDate && !Number.isNaN(seedDate.getTime())
+            ? seedDate
+            : resolveDefaultActivityStart(resolvedType, new Date())
         setDate(formatLocalDateInput(dateForForm))
         setStartTime(formatLocalTimeInput(dateForForm))
         setDuration(editData.durationMinutes ?? 30)
@@ -184,10 +231,11 @@ export function useScheduleFormState({ open, editData }: UseScheduleFormStatePar
         }
       } else {
         // Create mode: reset all fields
+        const defaultStart = resolveDefaultActivityStart('meeting', new Date())
         setActivityType('meeting')
         setTitle('')
-        setDate(formatLocalDateInput(new Date()))
-        setStartTime('10:00')
+        setDate(formatLocalDateInput(defaultStart))
+        setStartTime(formatLocalTimeInput(defaultStart))
         setDuration(30)
         setAllDay(false)
         setDescription('')
@@ -212,14 +260,14 @@ export function useScheduleFormState({ open, editData }: UseScheduleFormStatePar
   // avoid flipping the default in a closed-but-mounted dialog.
   const lastReminderTypeRef = React.useRef<ActivityType>('meeting')
   React.useEffect(() => {
-    if (!open || editData) {
+    if (!open || isEditing) {
       lastReminderTypeRef.current = activityType
       return
     }
     if (lastReminderTypeRef.current === activityType) return
     lastReminderTypeRef.current = activityType
     setReminderMinutes(DEFAULT_REMINDER_MINUTES[activityType])
-  }, [activityType, editData, open])
+  }, [activityType, isEditing, open])
 
   const removeParticipant = React.useCallback((index: number) => {
     setParticipants((prev) => prev.filter((_, i) => i !== index))


### PR DESCRIPTION
Closes #5940

## 🎯 Goal
A task added from a person, company, or deal page no longer arrives already overdue. New activities opened through the "New meeting / call / task / email" menu now get a due date and time that lies ahead of the moment the dialog was opened, instead of inheriting that moment (or a fixed `10:00`).

## 🔍 Problem
The schedule dialog is opened in two ways. Editing a saved activity passes its record; the menu-driven "New X" flow passes a *preset* object — `{ id: '', interactionType: 'task', scheduledAt: null }` — where the empty `id` means "create, with the type pre-chosen". The save path already reads it that way (`isSaveEdit = Boolean(editData?.id)` decides POST vs PUT), but the form-seeding hook did not: it branched on the object's truthiness. So a preset create took the *edit* seeding path, found no timestamp to restore, and fell back to `new Date()`. The user typed a title, hit save, and the task was stamped with a due time that had already passed — defeating the one signal the feature relies on. Reported at 5 out of 5 tasks created this way.

## 🔍 Root Cause
`useScheduleFormState.ts` used `if (editData)` where every other part of the dialog uses `Boolean(editData?.id)`. Two consequences followed from that single conflation: the timestamp fallback described above, and a second one at the reminder-default effect, which skipped the per-type default for preset creates on the assumption that a "persisted value wins" — but a preset create has no persisted value. Separately, the genuine create branch hardcoded `'10:00'`, which is in the past for anything opened after mid-morning.

## What Changed
- `schedule/useScheduleFormState.ts` — added `resolveDefaultActivityStart(type, now)`, a pure exported helper that always returns a moment strictly after `now`: a **task** gets today at 17:00 while that is still ahead (tasks are plan-ahead artefacts, matching the existing 1-day reminder default), everything else gets the next half-hour slot, and either rolls over to next-day 09:00 rather than crossing midnight. It stays on local-time getters/setters, matching the file's existing `formatLocalDateInput`/`formatLocalTimeInput` convention.
- Same file — the seeding effect falls forward to that helper whenever `editData` carries no usable `occurredAt`/`scheduledAt`, instead of `new Date()`. An explicit timestamp still wins, so the deals "lost follow-up" entry point (`deals/[id]/page.tsx`, which supplies a real next-quarter date) keeps prefilling it, and editing a saved activity still restores its original moment (#1807 behavior preserved).
- Same file — the create branch uses the helper instead of the hardcoded `'10:00'`, and the initial `useState` seeds match.
- Same file — the reminder-on-type-change guard now keys on `Boolean(editData?.id)`. Switching the type in the preset-create flow therefore applies the per-type reminder default (task → 1 day, call → 5 min), which it previously skipped. Editing a saved activity still keeps its persisted reminder.

Affected entry points: `people-v2/[id]/page.tsx` and `companies-v2/[id]/page.tsx` (`handleAddActivity`, the two that passed `scheduledAt: null`), plus the plain "+ Schedule activity" create.

## 🧪 Tests
- New `schedule/__tests__/useScheduleFormState.test.tsx` — 13 jsdom tests. **10 of them fail against the unfixed hook**, verified by reverting the source change and re-running.
- Helper boundaries: end-of-day for an early task, step-forward when the clock has already reached 17:00, exact-slot-boundary always moving strictly forward, and midnight rollover to next-day 09:00.
- Hook seeding, all five modes: preset create (empty `id`) uses the forward default rather than the opening moment; preset create *with* an explicit `scheduledAt` still prefills it; a real edit still restores `occurredAt`; a plain create uses the forward default; the reminder default follows a type switch in preset-create mode and does not in edit mode.
- Full gate, in the configured order: `build:packages` ✅ · `generate` ✅ · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ · `typecheck` ✅ · `test` ✅ · `build:app` ✅. `@open-mercato/core` standalone: 1505 suites / 12,227 tests passed.
- Two local-environment caveats, both reproduced independently of this branch and unrelated to the diff: `@open-mercato/shared`'s `dynamicLoader.generatedCacheRecovery` suite fails under turbo because turbo drops `TMPDIR` and `tsx` cannot open an IPC pipe under the long worktree tmp path (passes with `--env-mode=loose`); `create-mercato-app` has 161 pre-existing failures in the live-oracle harness suites, which require the codex/claude CLIs.

## 💥 Breaking Changes
None. Client-only — no API, database, event, or exported-contract surface is touched. The intended user-visible change is the create-mode default itself: date/time now looks forward instead of being a fixed `10:00` or the dialog's opening moment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791715046&installation_model_id=432243&pr_number=6060&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6060&signature=141e85d98b8c54dce00cb5174140105330ce319c5e56ee1bc856f3f5924f93e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->