### PR TITLE
security(shared): align tenant-wide encrypt/decrypt with the reported encrypted-field set (#5949)

### DIFF
--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -154,6 +154,7 @@ production-only encryption map still needs a test.
 - UI: extend Custom Entities editor to allow selecting system entities (e.g., `users`, `sales.order`, `sales.quote`, `customer_addresses`) and ticking which fields should be encrypted.
 - Defaults (seeded): `users.email`, customer addresses (address fields), sales orders/quotes snapshot + personal data, customer notes, order/quote notes.
 - Each map entry also marks optional hash columns for deterministic lookup (e.g., `users.email_hash`).
+- **Scope resolution** – an organization-scoped read or write resolves the most specific map for `(entity, tenant, organization)`, falling back to the tenant-wide and then the global map. At the **tenant-wide scope** (`organizationId = null`) the field list is the union of the resolved map and every organization-scoped map of that entity/tenant, so a field any organization encrypts is treated as ciphertext everywhere. `getEncryptedFieldNames`, `encryptEntityPayload`, and `decryptEntityPayload` all resolve the same set — a field declared only on an organization map is therefore still encrypted on a tenant-wide write and decrypted on a tenant-wide read.
 
 ## Key management
 

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -528,10 +528,10 @@ export class HybridQueryEngine implements QueryEngine {
         // `ignoreRuntimeHealth` asks the on-disk question -- a column holds ciphertext even while
         // the KMS is down -- so an outage keeps encrypted columns on the token path (#4622).
         // `organizationId: null` is deliberate, not an omission: the service then unions in every
-        // organization's map (`fetchAllOrganizationFieldNames`), so a field any org encrypts stays
-        // on the token path -- a wider set fails safe. Passing the request's org instead would
-        // silently break encrypted-column search for orgs without their own map. That union is an
-        // UNCACHED `encryption_maps` read, one extra round-trip per searched list request.
+        // organization's map, so a field any org encrypts stays on the token path -- a wider set
+        // fails safe. Passing the request's org instead would silently break encrypted-column
+        // search for orgs without their own map. The service caches that union (#5949), and the
+        // TTL cache in `resolveEncryptedLikeFieldSet` keeps even the lookup off the request path.
         try {
           const encryptionService = this.getEncryptionService()
           const readEncryptedFieldNames = encryptionService?.getEncryptedFieldNames?.bind(encryptionService)

--- a/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
@@ -297,3 +297,123 @@ describe('TenantDataEncryptionService.getEncryptedFieldNames', () => {
     )
   })
 })
