### PR TITLE
security(core,shared): re-check KMS health per write instead of gating encryption-subscriber registration once at boot

### DIFF
--- a/packages/core/src/__tests__/encryption-subscriber-registration-gate.test.ts
+++ b/packages/core/src/__tests__/encryption-subscriber-registration-gate.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Regression guard for issue #5948.
+ *
+ * `registerTenantEncryptionSubscriber` used to be called only when
+ * `kmsService.isHealthy()` returned true at bootstrap. That check runs once,
+ * synchronously, during process startup: a Vault/KMS outage overlapping startup
+ * left the subscriber unregistered for the entire process lifetime — every ORM
+ * write that relies on it was persisted as plaintext, with no retry and no
+ * re-registration once the KMS recovered. Only a restart cleared it.
+ *
+ * Registration must depend on the static `isTenantDataEncryptionEnabled()`
+ * toggle alone. Live KMS health is re-checked by the subscriber on every
+ * read/write (`TenantEncryptionSubscriber.encrypt`/`decrypt` both call
+ * `service.isEnabled()`), so registering while the KMS is down is a safe no-op
+ * that resumes encrypting the moment it recovers.
+ *
+ * bootstrap() itself needs a live ORM, DI container and the generated module
+ * registry, so this asserts on the source: the health probe must not appear in
+ * the condition that guards the registration call.
+ */
+
+const bootstrapSource = readFileSync(join(__dirname, '..', 'bootstrap.ts'), 'utf8')
+
+function registrationGuard(): string {
+  const call = bootstrapSource.indexOf('registerTenantEncryptionSubscriber(em,')
+  expect(call).toBeGreaterThan(-1)
+  // The `if (...) {` that opens the block containing the registration call.
+  const opener = bootstrapSource.lastIndexOf('if (', call)
+  expect(opener).toBeGreaterThan(-1)
+  return bootstrapSource.slice(opener, call)
+}
+
+describe('tenant encryption subscriber registration gate (issue #5948)', () => {
+  it('registers on the static encryption toggle', () => {
+    expect(registrationGuard()).toContain('isTenantDataEncryptionEnabled()')
+  })
+
+  it('never gates registration on live KMS health', () => {
+    expect(registrationGuard()).not.toContain('isHealthy')
+  })
+
+  it('still warns when the KMS is unhealthy at boot', () => {
+    expect(bootstrapSource).toContain('kmsService.isHealthy()')
+    expect(bootstrapSource).toMatch(/Vault\/KMS unhealthy/)
+  })
+})

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -213,14 +213,24 @@ export async function bootstrap(container: AwilixContainer) {
       defaultEncryptionMaps,
     })
     container.register({ tenantEncryptionService: asValue(tenantEncryptionService) })