+
+describe('TenantDataEncryptionService tenant-wide scope parity (issue #5949)', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+  const tenantId = 'tenant-5949'
+
+  beforeEach(() => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+  })
+
+  // A base (organization-less) map declaring `display_name`, plus an organization-scoped map that
+  // declares the extra `description` field. `getMap` only ever resolves the base map for
+  // organizationId = null; the all-organizations aggregate is the 2-parameter query.
+  function makeService(entityId: string) {
+    const execute = jest.fn(async (_sql: string, params: unknown[]) => {
+      if (params.length === 3) {
+        return params[2] === null
+          ? [{ entity_id: entityId, fields_json: [{ field: 'display_name' }] }]
+          : []
+      }
+      return [{ fields_json: [{ field: 'description', hashField: 'description_hash' }] }]
+    })
+    const service = new TenantDataEncryptionService(
+      { getConnection: () => ({ execute }) } as never,
+      {
+        kms: {
+          getTenantDek: jest.fn(async (keyId: string) => (
+            keyId === tenantId ? { tenantId: keyId, key: fixedKey, fetchedAt: new Date() } : null
+          )),
+          createTenantDek: jest.fn(async () => null),
+          isHealthy: () => true,
+        },
+      } as never,
+    )
+    return { service, execute }
+  }
+
+  it('encrypts fields declared only on an organization-scoped map at the tenant-wide scope', async () => {
+    const entityId = 'test:parity_encrypt_entity'
+    const { service } = makeService(entityId)
+
+    const encrypted = await service.encryptEntityPayload(
+      entityId,
+      { display_name: 'Acme Corp', description: 'confidential note' },
+      tenantId,
+      null,
+    )
+
+    expect(decryptWithAesGcm(encrypted.display_name as string, fixedKey)).toBe('Acme Corp')
+    expect(encrypted.description).not.toBe('confidential note')
+    expect(decryptWithAesGcm(encrypted.description as string, fixedKey)).toBe('confidential note')
+    expect(encrypted.description_hash).toBe(hashForLookup('confidential note'))
+  })
+
+  it('decrypts fields declared only on an organization-scoped map at the tenant-wide scope', async () => {
+    const entityId = 'test:parity_decrypt_entity'
+    const { service } = makeService(entityId)
+
+    const decrypted = await service.decryptEntityPayload(
+      entityId,
+      {
+        display_name: encryptWithAesGcm('Acme Corp', fixedKey).value as string,
+        description: encryptWithAesGcm('confidential note', fixedKey).value as string,
+      },
+      tenantId,
+      null,
+    )
+
+    expect(decrypted.display_name).toBe('Acme Corp')
+    expect(decrypted.description).toBe('confidential note')
+  })
+
+  it('reports exactly the fields the payload functions act on at the tenant-wide scope', async () => {
+    const entityId = 'test:parity_reported_entity'
+    const { service } = makeService(entityId)
+
+    const reported = await service.getEncryptedFieldNames(entityId, tenantId, null)
+    const encrypted = await service.encryptEntityPayload(
+      entityId,
+      { display_name: 'Acme Corp', description: 'confidential note' },
+      tenantId,
+      null,
+    )
+
+    expect(reported).toEqual(['display_name', 'description'])
+    const actuallyEncrypted = reported.filter((field) => encrypted[field] !== undefined
+      && decryptWithAesGcm(encrypted[field] as string, fixedKey) !== null)
+    expect(actuallyEncrypted).toEqual(reported)
+  })
+
+  it('leaves an organization-scoped call on its own map without the all-organizations read', async () => {
+    const entityId = 'test:parity_org_scoped_entity'
+    const { service, execute } = makeService(entityId)
+
+    const encrypted = await service.encryptEntityPayload(
+      entityId,
+      { display_name: 'Acme Corp', description: 'confidential note' },
+      tenantId,
+      'org-1',
+    )
+
+    expect(encrypted.description).toBe('confidential note')
+    expect(execute).not.toHaveBeenCalledWith(expect.anything(), [entityId, tenantId])
+  })
+
+  it('caches the all-organizations aggregate across payload calls', async () => {
+    const entityId = 'test:parity_cached_entity'
+    const { service, execute } = makeService(entityId)
+
+    await service.encryptEntityPayload(entityId, { description: 'first' }, tenantId, null)
+    await service.encryptEntityPayload(entityId, { description: 'second' }, tenantId, null)
+
+    const aggregateReads = execute.mock.calls.filter(([, params]) => (params as unknown[]).length === 2)
+    expect(aggregateReads).toHaveLength(1)
+  })
+})

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -44,10 +44,11 @@ function cacheKey(key: MapCacheKey): string {
   ].join(':')
 }
 
-// Tag for the aggregate of every organization-scoped map of an entity/tenant. It is deliberately
-// distinct from `cacheKey` so the aggregate never collides with a single map's cache entry.
+// Tag for the aggregate of every organization-scoped map of an entity/tenant. The prefix differs
+// from `cacheKey`'s in its first segment rather than by an extra one, so no entity id can spell a
+// tag that collides with an aggregate (`encmap:all-orgs:x:y` would be reachable both ways).
 function allOrganizationsCacheKey(entityId: string, tenantId: string | null): string {
-  return ['encmap', 'all-orgs', entityId.toLowerCase(), tenantId ?? 'null'].join(':')
+  return ['encmap-all-orgs', entityId.toLowerCase(), tenantId ?? 'null'].join(':')
 }
 
 function debug(event: string, payload: Record<string, unknown>) {

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -44,6 +44,12 @@ function cacheKey(key: MapCacheKey): string {
   ].join(':')
 }
 
+// Tag for the aggregate of every organization-scoped map of an entity/tenant. It is deliberately
+// distinct from `cacheKey` so the aggregate never collides with a single map's cache entry.
+function allOrganizationsCacheKey(entityId: string, tenantId: string | null): string {
+  return ['encmap', 'all-orgs', entityId.toLowerCase(), tenantId ?? 'null'].join(':')
+}
+
 function debug(event: string, payload: Record<string, unknown>) {
   if (!isEncryptionDebugEnabled()) return
   try {
@@ -113,11 +119,45 @@ function isEncryptedWithDek(value: unknown, dek: TenantDek): boolean {
   return decryptWithAesGcm(value, dek.key) !== null
 }
 
-function normalizeEncryptedFieldNames(fields: readonly { field?: unknown }[] | null | undefined): string[] {
+function normalizeEncryptedFieldRules(
+  fields: readonly { field?: unknown; hashField?: unknown }[] | null | undefined,
+): EncryptedFieldRule[] {
   if (!Array.isArray(fields)) return []
-  return fields
-    .map((rule) => rule.field)
-    .filter((field): field is string => typeof field === 'string' && field.trim().length > 0)
+  const rules: EncryptedFieldRule[] = []
+  for (const rule of fields) {
+    if (!rule || typeof rule !== 'object') continue
+    const field = rule.field
+    if (typeof field !== 'string' || field.trim().length === 0) continue
+    rules.push({ field, hashField: typeof rule.hashField === 'string' ? rule.hashField : null })
+  }
+  return rules
+}
+
+function normalizeEncryptedFieldNames(fields: readonly { field?: unknown }[] | null | undefined): string[] {
+  return normalizeEncryptedFieldRules(fields).map((rule) => rule.field)
+}
+
+/**
+ * Union of field rules, first declaration wins on the field name. A later duplicate only
+ * contributes its `hashField` when the winning rule declares none, so merging an organization-scoped
+ * map into a tenant-wide one never silently retargets an existing lookup-hash column.
+ */
+function mergeEncryptedFieldRules(...groups: readonly EncryptedFieldRule[][]): EncryptedFieldRule[] {
+  const merged: EncryptedFieldRule[] = []
+  const byField = new Map<string, EncryptedFieldRule>()
+  for (const group of groups) {
+    for (const rule of group) {
+      const existing = byField.get(rule.field)
+      if (!existing) {
+        const copy: EncryptedFieldRule = { field: rule.field, hashField: rule.hashField ?? null }
+        byField.set(rule.field, copy)
+        merged.push(copy)
+        continue
+      }
+      if (!existing.hashField && rule.hashField) existing.hashField = rule.hashField
+    }
+  }
+  return merged
 }
 
 function readEncryptedFieldsJson(row: Record<string, unknown>): EncryptedFieldRule[] {
@@ -323,7 +363,10 @@ export class TenantDataEncryptionService {
     return this.applySystemDefault(null, key.entityId)
   }
 
-  private async fetchAllOrganizationFieldNames(entityId: string, tenantId: string | null): Promise<string[]> {
+  private async fetchAllOrganizationFieldRules(
+    entityId: string,
+    tenantId: string | null,
+  ): Promise<EncryptedFieldRule[]> {
     const conn = getSqlConnection(this.em)
     if (!conn) return []
     const sql = `
@@ -337,23 +380,89 @@ export class TenantDataEncryptionService {
     `
     const rows = await conn.execute(sql, [entityId, tenantId])
     if (!Array.isArray(rows) || rows.length === 0) return []
-    const names = new Set<string>()
+    const groups: EncryptedFieldRule[][] = []
     for (const row of rows) {
       if (!row || typeof row !== 'object') continue
-      for (const field of normalizeEncryptedFieldNames(readEncryptedFieldsJson(row as Record<string, unknown>))) {
-        names.add(field)
-      }
+      groups.push(normalizeEncryptedFieldRules(readEncryptedFieldsJson(row as Record<string, unknown>)))
     }
-    return Array.from(names)
+    return mergeEncryptedFieldRules(...groups)
+  }
+
+  /**
+   * Cached aggregate of every organization-scoped map for an entity/tenant. `encryptEntityPayload`
+   * and `decryptEntityPayload` consult it on every row at the tenant-wide scope, so the uncached
+   * read this used to be would add a round-trip per flush and per load (#5949).
+   */
+  private async getAllOrganizationFieldRules(
+    entityId: string,
+    tenantId: string | null,
+  ): Promise<EncryptedFieldRule[]> {
+    const tag = allOrganizationsCacheKey(entityId, tenantId)
+    const missExpiresAt = this.missCache.get(tag)
+    if (missExpiresAt) {
+      if (missExpiresAt > Date.now()) return []
+      this.missCache.delete(tag)
+    }
+    const mem = this.memoryCache.get(tag)
+    if (mem) return mem.fields
+    if (this.cache && typeof this.cache.get === 'function') {
+      const cached = await this.cache.get(tag)
+      if (cached) return (cached as EncryptionMapRecord).fields
+    }
+    const inflight = this.inflightMaps.get(tag)
+    if (inflight) return (await inflight)?.fields ?? []
+    const pending = (async (): Promise<EncryptionMapRecord | null> => {
+      const fields = await this.fetchAllOrganizationFieldRules(entityId, tenantId)
+      return fields.length ? { entityId, fields } : null
+    })()
+    this.inflightMaps.set(tag, pending)
+    let loaded: EncryptionMapRecord | null
+    try {
+      loaded = await pending
+    } finally {
+      this.inflightMaps.delete(tag)
+    }
+    if (!loaded) {
+      this.missCache.set(tag, Date.now() + MAP_MISS_TTL_MS)
+      return []
+    }
+    this.missCache.delete(tag)
+    this.memoryCache.set(tag, loaded)
+    if (this.cache && typeof this.cache.set === 'function') {
+      await this.cache.set(tag, loaded, { ttl: 300 })
+    }
+    return loaded.fields
+  }
+
+  /**
+   * The field rules that are actually encrypted at rest for a scope.
+   *
+   * At the tenant-wide scope (`organizationId == null`) `getMap` resolves only the base map, but
+   * rows of the same entity may carry fields declared solely by an organization-scoped map. Reading
+   * or writing such a row with the base map alone stores those fields as plaintext and hands
+   * callers back undecrypted ciphertext, so every scope-aware path unions the organization maps in
+   * (#5949) — the same set `getEncryptedFieldNames` has reported since #2282.
+   */
+  private async resolveFieldRulesForScope(
+    entityId: string,
+    tenantId: string | null,
+    organizationId: string | null,
+    map: EncryptionMapRecord | null,
+  ): Promise<EncryptedFieldRule[]> {
+    const mapRules = normalizeEncryptedFieldRules(map?.fields)
+    if (organizationId != null) return mergeEncryptedFieldRules(mapRules)
+    return mergeEncryptedFieldRules(mapRules, await this.getAllOrganizationFieldRules(entityId, tenantId))
   }
 
   async invalidateMap(entityId: string, tenantId: string | null, organizationId: string | null): Promise<void> {
-    const tag = cacheKey({ entityId, tenantId, organizationId })
-    this.memoryCache.delete(tag)
-    this.inflightMaps.delete(tag)
-    this.missCache.delete(tag)
-    if (this.cache && typeof (this.cache as any).delete === 'function') {
-      await (this.cache as any).delete(tag)
+    const tags = [cacheKey({ entityId, tenantId, organizationId }), allOrganizationsCacheKey(entityId, tenantId)]
+    for (const tag of tags) {
+      this.memoryCache.delete(tag)
+      this.inflightMaps.delete(tag)
+      this.missCache.delete(tag)
+      if (this.cache && typeof (this.cache as any).delete === 'function') {
+        await (this.cache as any).delete(tag)
+      }
     }
   }
 
@@ -387,13 +496,13 @@ export class TenantDataEncryptionService {
       return []
     }
     const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
-    const fields = new Set(normalizeEncryptedFieldNames(map?.fields))
-    if (organizationId == null) {
-      for (const field of await this.fetchAllOrganizationFieldNames(entityId, tenantId ?? null)) {
-        fields.add(field)
-      }
-    }
-    return Array.from(fields)
+    const fields = await this.resolveFieldRulesForScope(
+      entityId,
+      tenantId ?? null,
+      organizationId ?? null,
+      map,
+    )
+    return fields.map((rule) => rule.field)
   }
 
   private encryptFields(
@@ -466,18 +575,24 @@ export class TenantDataEncryptionService {
       return payload
     }
     const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
-    if (!map || !map.fields?.length) {
+    const fields = await this.resolveFieldRulesForScope(
+      entityId,
+      tenantId ?? null,
+      organizationId ?? null,
+      map,
+    )
+    if (!fields.length) {
       debug('⚪️ encrypt.skip.no-map', { entityId, tenantId })
       return payload
     }
-    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+    const keyId = map?.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
     const dek = await this.resolveDekForEncrypt(keyId)
     if (!dek) {
-      debug('⚠️ encrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })
+      debug('⚠️ encrypt.skip.no-dek', { entityId, tenantId, keyScope: map?.keyScope ?? 'tenant' })
       return payload
     }
-    debug('🔒 encrypt_entity', { entityId, tenantId, organizationId, fields: map.fields.length })
-    return this.encryptFields(payload, map.fields, dek)
+    debug('🔒 encrypt_entity', { entityId, tenantId, organizationId, fields: fields.length })
+    return this.encryptFields(payload, fields, dek)
   }
 
   async decryptEntityPayload(
@@ -491,17 +606,23 @@ export class TenantDataEncryptionService {
       return payload
     }
     const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
-    if (!map || !map.fields?.length) {
+    const fields = await this.resolveFieldRulesForScope(
+      entityId,
+      tenantId ?? null,
+      organizationId ?? null,
+      map,
+    )
+    if (!fields.length) {
       debug('⚪️ decrypt.skip.no-map', { entityId, tenantId })
       return payload
     }
-    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+    const keyId = map?.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
     const dek = await this.getDek(keyId)
     if (!dek) {
-      debug('⚠️ decrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })
+      debug('⚠️ decrypt.skip.no-dek', { entityId, tenantId, keyScope: map?.keyScope ?? 'tenant' })
       return payload
     }
-    debug('🔓 decrypt_entity', { entityId, tenantId, organizationId, fields: map.fields.length })
-    return this.decryptFields(payload, map.fields, dek)
+    debug('🔓 decrypt_entity', { entityId, tenantId, organizationId, fields: fields.length })
+    return this.decryptFields(payload, fields, dek)
   }
 }

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -60,9 +60,10 @@ export function isEncryptedLikeField(encrypted: ReadonlySet<string>, field: stri
   return fieldNameCandidates(field).some((candidate) => encrypted.has(candidate))
 }
 
-// The all-orgs union behind `getEncryptedFieldNames(..., organizationId: null)` is an UNCACHED
-// `encryption_maps` read. Encryption maps change on deploys, not per request, so a short TTL
-// removes the per-search round-trip without meaningfully delaying a map rollout.
+// The all-orgs union behind `getEncryptedFieldNames(..., organizationId: null)` reads
+// `encryption_maps`. The service caches that aggregate since #5949, but this set is per-search
+// hot and also spans the name-shape expansion below, so a short TTL keeps the whole resolved
+// set out of the request path without meaningfully delaying a map rollout.
 const ENCRYPTED_LIKE_FIELDS_TTL_MS = 60_000
 const ENCRYPTED_LIKE_FIELDS_CACHE_CAP = 500
 const encryptedLikeFieldsCache = new Map<string, { at: number; fields: Set<string> }>()
@@ -455,10 +456,10 @@ export class BasicQueryEngine implements QueryEngine {
     // `ignoreRuntimeHealth` asks the on-disk question -- a column holds ciphertext even while the
     // KMS is down -- so an outage keeps encrypted columns on the token path (#4622).
     // `organizationId: null` is deliberate, not an omission: the service then unions in every
-    // organization's map (`fetchAllOrganizationFieldNames`), so a field any org encrypts stays on
-    // the token path -- a wider set fails safe. Passing the request's org instead would silently
-    // break encrypted-column search for orgs without their own map. That union is an UNCACHED
-    // `encryption_maps` read, one extra round-trip per searched list request. `null` means
+    // organization's map, so a field any org encrypts stays on the token path -- a wider set
+    // fails safe. Passing the request's org instead would silently break encrypted-column search
+    // for orgs without their own map. The service caches that union (#5949), and the TTL cache
+    // above keeps even the cache lookup off the request path. `null` means
     // the encryption service could not answer at all; keep the pre-existing rewrite-everything
     // behavior then, because guessing "plaintext" would turn encrypted-column search into an
     // ILIKE-on-ciphertext that matches nothing.


### PR DESCRIPTION
Closes #5949

## 🎯 Goal
A field that only an organization-scoped encryption map declares is no longer written to disk in plaintext when the row is saved at the tenant-wide scope, and is no longer handed back to callers still sealed when read at that scope. What `getEncryptedFieldNames` reports as encrypted is now exactly what the encrypt and decrypt paths act on.

## 🔍 Problem
`getEncryptedFieldNames(entity, tenant, null)` answers the read-side question "what might be ciphertext at the tenant-wide scope?" by unioning the base map's fields with those of every organization-scoped map for that entity/tenant. Query planning (`lib/query/engine.ts`), the ciphertext-search warning and the dashboards widget service all consult it and treat the columns it names as ciphertext.

`encryptEntityPayload` and `decryptEntityPayload` answered a narrower question. Given a base map declaring `A` and an organization map declaring `B`, a tenant-wide write stored `B` as plaintext while the metadata query claimed it was encrypted — a caller deciding whether `B` is safe to treat as ciphertext (a lookup-hash decision, a search-index exclusion, a manual query) got a false sense of protection for a column that is never sealed at that scope. The read side had the mirror defect: a genuinely-encrypted `B` came back undecrypted.

## 🔍 Root Cause
`getMap` walks the candidate chain `(entity, tenant, org)` → `(entity, tenant, null)` → `(entity, null, null)`, so for `organizationId = null` it never reaches an organization-scoped row. Commit `0c1664513` ("fix(query): sort encrypted fields across all organizations", #2282) added `fetchAllOrganizationFieldNames` and wired it into `getEncryptedFieldNames` only, leaving the two payload functions on the narrow single-map resolution. The scope is reached in practice by any caller passing `null` explicitly — `entities/cli.ts:1164` does — and by the ORM subscriber, which derives `organizationId = null` from any row without an organization.

## What Changed
- `packages/shared/src/lib/encryption/tenantDataEncryptionService.ts` — `getEncryptedFieldNames`, `encryptEntityPayload` and `decryptEntityPayload` now resolve their field list through one private `resolveFieldRulesForScope` helper, which unions in every active organization-scoped map when `organizationId == null`. The direction is to widen the two payload paths, not narrow the metadata one: narrowing would regress #2282's all-organization sort.
- The aggregate merges at the **rule** level rather than the name level (`fetchAllOrganizationFieldRules` replaces `fetchAllOrganizationFieldNames`), so an organization map's `hashField` survives into the write path and its deterministic lookup hash is populated. On a field-name collision the first declaration wins and only contributes a `hashField` where the winner declares none, so merging never silently retargets an existing hash column.
- The aggregate read was uncached — `lib/query/engine.ts:63` documents that cost for the search path, where it happens once per search. The payload functions run per row on every ORM flush and load, so it now goes through the existing map-cache machinery (memory + `CacheStrategy`, 300s TTL) with a negative-miss entry under `MAP_MISS_TTL_MS`, and `invalidateMap` clears the aggregate tag alongside the single-map tag.
- `apps/docs/docs/architecture/data-encryption.mdx` — documents the scope-resolution rule, which the encryption-maps section did not previously state.

## 🧪 Tests
- `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all exit 0.
- `yarn test` exits 1 on 5 `@open-mercato/cli` module-resolution tests (`resolve-environment.test.ts`, `resolver.enterprise.test.ts`). They pass standalone both with and without this change and fail only inside the full turbo run — a known location-dependent failure, unrelated to this diff. That failure also aborts turbo before six workspaces run, so those were run directly: shared (2242 passed), core (12214), ui (2067), search (346), enterprise (537), onboarding (139).
- Five new cases in `tenantDataEncryptionService.test.ts` lock in: a tenant-wide write sealing a field declared only on an organization map, including its lookup hash; a tenant-wide read decrypting it; parity between what `getEncryptedFieldNames` reports and what the payload functions act on; an organization-scoped call staying on its own map and issuing no aggregate read; and the aggregate being read once across repeated payload calls. Four of the five fail against the unfixed service — the fifth is the no-regression guard, which correctly passes either way.

## 💥 Breaking Changes
None to any signature, type or route. One deliberate runtime behavior change: a tenant-wide write now seals fields it previously left in plaintext, and populates the matching hash column where the organization map declares one. Rows written before this change keep their plaintext values and remain readable — `decryptFields` leaves any value that does not decrypt untouched — so no migration is required; operators who want historical rows sealed can use the existing `entities` backfill CLI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/6066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725127&installation_model_id=432243&pr_number=6066&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F6066&signature=e94cae921c53e2b371963c94882bf768e9766d66830f49f8605c7f8f07a23414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->