-    if (isTenantDataEncryptionEnabled() && kmsService.isHealthy()) {
+    // Register on the static config toggle only — never on KMS health. The
+    // subscriber re-checks `service.isEnabled()` (which includes KMS health) on
+    // every read/write, so registering while Vault is down is a no-op that
+    // starts encrypting again the moment KMS recovers. Gating registration on
+    // health instead left a boot-time outage fail-open for the whole process
+    // lifetime, recoverable only by a restart (#5948).
+    if (isTenantDataEncryptionEnabled()) {
       try {
         registerTenantEncryptionSubscriber(em, tenantEncryptionService)
       } catch (err) {
         logger.warn('Failed to register MikroORM encryption subscriber', { component: 'encryption', err })
       }
-    } else if (isTenantDataEncryptionEnabled() && !kmsService.isHealthy()) {
-      logger.warn('Vault/KMS unhealthy - tenant data encryption is disabled until recovery', { component: 'encryption' })
+      if (!kmsService.isHealthy()) {
+        logger.warn(
+          'Vault/KMS unhealthy - tenant data encryption is paused until it recovers; the subscriber is registered and resumes automatically',
+          { component: 'encryption' },
+        )
+      }
     }
   } catch (err) {
     logger.warn('Failed to initialize tenant encryption service', { component: 'encryption', err })

--- a/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
+++ b/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
@@ -259,6 +259,22 @@ describe('bootstrap once-guard cache', () => {
     expect(subscriberRegistered).toHaveBeenCalledTimes(2)
   })
 
+  it('skips registration when the encryption service cannot report its enabled state', async () => {
+    process.env.OM_BOOTSTRAP_CACHE = '1'
+    bootstrapMock.mockImplementationOnce(async (container: any) => {
+      container.register({
+        cache: asValue({ __value: 'cache-value' }),
+        eventBus: asValue({ __value: 'event-bus-value' }),
+        // A DI override supplying a partial service: the subscriber would throw
+        // on every read/write calling isEnabled(), so it must not be registered.
+        tenantEncryptionService: asValue({ __value: 'no-isEnabled' }),
+      })
+    })
+    const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+    await createRequestContainer()
+    expect(subscriberRegistered).not.toHaveBeenCalled()
+  })
+
   it('does not register the encryption subscriber when encryption is disabled by config', async () => {
     process.env.OM_BOOTSTRAP_CACHE = '1'
     const originalToggle = process.env.TENANT_DATA_ENCRYPTION

--- a/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
+++ b/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
@@ -210,7 +210,7 @@ describe('bootstrap once-guard cache', () => {
     expect(bootstrapMock).toHaveBeenCalledTimes(2)
   })
 
-  it('memoizes tenantEncryptionService.isEnabled() across requests', async () => {
+  it('registers the encryption subscriber per request without consulting tenantEncryptionService.isEnabled()', async () => {
     process.env.OM_BOOTSTRAP_CACHE = '1'
     let isEnabledCalls = 0
     bootstrapMock.mockImplementationOnce(async (container: any) => {
@@ -229,8 +229,48 @@ describe('bootstrap once-guard cache', () => {
     await createRequestContainer()
     await createRequestContainer()
     await createRequestContainer()
-    // Called once during the first bootstrap, then cached on globalThis.
-    expect(isEnabledCalls).toBe(1)
+    // The registration decision reads the static config toggle (memoized on
+    // globalThis), never the service's health-sensitive isEnabled() — see #5948.
+    expect(isEnabledCalls).toBe(0)
     expect(subscriberRegistered).toHaveBeenCalledTimes(3)
+  })
+
+  // Regression for issue #5948: `isEnabled()` is `config && kms.isHealthy()`, so
+  // memoizing it for the process lifetime pinned a transient Vault outage into a
+  // permanent "encryption off" verdict — the subscriber was never registered
+  // again on any later request, and every ORM write stayed plaintext until the
+  // process restarted.
+  it('keeps registering the encryption subscriber while the KMS is unhealthy', async () => {
+    process.env.OM_BOOTSTRAP_CACHE = '1'
+    bootstrapMock.mockImplementationOnce(async (container: any) => {
+      container.register({
+        cache: asValue({ __value: 'cache-value' }),
+        eventBus: asValue({ __value: 'event-bus-value' }),
+        // KMS is down for the whole run: isEnabled() never returns true.
+        tenantEncryptionService: asValue({ isEnabled: () => false }),
+      })
+    })
+    const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+    await createRequestContainer()
+    await createRequestContainer()
+
+    // Registration must not depend on live KMS health — the subscriber itself
+    // re-checks it per read/write, so it resumes encrypting on recovery.
+    expect(subscriberRegistered).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not register the encryption subscriber when encryption is disabled by config', async () => {
+    process.env.OM_BOOTSTRAP_CACHE = '1'
+    const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+    process.env.TENANT_DATA_ENCRYPTION = 'false'
+    try {
+      const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+      await createRequestContainer()
+      await createRequestContainer()
+      expect(subscriberRegistered).not.toHaveBeenCalled()
+    } finally {
+      if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+      else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+    }
   })
 })

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -327,7 +327,11 @@ export async function createRequestContainer(): Promise<AppContainer> {
     const tenantEncryptionService = container.hasRegistration('tenantEncryptionService')
       ? (container.resolve('tenantEncryptionService') as any)
       : null
-    if (emForEnc && tenantEncryptionService && getCachedEncryptionConfigured()) {
+    // The subscriber calls `service.isEnabled()` on every read/write, so a DI
+    // override supplying a service without it would throw per operation. Keep
+    // the shape check that the old health-probe helper performed.
+    const serviceCanReportEnabled = typeof tenantEncryptionService?.isEnabled === 'function'
+    if (emForEnc && serviceCanReportEnabled && getCachedEncryptionConfigured()) {
       const { registerTenantEncryptionSubscriber } = await import('@open-mercato/shared/lib/encryption/subscriber')
       registerTenantEncryptionSubscriber(emForEnc, tenantEncryptionService)
     }

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -9,6 +9,7 @@ import { applyDiOverridesToContainer } from '@open-mercato/shared/modules/overri
 import { createOptimisticLockGuardService } from '@open-mercato/shared/lib/crud/optimistic-lock'
 import { getAllOptimisticLockReaders } from '@open-mercato/shared/lib/crud/optimistic-lock-store'
 import { createCommandOptimisticLockGuardService } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { isTenantDataEncryptionEnabled } from '../encryption/toggles'
 import { createLogger } from '../logger'
 
 const logger = createLogger('shared').child({ component: 'di' })
@@ -93,19 +94,18 @@ function harvestBootstrapCache(container: AwilixContainer): BootstrapCacheEntry 
   return entry
 }
 
-type EncryptionEnabledProbe = { isEnabled?: () => boolean } | null | undefined
-
-function getCachedEncryptionEnabled(service: EncryptionEnabledProbe): boolean | null {
-  if (!service || typeof service.isEnabled !== 'function') return false
+// Caches the STATIC config toggle only. It deliberately does not consult
+// `tenantEncryptionService.isEnabled()`, which ANDs the toggle with the
+// volatile `kms.isHealthy()` — memoizing that for the process lifetime pinned a
+// transient Vault outage into a permanent "encryption off" verdict, so the
+// subscriber was never registered again until a restart (#5948). KMS health is
+// re-checked by the subscriber on every read/write instead.
+function getCachedEncryptionConfigured(): boolean {
   const cached = (globalThis as Record<string, unknown>)[ENCRYPTION_ENABLED_KEY]
   if (typeof cached === 'boolean') return cached
-  try {
-    const result = !!service.isEnabled()
-    ;(globalThis as Record<string, unknown>)[ENCRYPTION_ENABLED_KEY] = result
-    return result
-  } catch {
-    return null
-  }
+  const result = isTenantDataEncryptionEnabled()
+  ;(globalThis as Record<string, unknown>)[ENCRYPTION_ENABLED_KEY] = result
+  return result
 }
 
 function getGlobalRegistrars(): DiRegistrar[] | null {
@@ -319,15 +319,15 @@ export async function createRequestContainer(): Promise<AppContainer> {
     unregister: (key) => container.register({ [key]: asValue(undefined) }),
   })
   // Ensure tenant encryption subscriber is always registered on the fresh request-scoped EM
-  // Phase 5 — cache `tenantEncryptionService.isEnabled()` for the process
-  // lifetime. The result depends only on config that does not change at
-  // runtime, so reading it once skips a config lookup per request.
+  // Phase 5 — cache the tenant-encryption config toggle for the process
+  // lifetime. That toggle does not change at runtime, so reading it once skips
+  // a config lookup per request; KMS health is NOT part of this decision.
   try {
     const emForEnc = container.resolve('em') as any
     const tenantEncryptionService = container.hasRegistration('tenantEncryptionService')
       ? (container.resolve('tenantEncryptionService') as any)
       : null
-    if (emForEnc && tenantEncryptionService && getCachedEncryptionEnabled(tenantEncryptionService) === true) {
+    if (emForEnc && tenantEncryptionService && getCachedEncryptionConfigured()) {
       const { registerTenantEncryptionSubscriber } = await import('@open-mercato/shared/lib/encryption/subscriber')
       registerTenantEncryptionSubscriber(emForEnc, tenantEncryptionService)
     }

--- a/packages/shared/src/lib/encryption/__tests__/subscriber.kms-recovery.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/subscriber.kms-recovery.test.ts
@@ -1,0 +1,112 @@
+// Regression coverage for issue #5948: registration of the tenant-encryption ORM
+// subscriber used to be gated on `kmsService.isHealthy()`, evaluated exactly once
+// at bootstrap. A KMS outage overlapping process startup therefore left the
+// subscriber unregistered — and at-rest encryption off — for the whole process
+// lifetime, recoverable only by a restart.
+//
+// The fix registers on the static config toggle alone and leans on the
+// subscriber's own per-operation `service.isEnabled()` check. These tests pin
+// that contract: a subscriber registered while the KMS is down must start
+// encrypting the moment the KMS recovers, with no re-registration, and must
+// leave an ongoing (throttled) signal while it is failing open.
+
+const warn = jest.fn()
+
+jest.mock('../../logger', () => {
+  const logger: Record<string, unknown> = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => warn(...args),
+    error: jest.fn(),
+  }
+  logger.child = () => logger
+  return { createLogger: () => logger }
+})
+
+import { TenantEncryptionSubscriber, resetEncryptionPausedWarnThrottle } from '../subscriber'
+import { registerEntityIds } from '../entityIds'
+import type { TenantDataEncryptionService } from '../tenantDataEncryptionService'
+
+const META = {
+  className: 'Thing',
+  tableName: 'things',
+  properties: { secret: { name: 'secret', fieldName: 'secret' } },
+} as any
+
+function makeEm() {
+  return { getComparator: () => undefined, getMetadata: () => undefined }
+}
+
+// Mirrors the production service: `isEnabled()` ANDs the static config toggle
+// with the volatile KMS health flag, so it flips as Vault goes down and recovers.
+function makeService(kms: { healthy: boolean }): TenantDataEncryptionService {
+  return {
+    isEnabled: () => kms.healthy,
+    async encryptEntityPayload(_entityId: string, target: Record<string, unknown>) {
+      return { secret: `enc:${String(target.secret)}` }
+    },
+    async decryptEntityPayload() {
+      return {}
+    },
+  } as unknown as TenantDataEncryptionService
+}
+
+describe('TenantEncryptionSubscriber KMS recovery (issue #5948)', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    delete process.env.TENANT_DATA_ENCRYPTION // default => encryption enabled
+    registerEntityIds({ test: { thing: 'test:thing' } })
+    resetEncryptionPausedWarnThrottle()
+    warn.mockClear()
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+    jest.restoreAllMocks()
+  })
+
+  async function create(subscriber: TenantEncryptionSubscriber, entity: Record<string, unknown>) {
+    await subscriber.beforeCreate({ entity, meta: META, em: makeEm() } as any)
+  }
+
+  it('resumes encrypting after the KMS recovers, without re-registering the subscriber', async () => {
+    const kms = { healthy: false }
+    // The single subscriber instance a boot-time registration would have produced.
+    const subscriber = new TenantEncryptionSubscriber(makeService(kms))
+
+    const duringOutage: Record<string, unknown> = { tenantId: 't1', secret: 'plain' }
+    await create(subscriber, duringOutage)
+    expect(duringOutage.secret).toBe('plain')
+
+    // Vault comes back — the very same subscriber instance must start encrypting.
+    kms.healthy = true
+    const afterRecovery: Record<string, unknown> = { tenantId: 't1', secret: 'plain' }
+    await create(subscriber, afterRecovery)
+    expect(afterRecovery.secret).toBe('enc:plain')
+  })
+
+  it('warns while writes are failing open to plaintext, throttled to one line per window', async () => {
+    const subscriber = new TenantEncryptionSubscriber(makeService({ healthy: false }))
+
+    await create(subscriber, { tenantId: 't1', secret: 'a' })
+    await create(subscriber, { tenantId: 't1', secret: 'b' })
+    await create(subscriber, { tenantId: 't1', secret: 'c' })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toMatch(/KMS is unavailable/)
+    expect(warn.mock.calls[0][1]).toEqual({ entity: 'Thing' })
+  })
+
+  it('stays silent when encryption is deliberately disabled by config', async () => {
+    process.env.TENANT_DATA_ENCRYPTION = 'false'
+    const subscriber = new TenantEncryptionSubscriber(makeService({ healthy: false }))
+
+    const entity: Record<string, unknown> = { tenantId: 't1', secret: 'plain' }
+    await create(subscriber, entity)
+
+    expect(entity.secret).toBe('plain')
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/lib/encryption/subscriber.ts
+++ b/packages/shared/src/lib/encryption/subscriber.ts
@@ -50,6 +50,31 @@ function isJsonColumnProperty(prop: unknown): boolean {
   return typeof customTypeName === 'string' && customTypeName.toLowerCase().includes('json')
 }
 
+// Encryption is configured on but the service reports disabled — the KMS is
+// unreachable, so this write lands as plaintext. Throttle the warning so a long
+// outage does not flood the log while still leaving an ongoing signal that the
+// fail-open window is open (#5948).
+const ENCRYPTION_PAUSED_WARN_INTERVAL_MS = 60_000
+let lastEncryptionPausedWarnAt = 0
+
+function warnEncryptionPaused(entity: string | undefined): void {
+  const now = Date.now()
+  if (lastEncryptionPausedWarnAt && now - lastEncryptionPausedWarnAt < ENCRYPTION_PAUSED_WARN_INTERVAL_MS) return
+  lastEncryptionPausedWarnAt = now
+  try {
+    logger.warn(
+      'Tenant data encryption is enabled but the KMS is unavailable - entity writes persist as plaintext until it recovers',
+      { entity },
+    )
+  } catch {
+    // ignore
+  }
+}
+
+export function resetEncryptionPausedWarnThrottle(): void {
+  lastEncryptionPausedWarnAt = 0
+}
+
 const registeredEventManagers = new WeakSet<object>()
 
 const subscribersByService = new WeakMap<TenantDataEncryptionService, TenantEncryptionSubscriber>()
@@ -206,8 +231,10 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
     em?: { getMetadata?: () => any; getComparator?: () => any },
     changeSet?: { payload?: Record<string, unknown> },
   ) {
-    if (!isTenantDataEncryptionEnabled() || !this.service.isEnabled()) {
+    const encryptionConfigured = isTenantDataEncryptionEnabled()
+    if (!encryptionConfigured || !this.service.isEnabled()) {
       debug('⚪️ subscriber.skip', { reason: 'disabled', entity: meta?.className || meta?.name })
+      if (encryptionConfigured) warnEncryptionPaused(meta?.className || meta?.name)
       return
     }
     const resolvedMeta = this.resolveMeta(meta, target, em)


### PR DESCRIPTION
## Summary

Fixes #5948 — the tenant-encryption ORM subscriber was registered exactly once, at bootstrap, and only if `kmsService.isHealthy()` happened to be true at that instant. A Vault/KMS outage overlapping process startup left the subscriber unregistered for the whole process lifetime: no retry, no re-registration on recovery, and every ORM write relying on it persisted as plaintext until a restart.

While fixing the reported site I found **a second instance of the same one-shot gate, on the request path**, which the report does not cover. `getCachedEncryptionEnabled()` in `packages/shared/src/lib/di/container.ts` memoized `tenantEncryptionService.isEnabled()` on `globalThis` for the process lifetime — and `isEnabled()` is `isTenantDataEncryptionEnabled() && kms.isHealthy()`. The comment justified the cache on the premise that the value *"depends only on config that does not change at runtime"*: true of the toggle, false of the health flag it is ANDed with. So even a request-scoped re-registration could not recover. Both sites are fixed here.

## The fix

Registration is gated on the **static config toggle alone**; live KMS health is never part of the decision.

This is safe because the subscriber already self-gates: `TenantEncryptionSubscriber.encrypt()` and `.decrypt()` both re-check `service.isEnabled()` on *every* operation. Registering while the KMS is down is therefore a no-op that starts encrypting again the moment the KMS recovers — no restart, no re-registration, and it composes with the circuit-breaker recovery added in #2661. Gating registration on health was never necessary, only harmful.

Config-disabled behaviour is unchanged: with `TENANT_DATA_ENCRYPTION=false` the subscriber is still not registered.

### Signal gap

The issue also notes the fail-open window has no ongoing signal — the reporter runs an external canary to detect it. A write that falls through to plaintext because the KMS is unreachable now emits a throttled `logger.warn` (one line per minute, so a long outage does not flood the log). Deliberately disabling encryption by config stays silent.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/bootstrap.ts` | Register on `isTenantDataEncryptionEnabled()` alone; keep an (improved) boot warning when the KMS is unhealthy |
| `packages/shared/src/lib/di/container.ts` | `getCachedEncryptionConfigured()` caches the static toggle, not the health-sensitive `isEnabled()` |
| `packages/shared/src/lib/encryption/subscriber.ts` | Throttled warning when a write fails open to plaintext |

## Tests

Three new/updated suites, each verified to **fail without the fix**:

- `packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts` — registration no longer consults `isEnabled()`; keeps registering while the KMS is unhealthy; still skips when disabled by config. *(3 failed before the fix)*
- `packages/shared/src/lib/encryption/__tests__/subscriber.kms-recovery.test.ts` — one subscriber instance resumes encrypting after the KMS recovers with no re-registration; throttled fail-open warning; silent when config-disabled. *(warning test failed before the fix)*
- `packages/core/src/__tests__/encryption-subscriber-registration-gate.test.ts` — source guard that the registration condition never references `isHealthy`. *(failed before the fix)*

## Validation

Local (no compose container running). `build:packages` ×2, `generate`, `i18n:check-sync`, `i18n:check-usage`, `typecheck` (29/29), `lint` (0 errors), `build:app` — all green.

Tests: `@open-mercato/shared` 2242 passed, `@open-mercato/core` 12217 passed — the two packages this change touches, both fully green.

The full `yarn test` run reports 5 failures in `@open-mercato/cli` (`resolve-environment.test.ts`, `resolver.enterprise.test.ts`). Both suites **pass standalone** (10/10 and 6/6); they are the known location-dependent env suites, touch nothing in this diff, and their failure aborts the remaining packages in the turbo run — which is why the two affected packages were run directly.

> Note: `Fixes #5948` will not auto-close on merge because this targets `develop` rather than the repository default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724698&installation_model_id=432243&pr_number=6065&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6065&signature=f5a75cd2874a545ffee2507b4c7639c3d1cf36bec2455b21d6faf14d23f07daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->